### PR TITLE
check_license: accept Triple Slash Directive

### DIFF
--- a/check_license_config.yml
+++ b/check_license_config.yml
@@ -36,6 +36,7 @@ directories:
     js:
       - tests/e2e/cypress/cypress/support
       - tests/e2e/cypress/cypress/plugins
+      - tests/e2e/cypress/cypress/screenshots
       - tests/e2e/cypress/node_modules
     d.ts:
       - tests/e2e/cypress/cypress/support

--- a/tests/e2e/cypress/.gitignore
+++ b/tests/e2e/cypress/.gitignore
@@ -1,0 +1,1 @@
+cypress/screenshots

--- a/tests/e2e/cypress/cypress/integration/circulation/checkout-checkin.spec.js
+++ b/tests/e2e/cypress/cypress/integration/circulation/checkout-checkin.spec.js
@@ -1,3 +1,4 @@
+/// <reference types="Cypress" />
 /*
 
 RERO ILS

--- a/tests/e2e/cypress/cypress/support/commands.js
+++ b/tests/e2e/cypress/cypress/support/commands.js
@@ -1,3 +1,4 @@
+/// <reference types="Cypress" />
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite


### PR DESCRIPTION
run-tests.sh checks that Licenses are OK for some files.
This scripts fails when JS files use a Triple Slash Directive.
This commit change this.

* Improves check_license method to include Triple-Slash directives for
.js files (Cf.
https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
* Avoids checking screenshots directory in Cypress
* Adds a triple slash directive on 2 JS files (from Cypress).

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because Cypress tests needs to be done on RERO ILS and I need to extend developer environment to do so.

## How to test?

`poetry run run-tests` shouldn't give any error on Cypress JS files (that contains Triple Slash Directive)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
