### PR TITLE
editor: apply PO feedback

### DIFF
--- a/rero_ils/manual_translations.txt
+++ b/rero_ils/manual_translations.txt
@@ -53,3 +53,9 @@ _('bf:Place')
 # Harvested source
 _('ebibliomedia')
 _('mv-cantook')
+
+# Issuance main type
+_('rdami:1001')
+_('rdami:1002')
+_('rdami:1003')
+_('rdami:1004')

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -321,24 +321,52 @@
                 "year": {
                   "title": "Year",
                   "type": "string",
-                  "pattern": "^\\d{4}$"
+                  "pattern": "^\\d{4}$",
+                  "form": {
+                    "validation": {
+                      "messages": {
+                        "patternMessage": "Should be in the following format: 2020."
+                      }
+                    },
+                    "templateOptions": {
+                      "cssClass": "col-lg-3"
+                    }
+                  }
                 },
                 "volume": {
                   "title": "Volume",
                   "type": "integer",
-                  "minimum": 1
+                  "minimum": 1,
+                  "form": {
+                    "templateOptions": {
+                      "cssClass": "col-lg-3"
+                    }
+                  }
                 },
                 "issue": {
                   "title": "Issue",
-                  "type": "string",
-                  "minLength": 1
+                  "type": "integer",
+                  "minimum": 1,
+                  "form": {
+                    "templateOptions": {
+                      "cssClass": "col-lg-3"
+                    }
+                  }
                 },
                 "pages": {
                   "title": "Pages",
                   "type": "string",
                   "pattern": "^\\d+(-\\d+)?$",
                   "form": {
-                    "placeholder": "Examples: 135, 5-27, ..."
+                    "placeholder": "Ex: 135, 5-27, ...",
+                    "validation": {
+                      "messages": {
+                        "patternMessage": "Should be in the following format: 135 or 5-27."
+                      }
+                    },
+                    "templateOptions": {
+                      "cssClass": "col-lg-3"
+                    }
                   }
                 }
               },
@@ -1234,7 +1262,6 @@
         "properties": {
           "seriesTitle": {
             "title": "Title",
-            "description": "Title of the series.",
             "type": "array",
             "minItems": 1,
             "items": {
@@ -1244,12 +1271,11 @@
           },
           "seriesEnumeration": {
             "title": "Numbering",
-            "placeholder": "Example: vol. 3",
             "type": "array",
             "minItems": 1,
             "items": {
               "title": "Numbering",
-              "$ref": "#/definitions/language_script"
+              "$ref": "#/definitions/numbering_script"
             },
             "form": {
               "hide": true
@@ -1282,15 +1308,17 @@
                 },
                 "subseriesEnumeration": {
                   "title": "Numbering",
-                  "placeholder": "Example: no. 3",
                   "type": "array",
                   "minItems": 1,
                   "items": {
                     "title": "Numbering",
-                    "$ref": "#/definitions/language_script"
+                    "$ref": "#/definitions/numbering_script"
                   }
                 }
               }
+            },
+            "form": {
+              "hide": true
             }
           }
         }
@@ -1667,11 +1695,11 @@
           "url": {
             "title": "URL",
             "description": "Record a unique URL here.",
-            "placeholder": "Example: https://www.rero.ch/",
             "type": "string",
             "format": "uri",
             "minLength": 7,
             "form": {
+              "placeholder": "Example: https://www.rero.ch/",
               "templateOptions": {
                 "cssClass": "col-lg-4"
               }
@@ -4430,6 +4458,38 @@
           "type": "string",
           "minLength": 1,
           "form": {
+            "templateOptions": {
+              "cssClass": "col-lg-7"
+            }
+          }
+        },
+        "language": {
+          "$ref": "#/definitions/language_script_code"
+        }
+      }
+    },
+    "numbering_script": {
+      "title": "Values",
+      "type": "object",
+      "propertiesOrder": [
+        "language",
+        "value"
+      ],
+      "required": [
+        "value"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "row"
+        }
+      },
+      "properties": {
+        "value": {
+          "title": "Value",
+          "type": "string",
+          "minLength": 1,
+          "form": {
+            "placeholder": "Example: vol.3",
             "templateOptions": {
               "cssClass": "col-lg-7"
             }

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -234,6 +234,22 @@ msgstr "ebibliomedia"
 msgid "mv-cantook"
 msgstr "mv-cantook"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "القائمة"
@@ -308,8 +324,8 @@ msgid "Account ID"
 msgstr "رقم الحساب"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -392,8 +408,8 @@ msgstr "URI للمكتبة"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -517,8 +533,8 @@ msgid "Deleted"
 msgstr "تم الحذف"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "التاريخ"
 
@@ -539,7 +555,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "يجب أن تكون بالتنسيق: 2022-12-31 (YYYY-MM-DD)."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "ملاحظات"
@@ -665,9 +681,9 @@ msgid "Exchange rate"
 msgstr "سعر الصرف"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -723,7 +739,7 @@ msgid "Monograph"
 msgstr "دراسة علمية"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "دورية"
 
@@ -922,28 +938,28 @@ msgid "Item type URI"
 msgstr "URI لتصنيف النسخة"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "دورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "السلسلة"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -962,13 +978,13 @@ msgstr "PID المستند"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -977,7 +993,7 @@ msgid "Type"
 msgstr "تصنيف"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "مقالة"
 
@@ -1002,7 +1018,7 @@ msgid "Sound"
 msgstr "صوت"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "فيديو"
 
@@ -1012,10 +1028,10 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "العنوان"
@@ -1066,13 +1082,13 @@ msgid "Part name"
 msgstr "إسم الجزء"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "المسؤوليات"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "المسؤولية"
@@ -1124,10 +1140,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "ترقيم"
 
@@ -1135,235 +1151,245 @@ msgstr "ترقيم"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "اللغات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "اللغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "تصنيف فرعي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "الترجمة من"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "اللغة التي يتم ترجمة المصدر إليها"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "المؤلفين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "مؤلف(ي) المصدر. يمكن أن يكون إما أشخاص أو منظمات."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "إسناد المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "إسم إسنادات المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr "معلومات عن ولادة وموت اسناد مؤلف. مفيدة للناس إزالة الغموض."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "مؤهل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr "معلومات عن اسناد مؤلف، المهنة. مفيدة للناس إزالة الغموض."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "تاريخ الحقوق المحفوظة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "بيانات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "بيانات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "تسميات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "تسميات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "أنشطة توفير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "نشاط توفير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "اماكن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "مكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "صياغات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "صياغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr "بيان مكان وكيل النشاط المخصص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "ملصقات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "تاريخ بدء النشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1373,11 +1399,11 @@ msgstr ""
 "يستخدم لفرز نتائج البحث. بمجرد تعيين هذا الحقل ، يمكن إضافة تاريخ نشر اخر"
 " في الحقل التالي."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "تاريخ الانتهاء من النشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1387,4197 +1413,4191 @@ msgstr ""
 "-50. يستخدم لفرز نتائج البحث. بمجرد تعيين هذا الحقل ، يمكن إضافة تاريخ "
 "نشر اخر في الحقل التالي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "مدى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
 "is left full, cut, or folded."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "عنوان السلسلة"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "ملخصات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "ملخص للمصدر."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "الملخص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "معرف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "رقم الإصدار الصوتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "رقم التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "رقم التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "ملاحطة التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "تأهيل المعرف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "شروط المقنيات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "شروط المقنيات للمصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "مصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "مصدر رقم التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "الحالة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "حالة معرف ISBN/ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "المواضيع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "موضوع المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "الموضوع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr "معلومات مطلوبة لتحديد والإتصال بالمصدر الإلكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "سجل URL وحيد هنا."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "مثال: https://www.rero.ch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "تصنيف الرابط"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "إصدار المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "مصدر ذو صلة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "URL مخفي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "لا يوجد معلومات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "تصنيف المحتوى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "يتم عرضه كنص الرابط"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "ملصق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "صوت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "كرت بريدي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "إضافة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "تلخيص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "وثائق العروض"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "خطأ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "لوحة كتب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "استخلاص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "ورقة تعليمية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "الرسوم التوضيحية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "صورة الغلاف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "معلومات التسليم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "معلومات ببليوجرافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "مقدمة/تمهيد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "صف القراءة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "أدوات المعلم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "ملاحظة الناشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "ملاحظة عن  المحتوى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "صفحة العنوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "التصوير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "تلخيص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "الموارد عبر الإنترنت من خلال RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "استعراض الصحافة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "موقع الكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "جدول المحتويات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "النص الكامل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr "يتم عرض بجوار الرابط ، كمعلومات إضافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr "ملاحظة عامة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "مثال: الوصول هنا فقط عن طريق المكتبة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "محصود"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "يتم حصاد المستند أم لا ، سيتم تعطيل إصدار السجل أو ما شابه"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "قيمة اللغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "الأفارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "الأبخازية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "الأتشينيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "الأكولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "الأدانجمية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "الأديغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "lang_afa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "الأفريهيلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "الأفريقانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "الآينوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "الأكانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "الأكادية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "lang_alb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "الأليوتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "lang_alg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "الألطائية الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "الأمهرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "الإنجليزية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "الأنجيكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "lang_apa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "العربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "الآرامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "الأراغونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "lang_arm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "المابودونغونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "الأراباهو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "lang_art"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "الأراواكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "الأسامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "الأسترية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "lang_ath"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "lang_aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "الأوارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "الأفستية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "الأوادية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "الأيمارا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "الأذربيجانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "lang_bad"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "lang_bai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "الباشكيرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "البلوشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "البامبارا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "البالينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "lang_baq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "الباسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "lang_bat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "البيجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "البيلاروسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "البيمبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "البنغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "lang_ber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "البهوجبورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "lang_bih"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "البيكولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "البينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "البيسلامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "السيكسيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "lang_bnt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "البوسنية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "البراجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "البريتونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "lang_btk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "البرياتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "البجينيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "البلغارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "lang_bur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "البلينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "الكادو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "lang_cai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "الكاريبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "الكتالانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "القوقازيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "السيبيوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "lang_cel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "التشامورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "التشيبشا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "الشيشانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "التشاجاتاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "الصينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "التشكيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "الماري"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "الشينوك جارجون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "الشوكتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "الشيباوايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "الشيروكي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "سلافية كنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "التشوفاشي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "الشايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "lang_cmc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "lang_cnr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "القبطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "الكورنية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "الكورسيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "lang_cpe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "lang_cpf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "lang_cpp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "الكرى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "لغة تتار القرم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "lang_crp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "الكاشبايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "lang_cus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "lang_cze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "الداكوتا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "الدانمركية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "الدارجوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "lang_day"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "الديلوير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "السلافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "الدوجريب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "الدنكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "المالديفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "الدوجرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "lang_dra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "صوربيا السفلى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "الديولا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "الهولندية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "lang_dut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "الدايلا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "الزونخاية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "الإفيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "المصرية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "الإكاجك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "الإمايت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "الإنجليزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "الإنجليزية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "الإسبرانتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "الإستونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "الإيوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "الإيوندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "الفانج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "الفاروية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "الفانتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "الفيجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "الفلبينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "الفنلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "lang_fiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "الفون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "الفرنسية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "الفرنسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "الفريزينية الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "الفريزينية الشرقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "الفريزيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "الفولانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "الفريلايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "الجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "الجايو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "الجبيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "lang_gem"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "lang_geo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "الالمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "الجعزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "لغة أهل جبل طارق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "الغيلية الأسكتلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "الأيرلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "الجاليكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "المنكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "الألمانية العليا الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "الألمانية العليا القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "الجندي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "الجورونتالو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "القوطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "الجريبو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "اليونانية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "lang_gre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "الغوارانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "الألمانية السويسرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "الغوجاراتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "غوتشن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "الهيدا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "الكريولية الهايتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "الهوسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "لغة هاواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "العبرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "الهيريرو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "الهيليجينون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "lang_him"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "الهندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "الحثية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "الهمونجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "الهيري موتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "الكرواتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "الصوربية العليا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "الهنغارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "الهبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "الإيبان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "الإيجبو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "lang_ice"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "الإيدو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "السيتشيون يي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "lang_ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "الإينكتيتت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "الإنترلينج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "الإيلوكو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "اللّغة الوسيطة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "lang_inc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "الإندونيسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "lang_ine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "الإنجوشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "الإينبياك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "lang_ira"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "lang_iro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "الإيطالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "الجاوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "اللوجبان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "اليابانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "الفارسية اليهودية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "العربية اليهودية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "الكارا-كالباك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "القبيلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "الكاتشين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "الكالاليست"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "الكامبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "الكانادا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "lang_kar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "الكشميرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "الكانوري"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "الكوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "الكازاخستانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "الكاباردايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "الكازية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "lang_khi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "الخميرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "الخوتانيز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "الكيكيو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "الكينيارواندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "القيرغيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "الكيمبندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "الكونكانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "الكومي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "الكونغو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "الكورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "الكوسراين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "الكبيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "الكاراتشاي-بالكار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "الكاريلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "lang_kro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "الكوروخ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "الكيونياما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "القموقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "الكردية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "الكتيناي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "اللادينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "اللاهندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "اللامبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "اللاوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "اللاتينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "اللاتفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "الليزجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "الليمبورغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "اللينجالا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "الليتوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "منغولى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "اللوزي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "اللكسمبورغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "اللبا-لؤلؤ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "اللوبا كاتانغا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "الغاندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "اللوسينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "اللوندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "اللو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "الميزو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "lang_mac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "المادريز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "الماجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "المارشالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "المايثيلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "الماكاسار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "المالايالامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "الماندينغ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "lang_mao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "lang_map"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "الماراثية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "الماساي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "lang_may"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "الموكشا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "الماندار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "الميند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "الأيرلندية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "الميكماكيونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "المينانجكاباو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "lang_mis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "lang_mkh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "الملغاشي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "المالطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "المانشو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "المانيبورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "lang_mno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "الموهوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "المنغولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "الموسي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "لغات متعددة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "lang_mun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "الكريك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "الميرانديز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "الماروارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "lang_myn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "الأرزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "lang_nah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "lang_nai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "النابولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "النورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "النافاجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "النديبيل الجنوبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "النديبيل الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "الندونجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "الألمانية السفلى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "النيبالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "النوارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "النياس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "lang_nic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "النيوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "النرويجية نينورسك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "النرويجية بوكمال"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "النوجاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "النورس القديم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "النرويجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "أنكو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "السوتو الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "lang_nub"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "النوارية التقليدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "النيانجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "النيامويزي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "النيانكول"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "النيورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "النزيما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "الأوكسيتانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "الأوجيبوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "الأورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "الأورومية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "الأوساج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "الأوسيتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "التركية العثمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "lang_oto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "lang_paa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "البانجاسينان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "البهلوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "البامبانجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "البنجابية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "البابيامينتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "البالوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "الفارسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "lang_per"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "lang_phi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "الفينيقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "البالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "البولندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "البوهنبيايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "البرتغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "lang_pra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "البروفانسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "البشتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "الكويتشوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "الراجاسثانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "الراباني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "الراروتونجاني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "lang_roa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "الرومانشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "الغجرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "lang_rum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "الرندي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "الأرومانيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "الروسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "السانداوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "السانجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "الساخيّة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "lang_sai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "lang_sal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "الآرامية السامرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "السنسكريتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "الساساك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "السانتالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "الصقلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "الأسكتلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "السيلكب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "lang_sem"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "الأيرلندية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "lang_sgn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "الشان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "السيدامو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "السنهالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "lang_sio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "lang_sit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "lang_sla"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "lang_slo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "السلوفانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "السامي الجنوبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "سامي الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "lang_smi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "اللول سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "الإيناري سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "الساموائية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "السكولت سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "الشونا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "السندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "السونينك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "السوجدين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "الصومالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "lang_son"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "السوتو الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "الإسبانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "السردينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "السرانان تونجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "الصربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "السرر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "lang_ssa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "السواتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "السوكوما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "السوندانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "السوسو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "السومارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "السواحلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "السويدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "سريانية تقليدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "السريانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "التاهيتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "lang_tai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "التاميلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "التترية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "التيلوغوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "التيمن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "التيرينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "التيتم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "الطاجيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "التاغالوغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "التايلاندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "lang_tib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "التيغرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "التغرينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "التيف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "التوكيلاو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "الكلينجون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "التلينغيتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "التاماشيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "تونجا - نياسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "التونغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "التوك بيسين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "التسيمشيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "التسوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "السونجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "التركمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "التامبوكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "lang_tup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "التركية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "lang_tut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "التوفالو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "التوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "التوفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "الأدمرت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "اليجاريتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "الأويغورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "الأوكرانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "الأمبندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "لغة غير معروفة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "الأوردية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "الأوزبكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "الفاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "الفيندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "الفيتنامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "لغة الفولابوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "الفوتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "lang_wak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "الولاياتا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "الواراي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "الواشو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "lang_wel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "lang_wen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "الولونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "الولوفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "الكالميك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "الخوسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "الياو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "اليابيز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "اليديشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "اليوروبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "lang_ypk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "الزابوتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "رموز المعايير الأساسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "الزيناجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "الزهيونج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "lang_znd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "الزولو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "الزونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "بدون محتوى لغوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "زازا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "قيمات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "البلد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "country_aa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "country_abc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "country_ac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "country_aca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "country_ae"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "country_af"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "country_ag"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "country_ai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "country_air"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "country_aj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "country_ajr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "country_aku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "country_alu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "country_am"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "country_an"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "country_ao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "(aq) أنتيغوا وبربودا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "country_aru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "country_as"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "country_at"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "country_au"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "country_aw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "country_ay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "country_azu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "country_ba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "(bb) بربادوس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "(bbc) كولومبيا البريطانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "country_bd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "country_be"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "country_bf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "country_bg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "country_bh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "country_bi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "country_bl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "country_bm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "country_bn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "country_bo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "(bp) جزر سليمان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "country_br"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "country_bs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "(bt) بوتان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "country_bu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "(bv) جزيرة بوفيه"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "(bw) بيلاروس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "country_bwr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "(bx) بروناي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "country_ca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "(cau) كاليفورنيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "country_cb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "(cc) الصين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "country_cd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "country_ce"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "(cf) كونجو برازفيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "country_cg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "country_ch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "country_ci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "(cj) جزر كايمان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "country_ck"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "(cl) تشيلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "country_cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "country_cn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "country_co"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "country_cou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "country_cp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "(cq) جزر القمر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "country_cr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "country_cs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "country_ctu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "country_cu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "country_cv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "(cw) جزر كوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "(cx) جمهورية أفريقيا الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "country_cy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "(cz) قناة الزون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "country_dcu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "country_deu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "country_dk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "country_dm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "(dq) دومينيكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "country_dr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "country_ea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "(ec) الإكوادور"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "country_eg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "country_em"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "country_enk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "country_er"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "country_err"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "country_es"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "country_et"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "country_fa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "(fg) غويانا الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "country_fi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "country_fj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "(fk) جزر الفوكلاند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "country_flu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "country_fm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "(fp) بولينيزيا الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "country_fr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "country_fs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "country_ft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "country_gau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "country_gb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "country_gd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "country_ge"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "country_gg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "country_gh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "country_gi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "country_gl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "country_gm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "country_gn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "country_go"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "(gp) غوادلوب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "country_gr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "country_gs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "country_gsr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "country_gt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "country_gu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "country_gv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "country_gw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "country_gy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "country_gz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "country_hiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "country_hk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "country_hm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "country_ho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "country_ht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "country_hu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "country_iau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "country_ic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "country_idu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "country_ie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "country_ii"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "country_ilu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "country_im"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "country_inu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "country_io"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "(iq) العراق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "country_ir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "country_is"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "country_it"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "country_iu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "country_iv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "(iw) المناطق المنزوعة السلاح بين إسرائيل والأردن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "country_iy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "country_ja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "(je) جيرسي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "country_ji"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "(jm) جامايكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "country_jn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "country_jo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "country_ke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "(kg) قيرغيزستان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "country_kgr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "country_kn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "country_ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "country_ksu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "country_ku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "(kv) كوسوفو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "country_kyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "country_kz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "country_kzr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "country_lau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "country_lb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "country_le"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "country_lh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "country_li"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "country_lir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "country_ln"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "country_lo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "country_ls"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "country_lu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "country_lv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "country_lvr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "(ly) ليبيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "country_mau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "country_mbc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "country_mc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "country_mdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "country_meu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "country_mf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "country_mg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "country_mh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "country_miu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "country_mj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "country_mk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "country_ml"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "(mm) مالطا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "country_mnu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "country_mo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "country_mou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "(mp) منغوليا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "(mq) جزر المارتينيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "country_mr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "country_msu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "country_mtu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "country_mu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "country_mv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "country_mvr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "country_mw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "(mx) المكسيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "country_my"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "(mz) موزمبيق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "country_na"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "country_nbu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "country_ncu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "country_ndu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "country_ne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "country_nfc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "country_ng"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "country_nhu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "country_nik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "country_nju"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "country_nkc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "country_nl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "country_nm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "country_nmu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "country_nn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "country_no"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "country_np"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "country_nq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "country_nr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "country_nsc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "country_ntc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "country_nu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "country_nuc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "country_nvu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "country_nw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "(nx) جزيرة نورفولك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "country_nyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "country_nz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "country_ohu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "country_oku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "country_onc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "country_oru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "country_ot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "(pau) بنسلفانيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "(pc) جزيرة بيتكيرن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "country_pe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "(pf) جزر باراسيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "country_pg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "country_ph"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "country_pic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "country_pk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "country_pl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "country_pn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "country_po"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "country_pp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "country_pr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "(pt) تيمور البرتغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "(pw) بالاو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "(py) باراغواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "(qa) قطر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "country_qea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "country_quc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "country_rb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "country_re"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "country_rh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "country_riu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "country_rm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "country_ru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "country_rur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "country_rw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr "country_ry"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "country_sa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "country_sb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "country_sc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "country_scu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "country_sd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "country_sdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "country_se"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "(sf) ساو تومي وبرينسيبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "country_sg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "country_sh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "country_si"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "country_sj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "country_sk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "country_sl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "country_sm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "country_sn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "country_snc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "country_so"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "country_sp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "(sq) إسواتيني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "country_sr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "country_ss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "country_st"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "country_stk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "country_su"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "country_sv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "country_sw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "country_sx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "country_sy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "(sz) سويسرا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "country_ta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "country_tar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "(tc) جزر توركس وكايكوس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "country_tg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "country_th"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "country_ti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "country_tk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "country_tkr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "country_tl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "country_tma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "country_tnu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "country_to"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "country_tr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "country_ts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "country_tt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "country_tu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "country_tv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "country_txu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "country_tz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "country_ua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "(uc) الولايات المتحدة متفرقات. جزر الكاريبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "country_ug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "country_ui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "country_uik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "country_uk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "country_un"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "country_unr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "country_up"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "country_ur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "country_us"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "country_utu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "(uv) بوركينا فاسو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "(uy) أورغواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "country_uz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "country_uzr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "country_vau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "(vb) جزر فيرجن البريطانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "(vc) مدينة الفاتيكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "country_ve"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "country_vi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "(vm) فيتنام"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "country_vn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "(vp) أماكن متعددة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "country_vra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "(vs) فيتنام الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "country_vtu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "country_wau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "(wb) برلين الغربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "country_wea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "(wf) جزر والس وفوتونا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "country_wiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "(wj) الضفة الغربية لنهر الأردن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "(wk) جزيرة ويك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "country_wlk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "country_ws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "(wvu) فرجينيا الغربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "country_wyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "country_xa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "(xb) جزر كوكوس (كيلينغ)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "(xc) جزر المالديف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "(xd) سانت كيتس-نيفيس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "(xe) جزر مارشال"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "(xf) جزر ميدواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "country_xga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "country_xh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "(xi) سانت كيتس-نيفيس أنغيلا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "(xj) سانت هيلانة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "(xk) سانت لوسيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "country_xl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "(xm) سانت فنسنت وجزر غرينادين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "(xn) مقدونيا الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "country_xna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "country_xo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "country_xoa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "(xp) جزيرة سبراتلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "(xr) التشيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "country_xra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "(xs) جورجيا الجنوبية وجزر ساندويتش الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "(xv) سلوفينيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "country_xx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "country_xxc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "country_xxk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "country_xxr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "country_xxu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "country_ye"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "country_ykc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "(ys) الجمهورية اليمنية الديمقراطية الشعبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "country_yu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "country_za"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "canton_ag"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "canton_ai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "canton_ar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "canton_be"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "canton_bl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "canton_bs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "canton_fr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "canton_ge"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "canton_gl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "canton_gr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "canton_ju"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "canton_lu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "canton_ne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "canton_nw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "canton_ow"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "canton_sg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "canton_sh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "canton_so"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "canton_sz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "canton_tg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "canton_ti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "canton_ur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "canton_vd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "canton_vs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "canton_zg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "canton_zh"
 
@@ -6018,10 +6038,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr "URI لتصنيف النسخة"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6256,11 +6272,11 @@ msgid ""
 "state"
 msgstr "اسم الإجراء الصريح الذي أدى إلى الانتقال إلى الحالة الحالية"
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "يوجد مكان مباشر آخر في هذه المكتبة"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "مكان الإستلام إجباري"
 
@@ -7200,3 +7216,16 @@ msgstr "يتم حذف"
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "انقر هنا لإعادة تعيين كلمة المرور الخاصة بك"
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "عنوان السلسلة"
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: de\n"
@@ -239,6 +239,22 @@ msgstr "Zugriff"
 msgid "mv-cantook"
 msgstr "Zugriff"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "Menü"
@@ -313,8 +329,8 @@ msgid "Account ID"
 msgstr "ID des Kontos"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -397,8 +413,8 @@ msgstr "URI der Bibliothek"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -522,8 +538,8 @@ msgid "Deleted"
 msgstr "Gelöscht"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "Datum"
 
@@ -544,7 +560,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "Sollte im folgenden Format sein: 2022-12-31 (JJJJ-MM-TT)"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "Anmerkung"
@@ -670,9 +686,9 @@ msgid "Exchange rate"
 msgstr "Wechselkurs"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -728,7 +744,7 @@ msgid "Monograph"
 msgstr "Monographie"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "Serie"
 
@@ -929,28 +945,28 @@ msgid "Item type URI"
 msgstr "URI des Exemplartypen"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "Zeitschrift"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "Reihe"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -969,13 +985,13 @@ msgstr "PID des Dokuments"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -984,7 +1000,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "Artikel"
 
@@ -1009,7 +1025,7 @@ msgid "Sound"
 msgstr "Ton"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "Film"
 
@@ -1019,10 +1035,10 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "Titel"
@@ -1073,13 +1089,13 @@ msgid "Part name"
 msgstr "Name"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "Verantwortlichkeitsangaben"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "Verantwortlichkeitsangabe"
@@ -1132,10 +1148,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "Zählung"
 
@@ -1143,132 +1159,140 @@ msgstr "Zählung"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "Subtyp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "Übersetzt aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "Sprache, aus deren die Ressource übersetzt wurde."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "Autoren"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 "Autor(en) der Ressource. Es können sowohl Personen als auch "
 "Körperschaften sein."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "Autor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Person"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "Name der Person."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr "URI der MEF Person"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1276,12 +1300,12 @@ msgstr ""
 "Informationen über die Geburt und den Tod einer Person. Hilfreich, um "
 "Menschen zu unterscheiden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "Qualifizierend"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1289,97 +1313,97 @@ msgstr ""
 "Informationen über die Person (z.B. ihren Beruf). Hilfreich, um Menschen "
 "zu unterscheiden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr "Copyright-Daten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "Copyright-Datum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "Ausgabevermerke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "Ausgabevermerk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "Ausgabebezeichnungen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "Ausgabebezeichnung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "Veröffentlichung, Herstellung, Vertrieb, Entstehung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "Veröffentlichung, Herstellung, Vertrieb, Entstehung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr "Veröffentlichung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr "Herstellung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr "Verteilung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr "Entstehung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "Orte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "Ort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "Angaben"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "Angabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 "Angabe zum Ort und Akteur von Veröffentlichung, Herstellung, Vertrieb, "
 "Entstehung."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr "Akteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "Veröffentlichungsdatum 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1390,11 +1414,11 @@ msgstr ""
 "wurde, kann im nächsten Feld ein frei gestaltetes Erscheinungsdatum "
 "hinzugefügt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "Veröffentlichungsdatum 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1405,11 +1429,11 @@ msgstr ""
 "wurde, kann im nächsten Feld ein frei gestaltetes Erscheinungsdatum "
 "hinzugefügt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
@@ -1418,21 +1442,21 @@ msgstr ""
 "neuen Feld. Verwenden Sie einen oder mehrere der von RDA empfohlenen "
 "Begriffe, im Singular oder Plural (MARC 300$b)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr "Illustrierender Inhalt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 "Von RDA empfohlene Begriffe: Illustrationen, Karten, Fotografien, "
 "Porträts, ..."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "Umfang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
@@ -1440,15 +1464,15 @@ msgstr ""
 "Erfassen Sie die Anzahl der Einheiten und die Art der Einheit. Verwenden "
 "Sie die von RDA empfohlenen Begriffe."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr "Beispiel: 355 Seiten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
@@ -1456,135 +1480,135 @@ msgstr ""
 "Eine Wiedergabezeit, Aufführungszeit, Laufzeit usw. des Inhalts einer "
 "Expression."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr "Dauer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr "Beispiel: 1h50"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr "Monochrom"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr "Polychrom"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr "Entstehungsmethode"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr "Ein Verfahren, das angewendet wird, um eine Manifestation zu erzeugen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr "Entstehungsmethode"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr "Diazotypie (Blaupause)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr "Cyanotypie (Blaudruck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr "Lichtdruck (Collotypie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr "Daguerreotypie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr "Stich"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr "Radierung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr "Lithografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr "Fotokopie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr "Fotogravur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr "Druckverfahren"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr "Diazotypie (Lichtpause)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr "Holzschnitt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr "Heliogravüre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr "Einbrennen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr "Gravur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr "Stempeldruck"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr "Prägung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr "Solid dot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr "Schwellpapier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr "Thermoform"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr "Bibliographische Formate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
@@ -1595,17 +1619,17 @@ msgstr ""
 "die resultieren, wenn der Bogen im Ganzen gelassen, geschnitten oder "
 "gefaltet wird. "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr "Bibliographisches Format"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr "Masse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
@@ -1614,4006 +1638,4000 @@ msgstr ""
 "Spurbreite und des Durchmessers. Wenn die Breite des Bandes grösser als "
 "die Höhe, erfassen Sie Höhe × Breite."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr "Beispiel: 22 cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "Titel der Reihe."
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr "Anmerkungstyp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr "Begleitmaterial"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr "Allgemein"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr "Andere physikalische Details"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "Abstrakts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "Abstrakt der Ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "Abstrakt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr "Identifikatoren"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "Audioausgabennummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr "GTIN 14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr "Lokal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr "Matrix-Nummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr "Musikvertriebsnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr "Musik-Platte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr "Musikverlag Nummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr "Verlagsnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr "Videoaufzeichnungsnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "Identifikatorwert"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "Identifikatorwert."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "Anmerkung zum Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "Erläuterung zum Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "Bezugsbedingung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "Bezugsbedingung der Ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "Herkunft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "Quelle des Identifikators."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "Status"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status des ISBN/ISSN Identifikators"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "Schlagworte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "Schlagwort der Ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "Schlagwort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr "Uniform Resource Locators"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informationen, die benötigt werden, um eine elektronische Ressource zu "
 "finden und darauf zuzugreifen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr "Uniform Resource Locator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "Geben Sie eine eindeutige URL ein."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "Beispiel: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "Typ des Links"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "Andere version der Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "Verwandte Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "Versteckte URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "Keine Informationen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "Inhaltstyp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "Wird als Text des Links angezeigt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "Plakat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "Postkarte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "Ergänzung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "Protokoll"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "Ausstellungsdokumentation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "Exlibris"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "Auszug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "Unterrichtsmaterial"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "Illustrationen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "Titelbild"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "Informationen zum Transport"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Biografische Angaben"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "Einführung/Vorwort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "Klassenlektüre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "Themenkoffer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "Hinweis des Verlags"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "Inhaltstext"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "Titelblatt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "Fotografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "Zusammenfassung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "Online-Ressource über RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "Presseschau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "Website"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "Inhaltsverzeichnis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "Volltext"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr "Wird neben dem Link als zusätzliche Information angezeigt."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr "Öffentliche Anmerkung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "Beispiel: Zugang nur von der Bibliothek aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "Gesammelt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Dokument wird gesammelt oder nicht, deaktiviert Bearbeitung von Records"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "Sprachewert."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "Abchasisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "Achinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "Acholi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "Dangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "Adygeisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "Afroasiatische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "Albanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "Aleutisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "Algonkin Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "Südaltaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "Amharisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "Altenglisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "Apache Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "Reichsaramäisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "Aragonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "Armenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "Konstruierte Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "Assamesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "Athapaskische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "Australische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "Awarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "Aserbaidschanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "Banda Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "Bamileke Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "Baschkirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "Belutschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "Balinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "Basaa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "Baltische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "Bedscha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "Weissrussisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "Bengalisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "Berbersprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "Bikolano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "Edo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "Blackfoot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "Bantusprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "Braj-Bhakha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "Bretonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "Bataksprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "Burjatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "Buginesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "Bulgarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "Birmanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "Blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "Mesoamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "Karib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "Katalanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "Kaukasisch (anderes)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "Keltische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "Tschechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "Tschagataisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "Chinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "Chuukesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "Chinook Wawa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "Kirchenslawisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "Tschuwaschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "Chamische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "Montenegrinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "Kornisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "Korsisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "Englisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "Französisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "Portugiesisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "Krimtatarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "Kreol- und Pidginsprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "Kaschubisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "Kuschitische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "Tschechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "Dänisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "Darginisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "Land-Dayak-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "Delawarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "Dhivehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "Dravidische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "Niedersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "Mittelniederländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "Niederländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "Dioula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "Ägyptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "Elamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "Englisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "Mittelenglisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "Estnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "Färöisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "Fante"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "Fidschi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "Finnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "Finno-ugrische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "Französisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "Mittelfranzösisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "Altfranzösisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "Nordfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "Ostfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "Westfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "Fulfulde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "Germanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "Deutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "Geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "Kiribatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "Schottisch-gälisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "Irisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "Mittelhochdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "Althochdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "Gotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "Altgriechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "Griechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "Schweizerdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "Gwich'in (Sprache)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "Haitianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "Hawaiisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "Hebräisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "Otjiherero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "West-Paharisprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "Hethitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "Hmong-Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "Hiri-Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "Obersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "Ungarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "Hoopa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "Isländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "Ijo-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "Ilokano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "Indoarische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "Indogermanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "Inguschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "Iranische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "Irokesische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "Italienisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "Javanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "Japanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "Judäo-Persisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "Judäo-Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "Karakalpakisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "Jingpo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "Grönländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "Kikamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "Karenische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "Kaschmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "Kasachisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "Kabardinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "Khoisansprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "Khotanesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "Kirgisisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "Kikongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "Koreanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "Kosraeanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "Karatschai-balkarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "Kru-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "Kwanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "Kumykisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "Kurdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "Kutanaha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "Judenspanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "Laotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "Latein"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "Lettisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "Lesgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "Limburgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "Lingála"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "Litauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "Lomongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "Luxemburgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "Tschiluba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "Kiluba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "Chilunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "Luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "Mazedonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "Maduresisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "Magadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "Marschallesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "Makassar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "Manding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "Austronesische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "Maa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "Malaiisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "Mokschanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "Mittelirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "Míkmawísimk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "Minangkabauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "Verschiedene Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "Mon-Khmer-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "Maltesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "Mandschurisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "Meithei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "Manobo Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "Mongolisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "Mòoré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "Mehrsprachig"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "Munda-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "Muskogee-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "Mirandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "Maya Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "Ersjanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "Nordamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "Neapolitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "Nauruisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "Süd-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "Nord-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "Niederdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "Niger-Kongo-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "Niueanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "Nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "Bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "Nogaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "Altnordisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "Norwegisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "Nord-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "Nubische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "Klassisches Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "Chichewa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "Nyamwesi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "Runyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "Runyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "Nzema"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "Okzitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "Ojibwe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "Osmanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "Oto-Pame-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "Papuasprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "Pangasinensisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "Mittelpersisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "Kapampangan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "Papiamentu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "Palauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "Altpersisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "Persisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "Philippinische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "Phönizisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "Polnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "Pohnpeanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "Portugiesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "Altokzitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "Paschtunisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "Rarotonganisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "Romanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "Bündnerromanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "Rumänisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "Aromunisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "Sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "Jakutisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "Südamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "Salish-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "Samaritanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "Sizilianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "Scots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "Selkupisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "Semitische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "Altirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "Gebärdensprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "Sidama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "Singhalesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "Sioux-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "Sinotibetische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "Slawische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "Slowakisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "Slowenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "Südsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "Nordsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "Samische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "Lulesamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "Inarisamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "Samoanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "Skoltsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "Somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "Songhai-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "Sesotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "Spanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "Sardisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "Serbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "Nilosaharanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "Sundanesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "Susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "Sumerisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "Suaheli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "Schwedisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "Nordost-Neuaramäisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "Tahitianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "Tai-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "Tatarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "Temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "Terena"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "Tadschikisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "Tibetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "Tokelauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "Klingonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "Tuareg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "Tongaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "Setswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "Xitsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "Turkmenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "Tupí-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "Türkisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "Altaische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "Tuvaluisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "Tuwinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "Udmurtisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "Ugaritisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "Uigurisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "Ukrainisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "Unbekannte Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "Usbekisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "Tshivenda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "Vietnamesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "Wotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "Wakash-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "Wáray-Wáray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "Washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "Walisisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "Sorbische Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "Wallonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "Kalmückisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "Yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "Yapesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "Yupik-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "Zapotekisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "Bliss-Symbole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "Zande-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "Zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "Keine Sprachinhalte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "Zazaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "Werte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr "Wert"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Land"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "Albanien (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "Ashmore und Cartierinseln (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "Australisches Hauptstadtterritorium (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "Algerien (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "Argentinien (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "Armenien (Republik) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "Armenische Sozialistische Sowjetrepublik (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "Aserbaidschan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "Aserbaidschanische Sozialistische Sowjetrepublik (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "Antigua und Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "Amerikanisch-Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "Australien (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "Österreich (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "Antarktis (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "Bahrain (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "Britisch-Kolumbien (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "Belgien (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "Bangladesch (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "Britisches Territorium im Indischen Ozean (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "Brasilien (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "Bermudainseln (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "Bosnien und Herzegowina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "Bolivien (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "Salomonen (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "Botsuana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "Bulgarien (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "Bouvetinsel (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "Weißrussland (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "Weißrussische Sozialistische Sowjetrepublik (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "Karibische Niederlande (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "Kalifornien (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "Kambodscha (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "Tschad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "Kongo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "Kongo (Demokratische Republik) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "China (Republik: 1949- ) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "Kroatien (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "Kaimaninseln (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "Kolumbien (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "Kamerun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "Kanada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "Kanton und Enderbury-Inseln (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "Komoren (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "Tschechoslowakei (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "Kuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "Kap Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "Cookinseln (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "Zentralafrikanische Republik (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "Zypern (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "Panamakanalzone (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "Dänemark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "Dominikanische Republik (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "Äquatorialguinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "Osttimor (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "England (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "Estland (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "Estnische Sozialistische Sowjetrepublik (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "Äthiopien (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "Färöer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "Französisch-Guayana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "Finnland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "Fidschi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "Falklandinseln (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "Mikronesien (Föderierten Staaten) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "Französisch-Polynesien (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "Frankreich (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "Französische Süd- und Antarktisgebiete (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "Dschibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "OstDeutschland (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "Grönland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "Gilbert- und Elliceinseln (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "Gabun (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "Griechenland (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "Georgien (Republik) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "Georgische Sozialistische Sowjetrepublik (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "Deutschland (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "Gazastreifen (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "Sonderverwaltungsregion Hongkong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "Heard und McDonald-Inseln (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "Ungarn (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "Island (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "Irland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "Indien (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "Insel Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "Indonesien (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "Italien (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "Israel-Syrien Entmilitarisierte Zonen (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "Elfenbeinküste (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "Israelisch-jordanische entmilitarisierte Zonen (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "Irak-Saudi-Arabien Neutrale Zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "Johnston-Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "Jamaika (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "Jordanien (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "Kirgisistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "Kirgisische Sozialistische Sowjetrepublik (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "Nordkorea (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "Südkorea (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "Kasachstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "Kasachische Sozialistische Sowjetrepublik (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "Libanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "Litauen (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "Litauen (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "Zentrale und südliche Linieninseln (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "Luxemburg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "Lettland (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "Lettland (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "Libyen (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "Madagaskar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "Sonderverwaltungsregion Macau (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "Mongolei (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "Marokko (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "Mauretanien (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "Republik Moldau (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "Moldauische Sozialistische Sowjetrepublik (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "Mexiko (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "Mosambik (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "Niederländische Antillen (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "Niederlande (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "Neufundland und Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "Nordirland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "Neubraunschweig (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "Neukaledonien (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "Nördliche Marianen (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "Norwegen (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "Neuschottland (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "Nordwest-Territorien (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "Nördliche Marianen (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "Norfolkinsel (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "New York (Staat) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "Neuseeland (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "Insel Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "Paracel-Inseln (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "Philippinen (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "Prinz-Edward-Insel (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "Polen (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "Papua-Neuguinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "Portugiesisch-Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "Katar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "Quebec (Provinz) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "Serbien (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "Simbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "Rumänien (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "Russland (Föderation) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "Russische Sozialistische Föderative Sowjetrepublik (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr "Ryūkyū-Inseln (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "Südafrika (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "Spitzbergen (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "Südsudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "Seychellen (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "São Tomé und Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "Spanisch Nordafrika (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "Singapur (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "Sankt Martin (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "Spanien (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "Westsahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "St. Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "Schottland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "Saudi-Arabien (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "Schwaneninseln (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "Schweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "Syrien (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "Schweiz (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "Tadschikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "Tadschikische Sozialistische Sowjetrepublik (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "Turks- und Caicosinseln (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "Tunesien (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "Turkmenische Sozialistische Sowjetrepublik (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "Tasmanien (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "Trinidad und Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "Vereinigte Arabische Emirate (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "Treuhand-Territorium der Pazifischen Inseln (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "Türkei (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "Tansania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "Ägypten (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "Vereinigte Staaten Diverses Karibische Inseln (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "Vereinigtes Königreich Diverses Inseln (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "Vereinigtes Königreich Diverses Inseln (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "Vereinigtes Königreich (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "Vereinigte Staaten Diverses Pazifische Inseln (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "Sowjetunion (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "Vereinigte Staaten (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "Usbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "Usbekische Sozialistische Sowjetrepublik (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "Britische Jungferninseln (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "Vatikanstadt (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "Amerikanische Jungferninseln (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "Vietnam, Norden (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "Verschiedene Orte (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "Vietnam, Süden (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "Washington (Staat) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "Westberlin (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "Westaustralien (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "Wallis und Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "Westjordanland (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "Wake (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "Weihnachtsinsel (Indischer Ozean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "Kokosinseln (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "Malediven (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "St. Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "Marshallinseln (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "Midway-Inseln (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "Korallenmeer-Insel-Territorium (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "St. Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "Heilige Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "St. Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "St. Pierre und Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "St. Vincent und die Grenadinen (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "Nordmazedonien (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "Neusüdwales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "Slowakei (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "Nordterritorium (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "Spratly-Insel (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "Tschechien (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "Südaustralien (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "Südgeorgien und die Südlichen Sandwichinseln (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "Slowenien (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "Kein Ort, unbekannt oder unbestimmt (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "Kanada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "Vereinigtes Königreich (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "Sowjetunion (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "Vereinigte Staaten (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "Jemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "Yukon-Territorium (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "Jemen (Demokratische Volksrepublik) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "Serbien und Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "Sambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Kantone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "AG (Aargau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "AI (Appenzell Innerrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "AR (Appenzell Ausserrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "BE (Bern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "BL (Basel-Landschaft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "BS (Basel-Stadt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "FR (Freiburg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "GE (Genf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "GL (Glarus)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "GR (Graubünden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "LU (Luzern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "NE (Neuenburg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "SG (St. Gallen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "SH (Schaffhausen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "SO (Solothurn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "TG (Thurgau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "TI (Tessin)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "VD (Waadt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "VS (Wallis)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "ZH (Zürich)"
 
@@ -6069,10 +6087,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr "URI des Exemplartypen"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6309,11 +6323,11 @@ msgstr ""
 "Der Name der expliziten Aktion, die die Transition zum aktuellen Zustand "
 "ausgelöst hat."
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Ein anderer Online-Standort existiert bereits für diese Bibliothek"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "Das Feld des Abholortnamen ist erforderlich."
 
@@ -7267,3 +7281,16 @@ msgstr "wurde gelöscht."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Hier klicken um Passwort zurückzusetzen."
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "Titel der Reihe."
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Pascal Repond <pascalr.92@gmail.com>, 2020\n"
 "Language: en\n"
@@ -240,6 +240,22 @@ msgstr "Access"
 msgid "mv-cantook"
 msgstr "Access"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "Menu"
@@ -314,8 +330,8 @@ msgid "Account ID"
 msgstr "Account ID"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -398,8 +414,8 @@ msgstr "Library URI"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -523,8 +539,8 @@ msgid "Deleted"
 msgstr "Deleted"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "Date"
 
@@ -545,7 +561,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "Notes"
@@ -671,9 +687,9 @@ msgid "Exchange rate"
 msgstr "Exchange rate"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -729,7 +745,7 @@ msgid "Monograph"
 msgstr "Monograph"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "Serial"
 
@@ -928,28 +944,28 @@ msgid "Item type URI"
 msgstr "Item type URI"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "Journal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "Series"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -968,13 +984,13 @@ msgstr "Document PID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -983,7 +999,7 @@ msgid "Type"
 msgstr "Type"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "Article"
 
@@ -1008,7 +1024,7 @@ msgid "Sound"
 msgstr "Sound"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "Video"
 
@@ -1018,10 +1034,10 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "Title"
@@ -1072,13 +1088,13 @@ msgid "Part name"
 msgstr "Name"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "Statements of responsibility"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "Statement of responsibility"
@@ -1130,10 +1146,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "Numbering"
 
@@ -1141,130 +1157,138 @@ msgstr "Numbering"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "Languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "Language"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "Subtype"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "Translated from"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "Language from which a resource is translated."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "Authors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Author(s) of the resource. Can be either persons or organisations."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "Author"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Person"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "Person's name."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr "MEF person URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1272,12 +1296,12 @@ msgstr ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "Qualifier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1285,95 +1309,95 @@ msgstr ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr "Copyright dates"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "Copyright date"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "Edition statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "Edition statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "Designations of edition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "Designation of edition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "Publication, manufacture, distribution, production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "Publication, manufacture, distribution, production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr "Publication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr "Manufacture"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr "Distribution"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr "Production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "Places"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "Place"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "Statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "Statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr "Statement of place and agent."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr "Agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "Date of publication 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1383,11 +1407,11 @@ msgstr ""
 "-50. Used to sort search results. Once this field is set, a free formed "
 "date of publication can be added in the next field."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "Date of publication 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1397,11 +1421,11 @@ msgstr ""
 "-50. Used to sort search results. Once this field is set, a free formed "
 "date of publication can be added in the next field."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
@@ -1409,19 +1433,19 @@ msgstr ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr "Illustrative content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "Extent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
@@ -1429,15 +1453,15 @@ msgstr ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr "Example: 355 pages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
@@ -1445,135 +1469,135 @@ msgstr ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr "Duration"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr "Example: 1h50"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr "Monochrome"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr "Polychrome"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr "Process used to produce a manifestation."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr "Production method"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr "Blueline process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr "Blueprint process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr "Collotype"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr "Daguerreotype process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr "Engraving"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr "Etching"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr "Lithography"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr "Photocopying"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr "Photoengraving"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr "Printing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr "White print process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr "Woodcut making"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr "Photogravure process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr "Burning"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr "Inscribing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr "Stamping"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr "Embossing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr "Solid dot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr "Swell paper"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr "Thermoform"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr "Bibliographic formats"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
@@ -1583,17 +1607,17 @@ msgstr ""
 "manuscript resource, and the individual leaves that result if that sheet "
 "is left full, cut, or folded."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr "Bibliographic format"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
@@ -1601,4004 +1625,3998 @@ msgstr ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height × width."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr "Example: 22 cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "Title of the series."
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr "Accompanying material"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr "General"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "Abstracts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "Abstract of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "Abstract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr "Identifiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "Identifier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr "Music publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr "Publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "Identifier value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "Identifier value."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "Note of the identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "Qualifier of the identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "Acquisition terms"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "Acquisition terms of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "Source"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "Source of the identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "Status"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status of the ISBN/ISSN identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "Subjects"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "Subject of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "Subject"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr "Uniform Resource Locators"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Information needed to locate and access an electronic resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr "Uniform Resource Locator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "Record a unique URL here."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "Example: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "Type of link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "Resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "Version of resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "Related resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "Hidden URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "No info"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "Content type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "Is displayed as the text of the link."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "Poster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "Postcard"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "Addition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "Debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "Exhibition documentation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "Bookplate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "Extract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "Educational sheet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "Illustrations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "Cover image"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "Delivery information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Biographical information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "Introduction/preface"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "Class reading"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "Teacher's kit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "Publisher's note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "Note on content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "Title page"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "Photography"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "Summarization"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "Online resource via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "Press review"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "Web site"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "Full text"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr "Is displayed next to the link, as additional information."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr "Public note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "Example: Access only from the library"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "Harvested"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Document is harvested or not, will disable record edition or similar."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "Language value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "Abkhazian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "Achinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "Acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "Adyghe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "Afroasiatic (other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "Afrihili (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "Akkadian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "Albanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "Aleut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "Algonquian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "Altai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "Amharic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "English, Old (ca. 450-1100)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "Apache languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "Arabic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "Aramaic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "Aragonese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "Armenian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "Mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "Artificial (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "Assamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "Bable"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "Athapascan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "Australian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "Avaric"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "Avestan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "Azerbaijani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "Banda languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "Bamileke languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "Bashkir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "Baluchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "Balinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "Basque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "Basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "Baltic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "Beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "Belarusian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "Bengali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "Berber (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "Bihari (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "Edo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "Bantu (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "Bosnian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "Braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "Breton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "Batak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "Buriat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "Bugis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "Bulgarian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "Burmese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "Bilin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "Central American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "Carib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "Catalan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "Caucasian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "Celtic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "Chechen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "Chinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "Chuukese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "Chinook jargon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "Church Slavic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "Chuvash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "Chamic languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "Montenegrin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "Coptic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "Corsican"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "Creoles and Pidgins, English-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "Creoles and Pidgins, French-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "Creoles and Pidgins, Portuguese-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "Crimean Tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "Creoles and Pidgins (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "Kashubian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "Cushitic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "Czech"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "Danish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "Dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "Delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "Divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "Dravidian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "Lower Sorbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "Dutch, Middle (ca. 1050-1350)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "Dutch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "Egyptian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "Elamite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "English"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "English, Middle (1100-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "Estonian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "Faroese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "Fijian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "Finnish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "Finno-Ugrian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "French"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "French, Middle (ca. 1300-1600)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "French, Old (ca. 842-1300)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "North Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "East Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "Fula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "Gã"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "Germanic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "Georgian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "Ethiopic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "Gilbertese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "Scottish Gaelic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "Irish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "Galician"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "German, Middle High (ca. 1050-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "German, Old High (ca. 750-1050)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "Gothic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "Greek, Ancient (to 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "Greek, Modern (1453- )"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "Swiss German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "Gwich'in"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "Haitian French Creole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "Hawaiian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "Hebrew"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "Herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "Western Pahari languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "Hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "Croatian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "Upper Sorbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "Hungarian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "Icelandic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "Sichuan Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "Ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "Interlingua (International Auxiliary Language Association)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "Indic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "Indonesian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "Indo-European (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "Ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "Iranian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "Iroquoian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "Javanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "Lojban (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "Japanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "Judeo-Persian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "Judeo-Arabic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "Kara-Kalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "Kabyle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "Kalâtdlisut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "Karen languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "Kashmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "Kazakh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "Kabardian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "Khoisan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "Khotanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "Kyrgyz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "Korean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "Kosraean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "Karachay-Balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "Karelian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "Kru (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "Kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "Kurdish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "Kootenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "Lahndā"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "Lamba (Zambia and Congo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "Lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "Latin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "Latvian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "Lezgian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "Limburgish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "Lithuanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "Mongo-Nkundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "Luxembourgish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "Ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "Luo (Kenya and Tanzania)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "Lushai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "Macedonian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "Madurese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "Marshallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "Makasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "Austronesian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "Maasai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "Malay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "Moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "Irish, Middle (ca. 1100-1550)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "Micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "Miscellaneous languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "Mon-Khmer (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "Maltese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "Manchu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "Manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "Manobo languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "Mongolian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "Mooré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "Multiple languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "Munda (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "Creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "Mirandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "Mayan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "Erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "North American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "Neapolitan Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "Nauru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "Ndebele (South Africa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "Ndebele (Zimbabwe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "Low German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "Niger-Kordofanian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "Niuean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "Norwegian (Nynorsk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "Norwegian (Bokmål)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "Old Norse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "Norwegian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "N'Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "Northern Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "Nubian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "Newari, Old"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "Occitan (post-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "Ossetic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "Turkish, Ottoman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "Otomian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "Papuan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "Papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "paluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "Old Persian (ca. 600-400 B.C.)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "Persian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "Philippine (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "Phoenician"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "Polish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "Pohnpeian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "Portuguese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "Prakrit languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "Provençal (to 1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "Pushto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "Romance (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "Raeto-Romance"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "Romanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "Rundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "Aromanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "Russian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "Sango (Ubangi Creole)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "Yakut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "South American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "Salishan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "Samaritan Aramaic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "Sicilian Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "Scots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "Selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "Semitic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "Irish, Old (to 1100)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "Sign languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "Sinhalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "Siouan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "Sino-Tibetan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "Slavic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "Slovak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "Slovenian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "Southern Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "Northern Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "Lule Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "Inari Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "Samoan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "Skolt Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "Sogdian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "Somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "Songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "Spanish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "Sardinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "Sranan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "Serbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "Nilo-Saharan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "Sundanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "Susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "Sumerian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "Swedish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "Syriac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "Syriac, Modern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "Tahitian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "Tai (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "Tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "Temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "Terena"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "Tajik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "Tibetan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "Tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "Tokelauan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "Klingon (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "Tonga (Nyasa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "Tongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "Turkmen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "Tupi languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "Turkish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "Altaic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "Tuvaluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "Tuvinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "Udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "Ugaritic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "Uighur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "Ukrainian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "Undetermined"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "Uzbek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "Venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "Vietnamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "Votic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "Wakashan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "Wolayta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "Waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "Washoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "Sorbian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "Walloon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "Oirat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "Yao (Africa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "Yapese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "Yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "Yupik languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "Blissymbolics"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "Zande languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "No linguistic content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "Zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "Values"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Country"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "Ashmore and Cartier Islands (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "Australian Capital Territory (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "Algeria (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "Armenia (Republic) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "Armenian S.S.R. (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "Azerbaijan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "Azerbaijan S.S.R. (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "Antigua and Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "American Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "Antarctica (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "Bahrain (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "British Columbia (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "Belgium (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "British Indian Ocean Territory (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "Brazil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "Bermuda Islands (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "Bosnia and Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "Solomon Islands (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "Bouvet Island (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "Belarus (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "Byelorussian S.S.R. (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "Caribbean Netherlands (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "California (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "Cambodia (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "Chad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "Congo (Democratic Republic) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "China (Republic : 1949- ) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "Croatia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "Cayman Islands (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "Cameroon (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "Canton and Enderbury Islands (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "Comoros (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "Czechoslovakia (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "Cabo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "Cook Islands (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "Central African Republic (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "Cyprus (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "Canal Zone (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "Denmark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "Dominican Republic (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "Equatorial Guinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "Timor-Leste (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "England (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "Estonia (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "Ethiopia (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "Faroe Islands (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "French Guiana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "Finland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "Fiji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "Falkland Islands (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "Micronesia (Federated States) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "French Polynesia (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "France (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "Germany (East) (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "Greenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "Gilbert and Ellice Islands (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "Greece (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "Georgia (Republic) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "Georgian S.S.R. (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "Germany (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "Gaza Strip (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "Heard and McDonald Islands (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "Hungary (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "Iceland (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "Ireland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "Isle of Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "Iraq (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "Italy (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "Israel-Syria Demilitarized Zones (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "Côte d'Ivoire (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "Israel-Jordan Demilitarized Zones (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "Iraq-Saudi Arabia Neutral Zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "Johnston Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "Jordan (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "Kyrgyzstan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "Kirghiz S.S.R. (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "Korea (North) (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "Korea (South) (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "Kazakhstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "Kazakh S.S.R. (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "Lebanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "Lithuania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "Lithuania (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "Central and Southern Line Islands (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "Luxembourg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "Latvia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "Latvia (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "Libya (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "Morocco (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "Moldova (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "Moldavian S.S.R. (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "Mexico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "Netherlands Antilles (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "Netherlands (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "Northern Ireland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "New Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "New Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "Northern Mariana Islands (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "Norway (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "Nova Scotia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "Northwest Territories (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "Northern Mariana Islands (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "Norfolk Island (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "New York (State) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "New Zealand (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "Pitcairn Island (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "Paracel Islands (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "Philippines (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "Prince Edward Island (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "Poland (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "Papua New Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "Portuguese Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "Romania (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "Russia (Federation) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "Russian S.F.S.R. (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr "Ryukyu Islands, Southern (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "South Africa (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "South Sudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "Sao Tome and Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "Spanish North Africa (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "Spain (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "Western Sahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "Scotland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "Saudi Arabia (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "Swan Islands (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "Sweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "Syria (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "Switzerland (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "Tajikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "Tajik S.S.R. (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "Turks and Caicos Islands (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "Tunisia (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "Turkmen S.S.R. (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "Trinidad and Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "United Arab Emirates (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "Trust Territory of the Pacific Islands (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "Turkey (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "Egypt (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "United States Misc. Caribbean Islands (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "United Kingdom Misc. Islands (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "United Kingdom Misc. Islands (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "United Kingdom (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "United States Misc. Pacific Islands (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "Soviet Union (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "United States (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "Uzbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "Uzbek S.S.R. (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "British Virgin Islands (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "Vatican City (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "Virgin Islands of the United States (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "Vietnam, North (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "Various places (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "Vietnam, South (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "Washington (State) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "West Berlin (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "Western Australia (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "Wallis and Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "West Bank of the Jordan River (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "Wake Island (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "Christmas Island (Indian Ocean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "Cocos (Keeling) Islands (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "Maldives (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "Saint Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "Marshall Islands (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "Midway Islands (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "Coral Sea Islands Territory (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "Saint Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "Saint Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "Saint Pierre and Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "Saint Vincent and the Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "North Macedonia (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "New South Wales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "Slovakia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "Northern Territory (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "Spratly Island (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "Czech Republic (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "South Australia (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "South Georgia and the South Sandwich Islands (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "Slovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "No place, unknown, or undetermined (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "United Kingdom (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "Soviet Union (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "United States (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "Yukon Territory (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "Yemen (People's Democratic Republic) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "Serbia and Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "AG (Aargau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "AI (Appenzell Innerrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "AR (Appenzell Ausserrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "BE (Bern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "BL (Basel-Country)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "BS (Basel-City)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "FR (Fribourg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "GE (Geneva)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "GL (Glarus)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "GR (Grisons)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "LU (Lucerne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "SG (St. Gallen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "SH (Shaffhouse)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "SO (Solothurn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "TG (Thurgau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "TI (Ticino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "ZH (Zurich)"
 
@@ -6042,10 +6060,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr "Item Type URI"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6282,11 +6296,11 @@ msgstr ""
 "The name of the explicit action that triggered the transition to current "
 "state"
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Another online location exists in this library"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "Pickup location name field is required."
 
@@ -7230,3 +7244,16 @@ msgstr "has been deleted."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Click here to reset your password"
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "Title of the series."
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -235,6 +235,22 @@ msgstr "Acceso"
 msgid "mv-cantook"
 msgstr "Acceso"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "Menu"
@@ -309,8 +325,8 @@ msgid "Account ID"
 msgstr "Mi cuenta"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -393,8 +409,8 @@ msgstr "URI de la biblioteca"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -518,8 +534,8 @@ msgid "Deleted"
 msgstr "Suprimido"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "Fecha"
 
@@ -540,7 +556,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "Debería estar en el siguiente formato: 2022-12-31 (AAAA-MM-DD)."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "Notas"
@@ -666,9 +682,9 @@ msgid "Exchange rate"
 msgstr "Tasa de intercambio"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -726,7 +742,7 @@ msgid "Monograph"
 msgstr "Monografía"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "Seriada"
 
@@ -929,28 +945,28 @@ msgid "Item type URI"
 msgstr "URI del tipo de ejemplar"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "Periódico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "Series"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -969,13 +985,13 @@ msgstr "PID del documento"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -984,7 +1000,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "Artículo"
 
@@ -1009,7 +1025,7 @@ msgid "Sound"
 msgstr "Sonido"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "Video"
 
@@ -1019,10 +1035,10 @@ msgstr "Títulos"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "Título"
@@ -1073,13 +1089,13 @@ msgid "Part name"
 msgstr "Apellido"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "Responsabilidades"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "Responsabilidad"
@@ -1132,10 +1148,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "Numeración"
 
@@ -1143,130 +1159,138 @@ msgstr "Numeración"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "Idiomas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "Subtipo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "Traducido de"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "Idioma desde el que se traduce un recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "Autores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Autor(es) de un recurso. Puede ser una persona o una organización."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "Autores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Persona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "Nombre de la persona."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr "Referencia de persona MEF"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1274,12 +1298,12 @@ msgstr ""
 "Informaciones sobre las fechas del nacimiento y del fallecimiento de una "
 "persona. Útil para desambiguar una persona."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "Calificador"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1287,95 +1311,95 @@ msgstr ""
 "Informaciones sobre la persona, por ejemplo, su profesión. Útil para "
 "desambiguar las personas."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr "Fechas de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "Fecha de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "Menciones de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "Mención de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "Designaciones de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "Designación de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "Producción, publicación, difusión, distribución, fabricación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "Producción, publicación, difusión, distribución, fabricación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr "Publicación"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr "Fabricación"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr "Difusión"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr "Producción"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "Lugares"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "Lugar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "Menciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "Mención"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr "Mención"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr "Agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "Fecha de publicación 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1386,11 +1410,11 @@ msgstr ""
 "establecido este campo, se puede añadir una fecha de publicación de forma"
 " libre en el siguiente campo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "Fecha de publicación 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1401,11 +1425,11 @@ msgstr ""
 "establecido este campo, se puede añadir una fecha de publicación de forma"
 " libre en el siguiente campo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr "Contenidos ilustrativos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
@@ -1413,21 +1437,21 @@ msgstr ""
 "Registrar cada contenido ilustrativo diferente en un nuevo campo. Utilice"
 " términos recomendados por RDA, en singular o plural (300$b)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr "Contenido ilustrativo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 "Términos recomendados por la RDA: ilustraciones, mapas, fotografías, "
 "retratos, ..."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "Importancia material"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
@@ -1435,15 +1459,15 @@ msgstr ""
 "Registre el número de unidades de unidades y el tipo de unidad. Para el "
 "tipo de unidad, utilice los términos recomendados por RDA."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr "Ejemplo: 355 páginas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr "Duraciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
@@ -1451,20 +1475,20 @@ msgstr ""
 "El tiempo de juego, el tiempo de actuación, el tiempo de funcionamiento, "
 "etc., del contenido de una expresión."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr "Duración"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr "Ejemplo: 1h50"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr "Contenidos de color"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
@@ -1473,116 +1497,116 @@ msgstr ""
 "Registrar el contenido de un color si se considera importante para la "
 "identificación o selección."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr "Contenido de color"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr "Monocromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr "Polícromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr "Métodos de producción"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr "Proceso utilizado para producir una manifestación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr "Método de producción"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr "Blueline process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr "Blueprint process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr "Collotype"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr "Daguerreotype process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr "Engraving"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr "Etching"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr "Litografía"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr "Fotocopia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr "Fotograbado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr "Impresión"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr "Proceso de impresión en blanco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr "Xilografía"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr "Proceso de fotograbado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr "Grabación"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr "Inscripción"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr "Estampado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr "Embutición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr "Solid dot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr "Papel de la hinchada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr "Thermoform"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr "Formatos bibliogáficos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
@@ -1592,17 +1616,17 @@ msgstr ""
 "manuscrito, y las hojas individuales que resultan si esa hoja se deja "
 "llena, cortada o doblada."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr "Formato bibliogáfico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr "Dimensiones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
@@ -1611,4004 +1635,3998 @@ msgstr ""
 "longitud, calibre y diámetro. Para los volúmenes oblongos, registrar la "
 "altura \\u00d7 ancho."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr "Ejemplo : 22 cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "Título de la serie."
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr "Tipo de nota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr "Material de acompañamiento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr "General"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr "Otros detalles físicos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "Resumenes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "Resumen del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "Resumen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "Identificador"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr "GTIN 14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr "Local"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr "Matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr "Music plate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr "Music publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr "Número del editor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "Valor del identificador"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "Valor del identificador"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "Nota sobre el identificador."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "Calificador del identificador."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "Términos de adquisición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "Términos de adquisición del recurso."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "Fuente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "Fuente del identificador."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "Estado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Estado del identificador ISBN/ISSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "Sujetos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "Sujeto del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "Sujeto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr "Localizaciones electrónicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Información necesaria para localizar y acceder a un recurso electrónico."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr "Localización electrónica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "Registra una URL única aquí."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "Ejemplo: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "Tipo de enlace"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "Recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "Versión del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "Recurso relacionado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "URL oculto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "No hay información"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "Se muestra como el texto del enlace."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "Póster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "Postal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "Adición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "Informe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "Documentación de la exposición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "Placa de libro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "Extracto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "Hoja educativa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "Ilustraciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "Imagen de portada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "Información sobre la entrega"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Información bibliográfica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "Introducción/prefacio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "Lectura continuada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "Paquete educativo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "Nota del editor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "Nota sobre el contenido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "Página de título "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "Fotografía"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "Resumen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "Recurso en línea a través de RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "Revista de prensa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "Sitio web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "Tabla de contenidos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "Texto completo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr "Nota pública"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr "Se muestra junto al enlace, como información adicional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr "Nota pública"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "Ejemplo: Acceso sólo desde la biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "Importado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "El documento importado o no, no permitirá la edición de noticia."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "Valor del idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "abjasio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "acehnés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "adigué"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "lenguas afroasiáticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "afrikáans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "acadio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "albanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "aleutiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "lenguas algonquinas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "altái meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "amárico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "inglés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "lenguas apaches"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "árabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "arameo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "aragonés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "armenio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "idiomas artificiales"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "arahuaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "asamés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "idiomas Athapaskan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "idiomas australianos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "avar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "avéstico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "avadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "aimara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "azerbaiyano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "idiomas de la banda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "lenguas bamileké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "baskir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "baluchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "balinés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "vasco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "basaa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "lenguas bálticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "bielorruso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "bengalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "lenguas bereberes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "bhoyapurí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "bicol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "lenguas bantúes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "bosnio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "bretón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "lenguas Batak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "buriato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "buginés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "búlgaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "birmano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "lenguas indígenas centroamericanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "caribe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "catalán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "lenguas celtas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "checheno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "chagatái"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "chino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "trukés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "marí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "jerga chinuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "cheroqui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "eslavo eclesiástico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "chuvasio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "cheyene"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "idioma Cham"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "copto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "córnico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "corso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "criollos y pidgins basados en el inglés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "criollos y pidgins basados en el francés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "criollos y pidgins basados en portugués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "tártaro de Crimea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "criollos y pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "casubio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "lenguajes couchiticos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "checo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "danés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "dargva"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "idiomas Land Dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "slave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "lenguas dravidianas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "bajo sorbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "neerlandés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "holandés, flamenco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "diula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "egipcio antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "elamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "inglés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "inglés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "estonio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "ewé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "feroés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "fiyiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "finés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "lenguas fino-úgricas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "francés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "francés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "francés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "frisón septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "frisón oriental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "frisón occidental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "fula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "friulano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "lenguas germánicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "alemán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "gilbertés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "gaélico escocés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "irlandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "gallego"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "manés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "alto alemán medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "alto alemán antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "gótico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "griego antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "griego moderno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "alemán suizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "guyaratí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "kutchin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "criollo haitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "hebreo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "hitita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "croata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "alto sorbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "húngaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "islandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "yi de Sichuán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "lenguas indoarias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "indonesio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "lenguas indoeuropeas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "lenguas iraníes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "lenguas iroquesas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "italiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "javanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "japonés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "judeo-persa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "judeo-árabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "karakalpako"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "cabila"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "groenlandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "canarés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "lenguas karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "cachemiro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "kazajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "kabardiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "idiomas khoisan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "jemer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "kotanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "kirguís"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "konkaní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "coreano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "kosraeano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "karachay-balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "carelio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "lenguas krou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "kurdo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "latín"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "letón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "lezgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "limburgués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "lituano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "luxemburgués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "macedonia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "madurés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "marshalés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "macasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "māori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "idiomas austronesios"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "maratí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "masái"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "malayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "irlandés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "idiomas no codificados"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "lenguas mon-Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "maltés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "manchú"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "lenguas manobo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "mongol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "varios idiomas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "lenguas funda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "mirandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "lenguas mayas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "náhuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "lenguas indígenas norteamericanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "napolitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "nauruano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "ndebele meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "ndebele septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "bajo alemán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "nepalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "lenguas nigerianas y congolesas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "niueano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "noruego nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "noruego bokmal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "nórdico antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "noruego"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "sotho septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "lenguas nubias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "newari clásico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "occitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "osético"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "turco otomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "idioma otomí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "lenguas papúes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "pangasinán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "panyabí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "persa antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "persa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "lenguas filipinas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "polaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "pohnpeiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "portugués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "prácrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "provenzal antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "pastún"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "rarotongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "lenguas románicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "romanche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "romaní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "rumano, moldavo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "arrumano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "ruso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "sakha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "lenguas indígenas sudamericanas "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "lenguas salishas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "arameo samaritano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "sánscrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "escocés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "lenguas semíticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "irlandés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "lenguaje de señas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "cingalés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "lenguas sioux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "lenguas sino-tibetanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "lenguas eslavas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "eslovaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "esloveno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "sami meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "sami septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "lenguas sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "sami lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "sami inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "samoano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "soninké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "somalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "lenguas songhay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "sotho meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "español"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "sardo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "serbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "lenguas nilo-saharianas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "suazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "sundanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "sumerio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "suajili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "sueco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "siríaco clásico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "tahitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "lenguas tai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "tártaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "tetún"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "tayiko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "tagalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "tailandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "tigriña"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "tokelauano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "tonga del Nyasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "tongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "tsimshiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "setsuana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "turcomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "lenguas tupíes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "turco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "lenguas altaicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "tuvaluano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "tuviniano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "ugarítico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "uigur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "ucraniano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "lengua desconocida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "uzbeko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "vótico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "lenguas wakash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "wolayta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "galés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "lenguas sorabas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "valón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "wólof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "yapés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "yidis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "lenguas yupik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "zapoteco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "símbolos Bliss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "zulú"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "sin contenido lingüístico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "zazaki"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "Valores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr "Valor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "País"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "Islas Ashmore y Cartier (-ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "Territorio de la capital australiana (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "Argelia (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "Afganistán (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "Armenia (república) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "R.S.S. de Armenia (-air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "Azerbaiyán (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "R.S.S. de Azerbaiyán (-ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "Anguila (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "Antigua y Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "Samoa Americana (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "Antártida (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "Baréin (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "Columbia Británica (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "Bélgica (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "Bangladés (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "Belice (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "Territorio Británico del Océano Índico (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "Brasil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "Islas Bermudas (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "Bosnia y Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "Islas Salomón (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "Birmania (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "Botsuana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "Bután (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "Isla Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "Bielorrusia (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "R.S.S. de Bielorrusia (-bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "[Brunei] (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "Caribe neerlandés (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "Camboya (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "Chad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "Congo (República Democrática) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "China (República: 1949-) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "Croacia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "Islas Caimán (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "Camerún (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "Canadá (-cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "Curazao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "Islas Cantón y Enderbury (-cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "Comoras (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "Checoslovaquia (-cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "Cabo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "Islas Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "República Centroafricana (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "Chipre (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "Zona del canal (-cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "Distrito de Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "Dinamarca (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "Benín (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "República Dominicana (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "Guinea Ecuatorial (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "Timor-Leste (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "Inglaterra (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "Estonia (-err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "Etiopía (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "Islas Feroe (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "Guayana Francesa (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "Finlandia (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "Fiyi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "Islas Malvinas (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "Micronesia (Estados Federados) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "Polinesia Francesa (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "Francia (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "Tierras australes y antárticas francesas (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "Yibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "Granada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "Alemania (este) (-ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "Groenlandia (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "Islas Gilbert y Ellice (-gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "Gabón (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "Guadalupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "Grecia (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "Georgia (república) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "R.S.S. de Georgia (-gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "Alemania (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "Franja de Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "Hawai (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "R.A.E. de Hong Kong (China) (-hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "Islas Heard y McDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "Haití (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "Hungría (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "Islandia (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "Irlanda (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "Isla de Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "Italia (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "Zonas desmilitarizadas entre Israel y Siria (-iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "Costa de Marfil (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "Zonas desmilitarizadas entre Israel y Jordania (-iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "Zona neutral Iraq-Arabia Saudita (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "Japón (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "Atolón Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "Jan Mayen (-jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "Jordania (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "Kirguistán (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "R.S.S. de Kirguistán (-kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "Corea del Norte (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "Corea del Sur (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "[Kosovo] (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "Kazajistán (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "R.S.S. de Kazajstán (-kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "Luisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "Líbano (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "Lituania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "Lituania (-lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "Islas de la línea central y sur (-ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "Lesoto (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "Luxemburgo (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "Letonia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "Letonia (-lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "Libia (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "Mónaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "Mauricio (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "R.A.E. de Macao (China) (-mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "Omán (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "Misuri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "Martinica (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "Marruecos (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "Misisipí (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "Moldavia (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "R.S.S. de Moldavia (-mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "Malaui (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "México (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "Malasia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "Antillas Holandesas (-na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "Carolina del Norte (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "Dakota del Norte (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "Países Bajos (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "Níger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "Nuevo Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "Irlanda del Norte (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "Nuevo Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "Nueva Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "Islas Marianas del Norte (-nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "Nuevo Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "Noruega (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "Nueva Escocia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "Territorios del Noroeste (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "Islas Marianas del Norte (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "Isla Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "Estado de Nueva York (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "Nueva Zelanda (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "Oregón (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "Pensilvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "Isla Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "Perú (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "Islas Paracel (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "Guinea-Bisáu (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "Filipinas (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "Isla del Príncipe Eduardo (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "Pakistán (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "Polonia (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "Panamá (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "Papúa Nueva Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "Timor portugués (-pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "Palaos (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "Catar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "Quebec (provincia) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "Reunión (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "Zimbabue (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "Rumanía (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "Federacion Rusa (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "R.S.F.S. de Rusia (-rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr "Islas Ryukyu, Sur (-ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "Sudáfrica (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "Svalbard (-sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "San Bartolomé (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "Carolina del Sur (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "Sudán del Sur (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "Dakota del Sur (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "Santo Tomé y Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "África española (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "Singapur (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "Sudán (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "Sikkim (-sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "Sierra Leona (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "España (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "Esuatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "Sáhara Occidental (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "Escocia (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "Arabia Saudí (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "Islas del Cisne (-sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "Suecia (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "Siria (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "Suiza (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "Tayikistán (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "R.S.S. de Tayikistán (-tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "Islas Turcas y Caicos (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "Tailandia (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "Túnez (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "Turkmenistán (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "R.S.S. de Turkmenistán (-tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "Trinidad y Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "Emiratos Árabes Unidos (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "Territorio en Fideicomiso de las Islas del Pacífico (-tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "Turquía (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "Egipto (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "[United States Misc. Caribbean Islands] (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "Reino Unido Misc. Islas(-ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "Reino Unido Misc. Islas (-uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "Reino Unido (-uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "Ucrania (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "Ucrania (-unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "Estados Unidos Misc. Islas del pacifico (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "Unión soviética (-ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "Estados Unidos (-us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "Uzbekistán (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "R.S.S. de Uzbekistán (-uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "Islas Vírgenes Británicas (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "Ciudad del vaticano (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "Islas Vírgenes de EE. UU. (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "Vietnam del norte (-vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "Varios lugares (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "Vietnam del sur (-vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "Washington (estado) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "Berlín occidental (-wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "Australia occidental (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "Wallis y Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "Cisjordania del río Jordán (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "Isla Wake (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "Gales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "Virginia del Oeste (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "Isla Christmas (Océano Índico) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "Islas Cocos (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "Maldivas (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "San Cristóbal y Nieves (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "Islas Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "Islas Midway (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "Territorio de las Islas del Mar del Coral (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "San Cristóbal-Nevis-Anguila (-xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "Santa helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "Santa Lucía (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "San Pedro y Miquelón (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "San Vicente y las Granadinas (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "Macedonia del Norte (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "Nueva Gales del Sur (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "Eslovaquia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "Territorio del Norte (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "Isla Spratly (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "Chequia (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "Australia Meridional (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "Islas Georgia del Sur y Sandwich del Sur (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "Eslovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "Ningún lugar, desconocido o indeterminado (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "Canadá (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "Reino Unido (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "Unión soviética (-xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "Estados Unidos (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "Yukón (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "Yemen (República Democrática Popular) (-ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "Serbia y Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Cantones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "AG (Argovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "AI (Appenzell Rodas Interiores)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "AR (Appenzell Rodas Exteriores)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "BE (Berna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "BL (Basilea-Campiña)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "BS (Basilea-Ciudad)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "FR (Friburgo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "GE (Ginebra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "GL (Glaris)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "GR (Grisones)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "JU (JURA)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "LU (Lucerna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "SG (San Galo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "SH (Schaffhausen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "SO (Soleura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "TG (Turgovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "TI (Tesino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "ZH (Zúrich)"
 
@@ -6064,10 +6082,6 @@ msgstr "Categoría de préstamo del ejemplar"
 msgid "Item Type URI"
 msgstr "URI del tipo de ejemplar"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr "Número"
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr "Estado del número"
@@ -6302,11 +6316,11 @@ msgid ""
 "state"
 msgstr "El nombre de la acción que desencadenó la transición al estado actual"
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Otra ubicación en línea existe en biblioteca"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "El campo del nombre de la recogida es obligatorio."
 
@@ -7260,3 +7274,16 @@ msgstr "está suprimido."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Haga clic aquí para restablecer su contraseña"
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "Título de la serie."
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Pascal Repond <pascalr.92@gmail.com>, 2020\n"
 "Language: fr\n"
@@ -243,6 +243,22 @@ msgstr "Accès"
 msgid "mv-cantook"
 msgstr "Accès"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "Menu"
@@ -317,8 +333,8 @@ msgid "Account ID"
 msgstr "Mon compte"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -401,8 +417,8 @@ msgstr "URI de la bibliothèque"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -526,8 +542,8 @@ msgid "Deleted"
 msgstr "Supprimé"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "Date"
 
@@ -548,7 +564,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "La date doit être au format suivant: 2022-12-31 (AAAA-MM-JJ)"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "Notes"
@@ -674,9 +690,9 @@ msgid "Exchange rate"
 msgstr "Taux"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -732,7 +748,7 @@ msgid "Monograph"
 msgstr "Monographie"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "Série"
 
@@ -933,28 +949,28 @@ msgid "Item type URI"
 msgstr "URI du type d'exemplaire"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "Revue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "Collection"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -973,13 +989,13 @@ msgstr "PID du document"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -988,7 +1004,7 @@ msgid "Type"
 msgstr "Type"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "article"
 
@@ -1013,7 +1029,7 @@ msgid "Sound"
 msgstr "son"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "vidéo"
 
@@ -1023,10 +1039,10 @@ msgstr "Titres"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "Titre"
@@ -1077,13 +1093,13 @@ msgid "Part name"
 msgstr "Nom"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "Mentions de responsabilité"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "Mention de responsabilité"
@@ -1135,10 +1151,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "Numérotation"
 
@@ -1146,132 +1162,140 @@ msgstr "Numérotation"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "Langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "Sous-type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "Traduit de"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "Langue de laquelle la ressource a été traduite."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "Auteurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 "Auteur(s) de la ressource. Peut être soit une personne soit une "
 "collectivité."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "Auteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Personne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "Nom de la personne."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr "URI de la personne MEF"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1279,12 +1303,12 @@ msgstr ""
 "Informations sur les dates de naissance et de décès d'une personne. Utile"
 " pour distinguer les homonymes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "Qualificatif"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1292,95 +1316,95 @@ msgstr ""
 "Informations qualifiant la personne, par exemple sa profession. Utile "
 "pour distinguer les homonymes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr "Dates de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "Date de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "Mentions d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "Mention d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "Désignations d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "Désignation d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "Production, publication, diffusion, distribution, fabrication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "Production, publication, diffusion, distribution, fabrication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr "Publication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr "Fabrication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr "Diffusion, distribution"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr "Production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "Lieux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "Lieu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "Mentions"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "Mention"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr "Mention"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr "Agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "Date de publication 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1391,11 +1415,11 @@ msgstr ""
 "champ renseigné, une date de publication sous forme libre peut être "
 "ajoutée dans le champ suivant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "Date de publication 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1406,11 +1430,11 @@ msgstr ""
 "champ renseigné, une date de publication sous forme libre peut être "
 "ajoutée dans le champ suivant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr "Contenu illustratif"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
@@ -1419,21 +1443,21 @@ msgstr ""
 "Utilisez un ou plusieurs des termes recommandés par RDA, au singulier ou "
 "au pluriel (MARC 300$b)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr "Contenu illustratif"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 "Termes recommandés par RDA: illustrations, cartes, photographies, "
 "portraits, ..."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "Importance matérielle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
@@ -1441,15 +1465,15 @@ msgstr ""
 "Enregistrez le nombre d’unités et le type d’unité. Pour le type d'unité, "
 "utilisez les termes recommandés par RDA."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr "Exemple: 355 pages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr "Durée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
@@ -1457,20 +1481,20 @@ msgstr ""
 "Durée de lecture, d’exécution, de projection, etc. du contenu d’une "
 "expression."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr "Durée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr "Exemple: 1h50"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr "Contenu de couleur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
@@ -1479,116 +1503,116 @@ msgstr ""
 "Enregistrer un contenu de couleur si c’est jugé important pour "
 "l’identification ou la sélection."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr "Contenu de couleur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr "Monochrome"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr "Polychrome"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr "Méthodes de production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr "Procédé utilisé pour produire une manifestation."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr "Méthode de production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr "Diazocopie en bleu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr "Cyanotypie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr "Phototypie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr "Daguerréotypie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr "Gravure"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr "Eau-forte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr "Lithographie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr "Photocopie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr "Photogravure"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr "Impression"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr "Diazocopie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr "Gravure sur bois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr "Héliogravure"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr "Brûlage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr "Inscription"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr "Estampage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr "Embossage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr "Point rigide"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr "papier thermogonflé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr "Thermoformage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr "Formats bibliographiques"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
@@ -1598,17 +1622,17 @@ msgstr ""
 "imprimée ou manuscrite et les feuillets individuels qui sont produits "
 "lorsque cette feuille est coupée, pliée ou laissée à sa pleine grandeur."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr "Format bibliographique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
@@ -1618,4004 +1642,3998 @@ msgstr ""
 " du volume est supérieure à la hauteur, enregistrer la hauteur × la "
 "largeur."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr "Exemple: 22 cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "Titre de la collection."
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr "Type de note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr "Matériel d'accompagnement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr "Général"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr "Autres détails physiques"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "Résumés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "Résumé de la ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "Résumé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr "Identifiants"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "Identifiant"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr "GTIN 14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr "Local"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr "Cotage pour la musique notée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr "Music publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr "Numéro de l'éditeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "Valeur de l'identifiant"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "Valeur de l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "Note sur l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "Qualificatif de l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "Modalité d'acquisition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "Modalité d'acquisition de la ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "Source"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "Source de l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "Statut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Statut de l'identifiant ISBN/ISSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "Sujets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "Sujet de la ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "Sujet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr "Adresses URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Information nécessaire pour accéder à une ressource électronique."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr "Adresse URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "Entrez une URL unique."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "Exemple: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "Type de lien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "Autre version de la ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "Ressource en lien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "URL caché"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "Aucune information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "Type de contenu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "Est affiché comme texte du lien."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "Affiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "Carte postale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "Complément"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "Compte-rendu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "Documentation d'exposition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "Ex-libris"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "Extrait"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "Fiche pédagogique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "Illustrations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "Image de couverture"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "Information sur la livraison"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Informations biographiques"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "Introduction/préface"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "Lecture suivie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "Mallette pédagogique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "Note de l'éditeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "Note sur le contenu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "Page de titre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "Photographie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "Résumé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "Ressource en ligne via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "Revue de presse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "Site web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "Table des matières"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "Texte intégral"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr "Note publique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr "s'affiche à côté du lien, comme information supplémentaire"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr "Note publique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "Exemple: Accès uniquement depuis la bibliothèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "Importé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Document moissonné ou non, désactivera l'édition de la notice."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "Valeur de la langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "abkhaze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "aceh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "adyguéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "afro-asiatiques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "aïnou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "akkadien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "albanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "aléoute"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "algonquines, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "altaï du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "amharique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "ancien anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "apaches, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "arabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "araméen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "aragonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "arménien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "artificielles, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "assamais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "asturien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "athapascanes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "australiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "avar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "avestique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "azéri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "banda, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "bamilékés, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "bachkir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "baloutchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "balinais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "basque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "bassa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "baltes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "bedja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "biélorusse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "bengali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "berbères, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "bhodjpouri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "bichelamar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "bantoues, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "bosniaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "breton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "batak, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "bouriate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "bugi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "bulgare"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "birman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "indiennes d'Amérique centrale, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "caribe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "catalan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "caucasiens, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "celtique, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "tchétchène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "tchaghataï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "chinois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "chuuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "jargon chinook"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "slavon d’église"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "tchouvache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "monténégrin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "copte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "cornique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "corse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "créoles et pidgins anglais, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "créoles et pidgins français, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "créoles et pidgins portugais, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "turc de Crimée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "créoles et pidgins divers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "kachoube"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "couchitiques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "tchèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "danois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "Land Dayak, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "esclave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "maldivien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "dravidiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "bas-sorabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "douala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "moyen néerlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "néerlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "dioula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "éfik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "égyptien ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "ékadjouk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "élamite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "moyen anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "espéranto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "estonien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "éwé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "éwondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "féroïen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "fidjien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "finnois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "finno-ougriennnes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "moyen français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "ancien français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "frison du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "frison oriental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "frison occidental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "peul"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "frioulan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "germaniques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "géorgien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "guèze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "gilbertin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "gaélique écossais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "galicien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "mannois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "moyen haut-allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "ancien haut allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "gotique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "grec ancien (jusqu'à 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "grec moderne (après 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "suisse allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "goudjerati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "créole haïtien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "haoussa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "hawaïen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "hébreu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "héréro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "croate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "haut-sorabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "hongrois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "islandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "yi du Sichuan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "ijo, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "indo-aryennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "indonésien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "indo-européennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "ingouche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "iraniennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "iroquois, langues (famille)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "italien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "javanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "japonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "judéo-persan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "judéo-arabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "karakalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "kabyle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "groenlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "karen, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "cachemiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "kanouri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "kazakh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "kabarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "khoisan, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "khotanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "kirghize"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "kimboundou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "kikongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "coréen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "kosraéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "kpellé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "karatchaï balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "carélien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "krou, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "kouroukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "koumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "kurde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "latin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "letton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "lezghien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "limbourgeois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "lituanien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "luxembourgeois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "luba-kasaï (ciluba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "luba-katanga (kiluba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "lushaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "macédonien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "madurais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "marshallais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "maïthili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "makassar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "mandingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "malayo-polynésiennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "maasaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "malais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "mokcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "mendé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "moyen irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "diverses, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "môn-khmer, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "maltais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "mandchou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "manobo, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "mongol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "moré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "multilingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "mounda, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "muskogee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "mirandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "marwarî"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "maya, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "nahuatl, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "indiennes d'Amérique du Nord, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "napolitain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "nauruan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "ndébélé du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "ndébélé du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "bas-allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "népalais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "niha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "nigéro-congolaises,langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "niuéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "norvégien nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "norvégien bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "nogaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "vieux norrois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "norvégien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "sotho du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "nubiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "newarî classique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "chewa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "nyankolé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "nzema"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "occitan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "ossète"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "turc ottoman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "otomi, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "papoues, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "pampangan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "pendjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "paluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "persan ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "persan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "philippin, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "phénicien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "polonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "pohnpei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "portugais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "prâkrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "provençal ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "pachto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "rarotongien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "romanes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "romanche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "roumain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "roundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "aroumain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "russe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "iakoute"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "indiennes d'Amérique du Sud, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "salish, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "araméen samaritain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "sicilien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "écossais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "selkoupe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "sémitiques, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "ancien irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "langue des signes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "cingalais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "sioux, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "sino-tibétaines, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "slaves, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "slovaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "slovène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "same du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "same du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "sâmes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "same de Lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "same d’Inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "samoan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "same skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "soninké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "sogdien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "sotho du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "espagnol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "sarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "serbe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "sérère"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "nilo-sahariennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "swati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "soukouma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "soundanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "soussou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "sumérien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "suédois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "syriaque classique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "syriaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "tahitien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "tai, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "tamoul"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "télougou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "timné"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "tétoum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "tadjik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "thaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "tibétain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "tigrigna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "tamacheq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "tonga nyasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "tongien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "turkmène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "tupi, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "turc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "altaïques, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "touvain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "oudmourte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "ougaritique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "ouïghour"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "ukrainien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "langue indéterminée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "ourdou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "ouzbek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "vaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "vietnamien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "vote"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "wakashennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "walamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "gallois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "sorabes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "wallon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "kalmouk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "yapois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "yupik, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "zapotèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "symboles Bliss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "zandé, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "zoulou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "sans contenu linguistique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "zazaki"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "Valeurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr "valeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Pays"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "Albanie (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "Îles Ashmore-et-Cartier (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "Territoire de la capitale australienne (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "Algérie (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "Argentine (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "Arménie (République) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "R.S.S. d'Arménie (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "Azerbaïdjan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "R.S.S. d'Azerbaïjan (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "Andorre (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "Antigua-et-Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "Samoa américaines (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "Australie (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "Autriche (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "Antarctique (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "Bahreïn (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "Barbade (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "Colombie Britannique (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "Belgique (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "Territoire britannique de l’océan Indien (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "Brésil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "Îles Bermudes (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "Bosnie-Herzégovine (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "Bolivie (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "Îles Salomon (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "Birmanie (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "Bhoutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "Bulgarie (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "Île Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "Biélorussie (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "R.S.S. de Biélorussie (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "Pays-Bas caribéens  (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "Californie (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "Cambodge (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "Chine (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "Tchad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "Congo-Brazzaville (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "République démocratique du Congo (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "République populaire de Chine (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "Croatie (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "Îles Caïmans (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "Colombie (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "Chili (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "Cameroun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "Îles de Canton et Enderbury (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "Comores (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "Tchécoslovaquie (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "Cap-Vert (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "Îles Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "République centrafricaine (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "Chypre (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "Zone du Canal de Panama (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "District de Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "[Delaware] (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "Danemark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "Bénin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "Dominique (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "République dominicaine (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "Érythrée (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "Équateur (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "Guinée équatoriale (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "Timor oriental (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "Angleterre (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "Estonie (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "R.S.S. d'Estonie (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "Éthiopie (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "Îles Féroé (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "Guyane française (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "Finlande (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "Fidji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "Îles Malouines (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "Floride (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "États fédérés de Micronésie (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "Polynésie française (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "France (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "Géorgie (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "Grenade (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "Allemagne de l'Est (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "Guernesey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "Groenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "Gambie (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "Îles Gilbert et Ellice (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "Grèce (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "République de Géorgie (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "R.S.S. de Géorgie (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "Guinée (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "Allemagne (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "Guyane (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "Bande de Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "Hawaï (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "R.A.S. chinoise de Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "Îles Heard-et-MacDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "Haïti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "Hongrie (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "Islande (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "Irlande (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "Inde (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "Île de Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "Indonésie (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "Israël (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "Italie (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "Zones démilitarisées Israël-Syrie (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "Côte d’Ivoire (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "Zones démilitarisées Israël-Jordanie (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "Zone neutre Irak-Arabie saoudite (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "Japon (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "Atoll de Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "Jamaïque (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "Île Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "Jordanie (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "Kirghizistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "R.S.S. kirghize (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "Corée du Nord (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "Corée du Sud (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "Koweït (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "Kazakhstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "R.S.S. Kazakhe (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "Louisiane (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "Libéria (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "Liban (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "Lituanie (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "Lituanie (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "Îles de la Ligne Centrale et du Sud (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "Luxembourg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "Lettonie (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "Lettonie (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "Libye (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "Maurice (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "R.A.S. chinoise de Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "Malte (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "Monténégro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "Mongolie (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "Maroc (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "Mauritanie (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "Moldavie (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "R.S.S. Moldave (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "Mexique (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "Malaisie (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "Antilles néerlandaises (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "Caroline du Nord (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "Dakota du Nord (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "Pays-Bas (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "Terre-Neuve et Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "Irlande du Nord (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "Nouveau Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "Nouvelle-Calédonie (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "Îles Mariannes du Nord (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "Nouveau Mexique (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "Norvège (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "Népal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "Nigéria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "Nouvelle-Ecosse (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "Territoires du Nord-Ouest (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "Îles Mariannes du Nord (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "Île Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "État de New York (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "Nouvelle-Zélande (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "Pennsylvanie (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "Île Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "Pérou (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "Îles Paracels (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "Guinée-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "Philippines (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "Île du Prince Edouard (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "Pologne (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "Papouasie-Nouvelle-Guinée (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "Porto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "Timor portugais (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "Palaos (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "Serbie (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "La Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "Roumanie (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "Russie (Fédération) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "RSFS de Russie (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr " îles Ryūkyū du Sud (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "Afrique du Sud (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "Caroline du Sud (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "Soudan du Sud (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "Dakota du Sud (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "Sao Tomé-et-Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "Sénégal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "Afrique espagnole (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "Singapour (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "Soudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "Saint-Marin (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "Saint-Martin (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "Somalie (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "Espagne (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "Suriname (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "Sahara occidental (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "Écosse (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "Arabie saoudite (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "Îles du Cygne (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "Suède (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "Namibie (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "Syrie (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "Suisse (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "Tadjikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "R.S.S. du Tadjikistan (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "Îles Turques-et-Caïques (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "Thaïlande (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "Tunisie (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "Turkménistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "R.S.S. du Turkménistan (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "Tasmanie (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "[Tennessee] (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "Trinité-et-Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "Émirats arabes unis (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "Territoire sous tutelle des îles du Pacifique (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "Turquie (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "Tanzanie (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "Égypte (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "États-Unis, diverses îles caribéennes (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "Ouganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "Royaume-Uni, diverses îles (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "Royaume-Uni, diverses îles (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "Royaume-Uni (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "États-Unis, diverses îles du Pacifique (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "Union soviétique (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "États-Unis (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "Ouzbékistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "R.S.S. d'Ouzbékistan (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "Virginie (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "Îles Vierges britanniques (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "Vatican (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "Vénézuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "Îles Vierges des États-Unis (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "[Vietnam, North] (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "Plusieurs pays (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "Terre Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "[Vietnam, South] (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "Washington (État) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "Berlin Ouest (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "Australie-Occidentale (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "Wallis-et-Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "Cisjordanie (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "Wake (atoll) (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "Pays de Galles (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "Virginie-Occidentale (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "Île Christmas (Océan Indien) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "Îles Cocos (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "Maldives (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "Saint Kitts-et-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "Îles Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "Îles Midway (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "Territoire des îles de la mer de Corail (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "Saint Kitts-et-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "Sainte-Hélène (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "Sainte-Lucie (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "Saint-Pierre-et-Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "Saint-Vincent-et-les-Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "Macédoine du Nord (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "Nouvelle-Galles du Sud (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "Slovaquie (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "Territoire du Nord (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "Îles Spratleys (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "Tchéquie (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "Australie-Méridionale (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "Géorgie du Sud et îles Sandwich du Sud (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "Slovénie (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "Aucun pays, inconnu, indéterminé (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "Royaume-Uni (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "Union soviétique (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "États-Unis (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "Yémen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "Territoire du Yukon (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "Yémen (République démocratique populaire) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "Serbie et Monténégro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "Zambie (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "AG (Argovie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "AI (Appenzell Rhodes-Intérieures)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "AR (Appenzell Rhodes-Extérieures)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "BE (Berne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "BL (Bâle-Campagne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "BS (Bâle-Ville)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "FR (Fribourg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "GE (Genève)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "GL (Glaris)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "GR (Grisons)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "LU (Lucerne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "NW (Nidwald)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "OW (Obwald)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "SG (Saint-Gall)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "SH (Schaffhouse)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "SO (Soleure)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "SZ (Schwytz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "TG (Thurgovie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "TI (Tessin)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "ZG (Zoug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "ZH (Zurich)"
 
@@ -6061,10 +6079,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr "URI du type d'item"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6299,11 +6313,11 @@ msgid ""
 "state"
 msgstr "Le nom de l'action qui a déclenché la transition vers l'état actuel"
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Une autre localisation en ligne existe dans cette bibliothèque"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "Le champ du nom du lieu de retrait est obligatoire."
 
@@ -7255,3 +7269,16 @@ msgstr "a été supprimé."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Cliquez ici pour réinitialiser votre mot de passe"
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "Titre de la collection."
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: it\n"
@@ -241,6 +241,22 @@ msgstr "Accesso"
 msgid "mv-cantook"
 msgstr "Accesso"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "Menù"
@@ -315,8 +331,8 @@ msgid "Account ID"
 msgstr "ID del conto"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -399,8 +415,8 @@ msgstr "URI della biblioteca"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -524,8 +540,8 @@ msgid "Deleted"
 msgstr "Eliminato"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "Data"
 
@@ -546,7 +562,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "Deve essere nel formato seguente: 2022-12-31 (AAAA-MM-GG)."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "Nota"
@@ -672,9 +688,9 @@ msgid "Exchange rate"
 msgstr ""
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -730,7 +746,7 @@ msgid "Monograph"
 msgstr "Monografia"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "Serie"
 
@@ -931,28 +947,28 @@ msgid "Item type URI"
 msgstr "URI del tipo di esemplare"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "Rivista"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "Collezione"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -971,13 +987,13 @@ msgstr "PID di documento"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -986,7 +1002,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "Articolo"
 
@@ -1011,7 +1027,7 @@ msgid "Sound"
 msgstr "Audio"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "Video"
 
@@ -1021,10 +1037,10 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "Titolo"
@@ -1075,13 +1091,13 @@ msgid "Part name"
 msgstr "Nome"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "Responsabilità"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "Formulazione di responsabilità"
@@ -1134,10 +1150,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "Numerazione"
 
@@ -1145,130 +1161,138 @@ msgstr "Numerazione"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "Lingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "Lingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "Sottotipo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "Tradotto da"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "Lingua da cui l'opera è stata tradotta."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "Autori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Autore o autori dell'opera. Può essere una persona o un ente."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "Autore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Persona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "Nome della persona."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr "URI della persona MEF"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1276,12 +1300,12 @@ msgstr ""
 "Informazioni sulla data di nascita e di decesso di una persona. Utile per"
 " distinguere gli omonimi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "Qualificazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1289,95 +1313,95 @@ msgstr ""
 "Informazioni che qualificano la persona, come la sua occupazione. Utile "
 "per distinguere gli omonimi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr "Date di copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "Data di copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "Formulazioni di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "Formulazione di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "Designazioni di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "Designazione di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "Pubblicazione, manifattura, distribuzione, produzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "Pubblicazione, manifattura, distribuzione, produzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr "Pubblicazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr "Manifattura"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr "Distribuzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr "Produzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "Luoghi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "Luogo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "Formulazioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "Formulazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr "Formulazione di luogo e agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr "Agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "Data di pubblicazione 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1388,11 +1412,11 @@ msgstr ""
 "compilato il campo, è possibile aggiungere una data di pubblicazione in "
 "forma libera nel campo successivo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "Data di pubblicazione 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1403,11 +1427,11 @@ msgstr ""
 "compilato il campo, è possibile aggiungere una data di pubblicazione in "
 "forma libera nel campo successivo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
@@ -1416,21 +1440,21 @@ msgstr ""
 "utilizza uno o più termini raccomandati da RDA, al singolare o al plurale"
 " (MARC 300$b)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr "Contenuto illustrativo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 "Termini raccomandati da RDA: illustrazioni, carte geografiche, "
 "fotografie, ritratti, ..."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "Importanza materiale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
@@ -1438,15 +1462,15 @@ msgstr ""
 "Si registra il numero e il tipo di unità. Per il tipo di unità, si "
 "utilizza i termini raccomandati da RDA."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr "Esempio: 355 pagine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
@@ -1454,135 +1478,135 @@ msgstr ""
 "Tempo di riproduzione, di esecuzione, di proiezione , etc. del contenuto "
 "dell'espressione."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr "Durata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr "Esempio: 1h50"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr "Monocromatico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr "Policromatico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr "Processo usato nella produzione di una manifestazione."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr "Metodo di produzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr "Dagherrotipia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr "Incisione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr "Acquaforte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr "Litografia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr "Fotoincisione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr "Stampa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr "Xilografia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr "Bruciatura"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr "Iscrizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr "Goffratura"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr "Formati bibliografici"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
@@ -1593,17 +1617,17 @@ msgstr ""
 "folio, due volte per formare un in quarto, tre volte per formare un in "
 "ottavo)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr "Formato bibliografico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr "Dimensioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
@@ -1612,4008 +1636,4002 @@ msgstr ""
 "lunghezza, spessore e diametro. Se la larghezza del volume è più grande "
 "dell'altezza, Si registrano altezza x larghezza."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr "Esempio: 22 cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "Titolo della collezione."
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr "Materiale allegato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "Riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "Riassunto della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "Riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr "Identificatori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "Identificatore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr "Music publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr "Numero dell'editore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "Codice d'identificazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "Codice d'identificazione."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "Nota sull'identificatore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "Qualificatore dell'identificatore."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "Condizioni di disponibilità"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "Condizioni di disponibilità della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "Fonte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "Fonte del identificatore."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "Stato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Stato dell'identificatore ISBN/SSSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "Oggetti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "Oggetto della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "Oggetto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informazioni necessarie per localizzare una risorsa elettronica e "
 "accedervi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "Registrare qui un URL univoco."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "Esempio: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "Tipo di link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "Risorsa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "Versione della risorsa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "Risorse correlate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "URL nascosto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "Nessuna info"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "Tipo di contenuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "Viene visualizzato come testo del link."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "Poster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "Cartolina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "Aggiunta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "Debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "Documentazione della mostra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "Piastra per libri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "Estratto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "Scheda didattica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "Illustrazioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "Immagine di copertina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "Informazioni sulla consegna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Informazioni biografiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "Introduzione/prefazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "Lettura di classe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "Kit per insegnanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "Nota dell'editore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "Nota sul contenuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "Frontespizio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "Fotografia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "Riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "Risorsa online tramite RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "Rassegna stampa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "Sito web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "Indice dei contenuti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "Testo completo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "Esempio: Accesso solo dalla biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "Raccolto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 "Documento è stato raccolto o no, disattiva la possibilità di modificare "
 "il record o vice versa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "Codice di lingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "abcaso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "accinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "acioli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "adyghe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "afroasiatiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "accado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "albanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "aleuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "lingue algonchine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "altai meridionale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "amarico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "inglese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "lingue apache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "arabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "aramaico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "aragonese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "armeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "lingua artificiale (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "aruaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "assamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "lingue athabaska"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "lingue australiane aborigene"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "avaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "avestan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "azerbaigiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "banda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "lingue bamileke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "baschiro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "beluci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "balinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "basco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "lingue baltiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "begia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "bielorusso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "wemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "bengalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "lingue berbere"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "bicol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "bantu (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "bosniaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "bretone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "batak (indonesia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "buriat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "bugi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "bulgaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "birmano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "indiane centro-americane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "caribico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "catalano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "lingue caucasiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "lingue celtiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "ceceno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "ciagataico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "cinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "chuukese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "gergo chinook"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "slavo della Chiesa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "ciuvascio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "copto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "cornico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "corso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "creoli e pidgin basati sull'inglese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "creoli e pidgin basati sul francese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "creoli e pidgin basati sul portoghese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "turco crimeo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "creoli e pidgin (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "kashubian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "lingue cushitiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "ceco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "danese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "slave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "dinca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "dravidiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "basso sorabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "olandese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "olandese; fiammingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "diula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "egiziano antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "ekajuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "elamitico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "inglese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "inglese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "estone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "faroese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "figiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "filippino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "finlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "ugrofinniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "francese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "francese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "francese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "frisone settentrionale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "frisone orientale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "frisone occidentale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "fulah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "friulano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "lingue germaniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "tedesco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "gilbertese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "gaelico scozzese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "irlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "galiziano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "mannese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "tedesco medio alto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "tedesco antico alto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "gotico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "greco antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "greco moderno (dal 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "tedesco svizzero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "haitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "ebraico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "ilongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "croato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "alto sorabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "ungherese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "islandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "sichuan yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "lingue indoarie (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "indonesiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "lingue indoeuropee (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "inupiak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "lingue iraniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "lingue irochesi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "italiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "giavanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "giapponese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "giudeo persiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "giudeo arabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "kara-kalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "cabilo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "groenlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "kashmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "kazako"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "cabardino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "khoisan (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "khotanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "kirghiso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "coreano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "kosraean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "karachay-Balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "careliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "kru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "curdo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "giudeo-spagnolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "latino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "lettone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "lesgo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "limburghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "lituano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "lolo bantu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "lussemburghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "luiseno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "lushai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "macedone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "madurese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "marshallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "makasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "austronesiano (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "masai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "malay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "irlandese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "menangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "mon-khmer (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "malgascio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "maltese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "manchu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "lingue manobo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "mongolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "multilingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "lingue munda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "mirandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "maya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "indiano nordamericano (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "napoletano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "nauru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "ndebele del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "ndebele del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "basso tedesco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "nepalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "niger-kordofaniane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "niue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "norvegese nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "norvegese bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "norse antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "norvegese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "sotho del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "lingue nubiane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "newari classico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "occitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "ossetico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "turco ottomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "lingue otomiane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "papuasiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "punjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "palauano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "persiano antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "persiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "filippine (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "polacco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "ponape"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "portoghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "lingue pracrite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "provenzale antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "pashto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "rarotonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "lingue romanze (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "romancio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "romeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "rundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "arumeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "russo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "yakut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "lingue indiane sudamericane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "lingue salish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "aramaico samaritano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "sanscrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "scozzese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "lingue semitiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "irlandese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "lingua dei segni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "singalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "lingue sioux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "sinotibetane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "lingue slave (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "slovacco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "sloveno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "sami del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "sami del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "lingue sami (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "sami di Lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "sami di Inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "samoano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "somalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "sotho del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "spagnolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "sardo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "serbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "lingue nilo-sahariane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "swati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "sundanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "sumero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "svedese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "siriaco classico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "taitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "thailandese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "tataro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "tagico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "tigrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "nyasa del Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "tongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "turcomanno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "lingue tupi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "turco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "altaiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "ci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "tuvinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "ugaritico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "uiguro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "ucraino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "mbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "lingua imprecisata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "uzbeco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "voto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "lingue wakash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "walamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "gallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "lingue lusaziane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "vallone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "yao (bantu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "yapese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "lingue yupik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "blissymbol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "nessun contenuto linguistico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "Valori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Paese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "Isole Ashmore e Cartier (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "Territorio della Capitale Australiana (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "Algeria (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "Armenia (Repubblica) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "R.S.S. di Armenia (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "Azerbaigian (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "R.S.S. dell' Azerbaigian (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "Antigua e Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "Samoa americane (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "Antartide (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "Bahrein (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "Columbia Britannica (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "Belgio (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "Territorio britannico dell’Oceano Indiano (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "Brasile (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "Bermuda (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "Bosnia ed Erzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "Isole Salomone (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "Birmania (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "Isola Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "Bielorussia (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "R.S.S. Bielorussia (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "Paesi Bassi caraibici (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "California (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "Cambogia (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "Cina (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "Ciad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "Congo-Brazzaville (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "Repubblica Democratica del Congo (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "Repubblica Popolare Cinese (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "Croazia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "Isole Cayman (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "Cile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "Camerun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "Isole Canton ed Enderbury (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "Comore (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "Cecoslovacchia (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "Capo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "Isole Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "Repubblica Centrafricana (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "Cipro (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "Zona del Canale di Panama (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "Distretto di Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "Danimarca (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "Repubblica Dominicana (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "Guinea Equatoriale (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "Timor Est (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "Inghilterra (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "R.S.S. di Estonia (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "Etiopia (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "Isole Fær Øer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "Guyana francese (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "Finlandia (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "Figi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "Isole Falkland (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "Stati Federati di Micronesia (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "Polinesia francese (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "Francia (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "Terre australi e antartiche francesi (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "Gibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "Repubblica Democratica Tedesca (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "Gibilterra (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "Groenlandia (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "Isole Gilbert ed Ellice (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "Guadalupa (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "Grecia (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "Georgia (Repubblica) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "R.S.S. Georgiana (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "Germania (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "Striscia di Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "RAS di Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "Isole Heard e McDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "Ungheria (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "Islanda (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "Irlanda (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "Isola di Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "Iraq (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "Iràn (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "Israele (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "Italia (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "Zone demilitarizzate Israele-Siria (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "Costa d’Avorio (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "Zone demilitarizzate Israele-Giordania (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "zona neutrale iracheno-saudita (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "Giappone (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "atollo Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "Giamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "Giordania (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "Kirghizistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "R.S.S. Kirghiza (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "Corea del Nord (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "Corea del Sud (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "Kazakistan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "R.S.S. Kazaka (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "Libano (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "Lituania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "R.S.S. Lituana (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "Sporadi Equatoriali (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "Lussemburgo (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "Lettonia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "R.S.S. Lettone (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "Libia (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "RAS di Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "Martinica (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "Marocco (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "Moldavia (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "R.S.S. Moldava (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "Messico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "Mozambico (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "Antille Olandesi (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "Carolina del Nord  (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "Dakota del Nord (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "Paesi Bassi (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "Terranova e Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "Irlanda del Nord (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "Nuovo Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "Nuova Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "Isole Marianne settentrionali (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "Nuovo Messico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "Norvegia (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "[Nova Scotia] (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "[Northwest Territories] (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "[Nunavut] (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "[Nevada] (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "Isole Marianne settentrionali (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "Isola Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "[New York (State)] (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "Nuova Zelanda (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "[Ohio] (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "[Oklahoma] (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "[Ontario] (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "[Oregon] (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "[Pitcairn Island] (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "Perù (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "[Paracel Islands] (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "Filippine (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "[Prince Edward Island] (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "Polonia (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "Panamá (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "Portogallo (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "Papua Nuova Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "Portorico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "[Portuguese Timor] (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "[Queensland] (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "[Québec (Province)] (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "Riunione (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "[Rhode Island] (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "Romania (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "[Russia (Federation)] (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "[Russian S.F.S.R.] (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr "[Ryukyu Islands, Southern] (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "Sudafrica (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "[Svalbard] (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "[Saint-Barthélemy] (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "[South Carolina] (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "Sud Sudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "[South Dakota] (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "São Tomé e Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "[Spanish North Africa] (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "[Sikkim] (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "[Sint Maarten] (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "[Saskatchewan] (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "Spagna (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "Swaziland (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "[Surinam] (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "Sahara occidentale (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "[Saint-Martin] (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "[Scotland] (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "Arabia Saudita (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "[Swan Islands] (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "Svezia (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "[Syria] (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "Svizzera (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "Tagikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "[Tajik S.S.R.] (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "Isole Turks e Caicos (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "Thailandia (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "Tunisia (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "[Turkmen S.S.R.] (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "[Tasmania] (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "[Tennessee] (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "Trinidad e Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "Emirati Arabi Uniti (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "[Trust Territory of the Pacific Islands] (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "Turchia (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "[Texas] (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "Egitto (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "[United States Misc. Caribbean Islands] (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "[United Kingdom Misc. Islands] (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "[United Kingdom Misc. Islands] (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "Regno Unito (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "Ucraina (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "Ucraina (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "[United States Misc. Pacific Islands] (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "[Soviet Union] (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "Stati Uniti (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "[Utah] (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "Uzbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "[Uzbek S.S.R.] (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "[Virginia] (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "Isole Vergini Britanniche (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "[Vatican City] (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "Isole Vergini Americane (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "[Vietnam, North] (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "[Various places] (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "[Victoria] (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "[Vietnam, South] (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "[Vermont] (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "[Washington (State)] (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "[West Berlin] (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "[Western Australia] (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "Wallis e Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "[Wisconsin] (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "[West Bank of the Jordan River] (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "[Wake Island] (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "[Wales] (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "[West Virginia] (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "[Wyoming] (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "[Christmas Island (Indian Ocean)] (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "Isole Cocos (Keeling) (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "Maldive (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "[Saint Kitts-Nevis] (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "Isole Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "[Midway Islands] (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "[Coral Sea Islands Territory] (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "[Saint Kitts-Nevis-Anguilla] (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "[Saint Helena] (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "Saint-Pierre e Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "Saint Vincent e Grenadine (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "Macedonia del Nord (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "[New South Wales] (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "Slovacchia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "[Northern Territory] (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "[Spratly Island] (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "Cechia (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "[South Australia] (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "Georgia del Sud e Sandwich australi (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "Slovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "[No place, unknown, or undetermined] (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "Regno Unito (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "[Soviet Union] (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "Stati Uniti (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "[Yukon Territory] (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "[Yemen (People's Democratic Republic)] (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "[Serbia and Montenegro] (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Cantoni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "AG (Argovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "AI (Appenzello Interno)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "AR (Appenzello Esterno)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "BE (Berna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "BL (Basilea Campagna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "BS (Basilea Città)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "FR (Friburgo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "GE (Ginevra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "GL (Glarona)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "GR (Grigioni)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "JU (Giura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "LU (Lucerna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "NW (Nidvaldo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "OW (Obvaldo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "SG (San Gallo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "SH (Sciaffusa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "SO (Soletta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "SZ (Svitto)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "TG (Turgovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "TI (Ticino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "VS (Vallese)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "ZG (Zugo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "ZH (Zurigo)"
 
@@ -6056,10 +6074,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr "URI del tipo di esemplare"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6294,11 +6308,11 @@ msgid ""
 "state"
 msgstr "Il nome dell'azione che ha innescato la transizione verso lo stato attuale"
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Un'altra localizzazione online esiste in questa biblioteca"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "Il campo del nome del punto di ritiro è richiesto."
 
@@ -7244,3 +7258,16 @@ msgstr "è stato eliminato."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Clicca qui per reimpostare la password"
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "Titolo della collezione."
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.10.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -228,6 +228,22 @@ msgstr ""
 msgid "mv-cantook"
 msgstr ""
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr ""
@@ -302,8 +318,8 @@ msgid "Account ID"
 msgstr ""
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -386,8 +402,8 @@ msgstr ""
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -511,8 +527,8 @@ msgid "Deleted"
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr ""
 
@@ -533,7 +549,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr ""
@@ -659,9 +675,9 @@ msgid "Exchange rate"
 msgstr ""
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -717,7 +733,7 @@ msgid "Monograph"
 msgstr ""
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr ""
 
@@ -916,28 +932,28 @@ msgid "Item type URI"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -956,13 +972,13 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -971,7 +987,7 @@ msgid "Type"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr ""
 
@@ -996,7 +1012,7 @@ msgid "Sound"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr ""
 
@@ -1006,10 +1022,10 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr ""
@@ -1060,13 +1076,13 @@ msgid "Part name"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr ""
@@ -1116,10 +1132,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr ""
 
@@ -1127,4443 +1143,4445 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
 "date of publication can be added in the next field."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
 "of publication can be added in the next field."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
 "is left full, cut, or folded."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr ""
 
@@ -6004,10 +6022,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr ""
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6242,11 +6256,11 @@ msgid ""
 "state"
 msgstr ""
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr ""
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-07-03 11:05+0200\n"
+"POT-Creation-Date: 2020-07-14 12:44+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -234,6 +234,22 @@ msgstr "Toegang"
 msgid "mv-cantook"
 msgstr "Toegang"
 
+#: rero_ils/manual_translations.txt:58
+msgid "rdami:1001"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:59
+msgid "rdami:1002"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:60
+msgid "rdami:1003"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:61
+msgid "rdami:1004"
+msgstr ""
+
 #: rero_ils/views.py:57
 msgid "Menu"
 msgstr "Menu"
@@ -308,8 +324,8 @@ msgid "Account ID"
 msgstr "Account ID"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:696
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:315
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:342
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:381
@@ -392,8 +408,8 @@ msgstr "URI van de bibliotheek"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:686
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:271
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -517,8 +533,8 @@ msgid "Deleted"
 msgstr "Verwijderd"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:919
 msgid "Date"
 msgstr "Datum"
 
@@ -539,7 +555,7 @@ msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
 msgstr "Moet in het volgende formaat zijn: 2022-12-31 (JJJJ-MM-DD)."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:282
 msgid "Notes"
 msgstr "Notas"
@@ -665,9 +681,9 @@ msgid "Exchange rate"
 msgstr "Wisselkoers"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1578
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:44
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:286
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:57
@@ -723,7 +739,7 @@ msgid "Monograph"
 msgstr "Monografie"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:469
 msgid "Serial"
 msgstr "Serieel"
 
@@ -926,28 +942,28 @@ msgid "Item type URI"
 msgstr "URI van de type van kopie"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:83
-#: rero_ils/modules/documents/views.py:291
+#: rero_ils/modules/documents/views.py:213
 msgid "Journal"
 msgstr "Tijdschrift"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1218
-#: rero_ils/modules/documents/views.py:293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1252
+#: rero_ils/modules/documents/views.py:215
 msgid "Series"
 msgstr "Serie"
 
-#: rero_ils/modules/documents/views.py:295
+#: rero_ils/modules/documents/views.py:217
 msgid "Published in"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:305
+#: rero_ils/modules/documents/views.py:233
 msgid "vol"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:308
+#: rero_ils/modules/documents/views.py:236
 msgid "nr"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:311
+#: rero_ils/modules/documents/views.py:239
 msgid "p"
 msgstr ""
 
@@ -966,13 +982,13 @@ msgstr "Document PID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:54
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:649
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1449
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:298
@@ -981,7 +997,7 @@ msgid "Type"
 msgstr "Type"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:71
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
 msgid "Article"
 msgstr "Artikel"
 
@@ -1006,7 +1022,7 @@ msgid "Sound"
 msgstr "Geluid"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1891
 msgid "Video"
 msgstr "Video"
 
@@ -1016,10 +1032,10 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:113
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1269
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1305
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:99
 msgid "Title"
 msgstr "Titel"
@@ -1070,13 +1086,13 @@ msgid "Part name"
 msgstr "Onderdeelnaam"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:221
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:758
 msgid "Responsibilities"
 msgstr "Verantwoordelijkheden"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:225
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:229
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:762
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:24
 msgid "Responsibility"
 msgstr "Verantwoordelijkheid"
@@ -1129,10 +1145,10 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1245
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1314
 msgid "Numbering"
 msgstr "Nummering"
 
@@ -1140,130 +1156,138 @@ msgstr "Nummering"
 msgid "Year"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:328
+msgid "Should be in the following format: 2020."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
 msgid "Volume"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:347
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
 msgid "Issue"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:357
 msgid "Pages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:341
-msgid "Examples: 135, 5-27, ..."
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:361
+msgid "Ex: 135, 5-27, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:364
+msgid "Should be in the following format: 135 or 5-27."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
 msgid "Languages"
 msgstr "Talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4380
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:31
 msgid "Language"
 msgstr "Taal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:436
 msgid "Mode of issuance"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:449
 msgid "Main type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:461
 msgid "Single unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:465
 msgid "Multipart monograph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:473
 msgid "Integrating resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:483
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:53
 msgid "Subtype"
 msgstr "Subtype"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
 msgid "Material unit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
 msgid "Monographic series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:513
 msgid "Periodical"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:517
 msgid "Private file"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:521
 msgid "Private subfile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:525
 msgid "Serial in serial"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:529
 msgid "Set"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:533
 msgid "Updating website"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:537
 msgid "Updating loose leaf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:554
 msgid "Translated from"
 msgstr "Vertaald uit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:555
 msgid "Language from which a resource is translated."
 msgstr "Taal van waaruit een bron wordt vertaald."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:569
 msgid "Authors"
 msgstr "Auteurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:570
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Auteur(s) van de bron(nen). Kan zowel personen als organisaties zijn."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:574
 msgid "Author"
 msgstr "Auteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:604
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Persoon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:612
 msgid "Person's name."
 msgstr "Naam van de persoon."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:623
 msgid "MEF person reference"
 msgstr "MEF person reference"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:637
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1271,12 +1295,12 @@ msgstr ""
 "Informatie over de geboorte en de dood van een persoon. Handig om mensen "
 "te ontmaskeren."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
 msgid "Qualifier"
 msgstr "Kwalificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:648
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1284,95 +1308,95 @@ msgstr ""
 "Informatie over de persoon, dat wil zeggen haar beroep. Handig om mensen "
 "te ontmaskeren."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:723
 msgid "Copyright dates"
 msgstr "Datum van het auteursrecht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:728
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:36
 msgid "Copyright date"
 msgstr "Datum van het auteursrecht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:740
 msgid "Edition statements"
 msgstr "Edition statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:745
 msgid "Edition statement"
 msgstr "Edition statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:749
 msgid "Edition designations"
 msgstr "Edition designations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:753
 msgid "Edition designation"
 msgstr "Edition designation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:782
 msgid "Provision activities"
 msgstr "Productie, publicatie, verspreiding, distributie, verwerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:786
 msgid "Provision activity"
 msgstr "Productie, publicatie, verspreiding, distributie, verwerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:813
 msgid "Publication"
 msgstr "Publicatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:817
 msgid "Manufacture"
 msgstr "Verwerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:821
 msgid "Distribution"
 msgstr "Distributie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:825
 msgid "Production"
 msgstr "Productie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:835
 msgid "Places"
 msgstr "Plaatsen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:911
 msgid "Place"
 msgstr "Plaats"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:884
 msgid "Statements"
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:889
 msgid "Statement"
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:890
 msgid "Statement of place and agent of the provision activity."
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
 msgid "Agent"
 msgstr "Agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:929
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1378
 msgid "Label"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:948
 msgid "Start date of publication"
 msgstr "Datum van de publicatie 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:949
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1383,11 +1407,11 @@ msgstr ""
 "dit veld is ingesteld, kan een vrije datum van publicatie worden "
 "toegevoegd in het volgende veld."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
 msgid "End date of publication"
 msgstr "Datum van de publicatie 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:962
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1398,4201 +1422,4195 @@ msgstr ""
 "veld is ingesteld, kan een vrije datum van publicatie worden toegevoegd "
 "in het volgende veld."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
 msgid "Illustrative contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:987
 msgid ""
 "Record every different illustrative content in a new field. Use one or "
 "more RDA recommended terms, in the singular or plural (MARC 300$b)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:991
 msgid "Illustrative content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:995
 msgid "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
 msgid "Extent"
 msgstr "Materieel belang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1007
 msgid ""
 "Record the number of units and the type of unit. For the type of unit, "
 "use RDA recommended terms."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1011
 msgid "Example: 355 pages"
 msgstr "Voorbeeld: 355 pagina's"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
 msgid "Durations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1020
 msgid ""
 "A playing time, performance time, running time, etc., of the content of "
 "an expression."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1024
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:76
 msgid "Duration"
 msgstr "Duur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1028
 msgid "Example: 1h50"
 msgstr "Voorbeeld: 1u50"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1039
 msgid "Color contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1040
 msgid ""
 "A presence of color, tone, etc., in the content of an expression. Record "
 "a color content if considered important for identification or selection."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1044
 msgid "Color content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1053
 msgid "Monochrome"
 msgstr "Monochroom"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1057
 msgid "Polychrome"
 msgstr "Polychroom"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1071
 msgid "Production methods"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1072
 msgid "Process used to produce a manifestation."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1076
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:91
 msgid "Production method"
 msgstr "Productiemethode"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1103
 msgid "Blueline process"
 msgstr "Blueline process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1107
 msgid "Blueprint process"
 msgstr "Blueprint process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1111
 msgid "Collotype"
 msgstr "Collotype"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1115
 msgid "Daguerreotype process"
 msgstr "Daguerreotype process"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1119
 msgid "Engraving"
 msgstr "Engraving"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1123
 msgid "Etching"
 msgstr "Etching"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1127
 msgid "Lithography"
 msgstr "Lithografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1131
 msgid "Photocopying"
 msgstr "Fotokopiëren"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1135
 msgid "Photoengraving"
 msgstr "Fotogravure"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1139
 msgid "Printing"
 msgstr "Afdrukken"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1143
 msgid "White print process"
 msgstr "Witdrukproces"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1147
 msgid "Woodcut making"
 msgstr "Houtsnijwerk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1151
 msgid "Photogravure process"
 msgstr "Fotogravure proces"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1155
 msgid "Burning"
 msgstr "Verbranding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
 msgid "Inscribing"
 msgstr "Inschrijving"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1163
 msgid "Stamping"
 msgstr "Stempelen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1167
 msgid "Embossing"
 msgstr "Embossing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1171
 msgid "Solid dot"
 msgstr "Solid dot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1175
 msgid "Swell paper"
 msgstr "Zwelpapier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1179
 msgid "Thermoform"
 msgstr "Thermoform"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
 msgid "Bibliographic formats"
 msgstr "Bibliografisch formaten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1194
 msgid ""
 "A proportional relationship between a whole sheet in a printed or "
 "manuscript resource, and the individual leaves that result if that sheet "
 "is left full, cut, or folded."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1198
 msgid "Bibliographic format"
 msgstr "Bibliografisch formaat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:101
 msgid "Dimensions"
 msgstr "Afmetingen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1227
 msgid ""
 "Dimensions include measurements of height, width, depth, length, gauge, "
 "and diameter. For oblong volumes, record the height \\u00d7 width."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1235
 msgid "Example: 22 cm"
 msgstr "Voorbeeld: 22 cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1246
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:63
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1247
 msgid "Series and eventual subseries to which a resource belongs (MARC 490)."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1231
-msgid "Title of the series."
-msgstr "Titel van de serie."
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1241
-msgid "Example: vol. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1285
 msgid "Subseries statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1290
 msgid "Subseries"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1279
-msgid "Example: no. 3"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1350
 msgid "Type of note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1360
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:48
 msgid "Accompanying material"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1364
 msgid "General"
 msgstr "Algemeen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1368
 msgid "Other physical details"
 msgstr "Andere fysieke details"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1405
 msgid "Abstracts"
 msgstr "Abstracten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1406
 msgid "Abstract of the resource."
 msgstr "Abstract van de bron."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1410
 msgid "Abstract"
 msgstr "Abstract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1428
 msgid "Identifiers"
 msgstr "Identificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1493
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:107
 msgid "Identifier"
 msgstr "Identificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1477
 msgid "Audio issue number"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1481
 msgid "DOI"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1485
 msgid "EAN"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1489
 msgid "GTIN 14"
 msgstr "GTIN 14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1497
 msgid "ISAN"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1501
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1505
 msgid "ISMN"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1509
 msgid "ISRC"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1513
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1517
 msgid "ISSN-L"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1521
 msgid "Local"
 msgstr "Lokaal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1525
 msgid "Matrix number"
 msgstr "Matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1529
 msgid "Music distributor number"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
 msgid "Music plate"
 msgstr "Music plate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1537
 msgid "Music publisher number"
 msgstr "Music publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1541
 msgid "Publisher number"
 msgstr "Publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
 msgid "UPC"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1549
 msgid "URN"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1553
 msgid "Video recording number"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:101
 msgid "URI"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1567
 msgid "Identifier value"
 msgstr "Waarde van de identificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
 msgid "Identifier value."
 msgstr "Waarde van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
 msgid "Note of the identifier."
 msgstr "Nota van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
 msgid "Qualifier of the identifier."
 msgstr "Kwalificator van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1602
 msgid "Acquisition terms"
 msgstr "Aankoopvoorwaarden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1603
 msgid "Acquisition terms of the resource."
 msgstr "Aankoopvoorwaarden van de bron."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1613
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:147
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:106
 msgid "Source"
 msgstr "Bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1614
 msgid "Source of the identifier."
 msgstr "Bron van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:39
 msgid "Status"
 msgstr "Status"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1625
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status van de ISBN/ISSN-identificatiecode."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1657
 msgid "Subjects"
 msgstr "Onderwerpen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1658
 msgid "Subject of the resource."
 msgstr "Onderwerp van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1677
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr "Elektronische locaties"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1678
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informatie die nodig is om een elektronische bron te lokaliseren en te "
 "benaderen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1683
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr "Elektronische locatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1696
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1697
 msgid "Record a unique URL here."
 msgstr "Neem hier een unieke URL op."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1702
 msgid "Example: https://www.rero.ch/"
 msgstr "Voorbeeld: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1709
 msgid "Type of link"
 msgstr "Soort link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1721
 msgid "Resource"
 msgstr "Bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1725
 msgid "Version of resource"
 msgstr "Versie van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1729
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:129
 msgid "Related resource"
 msgstr "Verbonden bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1733
 msgid "Hidden URL"
 msgstr "Verborgen Url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1737
 msgid "No info"
 msgstr "Geen informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1747
 msgid "Content type"
 msgstr "Soort inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1748
 msgid "Is displayed as the text of the link."
 msgstr "Wordt weergegeven als de tekst van de link."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1783
 msgid "Poster"
 msgstr "Affiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1787
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1791
 msgid "Postcard"
 msgstr "Postkaart"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1795
 msgid "Addition"
 msgstr "Aanvulling"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1799
 msgid "Debriefing"
 msgstr "Debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1803
 msgid "Exhibition documentation"
 msgstr "Tentoonstellingsdocumentatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1807
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1811
 msgid "Bookplate"
 msgstr "Boekmerk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1815
 msgid "Extract"
 msgstr "Extract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1819
 msgid "Educational sheet"
 msgstr "Onderwijsformulier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1823
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:81
 msgid "Illustrations"
 msgstr "Illustraties"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1827
 msgid "Cover image"
 msgstr "Omslagafbeelding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1831
 msgid "Delivery information"
 msgstr "Leveringsinformatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1835
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Biografische informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1839
 msgid "Introduction/preface"
 msgstr "Introductie/voorwoord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1843
 msgid "Class reading"
 msgstr "Class reading"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1847
 msgid "Teacher's kit"
 msgstr "Educatief pakket"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1851
 msgid "Publisher's note"
 msgstr "uitgave opmerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1855
 msgid "Note on content"
 msgstr "Opmerking over de inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1859
 msgid "Title page"
 msgstr "titelpagina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1863
 msgid "Photography"
 msgstr "Fotografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
 msgid "Summarization"
 msgstr "Samenvatting"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1871
 msgid "Online resource via RERO DOC"
 msgstr "Online bron via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1875
 msgid "Press review"
 msgstr "Persoverzicht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1879
 msgid "Web site"
 msgstr "Website"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1883
 msgid "Table of contents"
 msgstr "Inhoudsopgave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1887
 msgid "Full text"
 msgstr "Integrale tekst"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
 msgid "Public notes"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1902
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1906
 msgid "Public note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1910
 msgid "Example: Access only from the library"
 msgstr "Voorbeeld: Toegang alleen vanuit de bibliotheek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1934
 msgid "Harvested"
 msgstr "Geoogst"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1935
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 "Document is geoogst of niet, zal de record editie of iets dergelijks "
 "uitschakelen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1942
 msgid "Language value"
 msgstr "Taalwaarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2434
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2438
 msgid "lang_abk"
 msgstr "Abchazisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2442
 msgid "lang_ace"
 msgstr "Atjehs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2446
 msgid "lang_ach"
 msgstr "Akoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2450
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2454
 msgid "lang_ady"
 msgstr "Adygees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2458
 msgid "lang_afa"
 msgstr "Afro-Aziatische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2462
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2466
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2470
 msgid "lang_ain"
 msgstr "Aino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2474
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2478
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2482
 msgid "lang_alb"
 msgstr "Albanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2486
 msgid "lang_ale"
 msgstr "Aleoetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2490
 msgid "lang_alg"
 msgstr "Algonkische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2494
 msgid "lang_alt"
 msgstr "Zuid-Altaïsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2498
 msgid "lang_amh"
 msgstr "Amhaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2502
 msgid "lang_ang"
 msgstr "Oudengels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2506
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2510
 msgid "lang_apa"
 msgstr "Na-Denétalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2514
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2518
 msgid "lang_arc"
 msgstr "Aramees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2522
 msgid "lang_arg"
 msgstr "Aragonees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2526
 msgid "lang_arm"
 msgstr "Armeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2530
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2534
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2538
 msgid "lang_art"
 msgstr "Kunsttalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2542
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2546
 msgid "lang_asm"
 msgstr "Assamees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2550
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2554
 msgid "lang_ath"
 msgstr "Athabaskische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2558
 msgid "lang_aus"
 msgstr "Australische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2562
 msgid "lang_ava"
 msgstr "Avarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2566
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2570
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2574
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2578
 msgid "lang_aze"
 msgstr "Azerbeidzjaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2582
 msgid "lang_bad"
 msgstr "Bandatalen (Centraal-Afrika)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2586
 msgid "lang_bai"
 msgstr "Bamileke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2590
 msgid "lang_bak"
 msgstr "Basjkiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2594
 msgid "lang_bal"
 msgstr "Beloetsji"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2598
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2602
 msgid "lang_ban"
 msgstr "Balinees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2606
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2610
 msgid "lang_bas"
 msgstr "Basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2614
 msgid "lang_bat"
 msgstr "Baltische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2618
 msgid "lang_bej"
 msgstr "Beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2622
 msgid "lang_bel"
 msgstr "Wit-Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2626
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2630
 msgid "lang_ben"
 msgstr "Bengaals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2634
 msgid "lang_ber"
 msgstr "Berber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2638
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2642
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2646
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2650
 msgid "lang_bin"
 msgstr "Bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2654
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2658
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2662
 msgid "lang_bnt"
 msgstr "Bantoetalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2666
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2670
 msgid "lang_bra"
 msgstr "Braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2674
 msgid "lang_bre"
 msgstr "Bretons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2678
 msgid "lang_btk"
 msgstr "Bataktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2682
 msgid "lang_bua"
 msgstr "Boerjatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2686
 msgid "lang_bug"
 msgstr "Buginees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2690
 msgid "lang_bul"
 msgstr "Bulgaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2694
 msgid "lang_bur"
 msgstr "Birmaans, Birmees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2698
 msgid "lang_byn"
 msgstr "Blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2702
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2706
 msgid "lang_cai"
 msgstr "Midden-Amerikaanse Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2710
 msgid "lang_car"
 msgstr "Caribisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2714
 msgid "lang_cat"
 msgstr "Catalaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2718
 msgid "lang_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2722
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2726
 msgid "lang_cel"
 msgstr "Keltische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2730
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2734
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2738
 msgid "lang_che"
 msgstr "Tsjetsjeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2742
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2746
 msgid "lang_chi"
 msgstr "Chinees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2750
 msgid "lang_chk"
 msgstr "Chuukees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2754
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2758
 msgid "lang_chn"
 msgstr "Chinook Jargon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2762
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2766
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2770
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2774
 msgid "lang_chu"
 msgstr "Kerkslavisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2778
 msgid "lang_chv"
 msgstr "Tsjoevasjisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2782
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2786
 msgid "lang_cmc"
 msgstr "Chamische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2790
 msgid "lang_cnr"
 msgstr "Montenegrijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2794
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2798
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2802
 msgid "lang_cos"
 msgstr "Corsicaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2806
 msgid "lang_cpe"
 msgstr "Engelse creoolse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2810
 msgid "lang_cpf"
 msgstr "Franse creoolse talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2814
 msgid "lang_cpp"
 msgstr "Portugese creoolse talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2818
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2822
 msgid "lang_crh"
 msgstr "Krim-Tataars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2826
 msgid "lang_crp"
 msgstr "Creools en Pidgin (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2830
 msgid "lang_csb"
 msgstr "Kasjoebisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2834
 msgid "lang_cus"
 msgstr "Koesjitische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2838
 msgid "lang_cze"
 msgstr "Tsjechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2842
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2846
 msgid "lang_dan"
 msgstr "Deens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2850
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2854
 msgid "lang_day"
 msgstr "Dajaktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2858
 msgid "lang_del"
 msgstr "Delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2862
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2866
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2870
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2874
 msgid "lang_div"
 msgstr "Divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2878
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2882
 msgid "lang_dra"
 msgstr "Dravidische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2886
 msgid "lang_dsb"
 msgstr "Nedersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2890
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2894
 msgid "lang_dum"
 msgstr "Middelnederlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2898
 msgid "lang_dut"
 msgstr "Nederlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2902
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2906
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2910
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2914
 msgid "lang_egy"
 msgstr "Oudegyptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2918
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2922
 msgid "lang_elx"
 msgstr "Elamitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2926
 msgid "lang_eng"
 msgstr "Engels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2930
 msgid "lang_enm"
 msgstr "Middelengels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2934
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2938
 msgid "lang_est"
 msgstr "Estisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2942
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2946
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2950
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2954
 msgid "lang_fao"
 msgstr "Faeröers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2958
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2962
 msgid "lang_fij"
 msgstr "Fijisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2966
 msgid "lang_fil"
 msgstr "Filipijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2970
 msgid "lang_fin"
 msgstr "Fins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2974
 msgid "lang_fiu"
 msgstr "Fins-Oegrische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2978
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2982
 msgid "lang_fre"
 msgstr "Frans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2986
 msgid "lang_frm"
 msgstr "Middelfrans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2990
 msgid "lang_fro"
 msgstr "Oudfrans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2994
 msgid "lang_frr"
 msgstr "Noord-Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2998
 msgid "lang_frs"
 msgstr "Oost-Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3002
 msgid "lang_fry"
 msgstr "Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3006
 msgid "lang_ful"
 msgstr "Fulah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3010
 msgid "lang_fur"
 msgstr "Friulisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3014
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3018
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3022
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3026
 msgid "lang_gem"
 msgstr "Germaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3030
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3034
 msgid "lang_ger"
 msgstr "Duits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3038
 msgid "lang_gez"
 msgstr "Ge’ez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3042
 msgid "lang_gil"
 msgstr "Gilbertees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3046
 msgid "lang_gla"
 msgstr "Schots-Gaelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3050
 msgid "lang_gle"
 msgstr "Iers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3054
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3058
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3062
 msgid "lang_gmh"
 msgstr "Middelhoogduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3066
 msgid "lang_goh"
 msgstr "Oudhoogduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3070
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3074
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3078
 msgid "lang_got"
 msgstr "Gothisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3082
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3086
 msgid "lang_grc"
 msgstr "Oudgrieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3090
 msgid "lang_gre"
 msgstr "Grieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3094
 msgid "lang_grn"
 msgstr "Guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3098
 msgid "lang_gsw"
 msgstr "Zwitserduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3102
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3106
 msgid "lang_gwi"
 msgstr "Gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3110
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3114
 msgid "lang_hat"
 msgstr "Haïtiaans Creools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3118
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3122
 msgid "lang_haw"
 msgstr "Hawaïaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3126
 msgid "lang_heb"
 msgstr "Hebreeuws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3130
 msgid "lang_her"
 msgstr "Herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3134
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3138
 msgid "lang_him"
 msgstr "Himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3142
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3146
 msgid "lang_hit"
 msgstr "Hettitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3150
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3154
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3158
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3162
 msgid "lang_hsb"
 msgstr "Oppersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3166
 msgid "lang_hun"
 msgstr "Hongaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3170
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3174
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3178
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3182
 msgid "lang_ice"
 msgstr "Ijslands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3186
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3190
 msgid "lang_iii"
 msgstr "Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3194
 msgid "lang_ijo"
 msgstr "Ijawtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3198
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3202
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3206
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3210
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3214
 msgid "lang_inc"
 msgstr "Indo-Arische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3218
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3222
 msgid "lang_ine"
 msgstr "Indo-Europese talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3226
 msgid "lang_inh"
 msgstr "Ingoesjetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3230
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3234
 msgid "lang_ira"
 msgstr "Iraanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3238
 msgid "lang_iro"
 msgstr "Irokese talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3242
 msgid "lang_ita"
 msgstr "Italiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3246
 msgid "lang_jav"
 msgstr "Javaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3250
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3254
 msgid "lang_jpn"
 msgstr "Japans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3258
 msgid "lang_jpr"
 msgstr "Judeo-Perzisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3262
 msgid "lang_jrb"
 msgstr "Judeo-Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3266
 msgid "lang_kaa"
 msgstr "Karakalpaks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3270
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3274
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3278
 msgid "lang_kal"
 msgstr "Groenlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3282
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3286
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3290
 msgid "lang_kar"
 msgstr "Karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3294
 msgid "lang_kas"
 msgstr "Kasjmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3298
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3302
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3306
 msgid "lang_kaz"
 msgstr "Kazachs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3310
 msgid "lang_kbd"
 msgstr "Kabardisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3314
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3318
 msgid "lang_khi"
 msgstr "Khoisantalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3322
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3326
 msgid "lang_kho"
 msgstr "Khotanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3330
 msgid "lang_kik"
 msgstr "Gikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3334
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3338
 msgid "lang_kir"
 msgstr "Kirgizisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3342
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3346
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3350
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3354
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3358
 msgid "lang_kor"
 msgstr "Koreaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3362
 msgid "lang_kos"
 msgstr "Kosraeaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3366
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3370
 msgid "lang_krc"
 msgstr "Karatsjaj-Balkarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3374
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3378
 msgid "lang_kro"
 msgstr "Krutalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3382
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3386
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3390
 msgid "lang_kum"
 msgstr "Koemuks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3394
 msgid "lang_kur"
 msgstr "Koerdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3398
 msgid "lang_kut"
 msgstr "Kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3402
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3406
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3410
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3414
 msgid "lang_lao"
 msgstr "Laotiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3418
 msgid "lang_lat"
 msgstr "Latijn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3422
 msgid "lang_lav"
 msgstr "Lets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3426
 msgid "lang_lez"
 msgstr "Lezgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3430
 msgid "lang_lim"
 msgstr "Limburgs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3434
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3438
 msgid "lang_lit"
 msgstr "Litouws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3442
 msgid "lang_lol"
 msgstr "Mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3446
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3450
 msgid "lang_ltz"
 msgstr "Luxemburgs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3454
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3458
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3462
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3466
 msgid "lang_lui"
 msgstr "Luiseno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3470
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3474
 msgid "lang_luo"
 msgstr "Luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3478
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3482
 msgid "lang_mac"
 msgstr "Macedonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3486
 msgid "lang_mad"
 msgstr "Madoerees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3490
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3494
 msgid "lang_mah"
 msgstr "Marshallees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3498
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3502
 msgid "lang_mak"
 msgstr "Makassaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3506
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3510
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3514
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3518
 msgid "lang_map"
 msgstr "Austronesische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3522
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3526
 msgid "lang_mas"
 msgstr "Maa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3530
 msgid "lang_may"
 msgstr "Maleis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3534
 msgid "lang_mdf"
 msgstr "Moksja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3538
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3542
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3546
 msgid "lang_mga"
 msgstr "Middeliers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3550
 msgid "lang_mic"
 msgstr "Mi’kmaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3554
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3558
 msgid "lang_mis"
 msgstr "niet gecodeerde talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3562
 msgid "lang_mkh"
 msgstr "Mon-Khmertalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3566
 msgid "lang_mlg"
 msgstr "Malagassisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3570
 msgid "lang_mlt"
 msgstr "Maltees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3574
 msgid "lang_mnc"
 msgstr "Mantsjoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3578
 msgid "lang_mni"
 msgstr "Meitei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3582
 msgid "lang_mno"
 msgstr "Manobotalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3586
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3590
 msgid "lang_mon"
 msgstr "Mongools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3594
 msgid "lang_mos"
 msgstr "Mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3598
 msgid "lang_mul"
 msgstr "Meerdere talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3602
 msgid "lang_mun"
 msgstr "Mundatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3606
 msgid "lang_mus"
 msgstr "Creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3610
 msgid "lang_mwl"
 msgstr "Mirandees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3614
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3618
 msgid "lang_myn"
 msgstr "Mayatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3622
 msgid "lang_myv"
 msgstr "Erzja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3626
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3630
 msgid "lang_nai"
 msgstr "Noord-Amerikaans Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3634
 msgid "lang_nap"
 msgstr "Napolitaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3638
 msgid "lang_nau"
 msgstr "Nauruaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3642
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3646
 msgid "lang_nbl"
 msgstr "Zuid-Ndbele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3650
 msgid "lang_nde"
 msgstr "Noord-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3654
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3658
 msgid "lang_nds"
 msgstr "Nedersaksisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3662
 msgid "lang_nep"
 msgstr "Nepalees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3666
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3670
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3674
 msgid "lang_nic"
 msgstr "Niger-Congotalen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3678
 msgid "lang_niu"
 msgstr "Niueaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3682
 msgid "lang_nno"
 msgstr "Noors - Nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3686
 msgid "lang_nob"
 msgstr "Noors - Bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3690
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3694
 msgid "lang_non"
 msgstr "Oudnoors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3698
 msgid "lang_nor"
 msgstr "Noors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3702
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3706
 msgid "lang_nso"
 msgstr "Noord-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3710
 msgid "lang_nub"
 msgstr "Nubisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3714
 msgid "lang_nwc"
 msgstr "Klassiek Nepalbhasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3718
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3722
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3726
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3730
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3734
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3738
 msgid "lang_oci"
 msgstr "Occitaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3742
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3746
 msgid "lang_ori"
 msgstr "Odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3750
 msgid "lang_orm"
 msgstr "Afaan Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3754
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3758
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3762
 msgid "lang_ota"
 msgstr "Ottomaans-Turks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3766
 msgid "lang_oto"
 msgstr "Otomi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3770
 msgid "lang_paa"
 msgstr "Papoeatalen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3774
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3778
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3782
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3786
 msgid "lang_pan"
 msgstr "Punjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3790
 msgid "lang_pap"
 msgstr "Papiaments"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3794
 msgid "lang_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3798
 msgid "lang_peo"
 msgstr "Oudperzisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3802
 msgid "lang_per"
 msgstr "Perzisch (Farsi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3806
 msgid "lang_phi"
 msgstr "Filipijns (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3810
 msgid "lang_phn"
 msgstr "Foenicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3814
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3818
 msgid "lang_pol"
 msgstr "Pools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3822
 msgid "lang_pon"
 msgstr "Pohnpeiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3826
 msgid "lang_por"
 msgstr "Portugees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3830
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3834
 msgid "lang_pro"
 msgstr "Oudprovençaals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3838
 msgid "lang_pus"
 msgstr "Pasjtoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3842
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3846
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3850
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3854
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3858
 msgid "lang_roa"
 msgstr "Romaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3862
 msgid "lang_roh"
 msgstr "Reto-Romaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3866
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3870
 msgid "lang_rum"
 msgstr "Roemeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3874
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3878
 msgid "lang_rup"
 msgstr "Aroemeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3882
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3886
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3890
 msgid "lang_sag"
 msgstr "Sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3894
 msgid "lang_sah"
 msgstr "Jakoets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3898
 msgid "lang_sai"
 msgstr "Zuid-Amerikaanse Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3902
 msgid "lang_sal"
 msgstr "Salishtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3906
 msgid "lang_sam"
 msgstr "Samaritaans-Aramees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3910
 msgid "lang_san"
 msgstr "Sanskriet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3914
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3918
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3922
 msgid "lang_scn"
 msgstr "Siciliaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3926
 msgid "lang_sco"
 msgstr "Schots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3930
 msgid "lang_sel"
 msgstr "Selkoeps"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3934
 msgid "lang_sem"
 msgstr "Semitische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3938
 msgid "lang_sga"
 msgstr "Oudiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3942
 msgid "lang_sgn"
 msgstr "Gebarentalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3946
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3950
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3954
 msgid "lang_sin"
 msgstr "Singalees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3958
 msgid "lang_sio"
 msgstr "Sioux-Catawbatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3962
 msgid "lang_sit"
 msgstr "Sino-Tibetaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3966
 msgid "lang_sla"
 msgstr "Slavische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3970
 msgid "lang_slo"
 msgstr "Slowaaks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3974
 msgid "lang_slv"
 msgstr "Sloveens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3978
 msgid "lang_sma"
 msgstr "Zuid-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3982
 msgid "lang_sme"
 msgstr "Noord-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3986
 msgid "lang_smi"
 msgstr "Samisch (Laps)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3990
 msgid "lang_smj"
 msgstr "Lule-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3994
 msgid "lang_smn"
 msgstr "Inari-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3998
 msgid "lang_smo"
 msgstr "Samoaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4002
 msgid "lang_sms"
 msgstr "Skolt-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4006
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4010
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4014
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4018
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4022
 msgid "lang_som"
 msgstr "Somalisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4026
 msgid "lang_son"
 msgstr "Songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4030
 msgid "lang_sot"
 msgstr "Zuid-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4034
 msgid "lang_spa"
 msgstr "Spaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4038
 msgid "lang_srd"
 msgstr "Sardijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4042
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4046
 msgid "lang_srp"
 msgstr "Servisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4050
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4054
 msgid "lang_ssa"
 msgstr "Nilo-Saharaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4058
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4062
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4066
 msgid "lang_sun"
 msgstr "Soendanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4070
 msgid "lang_sus"
 msgstr "Soesoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4074
 msgid "lang_sux"
 msgstr "Soemerisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4078
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4082
 msgid "lang_swe"
 msgstr "Zweeds"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4086
 msgid "lang_syc"
 msgstr "Klassiek Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4090
 msgid "lang_syr"
 msgstr "Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4094
 msgid "lang_tah"
 msgstr "Tahitiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4098
 msgid "lang_tai"
 msgstr "Taitalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4102
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4106
 msgid "lang_tat"
 msgstr "Tataars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4110
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4114
 msgid "lang_tem"
 msgstr "Timne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4118
 msgid "lang_ter"
 msgstr "Tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4122
 msgid "lang_tet"
 msgstr "Tetun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4126
 msgid "lang_tgk"
 msgstr "Tadzjieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4130
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4134
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4138
 msgid "lang_tib"
 msgstr "Tibetaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4142
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4146
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4150
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4154
 msgid "lang_tkl"
 msgstr "Tokelaus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4158
 msgid "lang_tlh"
 msgstr "Klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4162
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4166
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4170
 msgid "lang_tog"
 msgstr "Nyasa Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4174
 msgid "lang_ton"
 msgstr "Tongaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4178
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4182
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4186
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4190
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4194
 msgid "lang_tuk"
 msgstr "Turkmeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4198
 msgid "lang_tum"
 msgstr "Toemboeka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4202
 msgid "lang_tup"
 msgstr "Tupi-talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4206
 msgid "lang_tur"
 msgstr "Turks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4210
 msgid "lang_tut"
 msgstr "Altaïsche talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4214
 msgid "lang_tvl"
 msgstr "Tuvaluaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4218
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4222
 msgid "lang_tyv"
 msgstr "Toevaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4226
 msgid "lang_udm"
 msgstr "Oedmoerts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4230
 msgid "lang_uga"
 msgstr "Oegaritisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4234
 msgid "lang_uig"
 msgstr "Oeigoers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4238
 msgid "lang_ukr"
 msgstr "Oekraïens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4242
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4246
 msgid "lang_und"
 msgstr "onbekende taal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4250
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4254
 msgid "lang_uzb"
 msgstr "Oezbeeks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4258
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4262
 msgid "lang_ven"
 msgstr "Venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4266
 msgid "lang_vie"
 msgstr "Vietnamees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4270
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4274
 msgid "lang_vot"
 msgstr "Votisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4278
 msgid "lang_wak"
 msgstr "Wakashtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4282
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4286
 msgid "lang_war"
 msgstr "Waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4290
 msgid "lang_was"
 msgstr "Washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4294
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4298
 msgid "lang_wen"
 msgstr "Sorbische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4302
 msgid "lang_wln"
 msgstr "Waals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4306
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4310
 msgid "lang_xal"
 msgstr "Kalmuks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4314
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4318
 msgid "lang_yao"
 msgstr "Yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4322
 msgid "lang_yap"
 msgstr "Yapees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4326
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4330
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4334
 msgid "lang_ypk"
 msgstr "Yupiktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4338
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4342
 msgid "lang_zbl"
 msgstr "Blissymbolen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4346
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4350
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4354
 msgid "lang_znd"
 msgstr "Zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4358
 msgid "lang_zul"
 msgstr "Zoeloe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4362
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4366
 msgid "lang_zxx"
 msgstr "geen linguïstische inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4370
 msgid "lang_zza"
 msgstr "Zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4504
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:387
 msgid "Values"
 msgstr "Waarden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4520
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:392
 msgid "Value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4492
+msgid "Example: vol.3"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4536
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Land"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4925
 msgid "country_aa"
 msgstr "Albanië (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4929
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4933
 msgid "country_ac"
 msgstr "Ashmore- en Cartier-eilanden (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4937
 msgid "country_aca"
 msgstr "Australian Capital Territory (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4941
 msgid "country_ae"
 msgstr "Algerije (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4945
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4949
 msgid "country_ag"
 msgstr "Argentinië (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4953
 msgid "country_ai"
 msgstr "Armenië (Republiek) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4957
 msgid "country_air"
 msgstr "Armeense S.S.R. (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4961
 msgid "country_aj"
 msgstr "Azerbeidzjan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4965
 msgid "country_ajr"
 msgstr "Azerbeidzjan S.S.R. (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4969
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4973
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4977
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4981
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4985
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4989
 msgid "country_aq"
 msgstr "Antigua en Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4993
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4997
 msgid "country_as"
 msgstr "Amerikaans-Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5001
 msgid "country_at"
 msgstr "Australië (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5005
 msgid "country_au"
 msgstr "Oostenrijk (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5009
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5013
 msgid "country_ay"
 msgstr "Antarctica (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5017
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5021
 msgid "country_ba"
 msgstr "Bahrein (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5025
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5029
 msgid "country_bcc"
 msgstr "British Columbia (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5033
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5037
 msgid "country_be"
 msgstr "België (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5041
 msgid "country_bf"
 msgstr "Bahama’s (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5045
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5049
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5053
 msgid "country_bi"
 msgstr "Brits Indische Oceaanterritorium (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5057
 msgid "country_bl"
 msgstr "Brazilië (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5061
 msgid "country_bm"
 msgstr "Bermuda Islands (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5065
 msgid "country_bn"
 msgstr "Bosnië en Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5069
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5073
 msgid "country_bp"
 msgstr "Salomonseilanden (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5077
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5081
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5085
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5089
 msgid "country_bu"
 msgstr "Bulgarije (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5093
 msgid "country_bv"
 msgstr "Bouveteiland (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5097
 msgid "country_bw"
 msgstr "Belarus (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5101
 msgid "country_bwr"
 msgstr "Wit-Russische S.S.R. (-bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5105
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5109
 msgid "country_ca"
 msgstr "Caribisch Nederland (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5113
 msgid "country_cau"
 msgstr "Californië (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5117
 msgid "country_cb"
 msgstr "Cambodja (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5121
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5125
 msgid "country_cd"
 msgstr "Tsjaad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5129
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5133
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5137
 msgid "country_cg"
 msgstr "Congo (Democratische Republiek) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5141
 msgid "country_ch"
 msgstr "China (Republiek: 1949-) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5145
 msgid "country_ci"
 msgstr "Kroatië (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5149
 msgid "country_cj"
 msgstr "Kaaimaneilanden (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5153
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5157
 msgid "country_cl"
 msgstr "Chili (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5161
 msgid "country_cm"
 msgstr "Kameroen (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5165
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5169
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5173
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5177
 msgid "country_cp"
 msgstr "Canton en Enderbury Islands (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5181
 msgid "country_cq"
 msgstr "Comoren (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5185
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5189
 msgid "country_cs"
 msgstr "Tsjecho-Slowakije (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5193
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5197
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5201
 msgid "country_cv"
 msgstr "Kaapverdië (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5205
 msgid "country_cw"
 msgstr "Cookeilanden (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5209
 msgid "country_cx"
 msgstr "Centraal-Afrikaanse Republiek (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5213
 msgid "country_cy"
 msgstr "Cyprus (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5217
 msgid "country_cz"
 msgstr "[Canal Zone] (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5221
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5225
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5229
 msgid "country_dk"
 msgstr "Denemarken (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5233
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5237
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5241
 msgid "country_dr"
 msgstr "Dominicaanse Republiek (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5245
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5249
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5253
 msgid "country_eg"
 msgstr "Equatoriaal-Guinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5257
 msgid "country_em"
 msgstr "Oost-Timor (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5261
 msgid "country_enk"
 msgstr "[England] (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5265
 msgid "country_er"
 msgstr "Estland (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5269
 msgid "country_err"
 msgstr "Estland (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5273
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5277
 msgid "country_et"
 msgstr "Ethiopië (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5281
 msgid "country_fa"
 msgstr "Faeröer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5285
 msgid "country_fg"
 msgstr "Frans-Guyana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5289
 msgid "country_fi"
 msgstr "Finland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5293
 msgid "country_fj"
 msgstr "Fiji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5297
 msgid "country_fk"
 msgstr "Falkland Islands (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5301
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5305
 msgid "country_fm"
 msgstr "Micronesië (Federale Staten) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5309
 msgid "country_fp"
 msgstr "Frans-Polynesië (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5313
 msgid "country_fr"
 msgstr "Frankrijk (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5317
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5321
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5325
 msgid "country_gau"
 msgstr "Georgië (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5329
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5333
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5337
 msgid "country_ge"
 msgstr "Duitsland (Oost) (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5341
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5345
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5349
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5353
 msgid "country_gl"
 msgstr "Groenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5357
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5361
 msgid "country_gn"
 msgstr "Gilbert and Ellice Islands (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5365
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5369
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5373
 msgid "country_gr"
 msgstr "Griekenland (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5377
 msgid "country_gs"
 msgstr "Georgië (Republiek) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5381
 msgid "country_gsr"
 msgstr "Georgian S.S.R. (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5385
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5389
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5393
 msgid "country_gv"
 msgstr "Guinee (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5397
 msgid "country_gw"
 msgstr "Duitsland (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5401
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5405
 msgid "country_gz"
 msgstr "Gaza Strip (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5409
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5413
 msgid "country_hk"
 msgstr "Hongkong SAR van China (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5417
 msgid "country_hm"
 msgstr "Heard and McDonald Islands (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5421
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5425
 msgid "country_ht"
 msgstr "Haïti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5429
 msgid "country_hu"
 msgstr "Hongarije (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5433
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5437
 msgid "country_ic"
 msgstr "IJsland (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5441
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5445
 msgid "country_ie"
 msgstr "Ierland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5449
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5453
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5457
 msgid "country_im"
 msgstr "Isle of Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5461
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5465
 msgid "country_io"
 msgstr "Indonesië (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5469
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5473
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5477
 msgid "country_is"
 msgstr "Israël (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5481
 msgid "country_it"
 msgstr "Italië (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5485
 msgid "country_iu"
 msgstr "Gedemilitariseerde zones Israël-Syrië (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5489
 msgid "country_iv"
 msgstr "Ivoorkust (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5493
 msgid "country_iw"
 msgstr "Gedemilitariseerde zones Israël-Jordanië (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5497
 msgid "country_iy"
 msgstr "Irak-Saoedi-Arabië Neutrale zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5501
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5505
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5509
 msgid "country_ji"
 msgstr "Johnston Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5513
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5517
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5521
 msgid "country_jo"
 msgstr "Jordanië (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5525
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5529
 msgid "country_kg"
 msgstr "Kirgizië (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5533
 msgid "country_kgr"
 msgstr "Kirghiz S.S.R. (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5537
 msgid "country_kn"
 msgstr "Korea (Noord) (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5541
 msgid "country_ko"
 msgstr "Zuid Korea (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5545
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5549
 msgid "country_ku"
 msgstr "Koeweit (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5553
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5557
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5561
 msgid "country_kz"
 msgstr "Kazachstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5565
 msgid "country_kzr"
 msgstr "Kazakh S.S.R. (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5569
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5573
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5577
 msgid "country_le"
 msgstr "Libanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5581
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5585
 msgid "country_li"
 msgstr "Litouwen (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5589
 msgid "country_lir"
 msgstr "Litouwen (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5593
 msgid "country_ln"
 msgstr "Central and Southern Line Islands (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5597
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5601
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5605
 msgid "country_lu"
 msgstr "Luxemburg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5609
 msgid "country_lv"
 msgstr "Letland (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5613
 msgid "country_lvr"
 msgstr "Letland (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5617
 msgid "country_ly"
 msgstr "Libië (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5621
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5625
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5629
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5633
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5637
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5641
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5645
 msgid "country_mg"
 msgstr "Madagaskar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5649
 msgid "country_mh"
 msgstr "Macau SAR van China (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5653
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5657
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5661
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5665
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5669
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5673
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5677
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5681
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5685
 msgid "country_mp"
 msgstr "Mongolië (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5689
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5693
 msgid "country_mr"
 msgstr "Marokko (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5697
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5701
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5705
 msgid "country_mu"
 msgstr "Mauritanië (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5709
 msgid "country_mv"
 msgstr "Moldavië (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5713
 msgid "country_mvr"
 msgstr "Moldavian S.S.R. (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5717
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5721
 msgid "country_mx"
 msgstr "Mexico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5725
 msgid "country_my"
 msgstr "Maleisië (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5729
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5733
 msgid "country_na"
 msgstr "Nederlandse Antillen (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5737
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5741
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5745
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5749
 msgid "country_ne"
 msgstr "Nederland (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5753
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5757
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5761
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5765
 msgid "country_nik"
 msgstr "Noord-Ierland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5769
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5773
 msgid "country_nkc"
 msgstr "New Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5777
 msgid "country_nl"
 msgstr "Nieuw-Caledonië (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5781
 msgid "country_nm"
 msgstr "Noordelijke Marianen (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5785
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5789
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5793
 msgid "country_no"
 msgstr "Noorwegen (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5797
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5801
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5805
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5809
 msgid "country_nsc"
 msgstr "Nova Scotia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5813
 msgid "country_ntc"
 msgstr "Northwest Territories (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5817
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5821
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5825
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5829
 msgid "country_nw"
 msgstr "Noordelijke Marianen (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5833
 msgid "country_nx"
 msgstr "Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5837
 msgid "country_nyu"
 msgstr "New York (Staat) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5841
 msgid "country_nz"
 msgstr "Nieuw-Zeeland (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5845
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5849
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5853
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5857
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5861
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5865
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5869
 msgid "country_pc"
 msgstr "Pitcairn Island (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5873
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5877
 msgid "country_pf"
 msgstr "Paracel Islands (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5881
 msgid "country_pg"
 msgstr "Guinee-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5885
 msgid "country_ph"
 msgstr "Filipijnen (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5889
 msgid "country_pic"
 msgstr "Prince Edward Island (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5893
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5897
 msgid "country_pl"
 msgstr "Polen (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5901
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5905
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5909
 msgid "country_pp"
 msgstr "Papoea-Nieuw-Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5913
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5917
 msgid "country_pt"
 msgstr "Portugees Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5921
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5925
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5929
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5933
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5937
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5941
 msgid "country_rb"
 msgstr "Servië (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5945
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5949
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5953
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5957
 msgid "country_rm"
 msgstr "Roemenië (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5961
 msgid "country_ru"
 msgstr "Rusland (Federatie) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5965
 msgid "country_rur"
 msgstr "Russische S.F.S.R. (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5969
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5973
 msgid "country_ry"
 msgstr "Ryukyu Islands, Southern (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5977
 msgid "country_sa"
 msgstr "Zuid-Afrika (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5981
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5985
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5989
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5993
 msgid "country_sd"
 msgstr "Zuid-Soedan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5997
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6001
 msgid "country_se"
 msgstr "Seychellen (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6005
 msgid "country_sf"
 msgstr "Sao Tomé en Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6009
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6013
 msgid "country_sh"
 msgstr "Spaans Noord-Afrika (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6017
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6021
 msgid "country_sj"
 msgstr "Soedan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6025
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6029
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6033
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6037
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6041
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6045
 msgid "country_so"
 msgstr "Somalië (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6049
 msgid "country_sp"
 msgstr "Spanje (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6053
 msgid "country_sq"
 msgstr "eSwatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6057
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6061
 msgid "country_ss"
 msgstr "Westelijke Sahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6065
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6069
 msgid "country_stk"
 msgstr "Schotland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6073
 msgid "country_su"
 msgstr "Saoedi-Arabië (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6077
 msgid "country_sv"
 msgstr "Swan Islands (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6081
 msgid "country_sw"
 msgstr "Zweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6085
 msgid "country_sx"
 msgstr "Namibië (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6089
 msgid "country_sy"
 msgstr "[Syria] (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6093
 msgid "country_sz"
 msgstr "Zwitserland (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6097
 msgid "country_ta"
 msgstr "Tadzjikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6101
 msgid "country_tar"
 msgstr "Tajik S.S.R. (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6105
 msgid "country_tc"
 msgstr "Turks- en Caicoseilanden (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6109
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6113
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6117
 msgid "country_ti"
 msgstr "Tunesië (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6121
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6125
 msgid "country_tkr"
 msgstr "Turkmen S.S.R. (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6129
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6133
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6137
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6141
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6145
 msgid "country_tr"
 msgstr "Trinidad en Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6149
 msgid "country_ts"
 msgstr "Verenigde Arabische Emiraten (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6153
 msgid "country_tt"
 msgstr "Trust Territory of the Pacific Islands (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6157
 msgid "country_tu"
 msgstr "Turkije (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6161
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6165
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6169
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6173
 msgid "country_ua"
 msgstr "Egypte (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6177
 msgid "country_uc"
 msgstr "Verenigde Staten Misc. Caribbean Islands (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6181
 msgid "country_ug"
 msgstr "Oeganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6185
 msgid "country_ui"
 msgstr "Verenigd Koninkrijk Misc. Islands (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6189
 msgid "country_uik"
 msgstr "Verenigd Koninkrijk Misc. Islands (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6193
 msgid "country_uk"
 msgstr "Verenigd Koninkrijk (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6197
 msgid "country_un"
 msgstr "Oekraïne (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6201
 msgid "country_unr"
 msgstr "Oekraïne (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6205
 msgid "country_up"
 msgstr "Verenigde Staten Misc. Pacific Islands (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6209
 msgid "country_ur"
 msgstr "Sovjet-Unie (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6213
 msgid "country_us"
 msgstr "Verenigde Staten (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6217
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6221
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6225
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6229
 msgid "country_uz"
 msgstr "Oezbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6233
 msgid "country_uzr"
 msgstr "Uzbek S.S.R. (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6237
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6241
 msgid "country_vb"
 msgstr "Britse Maagdeneilanden (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6245
 msgid "country_vc"
 msgstr "Vaticaanstad (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6249
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6253
 msgid "country_vi"
 msgstr "Amerikaanse Maagdeneilanden (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6257
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6261
 msgid "country_vn"
 msgstr "Vietnam, Noord (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6265
 msgid "country_vp"
 msgstr "[Verschillende plaatsen] (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6269
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6273
 msgid "country_vs"
 msgstr "Vietnam, Zuid (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6277
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6281
 msgid "country_wau"
 msgstr "Washington (Staat) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6285
 msgid "country_wb"
 msgstr "West Berlijn (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6289
 msgid "country_wea"
 msgstr "Western Australia (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6293
 msgid "country_wf"
 msgstr "Wallis en Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6297
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6301
 msgid "country_wj"
 msgstr "Westelijke Jordaanoever (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6305
 msgid "country_wk"
 msgstr "Wake Island (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6309
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6313
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6317
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6321
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6325
 msgid "country_xa"
 msgstr "Christmas Island (Indian Ocean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6329
 msgid "country_xb"
 msgstr "Cocoseilanden (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6333
 msgid "country_xc"
 msgstr "Maldiven (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6337
 msgid "country_xd"
 msgstr "Saint Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6341
 msgid "country_xe"
 msgstr "Marshalleilanden (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6345
 msgid "country_xf"
 msgstr "Midway Islands (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6349
 msgid "country_xga"
 msgstr "Coral Sea Islands Territory (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6353
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6357
 msgid "country_xi"
 msgstr "Saint Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6361
 msgid "country_xj"
 msgstr "Saint Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6365
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6369
 msgid "country_xl"
 msgstr "Saint-Pierre en Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6373
 msgid "country_xm"
 msgstr "Saint Vincent en de Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6377
 msgid "country_xn"
 msgstr "Noord-Macedonië (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6381
 msgid "country_xna"
 msgstr "New South Wales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6385
 msgid "country_xo"
 msgstr "Slowakije (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6389
 msgid "country_xoa"
 msgstr "Northern Territory (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
 msgid "country_xp"
 msgstr "Spratly Island (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6397
 msgid "country_xr"
 msgstr "Tsjechië (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6401
 msgid "country_xra"
 msgstr "Zuid Australië (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6405
 msgid "country_xs"
 msgstr "Zuid-Georgia en Zuidelijke Sandwicheilanden (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6409
 msgid "country_xv"
 msgstr "Slovenië (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6413
 msgid "country_xx"
 msgstr "Geen plaats, onbekend of onbepaald (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6417
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6421
 msgid "country_xxk"
 msgstr "Verenigd Koninkrijk (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6425
 msgid "country_xxr"
 msgstr "Sovjet-Unie (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6429
 msgid "country_xxu"
 msgstr "Verenigde Staten (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6433
 msgid "country_ye"
 msgstr "Jemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6437
 msgid "country_ykc"
 msgstr "Yukon-gebied (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6441
 msgid "country_ys"
 msgstr "Jemen (Democratische Volksrepubliek) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6445
 msgid "country_yu"
 msgstr "Servië en Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6449
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6459
 msgid "Cantons"
 msgstr "Kantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6492
 msgid "canton_ag"
 msgstr "Aargau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6496
 msgid "canton_ai"
 msgstr "Appenzell Innerrhoden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6500
 msgid "canton_ar"
 msgstr "Appenzell Ausserrhoden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6504
 msgid "canton_be"
 msgstr "Bern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6508
 msgid "canton_bl"
 msgstr "Basel-Landschaft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6512
 msgid "canton_bs"
 msgstr "Basel-Stadt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6516
 msgid "canton_fr"
 msgstr "Fribourg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6520
 msgid "canton_ge"
 msgstr "Genève"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6524
 msgid "canton_gl"
 msgstr "Glarus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6528
 msgid "canton_gr"
 msgstr "Graubünden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6532
 msgid "canton_ju"
 msgstr "Jura"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6536
 msgid "canton_lu"
 msgstr "Luzern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6540
 msgid "canton_ne"
 msgstr "Neuchâtel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6544
 msgid "canton_nw"
 msgstr "Nidwalden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6548
 msgid "canton_ow"
 msgstr "Obwalden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6552
 msgid "canton_sg"
 msgstr "Sankt Gallen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6556
 msgid "canton_sh"
 msgstr "Schaffhausen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6560
 msgid "canton_so"
 msgstr "Solothurn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6564
 msgid "canton_sz"
 msgstr "Schwyz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6568
 msgid "canton_tg"
 msgstr "Thurgau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6572
 msgid "canton_ti"
 msgstr "Ticino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6576
 msgid "canton_ur"
 msgstr "Uri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6580
 msgid "canton_vd"
 msgstr "Vaud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6584
 msgid "canton_vs"
 msgstr "Valais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6588
 msgid "canton_zg"
 msgstr "Zug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:6592
 msgid "canton_zh"
 msgstr "Zürich"
 
@@ -6033,10 +6051,6 @@ msgstr ""
 msgid "Item Type URI"
 msgstr "Type van exemplaar URI"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:132
-msgid "Issue"
-msgstr ""
-
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:151
 msgid "Issue status"
 msgstr ""
@@ -6273,11 +6287,11 @@ msgstr ""
 "De naam van de actie die de overgang naar de huidige toestand in gang "
 "heeft gezet."
 
-#: rero_ils/modules/locations/api.py:76
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Een andere online locatie bestaat in deze bibliotheek"
 
-#: rero_ils/modules/locations/api.py:79
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 
@@ -7219,3 +7233,16 @@ msgstr "is verwijderd."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Klik hier om uw wachtwoord opnieuw in te stellen"
+
+#~ msgid "Examples: 135, 5-27, ..."
+#~ msgstr ""
+
+#~ msgid "Title of the series."
+#~ msgstr "Titel van de serie."
+
+#~ msgid "Example: vol. 3"
+#~ msgstr ""
+
+#~ msgid "Example: no. 3"
+#~ msgstr ""
+


### PR DESCRIPTION
* Applies PO's group feedback:
* Removes useless description.
* Adds missing placeholders.
* Corrects some fields display and validation.
* Adds strings to translate.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To apply some corrections:

* `seriesStatement.seriesTitle` should have no description; it is useless
* Placeholders for `seriesEnumeration` and `subseriesEnumeration` are missing.
* When editing a document with a series statement, the editor opens by default the subseries statement, which makes it impossible to save the document.
    * The subseries statement should always be added manually (except when it already contains data), as it is quite rare.
    * By default, fields `seriesTitle` and `seriesEnumeration` should be displayed inside `seriesStatement`.

* Format validation for `partOf`
    * when the data entered in `numbering.pages` does not respects the pattern, there should be a validation message: "Should be in the following format: 135 or 5-27". Same for year

* The main type of modeOfIssuance is displayed as a code in the pro detailed view; there should be a human translation.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
