### PR TITLE
circulation: add units testing for circulation scenarios

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -827,6 +827,8 @@ class ItemCirculation(IlsRecord):
                         res.patron_pid
                     raise ItemNotAvailableError(
                         item_pid=item_pid, description=msg)
+                # exit from loop after evaluation of the first request.
+                break
         return action_params, actions
 
     def dumps_for_circulation(self, sort_by=None):

--- a/tests/api/circulation/scenarios/test_scenario_a.py
+++ b/tests/api/circulation/scenarios/test_scenario_a.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests circulation scenario A."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json, postdata
+
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
+    get_last_transaction_loc_for_item, get_loans_by_patron_pid
+
+
+def test_circ_scenario_a(
+        client, librarian_martigny_no_email, lib_martigny,
+        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
+        circulation_policies):
+    """Test the first circulation scenario."""
+    # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
+    # A request is made on on-shelf item, that has no requests, to be picked
+    # up at the owning library. Validated by the librarian. Picked up at same
+    # owning library. and returned on-time at the owning library
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    # ADD_REQUEST_1.1
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    request_loan_pid = get_json(res)['action_applied']['request']['pid']
+    # VALIDATE_1.2
+    circ_params['pid'] = request_loan_pid
+    res, data = postdata(
+        client, 'api_item.validate_request', dict(circ_params))
+    assert res.status_code == 200
+    # CHECKOUT_2.1
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 200
+    # CHECKIN_3.1.1
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF

--- a/tests/api/circulation/scenarios/test_scenario_b.py
+++ b/tests/api/circulation/scenarios/test_scenario_b.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests circulation scenario B."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json, postdata
+
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
+    get_last_transaction_loc_for_item, get_loans_by_patron_pid
+
+
+def test_circ_scenario_b(
+        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
+        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
+        circulation_policies, loc_public_saxon, librarian_saxon_no_email):
+    """Test the second circulation scenario."""
+    # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
+    # A request is made on item of library A, on-shelf without previous
+    # requests, to be picked up at library B. Validated by the librarian A
+    # and goes in transit. Received by the librarian B and goes at desk.
+    # Picked up at library B. Returned on-time at the library B, goes
+    # in transit. Received at library A and goes on shelf.
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    request_loan_pid = get_json(res)['action_applied']['request']['pid']
+
+    circ_params['pid'] = request_loan_pid
+    res, data = postdata(
+        client, 'api_item.validate_request', dict(circ_params))
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_saxon_no_email.user)
+
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 200
+
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF

--- a/tests/api/circulation/scenarios/test_scenario_c.py
+++ b/tests/api/circulation/scenarios/test_scenario_c.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests circulation scenario C."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json, postdata
+
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
+    get_last_transaction_loc_for_item, get_loans_by_patron_pid
+
+
+def test_circ_scenario_c(
+        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
+        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
+        circulation_policies, loc_public_saxon, librarian_saxon_no_email,
+        patron2_martigny_no_email, lib_fully, loc_public_fully,
+        librarian_fully_no_email):
+    """Test the third circulation scenario."""
+    # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
+    # A request is made on item of library A, on-shelf without previous
+    # requests, to be picked up at library B. Validated by the librarian A
+    # and goes in transit. Received by the librarian B and goes at desk.
+    # Picked up at library B. Requested by another patron_2 to be picked up
+    # at library C. Returned on-time at the library B, goes in transit to
+    # library C. Received at library C and goes at desk. Picked up at library C
+    #  by patron_2. Renewed by patron_2. Returned on-time at the library C
+    # after the end of first renewal. goes in transit to library A. Received at
+    #  library A and goes on shelf.
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    request_loan_pid = get_json(res)['action_applied']['request']['pid']
+
+    circ_params['pid'] = request_loan_pid
+    res, data = postdata(
+        client, 'api_item.validate_request', dict(circ_params))
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_saxon_no_email.user)
+
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 200
+
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_fully.pid,
+            'transaction_library_pid': lib_fully.pid,
+            'transaction_user_pid': librarian_fully_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    fully_loan_pid = get_json(res)['action_applied']['request']['pid']
+
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF
+
+    login_user_via_session(client, librarian_fully_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_fully.pid,
+            'transaction_library_pid': lib_fully.pid,
+            'transaction_user_pid': librarian_fully_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 200
+
+    res, data = postdata(
+        client, 'api_item.extend_loan', dict(circ_params))
+    assert res.status_code == 200
+
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF

--- a/tests/api/circulation/scenarios/test_scenario_d.py
+++ b/tests/api/circulation/scenarios/test_scenario_d.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests circulation scenario D."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json, postdata
+
+from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
+    get_last_transaction_loc_for_item, get_loans_by_patron_pid
+
+
+def test_circ_scenario_d(
+        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
+        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
+        circulation_policies, loc_public_saxon, librarian_saxon_no_email,
+        patron2_martigny_no_email, lib_fully, loc_public_fully,
+        librarian_fully_no_email):
+    """Test the fourth circulation scenario."""
+    # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
+    # An inexperienced librarian A (library A) makes a checkin on item A,
+    # which is on shelf at library A and without requests (-> nothing happens).
+    # Item A is requested by patron A. Another librarian B of library B tries
+    # to check it out for patron B (-> denied). The item is requested by
+    # patron B with pickup library B. Librarian B tries again to check it out
+    # for patron B (-> denied), then for patron A (-> ok). Patron A tries to
+    # renew item A (-> denied). Patron A returns item A at library B. The item
+    # is at desk for patron B.
+
+    # Patron A requests it again, with pickup library A. Unexpectedly,
+    # libarian A tries to check out item A for patron A (-> denied).
+    # He then checks it out for patron B. Patron B returns item A at library C.
+    # It goes in transit to library A for patron A.
+
+    # Before arriving to library A, it transits through library B. Patron A
+    # cancels his request. Item A transits through library C. It is then
+    # received at its owning library A.
+
+    # An inexperienced librarian A (library A) makes a checkin on item A,
+    # which is on shelf at library A and without requests (-> nothing happens).
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 400
+
+    # Item A is requested by patron A.
+    circ_params['patron_pid'] = patron_martigny_no_email.pid
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    martigny_loan_pid = get_json(res)['action_applied']['request']['pid']
+
+    # Another librarian B of library B tries
+    # to check it out for patron B (-> denied).
+    login_user_via_session(client, librarian_saxon_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 403
+
+    # The item is requested by
+    # patron B with pickup library B.
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    saxon_loan_pid = get_json(res)['action_applied']['request']['pid']
+
+    # Librarian B tries again to check it out
+    # for patron B (-> denied),
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 403
+    # then for patron A (-> ok).
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_saxon.pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 200
+
+    # Patron A tries to renew item A (-> denied).
+    res, data = postdata(
+        client, 'api_item.extend_loan', dict(circ_params))
+    assert res.status_code == 400
+
+    # Patron A returns item A at library B. The item is at desk for patron B.
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+
+    # Patron A requests it again, with pickup library A.
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.librarian_request', dict(circ_params))
+    assert res.status_code == 200
+    martigny_loan_pid = get_json(res)['action_applied']['request']['pid']
+
+    # Unexpectedly, libarian A tries to check out item A for patron A
+    # (-> denied).
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 403
+
+    # He then checks it out for patron B.
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkout', dict(circ_params))
+    assert res.status_code == 200
+
+    # Patron B returns item A at library C.
+    # It goes in transit to library A for patron A.
+    login_user_via_session(client, librarian_fully_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron2_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_fully.pid,
+            'transaction_library_pid': lib_fully.pid,
+            'transaction_user_pid': librarian_fully_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200
+
+    # Before arriving to library A, it transits through library B.
+    login_user_via_session(client, librarian_saxon_no_email.user)
+    # Patron A
+    # cancels his request. Item A transits through library C. It is then
+    # received at its owning library A.
+    circ_params = {
+            'pid': martigny_loan_pid,
+            'transaction_library_pid': lib_saxon.pid,
+            'transaction_user_pid': librarian_saxon_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.cancel_item_request', dict(circ_params))
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    circ_params = {
+            'item_pid': item_lib_martigny.pid,
+            'patron_pid': patron_martigny_no_email.pid,
+            'pickup_location_pid': loc_public_martigny.pid,
+            'transaction_library_pid': lib_martigny.pid,
+            'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    res, data = postdata(
+        client, 'api_item.checkin', dict(circ_params))
+    assert res.status_code == 200


### PR DESCRIPTION
Ensures that all circulation scenarios listed in the file
https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
are tested in the backend.

Fixes bug: a checkout was not possible for an item with two pending loans.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1492?milestone=269576

## How to test?

`./run_tests.sh`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
