### PR TITLE
document: translate document type in detail view

### DIFF
--- a/rero_ils/manual_translations.txt
+++ b/rero_ils/manual_translations.txt
@@ -30,6 +30,7 @@ _('journal')
 _('score')
 _('sound')
 _('video')
+_('other')
 
 _('gnd')
 _('bnf')

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -6,12 +6,11 @@
 # Translators:
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Aly Badr <aly.badr@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -49,56 +48,56 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "مرحباً بك في RERO-ILS"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "تصنبف المستند"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "الشبكة"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "المكتبة"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "اللغة"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "الموضوع"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "الحالة"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "مهام"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "الميزانية"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "المصادر"
 
@@ -167,67 +166,71 @@ msgstr "صوت"
 msgid "video"
 msgstr "فيديو"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "gnd"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "bnf"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "rero"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "الانجليزية"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "الفرنسية"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "الالمانية"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "الايطالية"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "نشر"
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "تصنيع"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "توزيع"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "إنتاج"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "مكان"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "ebibliomedia"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "mv-cantook"
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -12,12 +12,11 @@
 # Peter Weber <peter.weber@rero.ch>, 2020
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: de\n"
@@ -54,56 +53,56 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Willkommen zu RERO ILS!"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "Dokumenttyp"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "Bibliothek"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "Autor"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "Autor"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "Autor"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "Autor"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "Sprache"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "Schlagwort"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "Status"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "Rollen"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "Budget"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "Quellen"
 
@@ -172,67 +171,71 @@ msgstr "Ton"
 msgid "video"
 msgstr "Film"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "GND"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "BNF"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "RERO"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr "IdRef"
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "English"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "Français"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "Deutsch"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "Italiano"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "Veröffentlichung"
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "Herstellung"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "Vertrieb"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "Entstehung"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "Ort"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "Zugriff"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "Zugriff"
 

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -13,12 +13,11 @@
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
 # Pascal Repond <pascalr.92@gmail.com>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Pascal Repond <pascalr.92@gmail.com>, 2020\n"
 "Language: en\n"
@@ -55,56 +54,56 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Welcome to RERO-ILS!"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "document type"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "library"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "author"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "author"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "author"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "author"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "language"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "subject"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "roles"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "sources"
 
@@ -173,67 +172,71 @@ msgstr "sound"
 msgid "video"
 msgstr "video"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr "other"
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "GND"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "BNF"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "RERO"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr "IdRef"
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "English"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "Français"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "Deutsch"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "Italiano"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "Publication"
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "Manufacture"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "Distribution"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "Production"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "Place"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "Access"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "Access"
 

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -8,12 +8,11 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # bibsys UCL <bibsys@uclouvain.be>, 2020
 # ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -50,56 +49,56 @@ msgstr "RERO-ILS"
 msgid "Welcome to RERO-ILS!"
 msgstr "¡Bienvenido en RERO-ILS!"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "Tipo de documento"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "organización"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "Autores"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "Autores"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "Autores"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "Autores"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "idioma"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "sujeto"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "estado"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "funcciones"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "presupuesto"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "fuentes"
 
@@ -168,67 +167,71 @@ msgstr "sonido"
 msgid "video"
 msgstr "video"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr "otro"
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "GND"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "BNF"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "RERO"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr "idref"
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "English"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "Français"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "Deutsch"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "Italiano"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "Publicación"
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "Fabricación"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "Distribución"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "Producción"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "Lugar"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "Acceso"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "Acceso"
 

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -16,12 +16,11 @@
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Pascal Repond <pascalr.92@gmail.com>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Pascal Repond <pascalr.92@gmail.com>, 2020\n"
 "Language: fr\n"
@@ -58,56 +57,56 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Bienvenue sur RERO-ILS!"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "Type de document"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "organisation"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "bibliothèque"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "auteur"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "auteur"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "auteur"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "auteur"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "langue"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "sujet"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "statut"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "rôles"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "sources"
 
@@ -176,67 +175,71 @@ msgstr "son"
 msgid "video"
 msgstr "vidéo"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr "autre"
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "GND"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "BNF"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "RERO"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr "IdRef"
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "English"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "Français"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "Deutsch"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "Italiano"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "Publication"
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "Fabrication"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "Diffusion, distribution"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "Production"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "Lieu"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "Accès"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "Accès"
 

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -14,12 +14,11 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: it\n"
@@ -56,56 +55,56 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Benvenuti su RERO ILS!"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "tipo di documento"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "Ente"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "autore"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "autore"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "autore"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "autore"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "lingua"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "oggetto"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "stato"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "ruoli"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "bilancio"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "fonti"
 
@@ -174,67 +173,71 @@ msgstr "audio"
 msgid "video"
 msgstr "video"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr "altro"
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "GND"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "BNF"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "RERO"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "English"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "Français"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "Deutsch"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "Italiano"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "Pubblicazione  "
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "Manifattura"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "Distribuzione"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "Produzione"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "Luogo"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "Accesso"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "Accesso"
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -3,12 +3,11 @@
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
-
 msgid ""
 msgstr ""
-"Project-Id-Version: rero-ils 0.9.1\n"
+"Project-Id-Version: rero-ils 0.10.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,56 +42,56 @@ msgstr ""
 msgid "Welcome to RERO-ILS!"
 msgstr ""
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr ""
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr ""
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr ""
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr ""
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr ""
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr ""
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr ""
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr ""
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr ""
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr ""
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr ""
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr ""
 
@@ -161,67 +160,71 @@ msgstr ""
 msgid "video"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr ""
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr ""
 

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -7,12 +7,11 @@
 # bibsys UCL <bibsys@uclouvain.be>, 2020
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-30 11:47+0200\n"
+"POT-Creation-Date: 2020-07-03 11:05+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -49,56 +48,56 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Welkom bij RERO-ILS!"
 
-#: rero_ils/config.py:1181
+#: rero_ils/config.py:1250
 msgid "document_type"
 msgstr "type van document"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1251
 msgid "organisation"
 msgstr "organisatie"
 
-#: rero_ils/config.py:1185 rero_ils/config.py:1229 rero_ils/config.py:1251
-#: rero_ils/config.py:1273
+#: rero_ils/config.py:1254 rero_ils/config.py:1298 rero_ils/config.py:1320
+#: rero_ils/config.py:1342
 msgid "library"
 msgstr "bibliotheek"
 
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1255
 msgid "author__en"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1256
 msgid "author__fr"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1257
 msgid "author__de"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1258
 msgid "author__it"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1259
 msgid "language"
 msgstr "taal"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1260
 msgid "subject"
 msgstr "onderwerp"
 
-#: rero_ils/config.py:1192 rero_ils/config.py:1252 rero_ils/config.py:1274
+#: rero_ils/config.py:1261 rero_ils/config.py:1321 rero_ils/config.py:1343
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1208
+#: rero_ils/config.py:1277
 msgid "roles"
 msgstr "rollen"
 
-#: rero_ils/config.py:1230
+#: rero_ils/config.py:1299
 msgid "budget"
 msgstr "begroting"
 
-#: rero_ils/config.py:1290
+#: rero_ils/config.py:1359
 msgid "sources"
 msgstr "bron"
 
@@ -167,67 +166,71 @@ msgstr "geluid"
 msgid "video"
 msgstr "video"
 
-#: rero_ils/manual_translations.txt:34
+#: rero_ils/manual_translations.txt:33
+msgid "other"
+msgstr "andere"
+
+#: rero_ils/manual_translations.txt:35
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:53
 msgid "gnd"
 msgstr "GND"
 
-#: rero_ils/manual_translations.txt:35
+#: rero_ils/manual_translations.txt:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:57
 msgid "bnf"
 msgstr "BNF"
 
-#: rero_ils/manual_translations.txt:36
+#: rero_ils/manual_translations.txt:37
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:49
 msgid "rero"
 msgstr "RERO"
 
-#: rero_ils/manual_translations.txt:37
+#: rero_ils/manual_translations.txt:38
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:61
 msgid "idref"
 msgstr "idref"
 
-#: rero_ils/manual_translations.txt:40
+#: rero_ils/manual_translations.txt:41
 msgid "ui_language_en"
 msgstr "English"
 
-#: rero_ils/manual_translations.txt:41
+#: rero_ils/manual_translations.txt:42
 msgid "ui_language_fr"
 msgstr "Français"
 
-#: rero_ils/manual_translations.txt:42
+#: rero_ils/manual_translations.txt:43
 msgid "ui_language_de"
 msgstr "Deutsch"
 
-#: rero_ils/manual_translations.txt:43
+#: rero_ils/manual_translations.txt:44
 msgid "ui_language_it"
 msgstr "Italiano"
 
-#: rero_ils/manual_translations.txt:46
+#: rero_ils/manual_translations.txt:47
 msgid "bf:Publication"
 msgstr "Publicatie"
 
-#: rero_ils/manual_translations.txt:47
+#: rero_ils/manual_translations.txt:48
 msgid "bf:Manufacture"
 msgstr "Productie"
 
-#: rero_ils/manual_translations.txt:48
+#: rero_ils/manual_translations.txt:49
 msgid "bf:Distribution"
 msgstr "Verspreiding, distributie"
 
-#: rero_ils/manual_translations.txt:49
+#: rero_ils/manual_translations.txt:50
 msgid "bf:Production"
 msgstr "Productie"
 
-#: rero_ils/manual_translations.txt:50
+#: rero_ils/manual_translations.txt:51
 msgid "bf:Place"
 msgstr "bf:Place"
 
-#: rero_ils/manual_translations.txt:53
+#: rero_ils/manual_translations.txt:54
 msgid "ebibliomedia"
 msgstr "Toegang"
 
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:55
 msgid "mv-cantook"
 msgstr "Toegang"
 


### PR DESCRIPTION
* Adds manual translation for "other" document type (as other document
types)
* Closes rero/rero-ils#917

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- In the professional interface, create a new documents with "other" as document type.
- In the public interface, choose french/italian/... language
- Display the detailed document view for your newly created document.


![image](https://user-images.githubusercontent.com/10031585/86453785-9f72f080-bd1e-11ea-97fc-2d2faaf2a3d4.png)
 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
