### PR TITLE
circulation: fix problem when checking out an item_at_desk

### DIFF
--- a/doc/circulation/scenarios.md
+++ b/doc/circulation/scenarios.md
@@ -87,16 +87,27 @@ CHECKIN_5.1.1
 
 ## scenario_E
 
-*WORK IN PROGRESS*
+:heavy_check_mark:
+:warning: Complete file action.md with the checkmark for each action
 
-A request is made by user B on item of library A, on-shelf without previous requests, to be picked up at library B. Librarian A finds this item on the floor and does a checkin, by security. The item is validated and goes in transit.
+A request is made by user B on item of library A, on-shelf without previous requests, to be picked up at library B.
+Librarian A finds this item on the floor and does a checkin, by security.
+The item is validated and goes in transit.
 
-A librarian C checks the item in, but it stays in transit, because it goes to library B. Impatient, user B tries to request again the item (impossible). Another person, user A, requests it with pickup at library A.
+A librarian C checks the item in, but it stays in transit, because it goes to library B.
+Impatient, user B tries to request again the item (impossible).
+Another person, user A, requests it with pickup at library A.
 
-A librarian B sees this document and wants to borrow it for himself. Before doing a *receive*, he tries to do a checkout (-> denied). He definitely forgots to do the receive, but by chance the requesting person, user B, come and ask for it. Checkout is done.
+A librarian B sees this document and wants to borrow it for himself. Before doing a receive, he tries to do a checkout (-> denied). He definitely forgots to do the receive, but by chance the requesting person, user B, come and ask for it. Checkout is done.
 
-User A is impatient as well and tries to request the item again (impossible). User C requests it with pickup library C. Librarian A tries to check it out for user C (-> denied). User B returns the item at library A; a checkin is done from the checkout interface. Item is directly at desk for user A.
+User A is impatient as well and tries to request the item again (impossible).
+User C requests it with pickup library C. Librarian A tries to check it out for user C (-> denied).
+User B returns the item at library B, the item goes in transit to library A for user A. User A changes the pickup location to library B.
+User A waited to long and cancels his request, the item goes in transit to library C for user C.
+User C cancels his request as well, the item is in transit to its owning library.
+User C adds a request again, with pickup library A, and removes it just after.
 
+By chance, user B find the item at library B and borrows it. He brings it back at library A, the item is on shelf.
 
 ```
 ADD_REQUEST_1.1
@@ -109,5 +120,12 @@ CHECKOUT_4.1
 ADD_REQUEST_3.2.2.1
 ADD_REQUEST_3.2.2.2
 CHECKOUT_3.2
-CHECKOUT_3.1
+CHECKIN_3_2_2_1
+CHANGE_PICKUP_LOCATION_4
+CANCEL_REQUEST_4_1_2
+CANCEL_REQUEST_4_1_1
+ADD_REQUEST_5_1
+CANCEL_REQUEST_4_1_1
+CHECKOUT_5.1
+CHECKIN_3.1.1
 ```

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -55,7 +55,7 @@ def search_active_loans_for_item(item_pid):
     search = search_by_pid(
         item_pid=item_pid_object,
         filter_states=states,
-        sort_by_field='transaction_date',
+        sort_by_field='_created',
         sort_order='desc'
     )
     loans_count = search.count()

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -876,7 +876,8 @@ class ItemCirculation(IlsRecord):
         :param loan_pid : the loan pid to exclude
         :return:  the list of loans states attached to the item
         """
-        exclude_states = [LoanState.ITEM_RETURNED, LoanState.CANCELLED]
+        exclude_states = [
+            LoanState.ITEM_RETURNED, LoanState.CANCELLED, LoanState.CREATED]
         item_pid_object = item_pid_to_object(item_pid)
         results = current_circulation.loan_search_cls()\
             .filter('term', item_pid__value=item_pid_object['value'])\
@@ -898,17 +899,17 @@ class ItemCirculation(IlsRecord):
             return None
 
     @classmethod
-    def get_pendings_loans(cls, library_pid=None, sort_by='transaction_date'):
+    def get_pendings_loans(cls, library_pid=None, sort_by='_created'):
         """Return list of sorted pending loans for a given library.
 
-        default sort is set to transaction_date
+        default sort is set to _created
         """
         # check if library exists
         lib = Library.get_record_by_pid(library_pid)
         if not lib:
             raise Exception('Invalid Library PID')
         # the '-' prefix means a desc order.
-        sort_by = sort_by or 'transaction_date'
+        sort_by = sort_by or '_created'
         order_by = 'asc'
         if sort_by.startswith('-'):
             sort_by = sort_by[1:]
@@ -925,14 +926,14 @@ class ItemCirculation(IlsRecord):
 
     @classmethod
     def get_checked_out_loans(
-            cls, patron_pid=None, sort_by='transaction_date'):
+            cls, patron_pid=None, sort_by='_created'):
         """Returns sorted checked out loans for a given patron."""
         # check library exists
         patron = Patron.get_record_by_pid(patron_pid)
         if not patron:
             raise InvalidRecordID('Invalid Patron PID')
         # the '-' prefix means a desc order.
-        sort_by = sort_by or 'transaction_date'
+        sort_by = sort_by or '_created'
         order_by = 'asc'
         if sort_by.startswith('-'):
             sort_by = sort_by[1:]
@@ -1171,7 +1172,7 @@ class ItemCirculation(IlsRecord):
     def get_requests(self, sort_by=None):
         """Return sorted pending, item_on_transit, item_at_desk loans.
 
-        default sort is transaction_date.
+        default sort is _created.
         """
         search = search_by_pid(
             item_pid=item_pid_to_object(self.pid), filter_states=[
@@ -1180,7 +1181,7 @@ class ItemCirculation(IlsRecord):
                 LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
             ]).params(preserve_order=True).source(['pid'])
         order_by = 'asc'
-        sort_by = sort_by or 'transaction_date'
+        sort_by = sort_by or '_created'
         if sort_by.startswith('-'):
             sort_by = sort_by[1:]
             order_by = 'desc'
@@ -1200,7 +1201,7 @@ class ItemCirculation(IlsRecord):
     def get_item_loans_by_state(self, state=None, sort_by=None):
         """Return sorted item loans with a given state.
 
-        default sort is transaction_date.
+        default sort is _created.
         :param state : the loan state
         :param sort_by : field to use for sorting
         :return: loans found
@@ -1210,7 +1211,7 @@ class ItemCirculation(IlsRecord):
                 state
             ]).params(preserve_order=True).source(['pid'])
         order_by = 'asc'
-        sort_by = sort_by or 'transaction_date'
+        sort_by = sort_by or '_created'
         if sort_by.startswith('-'):
             sort_by = sort_by[1:]
             order_by = 'desc'

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_requests.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_requests.html
@@ -62,7 +62,7 @@
           {% endif %}
         </div>
         <div class="col-lg-2 text-right">
-        {% if loan.state == 'PENDING' %}
+        {% if loan.state in ['PENDING', 'ITEM_IN_TRANSIT_FOR_PICKUP'] %}
           <form class="mt-0" action="{{ url_for('patrons.profile') }}" method="POST" name="cancel_request">
             <input type="hidden" name="type" value="cancel">
             <input type="hidden" name="loan_pid" value="{{ loan.pid }}">

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -341,7 +341,7 @@ def test_patron_checkouts_order(client, librarian_martigny_no_email,
     res = client.get(
         url_for(
             'api_item.loans', patron_pid=patron_martigny_no_email.pid,
-            sort='transaction_date'))
+            sort='_created'))
     assert res.status_code == 200
     data = get_json(res)
     items = data['hits']['hits']


### PR DESCRIPTION
Fixes a bug: the item API blocked checkout for an item_at_desk
item with pending requests.

Uses the field `loan._created` to sort requests instead of the
field `loan.transaction_date`.

Adds the property loan.request_creation_date fulfilled by loan._created.

Fixes a bug when loan state CREATED was returned in a loan search.

* close #1160 
* Adds the full description of the circulation scenario E.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
