### PR TITLE
cypress: test the creation of a simple document

### DIFF
--- a/rero_ils/jsonschemas/common/countries-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/countries-v0.0.1.json
@@ -2,6 +2,7 @@
   "country": {
     "title": "Country",
     "type": "string",
+    "default": "xx",
     "enum": [
       "aa",
       "abc",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
@@ -96,14 +96,9 @@
                 "title": "Type",
                 "type": "string",
                 "const": "bf:Place",
+                "default": "bf:Place",
+                "readOnly": true,
                 "form": {
-                  "hideExpression": "true",
-                  "options": [
-                    {
-                      "label": "Place",
-                      "value": "bf:Place"
-                    }
-                  ],
                   "templateOptions": {
                     "cssClass": "col-lg-4"
                   }

--- a/tests/e2e/cypress/cypress/fixtures/document.json
+++ b/tests/e2e/cypress/cypress/fixtures/document.json
@@ -1,0 +1,41 @@
+{
+  "completeDocument": {
+    "type": "Book",
+    "title": {
+      "mainTitle": "Title test",
+      "language": "arm-armn",
+      "subTitle": "Other title",
+      "partNumber": "Part number",
+      "partName": "Part name"
+    },
+    "language1": "French",
+    "language2": "English",
+    "provisionActivity": {
+      "type": "Distribution",
+      "publicationDate1": "2019",
+      "publicationDate2": "2020",
+      "statement":{
+        "place": "Place",
+        "agent": "Agent",
+        "date": "Date"
+      },
+      "note": "Provision activity note",
+      "place": "Afghanistan (af)"
+    },
+    "issuance": {
+     "issuanceMainType": "Serial",
+     "issuanceMainTypeCode": "rdami:1003",
+     "issuanceSubtype": "Monographic series"
+    },
+    "authors": {
+      "person":{
+        "search": "plo",
+        "name": "Plo, Isabelle"
+      }
+    },
+    "responsibilityStatement": {
+      "value": "Allen J Coombes",
+      "language": "arm-armn"
+    }
+  }
+}

--- a/tests/e2e/cypress/cypress/fixtures/users.json
+++ b/tests/e2e/cypress/cypress/fixtures/users.json
@@ -12,5 +12,11 @@
       "email": "reroilstest+virgile@gmail.com",
       "name": "Virgile"
     }
+  },
+  "sysLibrarians": {
+    "astrid": {
+      "email": "reroilstest@gmail.com",
+      "name": "Astrid"
+    }
   }
 }

--- a/tests/e2e/cypress/cypress/integration/editor/document/create-simple-document.spec.js
+++ b/tests/e2e/cypress/cypress/integration/editor/document/create-simple-document.spec.js
@@ -1,0 +1,58 @@
+/// <reference types="Cypress" />
+/*
+
+RERO ILS
+Copyright (C) 2020 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+before(function () {
+  cy.fixture('document').then(function (documentData) {
+    this.document = documentData;
+  });
+  cy.fixture('users').then(function (userData) {
+    this.users = userData;
+  });
+  cy.fixture('common').then(function (commonData) {
+    this.common = commonData;
+  });
+})
+
+describe('Document editor', function() {
+  it('Creates a document with only essential fields', function() {
+    const document = this.document.completeDocument;
+
+    // Go to frontpage and log in as system librarian
+    cy.setup();
+    cy.adminLogin(this.users.sysLibrarians.astrid.email, this.common.uniquePwd);
+
+    // Go to document editor
+    cy.goToMenu('create-bibliographic-record-menu-frontpage');
+
+    // Populate form with simple record
+    cy.populateSimpleRecord(document);
+
+    //Save record
+    cy.saveRecord();
+
+    // Go to description tab
+    cy.get('#documents-description-tab-link').click()
+
+    // Assert that the values are correctly displayed
+    cy.checkDocumentEssentialFields(document);
+
+    // Delete record
+    cy.deleteRecordFromDetailView();
+  });
+})


### PR DESCRIPTION
* Creates a test for the creation of a document with only essential
fields.
* Creates document fixture.
* Corrects jsonschema (countries, provision activity).
* Corrects checkout-checkin test to use custom ids in editor.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To implement a test of the user interface of the documents editor. First case: create a document with essential fields only.
https://tree.taiga.io/project/rero21-reroils/task/1562?kanban-status=1224894

## Dependencies

My PR depends on the following PR(s):

* dev of rero-ils-ui
* dev of ng-core

## How to test?

You need a bootstrap and a setup, and run the server with `FLASK_DEBUG=False poetry run server`, otherwise the test will fail.
Check that `FLASK_DEBUG=False` is not overwritten in invenio.cfg.

To run the tests on command line: `poetry run cypress` (all the tests).
Or with a GUI: `cd tests/e2e/cypress`, then `npm run cypress`. Click on `Run all specs` on top right of the interface.
Try different browsers.

Documentation: https://github.com/rero/developer-resources/blob/master/base/cypress.md

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
