### PR TITLE
cypress: enhance commands to improve tests

### DIFF
--- a/scripts/server
+++ b/scripts/server
@@ -65,8 +65,12 @@ if [[ -z "${VIRTUAL_ENV}" ]]; then
   error_msg+exit "Error - Launch this script via poetry command:\n\tpoetry run ${PROGRAM}"
 fi
 
-export FLASK_DEBUG=True
-export FLASK_ENV=development
+if [[ -z "${FLASK_DEBUG}" ]]; then
+  export FLASK_DEBUG=True
+fi
+if [[ -z "${FLASK_ENV}" ]]; then
+  export FLASK_ENV="development"
+fi
 # Start Worker and Beat
 celery worker --app rero_ils.celery --loglevel INFO --beat --scheduler rero_ils.schedulers.RedisScheduler & PID_CELERY=$!
 

--- a/tests/e2e/cypress/cypress/integration/circulation/checkout-checkin.spec.js
+++ b/tests/e2e/cypress/cypress/integration/circulation/checkout-checkin.spec.js
@@ -28,29 +28,16 @@ describe('Circulation checkout checkin', function() {
     const documentUrl = '/professional/records/documents/detail/253'
     const circUrl = '/professional/circulation/checkout'
     const itemBarcode = 'checkout-checkin'
-    const timeOut = 30000;
+    const timeOut = 3000;
 
     cy.setup()
     cy.adminLogin(librarianEmail, librarianPwd)
 
-    // Go to the detailed view of a document
-    cy.visit(documentUrl, { timeout: timeOut })
-
     // Create an item
-    cy.get('.col > .btn',{timeout: timeOut}).click()
-    cy.get('#formly_6_string_barcode_0').type(itemBarcode)
-    cy.wait(3000)
-    cy.get('#formly_6_string_call_number_1').type(itemBarcode)
-    cy.get('select').first().select('Standard')
-    cy.get('select').eq(1).select('Espaces publics')
-    cy.get('.mt-4 > [type="submit"]').click()
-
-    // Assert that the item has been created
-    cy.get(':nth-child(3) > .card > .card-body > .mt-1 > .offset-sm-1 > a', {timeout: timeOut})
-      .should('contain',itemBarcode)
+    cy.createItem(itemBarcode, 'Standard', 'Espaces publics')
 
     // Go to Circulation
-    cy.visit(circUrl, { timeout: timeOut })
+    cy.goToMenu('circulation-menu-frontpage')
 
     // Enter a patron barcode
     cy.get('#search', {timeout: timeOut})
@@ -58,13 +45,15 @@ describe('Circulation checkout checkin', function() {
       .type('{enter}')
 
     // Assert that patron info is displayed
+    cy.wait(3000)
     cy.get(':nth-child(2) > :nth-child(1) > .col-md-10', {timeout: timeOut})
       .should('contain', patronInfo)
 
     // Checkout
-    cy.get('#search', {timeout: timeOut})
+    cy.get('#search', {timeout: 4500})
       .type(itemBarcode)
       .type('{enter}')
+    cy.wait(800)
 
     // Assert checkout
     cy.get(':nth-child(2) > .col > admin-item > .row > :nth-child(1) > a', {timeout: timeOut})
@@ -83,9 +72,11 @@ describe('Circulation checkout checkin', function() {
     cy.get(':nth-child(11) > .col > admin-item > .row > :nth-child(4) > .fa', {timeout: timeOut})
       .should('have.class', 'fa-arrow-circle-o-down')
 
-    // Go back to document detailed view and delete item
-    cy.visit(documentUrl, { timeout: timeOut })
-    cy.get(':nth-child(3) > .card > .card-body > .mt-1 > .col-sm-4 > .btn-outline-danger', {timeout: timeOut}).click()
+    // Go back to homepage, search document and delete item
+    cy.goToItem(itemBarcode)
+    // click on Delete button
+    cy.get('#item-' + itemBarcode + '-delete', {timeout: timeOut}).click()
+    // Then confirm
     cy.get('.modal-footer > .btn-primary', {timeout: timeOut}).click()
   });
 })

--- a/tests/e2e/cypress/cypress/support/commands.js
+++ b/tests/e2e/cypress/cypress/support/commands.js
@@ -25,29 +25,120 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+Cypress.Commands.add('setLanguageToEnglish', () => {
+  // Check language and force to given languageCode
+  cy.get('#language-menu').then((menu) => {
+    menu.click()
+    cy.wait(800)
+    // Check language and force to English if needed
+    cy.get('#help-menu').invoke('text').then((helpmenu) => {
+      if (helpmenu == ' Help' || helpmenu == ' Help ') {
+        // close Menu (because we're already in english)
+        menu.click()
+        cy.wait(800)
+      }
+      else {
+        cy.get('#language-menu-en').click()
+      }
+    })
+  })
+})
+
 // Setup
 Cypress.Commands.add("setup", () => {
   // Set preview size
   cy.viewport(1400, 900)
   // Go to frontpage and hide toolbar
   cy.visit('')
-  cy.get('#flHideToolBarButton').click()
-  // Check language and force to english if needed
-  cy.get('header h1').invoke('text').then((text) => {
-    if (text !== 'Get into your library') {
-      cy.contains('Menu').click()
-      cy.contains('English').click()
-    }
-  })
+
+  // Next line is considered as an anti-pattern by cypress as it depends on some specific condition in our application (FLASK_DEBUG=True)
+  // Please use `FLASK_DEBUG=False poetry run server` to launch server
+  // cy.get('#flHideToolBarButton').click()
+
+  // Check language and force to english
+  cy.setLanguageToEnglish()
+})
+
+// Logout
+Cypress.Commands.add("logout", () => {
+  // click on username
+  cy.get('#my-account-menu').click()
+  // then click on Logout link
+  cy.get('#logout-menu').click()
+})
+
+Cypress.Commands.add("login", (email, password) => {
+  // click on "My account"
+  cy.get('#my-account-menu').click()
+  cy.get('#login-menu').click()
+  cy.get('#email').type(email)
+  cy.get('#password').type(password)
+  cy.get('form[name="login_user_form"]').submit()
 })
 
 // Login to professional interface
 Cypress.Commands.add("adminLogin", (email, password) => {
-  cy.visit('/professional')
-  cy.get('#email').type(email)
-  cy.get('#password').type(password)
-  cy.get('form[name="login_user_form"]').submit()
-  // Check language and force to english if needed
-  cy.get('ng-core-menu a').contains('Menu').click()
-  cy.get('ng-core-menu .dropdown-item').first().click()
+  cy.login(email, password)
+
+  // go to professional interface
+  cy.get('#my-account-menu').click()
+  cy.get('#professional-interface-menu').click()
+  cy.url().should('include', '/professional/')
+  // Check language and force to english
+  cy.wait(1000)
+  cy.get('#language-menu').click()
+  cy.setLanguageToEnglish()
  })
+
+// Go to /professional/records/documents (using main menu and click)
+Cypress.Commands.add("goToMenu", (menuId) => {
+  // Go to professional homepage
+  cy.get('.logo').click()
+  // Check we're on admin page
+  cy.url().should('include', '/professional/')
+  // Click on 'menuTitle' from Catalog menu
+  cy.get('#' + menuId).click()
+})
+
+Cypress.Commands.add("createItem", (barcode, itemType, localisation) => {
+  // Go to Catalog > Documents
+  cy.goToMenu('documents-menu-frontpage')
+  // Use one document (between first and tenth)
+  let randomInteger = Math.floor((Math.random() * 9) + 1);
+  cy.get(':nth-child(' + randomInteger.toString() + ') > ng-core-record-search-result > admin-documents-brief-view > .card-title > a').click()
+  // Click on "Add…" button to add an item
+  cy.get('.col > .btn').click()
+  // Fill in Item barcode
+  cy.get('#formly_9_string_barcode_0').type(barcode)
+  // Wait that barcode to be checked (by API)
+  cy.wait(800)
+  // Fill in Item Call number with barcode content
+  cy.get('#formly_9_string_call_number_1').type(barcode)
+  // Fill in Item Category
+  cy.get('select').first().select(itemType)
+  // Fill in localisation (could be 0, 1, etc. to select first element from select list)
+  cy.get('select').eq(1).select(localisation)
+  
+  // Validate the form
+  cy.get('.mt-4 > [type="submit"]').click()
+
+  // Assert that the item has been created
+  cy.contains(barcode)
+})
+
+Cypress.Commands.add("goToItem", (itemBarcode) => {
+  // Go to homepage
+  if (cy.url().should('include', '/professional/')) {
+    // on professional context
+    cy.get('.logo').click()
+    cy.get('.form-control').type(itemBarcode).type('{enter}')
+  }
+  else {
+    // on public context
+    cy.get('#global-logo').click()
+    cy.wait(800)
+    cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').type(itemBarcode).type('{enter}')
+  }
+  // Use first element
+  cy.get('.card-title > a').click()
+})


### PR DESCRIPTION
Previously Cypress tests use a lot of code to fake a clic on the right
menu. Now that `id=` attributes are available in RERO we can simplify
Cypress tests, and improve them!

* Doesn't hide the Debug toolbar in Cypress tests as FLASK_DEBUG
should be set to False when launching the server.
* Creates new setLanguageToEnglish Cypress command to set language to
English.
* Deletes all cy.visit() method and use menus to navigate in the
application.
* Creates new logout() Cypress command.
* Creates new goToMenu() Cypress command.
* Creates new createItem() Cypress command.
* Creates new goToItem() Cypress command.
* Improves checkout-checkin.spec.js Cypress tests using new Cypress
commands.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

To improve use of Cypress commands in rero-ils for future tests.

## Dependencies

My PR depends on the following PR(s):

* https://github.com/rero/ng-core/ (dev branch)

## How to test?

```bash
# clone rero/rero-ils-ui (dev branch)
cd rero-ils-ui
npm i && npm run pack
# this generates a rero-rero-ils-ui-0.3.0.tgz file
# clone this repository
cd rero-ils
poetry run bootstrap -t ../rero-ils-ui/rero-rero-ils-ui-0.3.0.tgz
poetry run setup
FLASK_DEBUG=False poetry run server
# after the server is launched you can check Cypress tests
cd rero-ils/tests/e2e/cypress
npm i && npm run cypress
# click on checkout-checkin.spec.js to launch the test
```

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
