### PR TITLE
help: update the public help menu entry url

### DIFF
--- a/rero_ils/views.py
+++ b/rero_ils/views.py
@@ -132,9 +132,7 @@ def init_menu_lang():
         rero_register(
             item,
             endpoint='wiki.page',
-            endpoint_arguments_constructor=lambda: {
-                'url': 'home/public_help_{0}'.format(current_i18n.language)
-            },
+            endpoint_arguments_constructor=lambda: {'url': 'public'},
             text='{icon} {help}'.format(
                 icon='<i class="fa fa-info"></i>',
                 help=_('Help')


### PR DESCRIPTION
Updates the url from the public help menu entry from 'help' to
the public help page ('help/public')

Closes rero/rero-ils#1127

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
