### PR TITLE
circulation: allow requests on ITEM_IN_TRANSIT_TO_HOUSE loans.

### DIFF
--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -353,8 +353,8 @@ def test_items_receive(client, librarian_martigny_no_email,
     item = item_lib_martigny
     item_pid = item.pid
     patron_pid = patron_martigny_no_email.pid
-    assert not item.is_loaned_to_patron(patron_martigny_no_email.get(
-        'barcode'))
+    assert not item.patron_has_an_active_loan_on_item(
+        patron_martigny_no_email.get('barcode'))
     location = loc_public_martigny
     # checkout
     res, data = postdata(
@@ -372,7 +372,8 @@ def test_items_receive(client, librarian_martigny_no_email,
     actions = data.get('action_applied')
     assert item_data.get('status') == ItemStatus.ON_LOAN
     assert actions.get(LoanAction.CHECKOUT)
-    assert item.is_loaned_to_patron(patron_martigny_no_email.get('barcode'))
+    assert item.patron_has_an_active_loan_on_item(
+        patron_martigny_no_email.get('barcode'))
     loan_pid = actions[LoanAction.CHECKOUT].get('pid')
 
     # checkin

--- a/tests/api/test_item_rest.py
+++ b/tests/api/test_item_rest.py
@@ -353,8 +353,8 @@ def test_items_receive(client, librarian_martigny_no_email,
     item = item_lib_martigny
     item_pid = item.pid
     patron_pid = patron_martigny_no_email.pid
-    assert not item.is_loaned_to_patron(patron_martigny_no_email.get(
-        'barcode'))
+    assert not item.patron_has_an_active_loan_on_item(
+        patron_martigny_no_email.get('barcode'))
     location = loc_public_martigny
     # checkout
     res, data = postdata(
@@ -372,7 +372,8 @@ def test_items_receive(client, librarian_martigny_no_email,
     actions = data.get('action_applied')
     assert item_data.get('status') == ItemStatus.ON_LOAN
     assert actions.get(LoanAction.CHECKOUT)
-    assert item.is_loaned_to_patron(patron_martigny_no_email.get('barcode'))
+    assert item.patron_has_an_active_loan_on_item(
+            patron_martigny_no_email.get('barcode'))
     loan_pid = actions[LoanAction.CHECKOUT].get('pid')
 
     # checkin

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -104,8 +104,8 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
 
     assert not get_last_transaction_loc_for_item(item_pid)
 
-    assert not item.is_loaned_to_patron(patron_martigny_no_email.get(
-        'barcode'))
+    assert not item.patron_has_an_active_loan_on_item(
+        patron_martigny_no_email.get('barcode'))
     assert item.can_delete
     assert item.available
 


### PR DESCRIPTION
According to the new circulation specs given by the PO, requests are allowed
on loans with ITEM_IN_TRANSIT_TO_HOUSE state.

Remove the unused method is_loaned_to_patron.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
