### PR TITLE
document: index host document title in child document record

### DIFF
--- a/tests/data/documents.json
+++ b/tests/data/documents.json
@@ -92,6 +92,18 @@
       "Litt\u00e9rature",
       "Culture",
       "[Notes, esquisses, etc.]"
+    ],
+    "partOf": [
+      {
+        "document": {
+          "$ref": "https://ils.rero.ch/api/documents/12"
+        },
+        "numbering": [
+          {
+            "volume": 25
+          }
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
* Indexes host document title in order to get child document in search results.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

To implement a correction asked by PO's group
Task: https://tree.taiga.io/project/rero21-reroils/task/1602?kanban-status=1224895

## Dependencies

N/A

## How to test?

Find a document that has a part of field. Search the host document in public view. You should have both host and child document in search results (for example journal and article).

Try to add several child documents to host document and check that the search result is correct.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
