### PR TITLE
document: add marcxml support for the document API

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -430,6 +430,11 @@ RECORDS_REST_ENDPOINTS = dict(
                 'rero_ils.modules.documents.serializers:json_doc_search'
             ),
         },
+        record_loaders={
+            'application/marcxml+xml': 'rero_ils.modules.documents.loaders:marcxml_loader',
+            'application/json': lambda: Document(request.get_json()),
+        },
+
         list_route='/documents/',
         record_class='rero_ils.modules.documents.api:Document',
         item_route=('/documents/<pid(doc, record_class='

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -115,6 +115,9 @@ class IlsRecord(Record):
         extended validation per record class
         and test of pid existence.
         """
+        if self.get('_draft'):
+            # No validation is needed for draft records
+            return True
         super(IlsRecord, self).validate(**kwargs)
         validation_message = self.extended_validation(**kwargs)
         # We only like to run pids_exist_check if validation_message is True

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -131,6 +131,15 @@
       "description": "Document is harvested or not, will disable record edition or similar.",
       "type": "boolean",
       "default": false
+    },
+    "_draft": {
+      "title": "Draft",
+      "description": "Document is a draft record or not, will disable record validation.",
+      "type": "boolean",
+      "default": false,
+      "form": {
+        "hideExpression": "true"
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/loaders/__init__.py
+++ b/rero_ils/modules/documents/loaders/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Document loaders."""
+
+from .marcxml import marcxml_marshmallow_loader
+
+marcxml_loader = marcxml_marshmallow_loader

--- a/rero_ils/modules/documents/loaders/marcxml.py
+++ b/rero_ils/modules/documents/loaders/marcxml.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Document loaders."""
+
+from dojson.contrib.marc21.utils import create_record, split_stream
+from flask import abort, request
+from six import BytesIO
+
+from rero_ils.modules.documents.dojson.contrib.marc21tojson import marc21
+
+
+def marcxml_marshmallow_loader():
+    """Marshmallow loader for MARCXML requests.
+
+    The method convert only one record, otherwise will return a bad request.
+    :return: converted marc21 json record.
+    """
+    marcxml_records = split_stream(BytesIO(request.data))
+    number_of_xml_records = 0
+    josn_record = {}
+    for marcxml_record in marcxml_records:
+        marc21json_record = create_record(marcxml_record)
+        josn_record = marc21.do(marc21json_record)
+        # converted records are considered as draft
+        josn_record['_draft'] = True
+        if number_of_xml_records > 0:
+            abort(400)
+        number_of_xml_records += 1
+    return josn_record

--- a/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
@@ -714,6 +714,9 @@
         "harvested": {
           "type": "boolean"
         },
+        "_draft": {
+          "type": "boolean"
+        },
         "_created": {
           "type": "date"
         },

--- a/tests/api/documents/test_marcxml_rest_api.py
+++ b/tests/api/documents/test_marcxml_rest_api.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests POST REST API for MARC21 documents."""
+
+
+import mock
+from utils import VerifyRecordPermissionPatch, postdata
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_marcxml_documents_create(
+        client, document_marcxml, documents_marcxml, rero_marcxml_header):
+    """Test post of marcxml document."""
+    res, data = postdata(
+        client,
+        'invenio_records_rest.doc_list',
+        document_marcxml,
+        headers=rero_marcxml_header,
+        force_data_as_json=False
+    )
+    assert res.status_code == 201
+    assert data['metadata']['_draft']
+
+    #  test fails when multiple xml records are sent.
+    res, data = postdata(
+        client,
+        'invenio_records_rest.doc_list',
+        documents_marcxml,
+        headers=rero_marcxml_header,
+        force_data_as_json=False
+    )
+    assert res.status_code == 400

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,15 @@ def json_header():
 
 
 @pytest.fixture(scope="session")
+def rero_marcxml_header():
+    """Load marcxml headers."""
+    return [
+        ('Accept', 'application/json'),
+        ('Content-Type', 'application/marcxml+xml')
+    ]
+
+
+@pytest.fixture(scope="session")
 def rero_json_header():
     """Load json headers."""
     return [

--- a/tests/data/document.xml
+++ b/tests/data/document.xml
@@ -1,0 +1,82 @@
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00975nam a2200277 a 4500</leader>
+  <controlfield tag="001">REROILS:1</controlfield>
+  <controlfield tag="005">20170518120100.0</controlfield>
+  <controlfield tag="008">000918s1999    gw ||| |  ||||00|  |ger d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9783503057221</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">R270072860</subfield>
+  </datafield>
+  <datafield tag="039" ind1=" " ind2=" ">
+    <subfield code="b">4606</subfield>
+  </datafield>
+  <datafield tag="039" ind1=" " ind2="9">
+    <subfield code="a">201705181201</subfield>
+    <subfield code="b">VLOAD</subfield>
+    <subfield code="c">200812211738</subfield>
+    <subfield code="d">VLOAD</subfield>
+    <subfield code="y">200009182231</subfield>
+    <subfield code="z">VLOAD</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">RERO neubfd</subfield>
+  </datafield>
+  <datafield tag="072" ind1=" " ind2="7">
+    <subfield code="a">s1dr</subfield>
+    <subfield code="2">rero</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Zacharias, Erwin</subfield>
+    <subfield code="4">cre</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Going Public einer Fussball-Kapitalgesellschaft :</subfield>
+    <subfield code="b">rechtliche, betriebswirtschaftliche und strategische Konzepte bei der Vorbereitung der Börseneinführung eines Fussball-Bundesligavereins /</subfield>
+    <subfield code="c">von Erwin Zacharias</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Bielefeld :</subfield>
+    <subfield code="b">Erich Schmidt,</subfield>
+    <subfield code="c">1999</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">617 S. :</subfield>
+    <subfield code="b">Taf. ;</subfield>
+    <subfield code="c">21 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="904" ind1=" " ind2=" ">
+    <subfield code="a">neciesna</subfield>
+    <subfield code="b">2000/05</subfield>
+  </datafield>
+  <datafield tag="962" ind1=" " ind2=" ">
+    <subfield code="a">necies</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="2">dr-sys</subfield>
+    <subfield code="a">A 79.1 h</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="2">dr-sys</subfield>
+    <subfield code="a">A 61 h</subfield>
+  </datafield>
+  <datafield tag="984" ind1=" " ind2=" ">
+    <subfield code="2">dr-necies</subfield>
+    <subfield code="a">A 79.1 h ZACH 1999</subfield>
+  </datafield>
+</record>
+</collection>

--- a/tests/data/documents.xml
+++ b/tests/data/documents.xml
@@ -1,0 +1,162 @@
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00975nam a2200277 a 4500</leader>
+  <controlfield tag="001">REROILS:1</controlfield>
+  <controlfield tag="005">20170518120100.0</controlfield>
+  <controlfield tag="008">000918s1999    gw ||| |  ||||00|  |ger d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9783503057221</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">R270072860</subfield>
+  </datafield>
+  <datafield tag="039" ind1=" " ind2=" ">
+    <subfield code="b">4606</subfield>
+  </datafield>
+  <datafield tag="039" ind1=" " ind2="9">
+    <subfield code="a">201705181201</subfield>
+    <subfield code="b">VLOAD</subfield>
+    <subfield code="c">200812211738</subfield>
+    <subfield code="d">VLOAD</subfield>
+    <subfield code="y">200009182231</subfield>
+    <subfield code="z">VLOAD</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">RERO neubfd</subfield>
+  </datafield>
+  <datafield tag="072" ind1=" " ind2="7">
+    <subfield code="a">s1dr</subfield>
+    <subfield code="2">rero</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Zacharias, Erwin</subfield>
+    <subfield code="4">cre</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Going Public einer Fussball-Kapitalgesellschaft :</subfield>
+    <subfield code="b">rechtliche, betriebswirtschaftliche und strategische Konzepte bei der Vorbereitung der Börseneinführung eines Fussball-Bundesligavereins /</subfield>
+    <subfield code="c">von Erwin Zacharias</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Bielefeld :</subfield>
+    <subfield code="b">Erich Schmidt,</subfield>
+    <subfield code="c">1999</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">617 S. :</subfield>
+    <subfield code="b">Taf. ;</subfield>
+    <subfield code="c">21 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="904" ind1=" " ind2=" ">
+    <subfield code="a">neciesna</subfield>
+    <subfield code="b">2000/05</subfield>
+  </datafield>
+  <datafield tag="962" ind1=" " ind2=" ">
+    <subfield code="a">necies</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="2">dr-sys</subfield>
+    <subfield code="a">A 79.1 h</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="2">dr-sys</subfield>
+    <subfield code="a">A 61 h</subfield>
+  </datafield>
+  <datafield tag="984" ind1=" " ind2=" ">
+    <subfield code="2">dr-necies</subfield>
+    <subfield code="a">A 79.1 h ZACH 1999</subfield>
+  </datafield>
+</record>
+<record>
+  <leader>00975nam a2200277 a 4500</leader>
+  <controlfield tag="001">REROILS:1</controlfield>
+  <controlfield tag="005">20170518120100.0</controlfield>
+  <controlfield tag="008">000918s1999    gw ||| |  ||||00|  |ger d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9783503057221</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">R270072860</subfield>
+  </datafield>
+  <datafield tag="039" ind1=" " ind2=" ">
+    <subfield code="b">4606</subfield>
+  </datafield>
+  <datafield tag="039" ind1=" " ind2="9">
+    <subfield code="a">201705181201</subfield>
+    <subfield code="b">VLOAD</subfield>
+    <subfield code="c">200812211738</subfield>
+    <subfield code="d">VLOAD</subfield>
+    <subfield code="y">200009182231</subfield>
+    <subfield code="z">VLOAD</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">RERO neubfd</subfield>
+  </datafield>
+  <datafield tag="072" ind1=" " ind2="7">
+    <subfield code="a">s1dr</subfield>
+    <subfield code="2">rero</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Zacharias, Erwin</subfield>
+    <subfield code="4">cre</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Going Public einer Fussball-Kapitalgesellschaft :</subfield>
+    <subfield code="b">rechtliche, betriebswirtschaftliche und strategische Konzepte bei der Vorbereitung der Börseneinführung eines Fussball-Bundesligavereins /</subfield>
+    <subfield code="c">von Erwin Zacharias</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Bielefeld :</subfield>
+    <subfield code="b">Erich Schmidt,</subfield>
+    <subfield code="c">1999</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">617 S. :</subfield>
+    <subfield code="b">Taf. ;</subfield>
+    <subfield code="c">21 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="904" ind1=" " ind2=" ">
+    <subfield code="a">neciesna</subfield>
+    <subfield code="b">2000/05</subfield>
+  </datafield>
+  <datafield tag="962" ind1=" " ind2=" ">
+    <subfield code="a">necies</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="2">dr-sys</subfield>
+    <subfield code="a">A 79.1 h</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="2">dr-sys</subfield>
+    <subfield code="a">A 61 h</subfield>
+  </datafield>
+  <datafield tag="984" ind1=" " ind2=" ">
+    <subfield code="2">dr-necies</subfield>
+    <subfield code="a">A 79.1 h ZACH 1999</subfield>
+  </datafield>
+</record>
+</collection>

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -729,3 +729,17 @@ def babel_filehandle():
         join(dirname(__file__), '..', 'data', 'babel_extraction.json'),
         'rb'
     )
+
+
+@pytest.fixture(scope='module')
+def documents_marcxml():
+    """Load marc xml records in one file."""
+    with open(join(dirname(__file__), '..', 'data', 'documents.xml')) as fh:
+        return fh.read()
+
+
+@pytest.fixture(scope='module')
+def document_marcxml():
+    """Load one marc xml record in one file."""
+    with open(join(dirname(__file__), '..', 'data', 'document.xml')) as fh:
+        return fh.read()

--- a/tests/unit/test_documents_jsonschema.py
+++ b/tests/unit/test_documents_jsonschema.py
@@ -426,3 +426,12 @@ def test_harvested(document_schema, document_data_tmp):
     with pytest.raises(ValidationError):
         document_data_tmp['harvested'] = 2
         validate(document_data_tmp, document_schema)
+
+
+def test_draft(document_schema, document_data_tmp):
+    """Test draft for jsonschemas."""
+    validate(document_data_tmp, document_schema)
+
+    with pytest.raises(ValidationError):
+        document_data_tmp['_draft'] = 2
+        validate(document_data_tmp, document_schema)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,11 +71,13 @@ def get_csv(response):
     return response.get_data(as_text=True)
 
 
-def postdata(client, endpoint, data=None, headers=None, url_data=None):
-    """
-    Build URL from given endpoint and send given data to it.
+def postdata(
+        client, endpoint, data=None, headers=None, url_data=None,
+        force_data_as_json=True):
+    """Build URL from given endpoint and send given data to it.
 
-    Returns result and JSON from result.
+    :param force_data_as_json: the data sent forced json.
+    :return: returns result and JSON from result.
     """
     if data is None:
         data = {}
@@ -86,10 +88,11 @@ def postdata(client, endpoint, data=None, headers=None, url_data=None):
         ]
     if url_data is None:
         url_data = {}
+    if force_data_as_json:
+        data = json.dumps(data)
     res = client.post(
         url_for(endpoint, **url_data),
-        data=json.dumps(data),
-        content_type='application/json',
+        data=data,
         headers=headers
     )
     output = get_json(res)


### PR DESCRIPTION
With this commit, authenticated users can post marcxml records using the
document REST API. The imported records receive the flag _draft as True. The
record validation for the draft records is disabled.

* Adds a new field _draft to the document json schema.
* Updates tests/fixtures accordingly.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

For MARCXML import records from EZpump:

https://tree.taiga.io/project/rero21-reroils/us/1546?milestone=269576

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

run_tests.sh

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
