### PR TITLE
server: enable options to server script

### DIFF
--- a/scripts/server
+++ b/scripts/server
@@ -71,8 +71,33 @@ fi
 if [[ -z "${FLASK_ENV}" ]]; then
   export FLASK_ENV="development"
 fi
+
+# loglevel: celery log level (Cf. https://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-l)
+# no-worker: disable celery worker
+if ! options=$(getopt -o nl: -l no-worker,loglevel: -- "$@"); then
+  exit 1
+fi
+
+CELERY_LOG_LEVEL="INFO"
+worker=true
+while test $# -gt 0
+do
+  case "$1" in
+    -l|--loglevel)
+      CELERY_LOG_LEVEL=$2
+      shift ;;
+    -n|--no-worker)
+      worker=false ;;
+    (--) shift; break;;
+    (*) break;;
+  esac
+  shift
+done
+
 # Start Worker and Beat
-celery worker --app rero_ils.celery --loglevel INFO --beat --scheduler rero_ils.schedulers.RedisScheduler & PID_CELERY=$!
+if $worker; then
+  celery worker --app rero_ils.celery --loglevel ${CELERY_LOG_LEVEL} --beat --scheduler rero_ils.schedulers.RedisScheduler & PID_CELERY=$!
+fi
 
 # Start Server
 invenio run \


### PR DESCRIPTION
The Team uses scripts/server to launch a server with celery.
Sometimes Celery is not mandatory, and sometimes we need a different log
level.

* Adds new `-l` or `--loglevel` server script option to change Celery
log level.
* Adds new `-n` or `--no-worker` server script option to disable Celery
workers.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

DEV Team needs to add more options to `server` script because of too many logs in server.

## How to test?

* Check `poetry run server --no-worker` first (to check with `ps aux|grep celery` that no worker belongs)
* Check then `poetry run server --loglevel FATAL` (and then `ps aux |grep celery` to check that Celery workers exists with `--loglevel FATAL`) 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
