### PR TITLE
json schema: use the select menu with order

### DIFF
--- a/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
+++ b/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
@@ -132,6 +132,10 @@
       ],
       "default": "in progress",
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "value": "in_progress",
@@ -145,7 +149,12 @@
             "value": "deleted",
             "label": "Deleted"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     },
     "invoice_date": {
@@ -192,6 +201,10 @@
               "miscellaneous"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "value": "shipping_and_handling",
@@ -205,7 +218,12 @@
                   "value": "miscellaneous",
                   "label": "Miscellaneous"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
+              }
             }
           },
           "amount": {

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -48,6 +48,10 @@
       ],
       "default": "pending",
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "value": "approved",
@@ -73,7 +77,12 @@
             "value": "received",
             "label": "Received"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     },
     "quantity": {

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -66,6 +66,10 @@
       ],
       "default": "monograph",
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "value": "monograph",
@@ -91,7 +95,12 @@
             "value": "multi_volume",
             "label": "Multi-volume"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     },
     "description": {
@@ -112,6 +121,10 @@
       ],
       "default": "pending",
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "value": "approved",
@@ -137,7 +150,12 @@
             "value": "received",
             "label": "Received"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     },
     "currency": {
@@ -148,6 +166,17 @@
         "EUR",
         "USD"
       ],
+      "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
+      },
       "default": "CHF"
     },
     "order_date": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -64,6 +64,10 @@
       ],
       "minLength": 4,
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "Article",
@@ -99,7 +103,10 @@
           }
         ],
         "templateOptions": {
-          "cssClass": "rero-ils-editor-max-width"
+          "cssClass": "rero-ils-editor-max-width",
+          "selectWithSortOptions": {
+            "order": "label"
+          }
         }
       }
     },
@@ -132,6 +139,10 @@
               "bf:VariantTitle"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "Title",
@@ -147,7 +158,10 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "rero-ils-editor-max-width"
+                "cssClass": "rero-ils-editor-max-width",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
               }
             }
           },
@@ -565,6 +579,10 @@
               "bf:Production"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "Publication",
@@ -584,7 +602,10 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "rero-ils-editor-max-width"
+                "cssClass": "rero-ils-editor-max-width",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
               }
             }
           },
@@ -663,6 +684,10 @@
                     "Date"
                   ],
                   "form": {
+                    "type": "selectWithSort",
+                    "wrappers": [
+                      "form-field-horizontal"
+                    ],
                     "options": [
                       {
                         "label": "Place",
@@ -678,7 +703,10 @@
                       }
                     ],
                     "templateOptions": {
-                      "cssClass": "rero-ils-editor-max-width"
+                      "cssClass": "rero-ils-editor-max-width",
+                      "selectWithSortOptions": {
+                        "order": "label"
+                      }
                     }
                   }
                 },
@@ -805,6 +833,10 @@
           "rdacc:1003"
         ],
         "form": {
+          "type": "selectWithSort",
+          "wrappers": [
+            "form-field-horizontal"
+          ],
           "options": [
             {
               "label": "Monochrome",
@@ -814,7 +846,12 @@
               "label": "Polychrome",
               "value": "rdacc:1003"
             }
-          ]
+          ],
+          "templateOptions": {
+            "selectWithSortOptions": {
+              "order": "label"
+            }
+          }
         }
       },
       "form": {
@@ -855,6 +892,10 @@
           "rdapm:1021"
         ],
         "form": {
+          "type": "selectWithSort",
+          "wrappers": [
+            "form-field-horizontal"
+          ],
           "options": [
             {
               "label": "Blueline process",
@@ -936,7 +977,12 @@
               "label": "Thermoform",
               "value": "rdapm:1021"
             }
-          ]
+          ],
+          "templateOptions": {
+            "selectWithSortOptions": {
+              "order": "label"
+            }
+          }
         }
       },
       "form": {
@@ -1076,6 +1122,10 @@
               "otherPhysicalDetails"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "Accompanying material",
@@ -1091,7 +1141,10 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-6"
+                "cssClass": "col-lg-6",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
               }
             }
           },
@@ -1193,6 +1246,10 @@
               "uri"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "Audio issue number",
@@ -1280,7 +1337,10 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-4"
+                "cssClass": "col-lg-4",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
               }
             }
           },
@@ -1437,6 +1497,10 @@
               "noInfo"
             ],
             "form": {
+              "Type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "Resource",
@@ -1460,7 +1524,10 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-4"
+                "cssClass": "col-lg-4",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
               }
             }
           },
@@ -1499,6 +1566,10 @@
               "video"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "Poster",
@@ -1614,7 +1685,10 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-4"
+                "cssClass": "col-lg-4",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
               }
             }
           },
@@ -2150,6 +2224,10 @@
         "zza"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "lang_aar",
@@ -4093,7 +4171,10 @@
           }
         ],
         "templateOptions": {
-          "cssClass": "rero-ils-editor-max-width"
+          "cssClass": "rero-ils-editor-max-width",
+          "selectWithSortOptions": {
+            "order": "label"
+          }
         }
       }
     },
@@ -4609,6 +4690,10 @@
         "za"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "country_aa",
@@ -6140,7 +6225,10 @@
           }
         ],
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "cssClass": "col-lg-4",
+          "selectWithSortOptions": {
+            "order": "label"
+          }
         }
       }
     },
@@ -6176,6 +6264,10 @@
         "zh"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "canton_ag",
@@ -6283,7 +6375,10 @@
           }
         ],
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "cssClass": "col-lg-4",
+          "selectWithSortOptions": {
+            "order": "label"
+          }
         }
       }
     }

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -176,6 +176,10 @@
             "rdafr:1016"
           ],
           "form": {
+            "type": "selectWithSort",
+            "wrappers": [
+              "form-field-horizontal"
+            ],
             "options": [
               {
                 "label": "Annual",
@@ -241,7 +245,12 @@
                 "label": "Weekly",
                 "value": "rdafr:1004"
               }
-            ]
+            ],
+            "templateOptions": {
+              "selectWithSortOptions": {
+                "order": "label"
+              }
+            }
           }
         },
         "next_expected_date": {

--- a/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
@@ -64,6 +64,10 @@
         "standard"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "value": "standard",
@@ -74,6 +78,11 @@
             "label": "Online"
           }
         ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        },
         "validation": {
           "validators": {
             "valueAlreadyExists": {

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -155,7 +155,18 @@
             "received",
             "claimed",
             "deleted"
-          ]
+          ],
+          "form": {
+            "type": "selectWithSort",
+            "wrappers": [
+              "form-field-horizontal"
+            ],
+            "templateOptions": {
+              "selectWithSortOptions": {
+                "order": "label"
+              }
+            }
+          }
         },
         "display_text": {
           "title": "displayed text",
@@ -226,6 +237,10 @@
         "excluded"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "on_shelf",
@@ -252,6 +267,11 @@
             "value": "excluded"
           }
         ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        },
         "hideExpression": "true"
       }
     },
@@ -303,6 +323,10 @@
               "checkout_note"
             ],
             "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
               "options": [
                 {
                   "label": "public note",
@@ -320,7 +344,12 @@
                   "label": "checkout note",
                   "value": "checkout_note"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
+              }
             }
           },
           "content": {

--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -240,7 +240,18 @@
                   "weekly",
                   "monthly",
                   "yearly"
-                ]
+                ],
+                "form": {
+                  "type": "selectWithSort",
+                  "wrappers": [
+                    "form-field-horizontal"
+                  ],
+                  "templateOptions": {
+                    "selectWithSortOptions": {
+                      "order": "label"
+                    }
+                  }
+                }
               },
               "data": {
                 "type": "array",

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -102,6 +102,10 @@
         "CANCELLED"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "CREATED",
@@ -135,7 +139,12 @@
             "label": "CANCELLED",
             "value": "CANCELLED"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     },
     "trigger": {

--- a/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
+++ b/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
@@ -59,6 +59,10 @@
         "recall"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "due_soon",
@@ -76,7 +80,12 @@
             "label": "recall",
             "value": "recall"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     }
   }

--- a/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
@@ -42,6 +42,17 @@
         "open",
         "closed"
       ],
+      "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
+      },
       "default": "open"
     },
     "type": {
@@ -56,6 +67,17 @@
         "interlibrary_loan",
         "other"
       ],
+      "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
+      },
       "default": "overdue"
     },
     "patron": {

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -211,6 +211,10 @@
           "system_librarian"
         ],
         "form": {
+          "type": "selectWithSort",
+          "wrappers": [
+            "form-field-horizontal"
+          ],
           "options": [
             {
               "label": "Patron",
@@ -224,7 +228,12 @@
               "label": "System Librarian",
               "value": "system_librarian"
             }
-          ]
+          ],
+          "templateOptions": {
+            "selectWithSortOptions": {
+              "order": "label"
+            }
+          }
         }
       },
       "form": {
@@ -239,6 +248,10 @@
         "mail"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "email",
@@ -249,6 +262,11 @@
             "value": "mail"
           }
         ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        },
         "hideExpression": "!model.roles.some(v => v === 'patron')",
         "expressionProperties": {
           "templateOptions.required": "model.roles.some(v => v === 'patron')"
@@ -265,6 +283,10 @@
         "ita"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "label": "French",
@@ -283,6 +305,11 @@
             "value": "ita"
           }
         ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        },
         "hideExpression": "!model.roles.some(v => v === 'patron')",
         "expressionProperties": {
           "templateOptions.required": "model.roles.some(v => v === 'patron')"

--- a/rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json
+++ b/rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json
@@ -44,6 +44,10 @@
           "idref"
         ],
         "form": {
+          "type": "selectWithSort",
+          "wrappers": [
+            "form-field-horizontal"
+          ],
           "options": [
             {
               "label": "rero",
@@ -61,7 +65,12 @@
               "label": "idref",
               "value": "idref"
             }
-          ]
+          ],
+          "templateOptions": {
+            "selectWithSortOptions": {
+              "order": "label"
+            }
+          }
         }
       }
     },

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -74,6 +74,10 @@
         "spa"
       ],
       "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
         "options": [
           {
             "value": "fre",
@@ -95,7 +99,12 @@
             "value": "spa",
             "label": "Spanish"
           }
-        ]
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
       }
     },
     "default_contact": {
@@ -236,7 +245,18 @@
         "AUD"
       ],
       "default": "CHF",
-      "pattern": "^[A-Z]{3}$"
+      "pattern": "^[A-Z]{3}$",
+      "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
+      }
     },
     "vat_rate": {
       "title": "VAT rate",


### PR DESCRIPTION
* Updates JSON schema form to use the new select menu with order.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Dependencies

My PR depends on the following `ng-core`'s PR(s):
* rero/ng-core#7400a310fbeda8432ebf944c402325e6bc9878c1

## How to test?

- Add a document (or other ressource) and check select menu order.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
