### PR TITLE
wiki: update the public help menu entry url

### DIFF
--- a/rero_ils/views.py
+++ b/rero_ils/views.py
@@ -131,7 +131,10 @@ def init_menu_lang():
 
         rero_register(
             item,
-            endpoint='wiki.index',
+            endpoint='wiki.page',
+            endpoint_arguments_constructor=lambda: {
+                'url': 'home/public_help_{0}'.format(current_i18n.language)
+            },
             text='{icon} {help}'.format(
                 icon='<i class="fa fa-info"></i>',
                 help=_('Help')


### PR DESCRIPTION
Updates the url from the public help menu entry from 'help' to
the public help page corresponding to the interface current selected
language ('help/home/public_help_{language}')

Closes rero/rero-ils#1127

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Check the main help menu entry. Mus be point to `/help/public` 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
