### PR TITLE
editor: link issuance main type and subtype values

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -407,115 +407,244 @@
     "issuance": {
       "title": "Mode of issuance",
       "type": "object",
-      "required": [
-        "main_type",
-        "subtype"
-      ],
-      "propertiesOrder": [
-        "main_type",
-        "subtype"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "main_type": {
-          "title": "Main type",
-          "type": "string",
-          "default": "rdami:1001",
-          "enum": [
-            "rdami:1001",
-            "rdami:1002",
-            "rdami:1003",
-            "rdami:1004"
+      "oneOf": [
+        {
+          "title": "Single unit",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "main_type",
+            "subtype"
           ],
-          "form": {
-            "options": [
-              {
-                "label": "Single unit",
-                "value": "rdami:1001"
-              },
-              {
-                "label": "Multipart monograph",
-                "value": "rdami:1002"
-              },
-              {
-                "label": "Serial",
-                "value": "rdami:1003"
-              },
-              {
-                "label": "Integrating resource",
-                "value": "rdami:1004"
+          "required": [
+            "main_type",
+            "subtype"
+          ],
+          "properties": {
+            "subtype": {
+              "title": "Subtype",
+              "type": "string",
+              "default": "article",
+              "enum": [
+                "article",
+                "materialUnit",
+                "privateFile",
+                "privateSubfile"
+              ],
+              "form": {
+                "options": [
+                  {
+                    "label": "Article",
+                    "value": "article"
+                  },
+                  {
+                    "label": "Material unit",
+                    "value": "materialUnit"
+                  },
+                  {
+                    "label": "Private file",
+                    "value": "privateFile"
+                  },
+                  {
+                    "label": "Private subfile",
+                    "value": "privateSubfile"
+                  }
+                ],
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
               }
-            ],
+            },
+            "main_type": {
+              "title": "Main type",
+              "type": "string",
+              "readOnly": true,
+              "default": "rdami:1001",
+              "form": {
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            }
+          },
+          "form": {
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "cssClass": "row"
             }
           }
         },
-        "subtype": {
-          "title": "Subtype",
-          "type": "string",
-          "default": "materialUnit",
-          "enum": [
-            "article",
-            "materialUnit",
-            "monographicSeries",
-            "periodical",
-            "privateFile",
-            "privateSubfile",
-            "serialInSerial",
-            "set",
-            "updatingWebsite",
-            "updatingLoose-leaf"
+        {
+          "title": "Multipart monograph",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "main_type",
+            "subtype"
           ],
-          "form": {
-            "options": [
-              {
-                "label": "Article",
-                "value": "article"
-              },
-              {
-                "label": "Material unit",
-                "value": "materialUnit"
-              },
-              {
-                "label": "Monographic series",
-                "value": "monographicSeries"
-              },
-              {
-                "label": "Periodical",
-                "value": "periodical"
-              },
-              {
-                "label": "Private file",
-                "value": "privateFile"
-              },
-              {
-                "label": "Private subfile",
-                "value": "privateSubfile"
-              },
-              {
-                "label": "Serial in serial",
-                "value": "serialInSerial"
-              },
-              {
-                "label": "Set",
-                "value": "set"
-              },
-              {
-                "label": "Updating website",
-                "value": "updatingWebsite"
-              },
-              {
-                "label": "Updating loose leaf",
-                "value": "updatingLoose-leaf"
+          "required": [
+            "main_type",
+            "subtype"
+          ],
+          "properties": {
+            "subtype": {
+              "title": "Subtype",
+              "type": "string",
+              "default": "set",
+              "enum": [
+                "set",
+                "partIndependentTitle",
+                "partDependantTitle"
+              ],
+              "form": {
+                "options": [
+                  {
+                    "label": "Set",
+                    "value": "set"
+                  },
+                  {
+                    "label": "Independant title",
+                    "value": "partIndependentTitle"
+                  },
+                  {
+                    "label": "Dependant title",
+                    "value": "partDependantTitle"
+                  }
+                ],
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
               }
-            ],
+            },
+            "main_type": {
+              "title": "Main type",
+              "type": "string",
+              "readOnly": true,
+              "default": "rdami:1002",
+              "form": {
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            }
+          },
+          "form": {
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "cssClass": "row"
+            }
+          }
+        },
+        {
+          "title": "Serial",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "main_type",
+            "subtype"
+          ],
+          "required": [
+            "main_type",
+            "subtype"
+          ],
+          "properties": {
+            "subtype": {
+              "title": "Subtype",
+              "type": "string",
+              "default": "serialInSerial",
+              "enum": [
+                "serialInSerial",
+                "monographicSeries",
+                "periodical"
+              ],
+              "form": {
+                "options": [
+                  {
+                    "label": "Serial in serial",
+                    "value": "serialInSerial"
+                  },
+                  {
+                    "label": "Monographic series",
+                    "value": "monographicSeries"
+                  },
+                  {
+                    "label": "Periodical",
+                    "value": "periodical"
+                  }
+                ],
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            },
+            "main_type": {
+              "title": "Main type",
+              "type": "string",
+              "readOnly": true,
+              "default": "rdami:1003",
+              "form": {
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            }
+          },
+          "form": {
+            "templateOptions": {
+              "cssClass": "row"
+            }
+          }
+        },
+        {
+          "title": "Integrating resource",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "main_type",
+            "subtype"
+          ],
+          "required": [
+            "main_type",
+            "subtype"
+          ],
+          "properties": {
+            "subtype": {
+              "title": "Subtype",
+              "type": "string",
+              "default": "updatingWebsite",
+              "enum": [
+                "updatingWebsite",
+                "updatingLoose-leaf"
+              ],
+              "form": {
+                "options": [
+                  {
+                    "label": "Updating website",
+                    "value": "updatingWebsite"
+                  },
+                  {
+                    "label": "Updating loose leaf",
+                    "value": "updatingLoose-leaf"
+                  }
+                ],
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            },
+            "main_type": {
+              "title": "Main type",
+              "type": "string",
+              "readOnly": true,
+              "default": "rdami:1004",
+              "form": {
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            }
+          },
+          "form": {
+            "templateOptions": {
+              "cssClass": "row"
             }
           }
         }
-      },
+      ],
       "form": {
         "templateOptions": {
           "cssClass": "rero-ils-editor-title"
@@ -563,6 +692,7 @@
               "type": {
                 "title": "Type",
                 "type": "string",
+                "readOnly": true,
                 "enum": [
                   "person"
                 ],
@@ -649,6 +779,7 @@
                 "title": "Type",
                 "type": "string",
                 "default": "organisation",
+                "readOnly": true,
                 "enum": [
                   "organisation"
                 ],


### PR DESCRIPTION
* Implements 'oneOf' attribute in order to link issuance main type and subtype values in editor.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

This PR is part of US1432 (task 1603)
https://tree.taiga.io/project/rero21-reroils/us/1432?milestone=268117
https://tree.taiga.io/project/rero21-reroils/task/1603?kanban-status=1224894

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* https://github.com/rero/ng-core/pull/215
* https://github.com/rero/rero-ils-ui/pull/283

## How to test?

See https://github.com/rero/ng-core/pull/215 description

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
