### PR TITLE
inventory: export document creator field

### DIFF
--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -31,6 +31,7 @@ csv_item = ItemCSVSerializer(
         'pid',
         'document_pid',
         'document_title',
+        'document_creator',
         'document_type',
         'location_name',
         'barcode',

--- a/rero_ils/modules/items/serializers/csv.py
+++ b/rero_ils/modules/items/serializers/csv.py
@@ -29,6 +29,29 @@ from rero_ils.modules.documents.utils import title_format_text_head
 from rero_ils.modules.items.api import search_active_loans_for_item
 from rero_ils.modules.locations.api import LocationsSearch
 
+role_filter = [
+    'rsp',
+    'cre',
+    'enj',
+    'dgs',
+    'prg',
+    'dsr',
+    'ctg',
+    'cmp',
+    'inv',
+    'com',
+    'pht',
+    'ivr',
+    'art',
+    'ive',
+    'chr',
+    'aut',
+    'arc',
+    'fmk',
+    'pra',
+    'csl'
+]
+
 
 class ItemCSVSerializer(CSVSerializer):
     """Serialize and filter item circulation status."""
@@ -68,6 +91,17 @@ class ItemCSVSerializer(CSVSerializer):
         document = search_document_by_pid(record['document']['pid'])
         record['document_title'] = title_format_text_head(document.title,
                                                           with_subtitle=True)
+        creator = []
+        for contribution in document.contribution:
+            if any(role in contribution.role for role in role_filter):
+                try:
+                    creator.append(contribution['agent']['preferred_name'])
+                except KeyError:
+                    creator.append(
+                        contribution['agent']['authorized_access_point_en']
+                    )
+        if creator:
+            record['document_creator'] = ' ; '.join(creator)
         record['document_type'] = document.type
 
         # get loans information

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -81,7 +81,7 @@ def test_items_serializers(
     assert response.status_code == 200
     data = get_csv(response)
     assert data
-    assert '"pid","document_pid","document_title","document_type",' \
-           '"location_name","barcode","call_number","second_call_number",' \
-           '"loans_count","last_transaction_date","status",' \
-           '"created"' in data
+    assert '"pid","document_pid","document_title","document_creator",' \
+           '"document_type","location_name","barcode","call_number",' \
+           '"second_call_number","loans_count","last_transaction_date",' \
+           '"status","created"' in data


### PR DESCRIPTION
In item inventory list, we need to have the information about document creator.

* Adds document creator into csv file.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/task/1644

## Dependencies

My PR depends on the following `rero-ils`'s PR(s):

* rero/rero-ils#1129

**MERGE THIS PR AFTER rero/rero-ils#1129**

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?