### PR TITLE
utils: new method to return record class

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -460,14 +460,11 @@ class IlsRecordsIndexer(RecordIndexer):
 
     def _get_record_class(self, payload):
         """Get the record class from payload."""
+        from .utils import get_record_class_from_schema_or_pid_type
+
         # take the first defined doc type for finding the class
         pid_type = payload.get('doc_type', 'rec')
-        record_class = obj_or_import_string(
-            current_app.config.get('RECORDS_REST_ENDPOINTS').get(
-                pid_type
-            ).get('record_class', Record)
-        )
-        return record_class
+        return get_record_class_from_schema_or_pid_type(pid_type=pid_type)
 
     def _actionsiter(self, message_iterator):
         """Iterate bulk actions.

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -376,3 +376,28 @@ def get_ref_for_pid(module, pid):
             route=configuration.get('list_route'),
             pid=pid
         )
+
+
+def get_record_class_from_schema_or_pid_type(schema=None, pid_type=None):
+    """Get the record class from a given schema or a pid type.
+
+    If both the schema and pid_type are given, the record_class of the
+    schema will be returned.
+
+    :param schema: record schema.
+    :param pid_type: record pid type.
+    :return: the record class.
+    """
+    if schema:
+        try:
+            pid_type_schema_value = schema.split('schemas')[1]
+            schemas = current_app.config.get('RECORDS_JSON_SCHEMA')
+            pid_type = [key for key, value in schemas.items()
+                        if value == pid_type_schema_value][0]
+        except IndexError:
+            pass
+    record_class = obj_or_import_string(
+        current_app.config
+        .get('RECORDS_REST_ENDPOINTS')
+        .get(pid_type, {}).get('record_class'))
+    return record_class

--- a/tests/ui/test_utils_app.py
+++ b/tests/ui/test_utils_app.py
@@ -18,7 +18,9 @@
 """Test utils."""
 
 from rero_ils.modules.documents.api import Document
-from rero_ils.modules.utils import get_ref_for_pid, pids_exists_in_data
+from rero_ils.modules.patrons.api import Patron
+from rero_ils.modules.utils import get_record_class_from_schema_or_pid_type, \
+    get_ref_for_pid, pids_exists_in_data
 from rero_ils.utils import get_current_language
 
 
@@ -87,3 +89,34 @@ def test_pids_exists_in_data(app, org_martigny, lib_martigny):
 def test_get_language(app):
     """Test get the current language of the application."""
     assert get_current_language() == 'en'
+
+
+def test_get_record_class_from_schema_or_pid_type(app):
+    """Test get record class from schema or pid_type."""
+    schema = 'https://ils.rero.ch/schemas/documents/document-v0.0.1.json'
+    assert get_record_class_from_schema_or_pid_type(schema=schema) == Document
+    assert get_record_class_from_schema_or_pid_type(pid_type='doc') == Document
+    assert get_record_class_from_schema_or_pid_type(
+        schema=schema, pid_type='doc') == Document
+    assert get_record_class_from_schema_or_pid_type(
+        schema=schema, pid_type='ptrn') == Document
+
+    schema = 'https://ils.rero.ch/schemas/patrons/patron-v0.0.1.json'
+    assert get_record_class_from_schema_or_pid_type(
+        schema=schema, pid_type='doc') == Patron
+    assert get_record_class_from_schema_or_pid_type(
+        schema=schema, pid_type='ptrn') == Patron
+    assert get_record_class_from_schema_or_pid_type(pid_type='ptrn') == Patron
+
+    assert not get_record_class_from_schema_or_pid_type(pid_type='toto')
+    assert not get_record_class_from_schema_or_pid_type(
+        schema='toto', pid_type=None)
+    assert not get_record_class_from_schema_or_pid_type(
+        schema='toto', pid_type='toto')
+    assert not get_record_class_from_schema_or_pid_type(
+        schema=None, pid_type=None)
+    assert not get_record_class_from_schema_or_pid_type(
+        schema=None, pid_type='toto')
+    assert not get_record_class_from_schema_or_pid_type(schema=None)
+    assert not get_record_class_from_schema_or_pid_type(pid_type=None)
+    assert not get_record_class_from_schema_or_pid_type()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -79,7 +79,6 @@ def test_extract_data_from_ref(app, patron_sion_data,
     """Test extract_data_from_ref."""
     # Check real data
     ptty = patron_sion_data['patron_type']
-    print(ptty)
     assert extracted_data_from_ref(ptty, data='pid') == 'ptty4'
     assert extracted_data_from_ref(ptty, data='resource') == 'patron_types'
     assert extracted_data_from_ref(ptty, data='record_class') == PatronType


### PR DESCRIPTION
A new method to return a record class from a given
pid_type or a record schema. This method is to group
codes used in different areas and replace it with this
method.

* Adapts areas of codes as necessary.
* Creates tests.
* Removes forgotten print line.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
