### PR TITLE
ui: select menu items by Cypress through ids

### DIFF
--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -143,7 +143,8 @@ def logged_user():
     blueprint,
     'main.profile.profile',
     _('%(icon)s Profile', icon='<i class="fa fa-user fa-fw"></i>'),
-    visible_when=user_has_patron
+    visible_when=user_has_patron,
+    id="my-account-menu"
 )
 def profile(viewcode):
     """Patron Profile Page."""

--- a/rero_ils/templates/rero_ils/header.html
+++ b/rero_ils/templates/rero_ils/header.html
@@ -61,6 +61,7 @@
               <a class="nav-link collapsed" data-toggle="collapse" role="button"
                  aria-controls="collapseExample" aria-expanded="false"
                  href="#{{ item.name }}"
+                 {{ "id={}".format(item.id) if item.id }}
               >
                {{ item.text|safe }}
               <i class="fa fa-caret-down" aria-hidden="true"></i>
@@ -68,7 +69,7 @@
             </li>
             {%- else %}
             <li class="nav-item{{ ' active' if item.active else ''}}">
-              <a href="{{ item.url }}">{{ item.text|safe }}</a>
+              <a href="{{ item.url }}" {{ "id={}".format(item.id) if item.id }}>{{ item.text|safe }}</a>
             </li>
             {%- endif %}
             {%- endfor %}
@@ -86,7 +87,7 @@
               <ul class="navbar-nav justify-content-end">
                 {%- for child in item.children if child.visible %}
                   <li class="nav-item {{class_name if class_name}}">
-                    <a class="nav-link" href="{{ child.url }}">{{ child.text|safe }}</a>
+                    <a class="nav-link" href="{{ child.url }}" {{ "id={}".format(child.id) if child.id }}>{{ child.text|safe }}</a>
                   </li>
                 {%- endfor %}
               </ul>
@@ -103,18 +104,18 @@
           {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible %}
             {%- if item.children %}
               <li class="nav-item{{ ' active' if item.active else ''}} w-100 list-group-item bg-light">
-                <a class="nav-link collapsed" href="#{{ item.name }}" data-toggle="collapse" role="button" aria-controls="collapseExample" aria-expanded="false">{{ item.text|safe }} <i class="fa fa-caret-down float-right" aria-hidden="true"></i></a>
+                <a class="nav-link collapsed" href="#{{ item.name }}" data-toggle="collapse" role="button" aria-controls="collapseExample" aria-expanded="false" {{ "id={}".format(item.id) if item.id }}>{{ item.text|safe }} <i class="fa fa-caret-down float-right" aria-hidden="true"></i></a>
                 <ul class="nav collapse pl-2" id="{{ item.name }}" data-parent="#mobileHide">
                   {%- for child in item.children if child.visible %}
                     <li class="nav-item {{class_name if class_name}} w-100">
-                      <a class="nav-link" href="{{ child.url }}">{{ child.text|safe }}</a>
+                      <a class="nav-link" href="{{ child.url }}" {{ "id={}".format(child.id) if child.id }}>{{ child.text|safe }}</a>
                     </li>
                   {%- endfor %}
                 </ul>
               </li>
             {%- else %}
               <li class="nav-item{{ ' active' if item.active else ''}}">
-                <a href="{{ item.url }}" class="nav-link">{{ item.text|safe }}</a>
+                <a href="{{ item.url }}" class="nav-link" {{ "id={}".format(item.id) if item.id }}>{{ item.text|safe }}</a>
               </li>
             {%- endif %}
           {%- endfor %}


### PR DESCRIPTION
In Cypress it's difficult to choose a specific item in the menu if you
don't know in which language you are. Each element can be in French,
English, etc.
To facilitate this work we can add id= on each element on the menu.
With a specific word. This way you don't need to know in which language
you are.

* Adds Id on all menus ('My Account' menu, languages menu, help menu,
logout, etc.) for testing purposes.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

To fix problems to target menu elements with Cypress.

## How to test?

1. make a setup
1. open the homepage (https://localhost:5000/)
1. Open your web browser development tab (F12 on Chrome)
1. Use the "select" option to click on menu and check that the item have `id=` as attribute. For example `id=help-menu`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
