### PR TITLE
patron: fix missing configuration for patron subscriptions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,6 +276,7 @@ setup(
             'ebooks = rero_ils.modules.ebooks.tasks',
             'apiharvester = rero_ils.modules.apiharvester.tasks',
             'notifications = rero_ils.modules.notifications.tasks',
+            'patrons = rero_ils.modules.patrons.tasks',
         ],
         'invenio_records.jsonresolver': [
             'organisations = rero_ils.modules.organisations.jsonresolver',


### PR DESCRIPTION
In a deployed environment, celery scheduler is unable to locate the method
task_clear_and_renew_subscriptions which is used to clear patron subscriptions.

This is due to the fact that task_clear_and_renew_subscriptions is configured
in config.py and its path not present in setup.py

* close #1158

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

To fix Sentry errors:
`
KeyError celery.worker.consumer.consumer in on_task_received
rero_ils.modules.patrons.tasks.task_clear_and_renew_subscriptions
`

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
