### PR TITLE
circulation: ensure request validation from ui

### DIFF
--- a/doc/circulation/actions.md
+++ b/doc/circulation/actions.md
@@ -144,6 +144,11 @@
 
 ## Manual validate
 
+#### required_parameters:
+    pid (loan pid)
+    transaction_location_pid or transaction_library_pid,
+    transaction_user_pid
+
 1. :100:__VALIDATE_1__: item on_shelf (no current loan)
 	1. __VALIDATE_1_1__: PENDING loan does not exist →  (validate not possible)
 	1. :white_check_mark: :white_check_mark: :white_check_mark: __VALIDATE_1_2__: PENDING loan exists

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -101,7 +101,6 @@ def do_jsonify_action(func):
                 # from a given loan pid parameter
                 item_pid = Loan.get_record_by_pid(loan_pid).item_pid
                 item = Item.get_record_by_pid(item_pid)
-
             if not item:
                 abort(404)
             item_data, action_applied = \
@@ -278,13 +277,16 @@ def lose(item, params):
     return item.lose()
 
 
-@api_blueprint.route('/validate', methods=['POST'])
+@api_blueprint.route('/validate_request', methods=['POST'])
 @check_authentication
-@jsonify_action
+@do_jsonify_action
 def validate_request(item, data):
-    """HTTP request for Item request validation action..
+    """HTTP GET request for Item request validation action.
 
-    required_parameters: item_pid
+    required_parameters:
+        pid (loan pid)
+        transaction_location_pid or transaction_library_pid,
+        transaction_user_pid
     """
     return item.validate_request(**data)
 

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -127,7 +127,8 @@ class Loan(IlsRecord):
                 'pid'
             ],
             'cancel_loan': [],
-            'checkin': []
+            'checkin': [],
+            'validate_request': []
         }
 
         return params.get(action) + shared_params

--- a/tests/api/circulation/test_actions_views_validate_request.py
+++ b/tests/api/circulation/test_actions_views_validate_request.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST validate item request API methods in the item api_views."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import postdata
+
+from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
+    get_last_transaction_loc_for_item, get_loans_by_patron_pid
+
+
+def test_validate_item_request(
+        client, librarian_martigny_no_email, lib_martigny,
+        item2_on_shelf_martigny_patron_and_loan_pending,
+        item_on_shelf_martigny_patron_and_loan_pending, loc_public_martigny,
+        circulation_policies):
+    """Test the frontend validate an item request action."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
+
+    # test fails when there is a missing required parameter
+    res, data = postdata(
+        client,
+        'api_item.validate_request',
+        dict(
+            pid=loan.pid
+        )
+    )
+    assert res.status_code == 400
+
+    # test fails when there is a missing required parameter
+    res, data = postdata(
+        client,
+        'api_item.validate_request',
+        dict(
+            pid=loan.pid,
+            transaction_location_pid=loc_public_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+
+    # test fails when there is a missing required parameter
+    res, data = postdata(
+        client,
+        'api_item.validate_request',
+        dict(
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 400
+
+    # test passes when the transaction location pid is given
+    res, data = postdata(
+        client,
+        'api_item.validate_request',
+        dict(
+            pid=loan.pid,
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 200
+
+    # test passes when the transaction library pid is given
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item, patron, loan = item2_on_shelf_martigny_patron_and_loan_pending
+    res, data = postdata(
+        client,
+        'api_item.validate_request',
+        dict(
+            pid=loan.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 200

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -237,7 +237,9 @@ def test_item_holding_document_availability(
         'api_item.validate_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            pid=loan_pid
+            pid=loan_pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -275,7 +275,9 @@ def test_checkout_item_transit(client, item2_lib_martigny,
         'api_item.validate_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            pid=loan_pid
+            pid=loan_pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200


### PR DESCRIPTION
Replaces the api call /validate by /validate_request.

Users have now the choice to give one of the transaction_location_pid
or transaction_library_pid when placing a request.

The validate action of item request is now possible from the item views.
The list of required parameters are clearly noted for frontend calls in
the actions.md and api_views.

* Creates additional units testing for frontend calls.

Co-Authored-by: Aly Badr<aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
