### PR TITLE
circulation: fix validate request return type

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -480,7 +480,7 @@ class ItemCirculation(IlsRecord):
             item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
             item, validate_actions = self.validate_request(
                 pid=pending.pid, **kwargs)
-            actions.update({LoanAction.VALIDATE: validate_actions})
+            actions.update(validate_actions)
         else:
             item = self
         return item, actions

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -118,7 +118,6 @@ def do_item_jsonify_action(func):
                 abort(404)
             item_data, action_applied = \
                 func(item, data, *args, **kwargs)
-
             for action, loan in action_applied.items():
                 if loan:
                     action_applied[action] = loan.dumps_for_circulation()
@@ -150,7 +149,7 @@ def do_item_jsonify_action(func):
                 error=error)}), 400
         except Exception as error:
             # TODO: need to know what type of exception and document there.
-            # raise(error)
+            # raise error
             current_app.logger.error(str(error))
             return jsonify({'status': 'error: {error}'.format(
                 error=error)}), 400


### PR DESCRIPTION
When a request is canceled, if another one has to be validated, the
return statement is wrong (double dict key). This commit fixes this
problem and returns a correct actions applied list.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
