### PR TITLE
loans: item deletion allowed with CREATED loan

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -1151,10 +1151,14 @@ class ItemCirculation(IlsRecord):
         }
 
     def get_number_of_loans(self):
-        """Get number of loans."""
+        """Get number of loans.
+
+        Exclude CREATED Loan as it can block Item deletion.
+        """
         search = search_by_pid(
             item_pid=item_pid_to_object(self.pid),
             exclude_states=[
+                LoanState.CREATED,
                 LoanState.CANCELLED,
                 LoanState.ITEM_RETURNED,
             ]


### PR DESCRIPTION
Sometimes items have Loan in CREATED state. Mainly due to circulation
action that are interrupted.
These Loan are not considered as important for the Circulation. But the
delete button on Item cannot be active if CREATED Loan exists.
This commit fixes the problem by bypassing CREATED Loan in item delete
button.

* Fixes bug about Item that have Loan in state CREATED and cannot be
deleted.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because you cannot delete an item that have CREATED Loan.

## How to test?

* Attempt a checkout on an item not allowed by policy (an error should appear)
* Check that you have CREATED Loan here: http://localhost:9200/loans/_search/?q=CREATED
* Go to the item and check that the "delete" button is possible
* Click on it.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
