### PR TITLE
editor: fix 'oneOf' data loading

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -487,6 +487,7 @@
               "type": "string",
               "readOnly": true,
               "default": "rdami:1001",
+              "const": "rdami:1001",
               "form": {
                 "templateOptions": {
                   "cssClass": "col-lg-6"
@@ -546,6 +547,7 @@
               "type": "string",
               "readOnly": true,
               "default": "rdami:1002",
+              "const": "rdami:1002",
               "form": {
                 "templateOptions": {
                   "cssClass": "col-lg-6"
@@ -605,6 +607,7 @@
               "type": "string",
               "readOnly": true,
               "default": "rdami:1003",
+              "const": "rdami:1003",
               "form": {
                 "templateOptions": {
                   "cssClass": "col-lg-6"
@@ -659,6 +662,7 @@
               "type": "string",
               "readOnly": true,
               "default": "rdami:1004",
+              "const": "rdami:1004",
               "form": {
                 "templateOptions": {
                   "cssClass": "col-lg-6"
@@ -721,20 +725,12 @@
                 "title": "Type",
                 "type": "string",
                 "readOnly": true,
-                "enum": [
-                  "person"
-                ],
                 "default": "person",
+                "const": "person",
                 "form": {
                   "templateOptions": {
                     "cssClass": "col-lg-6"
-                  },
-                  "options": [
-                    {
-                      "label": "Person",
-                      "value": "person"
-                    }
-                  ]
+                  }
                 }
               },
               "name": {
@@ -807,17 +803,9 @@
                 "title": "Type",
                 "type": "string",
                 "default": "organisation",
+                "const": "organisation",
                 "readOnly": true,
-                "enum": [
-                  "organisation"
-                ],
                 "form": {
-                  "options": [
-                    {
-                      "label": "Organisation",
-                      "value": "organisation"
-                    }
-                  ],
                   "templateOptions": {
                     "cssClass": "col-lg-6"
                   }


### PR DESCRIPTION
* Fixes the loading of 'oneOf' data when editing a record.
* Closes rero/rero-ils#1102.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Task 1619 of US1432
https://tree.taiga.io/project/rero21-reroils/task/1619?kanban-status=1224894
https://tree.taiga.io/project/rero21-reroils/us/1432?milestone=268117

## Dependencies

My PR depends on the following PR(s):

* https://github.com/rero/rero-ils-ui/pull/283
* https://github.com/rero/ng-core/pull/220

## How to test?

See issue description.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
