### PR TITLE
bootstrap scripts: fix npm utils installation

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -129,7 +129,12 @@ fi
 # install assets utils
 virtualenv_path=`poetry env info -p`
 info_msg "Install npm assets utils in: ${virtualenv_path}"
-npm i npm@latest -g --prefix "${virtualenv_path}" && npm install --prefix "${virtualenv_path}" --silent -g  node-sass@4.14.1 clean-css-cli@4.3.0 uglify-js@3.9.4 requirejs@2.3.6
+npm install npm@latest -g --prefix "${virtualenv_path}" \
+  && success_msg "Latest NPM: installed." \
+  || error_msg+exit "Failed to install latest NPM."
+npm install --prefix "${virtualenv_path}" --silent --force -g node-sass@4.14.1 clean-css-cli@4.3.0 uglify-js@3.9.4 requirejs@2.3.6 \
+  && success_msg "NPM assets utils: installed." \
+  || error_msg+exit "NPM assets utils installation failed."
 
 # collect static files and compile html/css assets
 # ------------------------------------------------


### PR DESCRIPTION
Sometimes a bootstrap scripts failed while in step "Install npm assets
utils" without errors.
It failed on cleancss installation (because symbolic links already
exists).
To avoid this problem a clean-install of npm assets utils should resolve
the problem.
An error is now already given when it fails.

* Adds error message when npm asset utils fails.
* Uses clean-install option for npm instead of install one.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Sometimes, when installing RERO-ils with a `poetry run bootstrap` command, you get:

```bash
❯ poetry run bootstrap
PROGRAM: bootstrap                                                          
[INFO]: Install with command: poetry install 
Installing dependencies from lock file                     

No dependencies to install or update
                                                                              - Installing rero-ils (10.0.1)                                             
[INFO]: Install npm assets utils in: /home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/bin/npx -> /home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/lib/node_modules/np
m/bin/npx-cli.js                                                            
/home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/bin/npm -> /home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/lib/node_modules/np
m/bin/npm-cli.js                      
+ npm@6.14.5                          
updated 1 package in 5.088s
```

By deleting the `--silent` option in bootstrap script, you get this error:

```bash
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm ERR! code EEXIST
npm ERR! syscall symlink
npm ERR! path ../lib/node_modules/clean-css-cli/bin/cleancss
npm ERR! dest /home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/bin/cleancss
npm ERR! errno -17                    
npm ERR! EEXIST: file already exists, symlink '../lib/node_modules/clean-css-cli/bin/cleancss' -> '/home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1D
s-py3.6/bin/cleancss'
npm ERR! File exists: /home/od/.cache/pypoetry/virtualenvs/rero-ils-uCwHA1Ds-py3.6/bin/cleancss
npm ERR! Remove the existing file and try again, or run npm
npm ERR! with --force to overwrite files recklessly.
npm ERR! A complete log of this run can be found in:npm ERR!     /home/od/.npm/_logs/2020-06-23T09_31_05_935Z-debug.log
```

This commit should resolve the problem.

## How to test?

Use bootstrap twice to check if problems occurs. It should not.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
