### PR TITLE
document: exclude drafts from search results

### DIFF
--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -114,6 +114,9 @@ def view_search_factory(self, search, query_parser=None):
         search = search.filter(
             'term', **{'holdings__organisation__organisation_pid': org['pid']}
         )
+    # exclude draft records
+    search = search.filter('bool', must_not=[Q('term', _draft=True)])
+
     return search, urlkwargs
 
 

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -501,3 +501,38 @@ def test_documents_resolve(
         'rero', 'gnd', 'bnf'
     ]
     assert res.status_code == 200
+
+
+def test_document_exclude_draft_records(client, document):
+    """Test document exclude draft record."""
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q='Lingliang'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total'] == 1
+    data = hits['hits'][0]['metadata']
+    assert data['pid'] == document.get('pid')
+
+    document['_draft'] = True
+    document.update(document, dbcommit=True, reindex=True)
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q='Lingliang'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total'] == 0
+
+    document['_draft'] = False
+    document.update(document, dbcommit=True, reindex=True)
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q='Lingliang'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total'] == 1


### PR DESCRIPTION
As https://github.com/rero/rero-ils/pull/1155 allows posting
of marcxml records as draft records. With this commit, the
search results will exclude draft records in case they are
not yet validated by the librarian

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1662?kanban-status=1224894

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
