### PR TITLE
templates: implement record templates

### DIFF
--- a/data/templates.json
+++ b/data/templates.json
@@ -1,0 +1,170 @@
+[
+  {
+    "pid": "1",
+    "name": "Public template for documents",
+    "description": "Public template for documents.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/1"
+    },
+    "visibility": "public",
+    "template_type": "documents",
+    "data": {}
+  },
+  {
+    "pid": "2",
+    "name": "Public template for holdings",
+    "description": "Public template for holdings.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/1"
+    },
+    "visibility": "public",
+    "template_type": "holdings",
+    "data": {}
+  },
+  {
+    "pid": "3",
+    "name": "Public template for items",
+    "description": "Public template for items.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/1"
+    },
+    "visibility": "public",
+    "template_type": "items",
+    "data": {}
+  },
+  {
+    "pid": "4",
+    "name": "Public template for patrons",
+    "description": "Public template for patrons.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/1"
+    },
+    "visibility": "public",
+    "template_type": "patrons",
+    "data": {}
+  },
+  {
+    "pid": "5",
+    "name": "Private template for documents - Jean Dupont",
+    "description": "Private template for documents Jean Dupont.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/2"
+    },
+    "visibility": "private",
+    "template_type": "documents",
+    "data": {}
+  },
+  {
+    "pid": "6",
+    "name": "Private template for holdings - Jean Dupont",
+    "description": "Private template for holdings Jean Dupont.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/2"
+    },
+    "visibility": "private",
+    "template_type": "holdings",
+    "data": {}
+  },
+  {
+    "pid": "7",
+    "name": "Private template for items - Jean Dupont",
+    "description": "Private template for items Jean Dupont.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/2"
+    },
+    "visibility": "private",
+    "template_type": "items",
+    "data": {}
+  },
+  {
+    "pid": "8",
+    "name": "Private template for patrons - Jean Dupont",
+    "description": "Private template for patrons Jean Dupont.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/2"
+    },
+    "visibility": "private",
+    "template_type": "patrons",
+    "data": {}
+  },
+  {
+    "pid": "9",
+    "name": "Private template for documents - Elena Rodriguez",
+    "description": "Private template for documents Elena Rodriguez.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/3"
+    },
+    "visibility": "private",
+    "template_type": "documents",
+    "data": {}
+  },
+  {
+    "pid": "10",
+    "name": "Private template for holdings - Elena Rodriguez",
+    "description": "Private template for holdings Elena Rodriguez.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/3"
+    },
+    "visibility": "private",
+    "template_type": "holdings",
+    "data": {}
+  },
+  {
+    "pid": "11",
+    "name": "Private template for items - Elena Rodriguez",
+    "description": "Private template for items Elena Rodriguez.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/3"
+    },
+    "visibility": "private",
+    "template_type": "items",
+    "data": {}
+  },
+  {
+    "pid": "12",
+    "name": "Private template for patrons - Elena Rodriguez",
+    "description": "Private template for patrons Elena Rodriguez.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/3"
+    },
+    "visibility": "private",
+    "template_type": "patrons",
+    "data": {}
+  }
+]

--- a/data/users.json
+++ b/data/users.json
@@ -1,5 +1,6 @@
 [
   {
+    "pid": "1",
     "birth_date": "1989-05-14",
     "city": "Aosta",
     "email": "reroilstest@gmail.com",
@@ -18,6 +19,7 @@
     "street": "Viale Rue Gran Paradiso, 44"
   },
   {
+    "pid": "2",
     "birth_date": "1974-03-21",
     "city": "Fribourg",
     "email": "reroilstest+jean@gmail.com",
@@ -35,6 +37,7 @@
     "street": "Avenue de la Gare, 80"
   },
   {
+    "pid": "3",
     "birth_date": "1992-11-23",
     "city": "Lugano",
     "email": "reroilstest+elena@gmail.com",
@@ -52,6 +55,7 @@
     "street": "Viale Carlo Cattaneo, 52"
   },
   {
+    "pid": "4",
     "barcode": "2050124311",
     "birth_date": "1969-06-07",
     "city": "Aosta",
@@ -74,6 +78,7 @@
     "blocked_note": "Test functionnality when active is false"
   },
   {
+    "pid": "5",
     "barcode": "2030124287",
     "birth_date": "2004-10-11",
     "city": "Aosta",
@@ -93,6 +98,7 @@
     "communication_language": "ita"
   },
   {
+    "pid": "6",
     "birth_date": "1969-02-01",
     "city": "Avise",
     "email": "reroilstest+virgile@gmail.com",
@@ -110,6 +116,7 @@
     "street": "Frazione Plan"
   },
   {
+    "pid": "7",
     "barcode": "reroils1",
     "birth_date": "2001-12-12",
     "city": "Sion",
@@ -129,6 +136,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "8",
     "barcode": "2000000001",
     "birth_date": "1970-05-25",
     "city": "Santa Clara",
@@ -149,6 +157,7 @@
     "communication_language": "eng"
   },
   {
+    "pid": "9",
     "barcode": "10000001",
     "birth_date": "1976-09-07",
     "city": "Lavey",
@@ -169,6 +178,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "10",
     "barcode": "2050124312",
     "birth_date": "1961-11-24",
     "city": "Bellinzona",
@@ -189,6 +199,7 @@
     "communication_language": "ita"
   },
   {
+    "pid": "11",
     "barcode": "kad001",
     "birth_date": "1980-10-01",
     "city": "Martigny",
@@ -209,6 +220,7 @@
     "communication_language": "eng"
   },
   {
+    "pid": "12",
     "barcode": "kad002",
     "birth_date": "1965-02-10",
     "city": "Fully",
@@ -229,6 +241,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "13",
     "birth_date": "1955-01-30",
     "city": "Hogsmeade",
     "email": "reroilstest+irma@gmail.com",
@@ -247,6 +260,7 @@
     "street": "High Street"
   },
   {
+    "pid": "14",
     "barcode": "3050124311",
     "birth_date": "1980-07-31",
     "city": "London",
@@ -266,6 +280,7 @@
     "communication_language": "eng"
   },
   {
+    "pid": "15",
     "barcode": "3050124312",
     "birth_date": "1979-09-19",
     "city": "London",
@@ -285,6 +300,7 @@
     "communication_language": "eng"
   },
   {
+    "pid": "16",
     "birth_date": "1900-01-01",
     "city": "Imagination",
     "email": "reroilstest+imagination@gmail.com",
@@ -303,6 +319,7 @@
     "street": "Imagination Street 48"
   },
   {
+    "pid": "17",
     "birth_date": "1956-01-30",
     "city": "no indication",
     "email": "jocasta@example.org",
@@ -320,6 +337,7 @@
     "street": "no indication"
   },
   {
+    "pid": "18",
     "birth_date": "1959-02-27",
     "city": "no indication",
     "email": "urrigon@example.org",
@@ -337,6 +355,7 @@
     "street": "no indication"
   },
   {
+    "pid": "19",
     "birth_date": "1962-03-24",
     "city": "no indication",
     "email": "thebeast@example.org",
@@ -354,6 +373,7 @@
     "street": "no indication"
   },
   {
+    "pid": "20",
     "birth_date": "1965-04-21",
     "city": "no indication",
     "email": "dream@example.org",
@@ -371,6 +391,7 @@
     "street": "no indication"
   },
   {
+    "pid": "21",
     "birth_date": "1971-05-18",
     "city": "no indication",
     "email": "felman@example.org",
@@ -388,6 +409,7 @@
     "street": "no indication"
   },
   {
+    "pid": "22",
     "birth_date": "1974-06-15",
     "city": "no indication",
     "email": "irma@example.org",
@@ -405,6 +427,7 @@
     "street": "no indication"
   },
   {
+    "pid": "23",
     "birth_date": "1977-07-12",
     "city": "no indication",
     "email": "jorge@example.org",
@@ -422,6 +445,7 @@
     "street": "no indication"
   },
   {
+    "pid": "24",
     "birth_date": "1980-08-09",
     "city": "no indication",
     "email": "malachie@example.org",
@@ -439,6 +463,7 @@
     "street": "no indication"
   },
   {
+    "pid": "25",
     "birth_date": "1983-09-06",
     "city": "no indication",
     "email": "lorren@example.org",
@@ -456,6 +481,7 @@
     "street": "no indication"
   },
   {
+    "pid": "26",
     "birth_date": "1987-10-03",
     "city": "no indication",
     "email": "fermin@example.org",
@@ -473,6 +499,7 @@
     "street": "no indication"
   },
   {
+    "pid": "27",
     "birth_date": "1990-11-01",
     "city": "no indication",
     "email": "winston@example.org",
@@ -490,6 +517,7 @@
     "street": "no indication"
   },
   {
+    "pid": "28",
     "birth_date": "2005-12-29",
     "city": "no indication",
     "email": "elrond@example.org",
@@ -507,6 +535,7 @@
     "street": "no indication"
   },
   {
+    "pid": "29",
     "birth_date": "1999-01-09",
     "city": "no indication",
     "email": "phelps@example.org",
@@ -524,6 +553,7 @@
     "street": "no indication"
   },
   {
+    "pid": "30",
     "birth_date": "1800-01-01",
     "city": "no indication",
     "email": "thelibrarian@example.org",
@@ -541,6 +571,7 @@
     "street": "no indication"
   },
   {
+    "pid": "31",
     "birth_date": "1925-07-31",
     "city": "no indication",
     "email": "wan@example.org",
@@ -558,6 +589,7 @@
     "street": "no indication"
   },
   {
+    "pid": "32",
     "birth_date": "1974-08-24",
     "city": "no indication",
     "email": "rupert@example.org",
@@ -575,6 +607,7 @@
     "street": "no indication"
   },
   {
+    "pid": "33",
     "barcode": "920001",
     "birth_date": "1941-01-31",
     "city": "Pregny-Chamb\u00e9sy",
@@ -595,6 +628,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "34",
     "barcode": "920002",
     "birth_date": "1945-02-28",
     "city": "Franex",
@@ -615,6 +649,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "35",
     "barcode": "920003",
     "birth_date": "1950-03-27",
     "city": "Fregi\u00e9court",
@@ -635,6 +670,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "36",
     "barcode": "920004",
     "birth_date": "1955-04-25",
     "city": "Neuch\u00e2tel",
@@ -655,6 +691,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "37",
     "barcode": "920005",
     "birth_date": "1960-05-23",
     "city": "Sierre",
@@ -675,6 +712,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "38",
     "barcode": "920006",
     "birth_date": "1965-06-21",
     "city": "Bulle",
@@ -695,6 +733,7 @@
     "communication_language": "fre"
   },
   {
+    "pid": "39",
     "barcode": "920007",
     "birth_date": "1970-07-19",
     "city": "Unterrindal",
@@ -715,6 +754,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "40",
     "barcode": "920008",
     "birth_date": "1975-08-17",
     "city": "Kempten",
@@ -735,6 +775,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "41",
     "barcode": "920009",
     "birth_date": "1980-09-15",
     "city": "Mettmenhasli",
@@ -755,6 +796,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "42",
     "barcode": "920010",
     "birth_date": "1985-10-13",
     "city": "Lenggenwil",
@@ -775,6 +817,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "43",
     "barcode": "920011",
     "birth_date": "1990-11-09",
     "city": "Thun",
@@ -795,6 +838,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "44",
     "barcode": "920012",
     "birth_date": "1995-12-07",
     "city": "Brunnwil",
@@ -815,6 +859,7 @@
     "communication_language": "ger"
   },
   {
+    "pid": "45",
     "barcode": "920013",
     "birth_date": "2000-01-05",
     "city": "Cevio",
@@ -835,6 +880,7 @@
     "communication_language": "ita"
   },
   {
+    "pid": "46",
     "barcode": "920014",
     "birth_date": "2005-02-03",
     "city": "Tenna",
@@ -855,6 +901,7 @@
     "communication_language": "ita"
   },
   {
+    "pid": "47",
     "barcode": "920015",
     "birth_date": "2010-03-01",
     "city": "Caslano",
@@ -875,6 +922,7 @@
     "communication_language": "ita"
   },
   {
+    "pid": "48",
     "barcode": "920016",
     "birth_date": "1993-04-02",
     "city": "Bellinzona",
@@ -895,6 +943,7 @@
     "communication_language": "ita"
   },
   {
+    "pid": "49",
     "barcode": "999999",
     "birth_date": "1970-01-01",
     "city": "Flueli-Ranft",

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -88,6 +88,8 @@ from .modules.patrons.permissions import PatronPermission
 from .modules.permissions import record_permission_factory
 from .modules.persons.api import Person
 from .modules.persons.permissions import PersonPermission
+from .modules.templates.api import Template
+from .modules.templates.permissions import TemplatePermission
 from .modules.vendors.api import Vendor
 from .modules.vendors.permissions import VendorPermission
 from .permissions import librarian_delete_permission_factory, \
@@ -1314,6 +1316,49 @@ RECORDS_REST_ENDPOINTS = dict(
         delete_permission_factory_imp=lambda record: record_permission_factory(
             action='delete', record=record, cls=AcqInvoicePermission)
     ),
+    tmpl=dict(
+        pid_type='tmpl',
+        pid_minter='template_id',
+        pid_fetcher='template_id',
+        search_class='rero_ils.modules.templates.api:TemplatesSearch',
+        search_index='templates',
+        indexer_class='rero_ils.modules.templates.api:TemplatesIndexer',
+        search_type=None,
+        record_serializers={
+            'application/json': (
+                'rero_ils.modules.serializers:json_v1_response'
+            )
+        },
+        record_serializers_aliases={
+            'json': 'application/json',
+        },
+        search_serializers={
+            'application/json': (
+                'rero_ils.modules.serializers:json_v1_search'
+            )
+        },
+        record_loaders={
+            'application/json': lambda: Template(request.get_json()),
+        },
+        list_route='/templates/',
+        record_class='rero_ils.modules.templates.api:Template',
+        item_route=('/templates/<pid(tmpl, record_class='
+                    '"rero_ils.modules.templates.api:'
+                    'Template"):pid_value>'),
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp='rero_ils.query:templates_search_factory',
+        list_permission_factory_imp=lambda record: record_permission_factory(
+            action='list', record=record, cls=TemplatePermission),
+        read_permission_factory_imp=lambda record: record_permission_factory(
+            action='read', record=record, cls=TemplatePermission),
+        create_permission_factory_imp=lambda record: record_permission_factory(
+            action='create', record=record, cls=TemplatePermission),
+        update_permission_factory_imp=lambda record: record_permission_factory(
+            action='update', record=record, cls=TemplatePermission),
+        delete_permission_factory_imp=lambda record: record_permission_factory(
+            action='delete', record=record, cls=TemplatePermission)
+    ),
 )
 
 SEARCH_UI_SEARCH_INDEX = 'documents'
@@ -1554,7 +1599,8 @@ indexes = [
     'patrons',
     'patron_types',
     'persons',
-    'vendors'
+    'vendors',
+    'templates'
 ]
 
 RECORDS_REST_SORT_OPTIONS = dict()
@@ -1668,6 +1714,7 @@ RECORDS_REST_SORT_OPTIONS['items']['issue_expected_date'] = dict(
     default_order='asc'
 )
 
+
 # Detailed View Configuration
 # ===========================
 RECORDS_UI_ENDPOINTS = {
@@ -1742,7 +1789,8 @@ RECORDS_JSON_SCHEMA = {
     'acol': '/acq_order_lines/acq_order_line-v0.0.1.json',
     'acin': '/acq_invoices/acq_invoice-v0.0.1.json',
     'pttr': '/patron_transactions/patron_transaction-v0.0.1.json',
-    'ptre': '/patron_transaction_events/patron_transaction_event-v0.0.1.json'
+    'ptre': '/patron_transaction_events/patron_transaction_event-v0.0.1.json',
+    'tmpl': '/templates/template-v0.0.1.json'
 }
 
 # Login Configuration

--- a/rero_ils/modules/templates/__init__.py
+++ b/rero_ils/modules/templates/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Templates Records."""

--- a/rero_ils/modules/templates/api.py
+++ b/rero_ils/modules/templates/api.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""API for manipulating Templates."""
+
+from functools import partial
+
+from .models import TemplateIdentifier, TemplateMetadata
+from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
+from ..fetchers import id_fetcher
+from ..minters import id_minter
+from ..providers import Provider
+
+# tmpl provider
+TemplateProvider = type(
+    'TemplateProvider',
+    (Provider,),
+    dict(identifier=TemplateIdentifier, pid_type='tmpl')
+)
+# tmpl minter
+template_id_minter = partial(id_minter, provider=TemplateProvider)
+# tmpl fetcher
+template_id_fetcher = partial(id_fetcher, provider=TemplateProvider)
+
+
+class TemplatesSearch(IlsRecordsSearch):
+    """RecordsSearch for Templates."""
+
+    class Meta:
+        """Search only on Templates index."""
+
+        index = 'templates'
+        doc_types = None
+
+
+class Template(IlsRecord):
+    """Templates class."""
+
+    minter = template_id_minter
+    fetcher = template_id_fetcher
+    provider = TemplateProvider
+    model_cls = TemplateMetadata
+    pids_exist_check = {
+        'required': {
+            'org': 'organisation',
+            'ptrn': 'creator'
+        }
+    }
+
+    @property
+    def creator_pid(self):
+        """Shortcut for template creator pid."""
+        return self.replace_refs().get('creator', {}).get('pid')
+
+    @property
+    def is_public(self):
+        """Shortcut for template public visibility."""
+        return self.get('visibility') == TemplateVisibility.PUBLIC
+
+    @property
+    def is_private(self):
+        """Shortcut for template private visibility."""
+        return self.get('visibility') == TemplateVisibility.PRIVATE
+
+
+class TemplatesIndexer(IlsRecordsIndexer):
+    """Indexing templates in Elasticsearch."""
+
+    record_cls = Template
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(TemplatesIndexer, self).bulk_index(record_id_iterator,
+                                                 doc_type='tmpl')
+
+
+class TemplateVisibility(object):
+    """Class to handle different template visibilities."""
+
+    PRIVATE = 'private'
+    PUBLIC = 'public'

--- a/rero_ils/modules/templates/jsonschemas/__init__.py
+++ b/rero_ils/modules/templates/jsonschemas/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Template JSON schemas."""

--- a/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Template",
+  "description": "JSON schema for templates.",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "pid",
+    "template_type",
+    "name",
+    "creator",
+    "organisation",
+    "visibility"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "Schema to validate templates records against.",
+      "type": "string",
+      "minLength": 9,
+      "default": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json"
+    },
+    "pid": {
+      "title": "Template ID",
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "title": "Name",
+      "type": "string",
+      "minLength": 2
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "minLength": 1
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/organisations/.*?$"
+        }
+      }
+    },
+    "creator": {
+      "title": "Creator",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Creator URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/patrons/.*?$"
+        }
+      }
+    },
+    "visibility": {
+      "title": "Visibility",
+      "description": "Public templates are visible by all users of the organisation. Private templates are visible only by its creator (you).",
+      "type": "string",
+      "enum": [
+        "public",
+        "private"
+      ],
+      "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
+        "options": [
+          {
+            "label": "public",
+            "value": "public"
+          },
+          {
+            "label": "private",
+            "value": "private"
+          }
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
+      }
+    },
+    "template_type": {
+      "title": "Template type",
+      "type": "string",
+      "enum": [
+        "documents",
+        "items",
+        "holdings",
+        "patrons"
+      ],
+      "form": {
+        "type": "selectWithSort",
+        "wrappers": [
+          "form-field-horizontal"
+        ],
+        "options": [
+          {
+            "label": "documents",
+            "value": "documents"
+          },
+          {
+            "label": "items",
+            "value": "items"
+          },
+          {
+            "label": "holdings",
+            "value": "holdings"
+          },
+          {
+            "label": "patrons",
+            "value": "patrons"
+          }
+        ],
+        "templateOptions": {
+          "selectWithSortOptions": {
+            "order": "label"
+          }
+        }
+      }
+    },
+    "data": {
+      "title": "Template json data",
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/rero_ils/modules/templates/mappings/__init__.py
+++ b/rero_ils/modules/templates/mappings/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Templates Elasticsearch mappings."""

--- a/rero_ils/modules/templates/mappings/v6/__init__.py
+++ b/rero_ils/modules/templates/mappings/v6/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Templates elasticsearch mappings."""

--- a/rero_ils/modules/templates/mappings/v6/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/mappings/v6/templates/template-v0.0.1.json
@@ -1,0 +1,56 @@
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
+    "max_result_window": 20000
+  },
+  "mappings": {
+    "template-v0.0.1": {
+      "date_detection": false,
+      "numeric_detection": false,
+      "properties": {
+        "$schema": {
+          "type": "keyword"
+        },
+        "pid": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "text"
+        },
+        "description": {
+          "type": "text"
+        },
+        "organisation": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "creator": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "visibility": {
+          "type": "keyword"
+        },
+        "template_type": {
+          "type": "keyword"
+        },
+        "data": {
+          "type": "object"
+        },
+        "_created": {
+          "type": "date"
+        },
+        "_updated": {
+          "type": "date"
+        }
+      }
+    }
+  }
+}

--- a/rero_ils/modules/templates/models.py
+++ b/rero_ils/modules/templates/models.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Define relation between records and buckets."""
+
+from __future__ import absolute_import
+
+from invenio_db import db
+from invenio_pidstore.models import RecordIdentifier
+from invenio_records.models import RecordMetadataBase
+
+
+class TemplateIdentifier(RecordIdentifier):
+    """Sequence generator for templates identifiers."""
+
+    __tablename__ = 'template_id'
+    __mapper_args__ = {'concrete': True}
+
+    recid = db.Column(
+        db.BigInteger().with_variant(db.Integer, 'sqlite'),
+        primary_key=True, autoincrement=True,
+    )
+
+
+class TemplateMetadata(db.Model, RecordMetadataBase):
+    """Template record metadata."""
+
+    __tablename__ = 'template_metadata'

--- a/rero_ils/modules/templates/permissions.py
+++ b/rero_ils/modules/templates/permissions.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2020 RERO
+# Copyright (C) 2020 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Templates permissions."""
+
+from rero_ils.modules.organisations.api import current_organisation
+from rero_ils.modules.patrons.api import current_patron
+from rero_ils.modules.permissions import RecordPermission
+
+
+class TemplatePermission(RecordPermission):
+    """Template permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :return: True is action can be done.
+        """
+        # Operation allowed only for staff members (lib, sys_lib)
+        return current_patron and current_patron.is_librarian
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :return: True is action can be done.
+        """
+        # Check the user is authenticated and a record exists as param.
+        if not record or not current_patron:
+            return False
+        # only librarian or system_librarian can read templates of own org
+        if current_organisation['pid'] == record.organisation_pid:
+            #   - 'sys_librarian' could always read any record
+            if current_patron.is_system_librarian:
+                return True
+            #   - 'librarian' could only read his public and his own records.
+            elif current_patron.is_librarian:
+                return record.is_public or \
+                    record.creator_pid == current_patron.pid
+        return False
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :return: True is action can be done.
+        """
+        # only librarian or system_librarian can create templates
+        if not current_patron or not current_patron.is_librarian:
+            return False
+        if not record:
+            return True
+        # Same as update
+        return cls.update(user, record)
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :return: True is action can be done.
+        """
+        # User must be be authenticated and have (at least) librarian role
+        if not current_patron or not current_patron.is_librarian:
+            return False
+        # * User can only update record of its own organisation
+        if current_organisation['pid'] == record.organisation_pid:
+            #   - 'sys_librarian' could always update any record
+            if current_patron.is_system_librarian:
+                return True
+            #   - 'librarian' could only update his own records.
+            elif current_patron.is_librarian and \
+                    record.is_private and \
+                    record.creator_pid == current_patron.pid:
+                return True
+        return False
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :return: True if action can be done.
+        """
+        if not record:
+            return False
+        # same as update
+        return cls.update(user, record)

--- a/rero_ils/modules/templates/views.py
+++ b/rero_ils/modules/templates/views.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Blueprint used for loading templates."""
+
+from __future__ import absolute_import, print_function
+
+from flask import Blueprint
+
+blueprint = Blueprint(
+    'templates',
+    __name__,
+    template_folder='templates',
+    static_folder='static',
+)

--- a/scripts/setup
+++ b/scripts/setup
@@ -352,6 +352,11 @@ info_msg "Acquisition accounts:"
 eval ${PREFIX} invenio fixtures create --pid_type acac ${DATA_PATH}/acq_accounts.json --append  ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio utils reindex -t acac --yes-i-know --no-info
 
+# create resource templates
+info_msg "Resource templates:"
+eval ${PREFIX} invenio fixtures create --pid_type tmpl ${DATA_PATH}/templates.json --append  ${CREATE_LAZY} ${DONT_STOP}
+eval ${PREFIX} invenio utils reindex -t tmpl --yes-i-know --no-info
+
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 # create circulation transactions

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ setup(
             'items = rero_ils.modules.items.api_views:api_blueprint',
             'persons = rero_ils.modules.persons.views:api_blueprint',
             'holdings = rero_ils.modules.holdings.api_views:api_blueprint',
-            'monitoring = rero_ils.modules.monitoring:api_blueprint'
+            'monitoring = rero_ils.modules.monitoring:api_blueprint',
+            'templates = rero_ils.modules.templates.views:blueprint',
         ],
         'invenio_config.module': [
             'rero_ils = rero_ils.config',
@@ -176,6 +177,7 @@ setup(
             'acq_invoices = rero_ils.modules.acq_invoices.models',
             'patron_transactions = rero_ils.modules.patron_transactions.models',
             'patron_transaction_events = rero_ils.modules.patron_transaction_events.models',
+            'templates = rero_ils.modules.templates.models',
         ],
         'invenio_pidstore.minters': [
             'organisation_id = rero_ils.modules.organisations.api:organisation_id_minter',
@@ -197,7 +199,8 @@ setup(
             'acq_order_line_id = rero_ils.modules.acq_order_lines.api:acq_order_line_id_minter',
             'acq_invoice_id = rero_ils.modules.acq_invoices.api:acq_invoice_id_minter',
             'patron_transaction_id = rero_ils.modules.patron_transactions.api:patron_transaction_id_minter',
-            'patron_transaction_event_id = rero_ils.modules.patron_transaction_events.api:patron_transaction_event_id_minter'
+            'patron_transaction_event_id = rero_ils.modules.patron_transaction_events.api:patron_transaction_event_id_minter',
+            'template_id = rero_ils.modules.templates.api:template_id_minter',
         ],
         'invenio_pidstore.fetchers': [
             'organisation_id = rero_ils.modules.organisations.api:organisation_id_fetcher',
@@ -220,6 +223,7 @@ setup(
             'acq_invoice_id = rero_ils.modules.acq_invoices.api:acq_invoice_id_fetcher',
             'patron_transaction_id = rero_ils.modules.patron_transactions.api:patron_transaction_id_fetcher',
             'patron_transaction_event_id = rero_ils.modules.patron_transaction_events.api:patron_transaction_event_id_fetcher',
+            'template_id = rero_ils.modules.templates.api:template_id_fetcher',
         ],
         'invenio_jsonschemas.schemas': [
             'common = rero_ils.jsonschemas',
@@ -244,6 +248,7 @@ setup(
             'acq_invoices = rero_ils.modules.acq_invoices.jsonschemas',
             'patron_transactions = rero_ils.modules.patron_transactions.jsonschemas',
             'patron_transaction_events = rero_ils.modules.patron_transaction_events.jsonschemas',
+            'templates = rero_ils.modules.templates.jsonschemas',
         ],
         'invenio_search.mappings': [
             'organisations = rero_ils.modules.organisations.mappings',
@@ -267,6 +272,7 @@ setup(
             'acq_invoices = rero_ils.modules.acq_invoices.mappings',
             'patron_transactions = rero_ils.modules.patron_transactions.mappings',
             'patron_transaction_events = rero_ils.modules.patron_transaction_events.mappings',
+            'templates = rero_ils.modules.templates.mappings',
         ],
         'invenio_search.templates': [
             'base-record = rero_ils.es_templates:list_es_templates',
@@ -298,7 +304,7 @@ setup(
             'acq_order_lines = rero_ils.modules.acq_order_lines.jsonresolver',
             'acq_invoices = rero_ils.modules.acq_invoices.jsonresolver',
             'patron_transactions = rero_ils.modules.patron_transactions.jsonresolver',
-            'patron_transaction_events = rero_ils.modules.patron_transaction_events.jsonresolver',
+            'patron_transaction_events = rero_ils.modules.patron_transaction_events.jsonresolver'
         ]
     },
     classifiers=[

--- a/tests/api/templates/test_templates_permissions.py
+++ b/tests/api/templates/test_templates_permissions.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2020 RERO
+# Copyright (C) 2020 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json
+
+from rero_ils.modules.templates.permissions import TemplatePermission
+
+
+def test_templates_permissions_api(client, patron_martigny_no_email,
+                                   templ_doc_private_martigny,
+                                   templ_doc_public_martigny,
+                                   librarian_martigny_no_email,
+                                   templ_doc_public_sion,
+                                   system_librarian_martigny_no_email):
+    """Test templates permissions api."""
+    template_permissions_url = url_for(
+        'api_blueprint.permissions',
+        route_name='templates'
+    )
+    templ_doc_pub_martigny_url = url_for(
+        'api_blueprint.permissions',
+        route_name='templates',
+        record_pid=templ_doc_public_martigny.pid
+    )
+    templ_doc_private_martigny_url = url_for(
+        'api_blueprint.permissions',
+        route_name='templates',
+        record_pid=templ_doc_private_martigny.pid
+    )
+    templ_sion_pub_url = url_for(
+        'api_blueprint.permissions',
+        route_name='templates',
+        record_pid=templ_doc_public_sion.pid
+    )
+
+    # Not logged
+    res = client.get(template_permissions_url)
+    assert res.status_code == 401
+
+    # Logged as patron
+    login_user_via_session(client, patron_martigny_no_email.user)
+    res = client.get(template_permissions_url)
+    assert res.status_code == 403
+
+    # Logged as librarian
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res = client.get(templ_doc_pub_martigny_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['read']['can']
+    assert data['list']['can']
+    assert data['create']['can']
+    assert not data['update']['can']
+    assert not data['delete']['can']
+
+    res = client.get(templ_doc_private_martigny_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['read']['can']
+    assert data['list']['can']
+    assert data['update']['can']
+    assert data['delete']['can']
+
+    res = client.get(templ_sion_pub_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert not data['read']['can']
+    assert data['list']['can']
+    assert not data['update']['can']
+    assert not data['delete']['can']
+
+    # Logged as system librarian
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.get(templ_doc_private_martigny_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['read']['can']
+    assert data['list']['can']
+    assert data['update']['can']
+    assert data['delete']['can']
+
+    res = client.get(templ_sion_pub_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert not data['read']['can']
+    assert not data['update']['can']
+    assert not data['delete']['can']
+
+
+def test_template_permissions(
+        patron_martigny_no_email, librarian_martigny_no_email,
+        system_librarian_martigny_no_email, org_martigny,
+        templ_doc_public_martigny, templ_doc_private_martigny,
+        templ_doc_public_sion):
+    """Test template permissions class."""
+
+    # Anonymous user
+    assert not TemplatePermission.list(None, {})
+    assert not TemplatePermission.read(None, {})
+    assert not TemplatePermission.create(None, {})
+    assert not TemplatePermission.update(None, {})
+    assert not TemplatePermission.delete(None, {})
+
+    # As Patron
+    with mock.patch(
+        'rero_ils.modules.templates.permissions.current_patron',
+        patron_martigny_no_email
+    ):
+        assert not TemplatePermission.list(None, {})
+        assert not TemplatePermission.read(None, {})
+        assert not TemplatePermission.create(None, {})
+        assert not TemplatePermission.update(None, {})
+        assert not TemplatePermission.delete(None, {})
+
+    # As Librarian
+    with mock.patch(
+        'rero_ils.modules.templates.permissions.current_patron',
+        librarian_martigny_no_email
+    ), mock.patch(
+        'rero_ils.modules.templates.permissions.current_organisation',
+        org_martigny
+    ):
+        assert TemplatePermission.list(None, templ_doc_public_martigny)
+        assert TemplatePermission.read(None, templ_doc_public_martigny)
+        assert not TemplatePermission.create(None, templ_doc_public_martigny)
+        assert not TemplatePermission.update(None, templ_doc_public_martigny)
+        assert not TemplatePermission.delete(None, templ_doc_public_martigny)
+
+        assert TemplatePermission.list(None, templ_doc_public_sion)
+        assert not TemplatePermission.read(None, templ_doc_public_sion)
+        assert not TemplatePermission.create(None, templ_doc_public_sion)
+        assert not TemplatePermission.update(None, templ_doc_public_sion)
+        assert not TemplatePermission.delete(None, templ_doc_public_sion)
+
+    # As SystemLibrarian
+    with mock.patch(
+        'rero_ils.modules.templates.permissions.current_patron',
+        system_librarian_martigny_no_email
+    ), mock.patch(
+        'rero_ils.modules.templates.permissions.current_organisation',
+        org_martigny
+    ):
+        assert TemplatePermission.list(None, templ_doc_private_martigny)
+        assert TemplatePermission.read(None, templ_doc_private_martigny)
+        assert TemplatePermission.create(None, templ_doc_private_martigny)
+        assert TemplatePermission.update(None, templ_doc_private_martigny)
+        assert TemplatePermission.delete(None, templ_doc_private_martigny)
+
+        assert not TemplatePermission.read(None, templ_doc_public_sion)
+        assert not TemplatePermission.create(None, templ_doc_public_sion)
+        assert not TemplatePermission.update(None, templ_doc_public_sion)
+        assert not TemplatePermission.delete(None, templ_doc_public_sion)

--- a/tests/api/templates/test_templates_rest.py
+++ b/tests/api/templates/test_templates_rest.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST API for templates."""
+
+import json
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
+
+
+def test_templates_permissions(
+        client, templ_doc_public_martigny, json_header):
+    """Test public template for document retrieval."""
+    item_url = url_for('invenio_records_rest.tmpl_item', pid_value='tmpl1')
+
+    res = client.get(item_url)
+    assert res.status_code == 401
+
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.tmpl_list',
+        {}
+    )
+    assert res.status_code == 401
+
+    res = client.put(
+        url_for('invenio_records_rest.tmpl_item', pid_value='tmpl1'),
+        data={},
+        headers=json_header
+    )
+
+    res = client.delete(item_url)
+    assert res.status_code == 401
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_templates_get(client, templ_doc_public_martigny):
+    """Test template retrieval."""
+    template = templ_doc_public_martigny
+    item_url = url_for('invenio_records_rest.tmpl_item', pid_value='tmpl1')
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    assert res.headers['ETag'] == '"{}"'.format(template.revision_id)
+
+    data = get_json(res)
+    assert template.dumps() == data['metadata']
+
+    # Check metadata
+    for k in ['created', 'updated', 'metadata', 'links']:
+        assert k in data
+
+    # Check self links
+    res = client.get(to_relative_url(data['links']['self']))
+    assert res.status_code == 200
+    json = get_json(res)
+    assert data == json
+    assert template.dumps() == data['metadata']
+
+    list_url = url_for('invenio_records_rest.tmpl_list', pid='tmpl1')
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+
+    assert data['hits']['hits'][0]['metadata'] == template.replace_refs()
+
+
+def test_filtered_templates_get(
+        client, librarian_martigny_no_email, templ_doc_public_martigny,
+        templ_doc_private_martigny, librarian_sion_no_email,
+        system_librarian_martigny_no_email, librarian_fully_no_email,
+        system_librarian_sion_no_email):
+    """Test templates filter by organisation."""
+    # Martigny
+    # system librarian can have access to all templates
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    list_url = url_for('invenio_records_rest.tmpl_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 2
+
+    # librarian martigny can have access to all public and his templates
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    list_url = url_for('invenio_records_rest.tmpl_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 2
+
+    # librarian fully can have access to all public templates only
+    login_user_via_session(client, librarian_fully_no_email.user)
+    list_url = url_for('invenio_records_rest.tmpl_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+    # Sion
+    # librarian sion can have access to no templates
+    login_user_via_session(client, librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.tmpl_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 0
+
+    # system librarian sion can have access to no templates
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.tmpl_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 0
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_templates_post_put_delete(client, org_martigny,
+                                   templ_doc_public_martigny_data,
+                                   json_header):
+    """Test template post."""
+    # Create policy / POST
+    item_url = url_for('invenio_records_rest.tmpl_item', pid_value='1')
+    list_url = url_for('invenio_records_rest.tmpl_list', q='pid:1')
+    del templ_doc_public_martigny_data['pid']
+    res, data = postdata(
+        client,
+        'invenio_records_rest.tmpl_list',
+        templ_doc_public_martigny_data
+    )
+    assert res.status_code == 201
+
+    # Check that the returned template matches the given data
+    templ_doc_public_martigny_data['pid'] = '1'
+
+    assert data['metadata'] == templ_doc_public_martigny_data
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert templ_doc_public_martigny_data == data['metadata']
+
+    # Update template/PUT
+    data = templ_doc_public_martigny_data
+    data['name'] = 'Test Name'
+    res = client.put(
+        item_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    # assert res.headers['ETag'] != '"{}"'.format(librarie.revision_id)
+
+    # Check that the returned template matches the given data
+    data = get_json(res)
+    assert data['metadata']['name'] == 'Test Name'
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    data = get_json(res)
+    assert data['metadata']['name'] == 'Test Name'
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    data = get_json(res)['hits']['hits'][0]
+    assert data['metadata']['name'] == 'Test Name'
+
+    # Delete tempalte/DELETE
+    res = client.delete(item_url)
+    assert res.status_code == 204
+
+    res = client.get(item_url)
+    assert res.status_code == 410
+
+
+def test_template_secure_api(client, json_header,
+                             templ_doc_public_martigny,
+                             librarian_martigny_no_email,
+                             librarian_sion_no_email):
+    """Test templates secure api access."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.tmpl_item',
+                         pid_value=templ_doc_public_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for('invenio_records_rest.tmpl_item',
+                         pid_value=templ_doc_public_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 403
+
+
+def test_template_secure_api_create(client, json_header,
+                                    system_librarian_martigny_no_email,
+                                    system_librarian_sion_no_email,
+                                    templ_doc_public_martigny_data):
+    """Test templates secure api create."""
+    # Martigny
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    post_entrypoint = 'invenio_records_rest.tmpl_list'
+
+    del templ_doc_public_martigny_data['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        templ_doc_public_martigny_data
+    )
+    assert res.status_code == 201
+
+    # Sion
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        templ_doc_public_martigny_data
+    )
+    assert res.status_code == 403
+
+
+def test_template_secure_api_update(client,
+                                    templ_doc_private_martigny,
+                                    templ_doc_private_martigny_data,
+                                    system_librarian_martigny_no_email,
+                                    system_librarian_sion_no_email,
+                                    librarian_martigny_no_email,
+                                    librarian_saxon_no_email,
+                                    json_header):
+    """Test templates secure api update."""
+    # Martigny
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.tmpl_item',
+                         pid_value=templ_doc_private_martigny.pid)
+
+    data = templ_doc_private_martigny_data
+    data['name'] = 'Test Name'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    data = templ_doc_private_martigny_data
+    data['name'] = 'Test Name'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_saxon_no_email.user)
+    data = templ_doc_private_martigny_data
+    data['name'] = 'Test Name'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_template_secure_api_delete(client,
+                                    templ_doc_private_martigny,
+                                    system_librarian_martigny_no_email,
+                                    system_librarian_sion_no_email,
+                                    templ_doc_public_martigny,
+                                    librarian_saxon_no_email,
+                                    librarian_martigny_no_email,
+                                    json_header):
+    """Test templates secure api delete."""
+    record_url = url_for('invenio_records_rest.tmpl_item',
+                         pid_value=templ_doc_private_martigny.pid)
+
+    # Saxon
+    login_user_via_session(client, librarian_saxon_no_email.user)
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    # Martigny
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.delete(record_url)
+    assert res.status_code == 204
+
+    record_url = url_for('invenio_records_rest.tmpl_item',
+                         pid_value=templ_doc_public_martigny.pid)
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.delete(record_url)
+    assert res.status_code == 204

--- a/tests/api/test_monitoring_rest.py
+++ b/tests/api/test_monitoring_rest.py
@@ -56,6 +56,7 @@ def test_monitoring_es_db_counts(client):
             'pttr': {'db': 0, 'db-es': 0, 'es': 0,
                      'index': 'patron_transactions'},
             'ptty': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'patron_types'},
+            'tmpl': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'templates'},
             'vndr': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'vendors'}
         }
     }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2940,5 +2940,95 @@
     "operator": {
       "$ref": "https://ils.rero.ch/api/patrons/ptrn8"
     }
+  },
+  "tmpl1": {
+    "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",
+    "pid": "tmpl1",
+    "name": "templ_doc_public_martigny",
+    "description": "Template for documents created at martigny.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn1"
+    },
+    "visibility": "public",
+    "template_type": "documents",
+    "data": {}
+  },
+  "tmpl2": {
+    "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",
+    "pid": "tmpl2",
+    "name": "templ_doc_private_martigny",
+    "description": "Template for private documents created at martigny.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn2"
+    },
+    "visibility": "private",
+    "template_type": "documents",
+    "data": {}
+  },
+  "tmpl3": {
+    "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",
+    "pid": "tmpl3",
+    "name": "templ_doc_public_sion",
+    "description": "Template for public documents created at sion.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org2"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn8"
+    },
+    "visibility": "public",
+    "template_type": "documents",
+    "data": {}
+  },
+  "tmpl4": {
+    "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",
+    "pid": "tmpl4",
+    "name": "templ_hold_public_martigny",
+    "description": "Template for public holdings created at martigny.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn1"
+    },
+    "visibility": "public",
+    "template_type": "holdings",
+    "data": {}
+  },
+  "tmpl5": {
+    "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",
+    "pid": "tmpl5",
+    "name": "templ_item_public_martigny",
+    "description": "Template for public items created at martigny.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn1"
+    },
+    "visibility": "public",
+    "template_type": "items",
+    "data": {}
+  },
+  "tmpl6": {
+    "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",
+    "pid": "tmpl6",
+    "name": "templ_patron_public_martigny",
+    "description": "Template for public patron created at martigny.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    },
+    "creator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn1"
+    },
+    "visibility": "public",
+    "template_type": "patrons",
+    "data": {}
   }
 }

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -29,6 +29,7 @@ from rero_ils.modules.documents.api import Document, DocumentsSearch
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.items.api import Item, ItemsSearch
 from rero_ils.modules.persons.api import Person, PersonsSearch
+from rero_ils.modules.templates.api import Template, TemplatesSearch
 
 
 @pytest.fixture(scope="module")
@@ -729,3 +730,132 @@ def babel_filehandle():
         join(dirname(__file__), '..', 'data', 'babel_extraction.json'),
         'rb'
     )
+
+
+# --------- Template records -----------
+
+
+@pytest.fixture(scope="function")
+def templ_doc_public_martigny_data_tmp(data):
+    """Load template for a public document martigny data scope function."""
+    return deepcopy(data.get('tmpl1'))
+
+
+@pytest.fixture(scope="module")
+def templ_doc_public_martigny_data(data):
+    """Load template for a public document martigny data."""
+    return deepcopy(data.get('tmpl1'))
+
+
+@pytest.fixture(scope="module")
+def templ_doc_public_martigny(
+        app, org_martigny, templ_doc_public_martigny_data,
+        system_librarian_martigny_no_email):
+    """Create template for a public document martigny."""
+    template = Template.create(
+        data=templ_doc_public_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template
+
+
+@pytest.fixture(scope="module")
+def templ_doc_private_martigny_data(data):
+    """Load template for a private document martigny data."""
+    return deepcopy(data.get('tmpl2'))
+
+
+@pytest.fixture(scope="module")
+def templ_doc_private_martigny(
+        app, org_martigny, templ_doc_private_martigny_data,
+        librarian_martigny_no_email):
+    """Create template for a private document martigny."""
+    template = Template.create(
+        data=templ_doc_private_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template
+
+
+@pytest.fixture(scope="module")
+def templ_doc_public_sion_data(data):
+    """Load template for a public document sion data."""
+    return deepcopy(data.get('tmpl3'))
+
+
+@pytest.fixture(scope="module")
+def templ_doc_public_sion(
+        app, org_sion, templ_doc_public_sion_data,
+        system_librarian_sion_no_email):
+    """Create template for a public document sion."""
+    template = Template.create(
+        data=templ_doc_public_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template
+
+
+@pytest.fixture(scope="module")
+def templ_holdings_public_martigny_data(data):
+    """Load template for a public holdings martigny data."""
+    return deepcopy(data.get('tmpl4'))
+
+
+@pytest.fixture(scope="module")
+def templ_holdings_public_martigny(
+        app, org_martigny, templ_holdings_public_martigny_data,
+        system_librarian_martigny_no_email):
+    """Load template for a public holdings martigny."""
+    template = Template.create(
+        data=templ_holdings_public_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template
+
+
+@pytest.fixture(scope="module")
+def templ_item_public_martigny_data(data):
+    """Load template for a public item martigny data."""
+    return deepcopy(data.get('tmpl5'))
+
+
+@pytest.fixture(scope="module")
+def templ_item_public_martigny(
+        app, org_martigny, templ_item_public_martigny_data,
+        system_librarian_martigny_no_email):
+    """Load template for a public item martigny."""
+    template = Template.create(
+        data=templ_item_public_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template
+
+
+@pytest.fixture(scope="module")
+def templ_patron_public_martigny_data(data):
+    """Load template for a public patron martigny data."""
+    return deepcopy(data.get('tmpl6'))
+
+
+@pytest.fixture(scope="module")
+def templ_patron_public_martigny(
+        app, org_martigny, templ_patron_public_martigny_data,
+        system_librarian_martigny_no_email):
+    """Load template for a public item martigny."""
+    template = Template.create(
+        data=templ_patron_public_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template

--- a/tests/ui/templates/test_template_mapping.py
+++ b/tests/ui/templates/test_template_mapping.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Libraries elasticsearch mapping tests."""
+
+from utils import get_mapping
+
+from rero_ils.modules.templates.api import Template, TemplatesSearch
+
+
+def test_template_es_mapping(es_clear, db, templ_doc_public_martigny_data,
+                             templ_doc_private_martigny_data,
+                             org_martigny, system_librarian_martigny_no_email,
+                             librarian_martigny_no_email):
+    """Test template elasticsearch mapping."""
+    search = TemplatesSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    Template.create(templ_doc_public_martigny_data,
+                    dbcommit=True, reindex=True, delete_pid=True)
+    new_mapping = get_mapping(search.Meta.index)
+    assert mapping == new_mapping
+
+
+def test_template_search_mapping(
+        app, templ_doc_public_martigny, templ_doc_private_martigny):
+    """Test template search mapping."""
+    search = TemplatesSearch()
+
+    c = search.query('match', template_type='documents').count()
+    assert c == 2
+
+    c = search.query('match', organisation__pid='org1').count()
+    assert c == 2

--- a/tests/ui/templates/test_templates_api.py
+++ b/tests/ui/templates/test_templates_api.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Template Record tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema.exceptions import ValidationError
+from utils import get_mapping
+
+from rero_ils.modules.templates.api import Template, TemplatesSearch
+from rero_ils.modules.templates.api import template_id_fetcher as fetcher
+
+
+def test_template_es_mapping(es_clear, db,
+                             templ_doc_public_martigny_data,
+                             org_martigny, system_librarian_martigny_no_email):
+    """Test template elasticsearch mapping."""
+    search = TemplatesSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    Template.create(
+        templ_doc_public_martigny_data,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)
+
+
+def test_template_create(db, es_clear, templ_doc_public_martigny_data,
+                         org_martigny, system_librarian_martigny_no_email):
+    """Test template creation."""
+    templ_doc_public_martigny_data['toto'] = 'toto'
+    with pytest.raises(ValidationError):
+        temp = Template.create(templ_doc_public_martigny_data, delete_pid=True)
+
+    db.session.rollback()
+
+    del templ_doc_public_martigny_data['toto']
+    temp = Template.create(templ_doc_public_martigny_data, delete_pid=True)
+    assert temp == templ_doc_public_martigny_data
+    assert temp.get('pid') == '1'
+
+    temp = Template.get_record_by_pid('1')
+    assert temp == templ_doc_public_martigny_data
+
+    fetched_pid = fetcher(temp.id, temp)
+    assert fetched_pid.pid_value == '1'
+    assert fetched_pid.pid_type == 'tmpl'
+
+
+def test_template_can_delete(templ_doc_public_martigny):
+    """Test can delete."""
+    assert templ_doc_public_martigny.get_links_to_me() == {}
+    assert templ_doc_public_martigny.can_delete

--- a/tests/ui/test_monitoring.py
+++ b/tests/ui/test_monitoring.py
@@ -50,6 +50,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
         '      0    ptrn          0                    patrons          0',
         '      0    pttr          0        patron_transactions          0',
         '      0    ptty          0               patron_types          0',
+        '      0    tmpl          0                  templates          0',
         '      0    vndr          0                    vendors          0'
     ]
 
@@ -89,6 +90,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
         'ptrn': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'patrons'},
         'pttr': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'patron_transactions'},
         'ptty': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'patron_types'},
+        'tmpl': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'templates'},
         'vndr': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'vendors'}
     }
     assert mon.__str__().split('\n') == cli_output + ['']

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,10 +33,20 @@ def create_app():
 
 @pytest.fixture()
 def circ_policy_schema(monkeypatch):
-    """Patron Jsonschema for records."""
+    """Circ policy Jsonschema for records."""
     schema_in_bytes = resource_string(
         'rero_ils.modules.circ_policies.jsonschemas',
         'circ_policies/circ_policy-v0.0.1.json',
+    )
+    return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture()
+def template_schema(monkeypatch):
+    """Template Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.templates.jsonschemas',
+        'templates/template-v0.0.1.json',
     )
     return get_schema(monkeypatch, schema_in_bytes)
 

--- a/tests/unit/test_templates_jsonschema.py
+++ b/tests/unit/test_templates_jsonschema.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Templates JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_required(template_schema, templ_doc_public_martigny_data_tmp):
+    """Test required for template jsonschema."""
+    validate(templ_doc_public_martigny_data_tmp, template_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, template_schema)
+        validate(templ_doc_public_martigny_data_tmp, template_schema)
+
+
+def test_template_all_jsonschema_keys_values(
+        template_schema, templ_doc_public_martigny_data_tmp):
+    """Test all keys and values for template jsonschema."""
+    record = templ_doc_public_martigny_data_tmp
+    validate(record, template_schema)
+    validator = [
+        {'key': 'pid', 'value': 25},
+        {'key': 'name', 'value': 25},
+        {'key': 'description', 'value': 25},
+        {'key': 'organistion', 'value': 25},
+        {'key': 'template_type', 'value': 25},
+        {'key': 'creator', 'value': 25},
+        {'key': 'visibility', 'value': 25},
+        {'key': 'data', 'value': 25}
+    ]
+    for element in validator:
+        with pytest.raises(ValidationError):
+            record[element['key']] = element['value']
+            validate(record, template_schema)


### PR DESCRIPTION
A new resource `template` is added for the records of
types document, patron, item and holdings.

A non-controlled field called `data` in the template
json schema is available for librarians to save
pre-validated data.

A template can have two visibilities either:
1. public, available for use for all users of the
organisation.
2. private, available only for use for its creator.

Users with role librarian can create private templates,
 edit their own private records, and access public and
their own private records of their organisation.

Users with role system_librarian can create/edit/access/delete
any type of templates of its organisation.

* Adds pids to the users.json fixtures data file.
* Adds units testing and fixtures for the new resource.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1642?milestone=271177

## How to test?

`bootstrap + setup`
login as `asrtid`, you can see some templates here ~/api/templates/ 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
