### PR TITLE
circulation: ensure the item extend loan action for frontend calls

### DIFF
--- a/doc/circulation/actions.md
+++ b/doc/circulation/actions.md
@@ -174,6 +174,12 @@
 
 ## Extend
 
+### required_parameters:
+
+    item_pid_value
+    transaction_location_pid
+    transaction_user_pid
+
 1. :100: __EXTEND_1__: item on_shelf (no current loan) →  (extend not possible)
 1. :100: __EXTEND_2__: item at_desk, requested (ITEM_AT_DESK) →  (extend not possible)
 1. :100: __EXTEND_3__: item on_loan (ITEM_ON_LOAN)

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -299,7 +299,7 @@ def validate_request(item, data):
 @check_authentication
 @jsonify_action
 def receive(item, data):
-    """HTTP HTTP request for receive item action..
+    """HTTP HTTP request for receive item action.
 
     required_parameters: item_pid
     """
@@ -310,7 +310,7 @@ def receive(item, data):
 @check_authentication
 @jsonify_action
 def return_missing(item, data=None):
-    """HTTP request for Item return_missing action..
+    """HTTP request for Item return_missing action.
 
     required_parameters: item_pid
     """
@@ -319,9 +319,9 @@ def return_missing(item, data=None):
 
 @api_blueprint.route('/extend_loan', methods=['POST'])
 @check_authentication
-@jsonify_action
+@do_jsonify_action
 def extend_loan(item, data):
-    """HTTP request for Item due date extend action..
+    """HTTP request for Item due date extend action.
 
     required_parameters: item_pid
     """

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -138,6 +138,9 @@ class Loan(IlsRecord):
                 'patron_pid',
                 'transaction_location_pid',
                 'transaction_user_pid',
+            ],
+            'extend_loan': [
+                'item_pid'
             ]
         }
 

--- a/tests/api/circulation/test_actions_views_extend_loan_request.py
+++ b/tests/api/circulation/test_actions_views_extend_loan_request.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2020 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST checkout API methods in the item api_views."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import postdata
+
+from rero_ils.modules.items.models import ItemStatus
+
+
+def test_extend_loan_missing_parameters(
+        client,
+        librarian_martigny_no_email,
+        lib_martigny,
+        loc_public_martigny,
+        circulation_policies,
+        item_on_loan_martigny_patron_and_loan_on_loan):
+    """Test extend loan with missing parameters.
+
+    Are needed:
+        - transaction_location_pid or transaction_library_pid
+        - transaction_user_pid
+    """
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    assert item.status == ItemStatus.ON_LOAN
+
+    # test fails when missing required parameter
+    res, _ = postdata(
+        client,
+        'api_item.extend_loan',
+        dict(
+            item_pid=item.pid
+        )
+    )
+    assert res.status_code == 400
+    res, _ = postdata(
+        client,
+        'api_item.extend_loan',
+        dict(
+            item_pid=item.pid,
+            transaction_location_pid=loc_public_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+    res, _ = postdata(
+        client,
+        'api_item.extend_loan',
+        dict(
+            item_pid=item.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 400
+
+
+def test_extend_loan(
+        client,
+        librarian_martigny_no_email,
+        lib_martigny,
+        loc_public_martigny,
+        circulation_policies,
+        item_on_loan_martigny_patron_and_loan_on_loan):
+    """Test a successful frontend checkout action."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    assert item.status == ItemStatus.ON_LOAN
+
+    # With only needed parameters
+    res, _ = postdata(
+        client,
+        'api_item.extend_loan',
+        dict(
+            item_pid=item.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_location_pid=loc_public_martigny.pid
+        )
+    )
+    assert res.status_code == 200


### PR DESCRIPTION
* adds new prior_extend_loan_actions method used before extend_loan
action
* adds new test_actions_views_extend_loan_request test file
* uses do_jsonify_action for extend_loan action

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because of [US1580 about extend_loan action in API views](https://tree.taiga.io/project/rero21-reroils/task/1580)

## How to test?

Just check that Travis tests are OK

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
