### PR TITLE
data: reorganisation of json schema.

### DIFF
--- a/rero_ils/jsonschemas/common/languages-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/languages-v0.0.1.json
@@ -2560,37 +2560,5 @@
         "$ref": "#/language_script_code"
       }
     }
-  },
-  "numbering_script": {
-    "title": "Values",
-    "type": "object",
-    "propertiesOrder": [
-      "language",
-      "value"
-    ],
-    "required": [
-      "value"
-    ],
-    "form": {
-      "templateOptions": {
-        "cssClass": "row"
-      }
-    },
-    "properties": {
-      "value": {
-        "title": "Value",
-        "type": "string",
-        "minLength": 1,
-        "form": {
-          "placeholder": "Example: vol.3",
-          "templateOptions": {
-            "cssClass": "col-lg-6"
-          }
-        }
-      },
-      "language": {
-        "$ref": "#/language_script_code"
-      }
-    }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json
@@ -32,7 +32,9 @@
           "minItems": 1,
           "items": {
             "title": "Numbering",
-            "$ref": "https://ils.rero.ch/schemas/common/languages-v0.0.1.json#/numbering_script"
+            "numbering_script": {
+              "$ref": "#/definitions/numbering_script"
+            }
           }
         },
         "subseriesStatement": {
@@ -66,7 +68,9 @@
                 "minItems": 1,
                 "items": {
                   "title": "Numbering",
-                  "$ref": "https://ils.rero.ch/schemas/common/languages-v0.0.1.json#/numbering_script"
+                  "numbering_script": {
+                    "$ref": "#/definitions/numbering_script"
+                  }
                 }
               }
             }
@@ -84,6 +88,40 @@
       },
       "templateOptions": {
         "cssClass": "editor-title"
+      }
+    }
+  },
+  "definitions": {
+    "numbering_script": {
+      "title": "Values",
+      "type": "object",
+      "propertiesOrder": [
+        "language",
+        "value"
+      ],
+      "required": [
+        "value"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "row"
+        }
+      },
+      "properties": {
+        "value": {
+          "title": "Value",
+          "type": "string",
+          "minLength": 1,
+          "form": {
+            "placeholder": "Example: vol.3",
+            "templateOptions": {
+              "cssClass": "col-lg-6"
+            }
+          }
+        },
+        "language": {
+          "$ref": "https://ils.rero.ch/schemas/common/languages-v0.0.1.json#/language_script_code"
+        }
       }
     }
   }


### PR DESCRIPTION
Reorganizes `numbering_script` from `common/languages-v0.0.1.json`
to `documents/document_series-v0.0.1.json`.

* closes #1147

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
