### PR TITLE
document: allow posting documents using OAuth token

### DIFF
--- a/rero_ils/modules/documents/permissions.py
+++ b/rero_ils/modules/documents/permissions.py
@@ -18,8 +18,13 @@
 
 """Permissions for documents."""
 
+from flask_principal import RoleNeed
+from invenio_access.permissions import Permission
+
 from rero_ils.modules.patrons.api import current_patron
 from rero_ils.modules.permissions import RecordPermission
+
+document_importer_permission = Permission(RoleNeed('document_importer'))
 
 
 class DocumentPermission(RecordPermission):
@@ -59,7 +64,8 @@ class DocumentPermission(RecordPermission):
         if not current_patron:
             return False
         # only staff members (lib, sys_lib) are allowed to create any documents
-        return current_patron.is_librarian
+        # users with document_importer permission can add new records
+        return current_patron.is_librarian or document_importer_permission
 
     @classmethod
     def update(cls, user, record):

--- a/scripts/setup
+++ b/scripts/setup
@@ -196,10 +196,14 @@ info_msg "Create new admin user"
 eval ${PREFIX} invenio users create -a admin@rero.ch --password administrator
 eval ${PREFIX} invenio users create -a editor@rero.ch --password editor
 
+info_msg "Create document_importer user"
+eval ${PREFIX} invenio users create -a gipi@ngscan.com --password ngscan
+
 # confirm users
 info_msg "Confirm admin creation"
 eval ${PREFIX} invenio users confirm admin@rero.ch
 eval ${PREFIX} invenio users confirm editor@rero.ch
+eval ${PREFIX} invenio users confirm gipi@ngscan.com
 
 # create roles
 info_msg "Create roles: admin, patron, librarian and system librarian"
@@ -214,8 +218,11 @@ eval "${PREFIX} invenio roles create -d 'Librarian' librarian"
 # create a role for users qualified as a System librarian
 eval "${PREFIX} invenio roles create -d 'System Librarian' system_librarian"
 
-# create a role for users qualified as a System librarian
+# create a role for users qualified as a Documentation Editor
 eval "${PREFIX} invenio roles create -d 'Documentation Editor' editor"
+
+# create a role for users qualified as a Documment Importing
+eval "${PREFIX} invenio roles create -d 'Documment Importing' document_importer"
 
 # grant accesses to action roles
 info_msg "Grant access to action roles (admins, superusers)"
@@ -227,6 +234,7 @@ info_msg "Grant roles to users"
 eval ${PREFIX} invenio roles add admin@rero.ch admins
 eval ${PREFIX} invenio roles add admin@rero.ch superusers
 eval ${PREFIX} invenio roles add editor@rero.ch editor
+eval ${PREFIX} invenio roles add gipi@ngscan.com document_importer
 
 # Generate fixtures
 info_msg "Generate fixtures:"
@@ -360,6 +368,16 @@ eval ${PREFIX} invenio fixtures create_loans ${DATA_PATH}/loans.json
 
 # process notifications
 eval ${PREFIX} invenio notifications process
+
+# create token access for ngscan (ezpump)
+# if the environement variable RERO_ACCESS_TOKEN_NGSCAN is not set a new
+# token will be generated
+if ${RERO_ACCESS_TOKEN_NGSCAN}
+then
+    eval ${PREFIX} invenio utils tokens_create -n ezpump -u gipi@ngscan.com -t ${RERO_ACCESS_TOKEN_NGSCAN}
+else
+    eval ${PREFIX} invenio utils tokens_create -n ezpump -u gipi@ngscan.com
+fi
 
 # # OAI configuration
 info_msg "OAI configuration:"

--- a/tests/api/documents/test_marcxml_rest_api.py
+++ b/tests/api/documents/test_marcxml_rest_api.py
@@ -18,15 +18,26 @@
 """Tests POST REST API for MARC21 documents."""
 
 
-import mock
-from utils import VerifyRecordPermissionPatch, postdata
+from click.testing import CliRunner
+from utils import login_user_via_session, postdata
+
+from rero_ils.modules.cli import tokens_create
 
 
-@mock.patch('invenio_records_rest.views.verify_record_permission',
-            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def test_marcxml_documents_create(
-        client, document_marcxml, documents_marcxml, rero_marcxml_header):
-    """Test post of marcxml document."""
+        client, document_marcxml, documents_marcxml, rero_marcxml_header,
+        librarian_martigny_no_email):
+    """Test post of marcxml document for logged users."""
+    res, data = postdata(
+        client,
+        'invenio_records_rest.doc_list',
+        document_marcxml,
+        headers=rero_marcxml_header,
+        force_data_as_json=False
+    )
+    assert res.status_code == 401
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
     res, data = postdata(
         client,
         'invenio_records_rest.doc_list',
@@ -46,3 +57,27 @@ def test_marcxml_documents_create(
         force_data_as_json=False
     )
     assert res.status_code == 400
+
+
+def test_marcxml_documents_create_with_a_token(
+        app, client, document_marcxml, rero_marcxml_header,
+        librarian_martigny_no_email, script_info):
+    """Test post of marcxml document with an access token."""
+    runner = CliRunner()
+    res = runner.invoke(
+        tokens_create,
+        ['-n', 'test', '-u', librarian_martigny_no_email.get('email'),
+         '-t', 'my_token'],
+        obj=script_info
+    )
+    access_token = res.output.strip().split('\n')[0]
+    res, data = postdata(
+        client,
+        'invenio_records_rest.doc_list',
+        document_marcxml,
+        url_data={'access_token': access_token},
+        headers=rero_marcxml_header,
+        force_data_as_json=False
+    )
+    assert res.status_code == 201
+    assert data['metadata']['_draft']

--- a/tests/data/document.xml
+++ b/tests/data/document.xml
@@ -1,7 +1,6 @@
 <collection xmlns="http://www.loc.gov/MARC21/slim">
 <record>
   <leader>00975nam a2200277 a 4500</leader>
-  <controlfield tag="001">REROILS:1</controlfield>
   <controlfield tag="005">20170518120100.0</controlfield>
   <controlfield tag="008">000918s1999    gw ||| |  ||||00|  |ger d</controlfield>
   <datafield tag="020" ind1=" " ind2=" ">

--- a/tests/data/documents.xml
+++ b/tests/data/documents.xml
@@ -1,7 +1,6 @@
 <collection xmlns="http://www.loc.gov/MARC21/slim">
 <record>
   <leader>00975nam a2200277 a 4500</leader>
-  <controlfield tag="001">REROILS:1</controlfield>
   <controlfield tag="005">20170518120100.0</controlfield>
   <controlfield tag="008">000918s1999    gw ||| |  ||||00|  |ger d</controlfield>
   <datafield tag="020" ind1=" " ind2=" ">
@@ -81,7 +80,6 @@
 </record>
 <record>
   <leader>00975nam a2200277 a 4500</leader>
-  <controlfield tag="001">REROILS:1</controlfield>
   <controlfield tag="005">20170518120100.0</controlfield>
   <controlfield tag="008">000918s1999    gw ||| |  ||||00|  |ger d</controlfield>
   <datafield tag="020" ind1=" " ind2=" ">

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,7 +21,7 @@ from os.path import dirname, join
 
 from click.testing import CliRunner
 
-from rero_ils.modules.cli import check_validate
+from rero_ils.modules.cli import check_validate, tokens_create
 
 
 def test_cli_validate(app, script_info):
@@ -39,3 +39,15 @@ def test_cli_validate(app, script_info):
         '\tTest record: 1',
         '\tTest record: 2'
     ]
+
+
+def test_cli_access_token(app, script_info, patron_martigny_no_email):
+    """Test access token cli."""
+    runner = CliRunner()
+    res = runner.invoke(
+        tokens_create,
+        ['-n', 'test', '-u', patron_martigny_no_email.get('email'),
+         '-t', 'my_token'],
+        obj=script_info
+    )
+    assert res.output.strip().split('\n') == ['my_token']


### PR DESCRIPTION
With this commit, a new role `document_importer` is created for users
creating document via the document post API only.

Currently, this role is assigned to one invenio user for ngscan tests.

A new cli to create personal OAuth token is added to the utils.

* Fixtures and tests updated accordingly.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1546


## How to test?

1. ./run_tests.sh
2. procedure to generate an access token is here 
https://github.com/rero/developer-resources/blob/master/permissions/generate_oauth_token.md

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
