### PR TITLE
acquisition: add document selector for order lines

### DIFF
--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "title": "AcqOrderLine",
-  "description": "JSON schema for Acquisition Order Line.",
+  "title": "Acquisition order line",
+  "description": "JSON schema for acquisition order line.",
   "additionalProperties": false,
   "propertiesOrder": [
     "acq_account",
@@ -25,13 +25,13 @@
   "properties": {
     "$schema": {
       "title": "Schema",
-      "description": "Schema to validate Acquisition Order Line records against.",
+      "description": "Schema to validate acquisition order line records against.",
       "type": "string",
       "default": "https://ils.rero.ch/schemas/acq_order_lines/acq_order_line-v0.0.1.json",
       "pattern": "^https://ils.rero.ch/schemas/acq_order_lines/acq_order_line-v([0-9]+?\\.){3}json$"
     },
     "pid": {
-      "title": "AcqOrderLine ID",
+      "title": "Acquisition order line ID",
       "type": "string",
       "minLength": 1
     },
@@ -142,7 +142,7 @@
       }
     },
     "acq_order": {
-      "title": "Acquisition Order",
+      "title": "Acquisition order",
       "type": "object",
       "properties": {
         "$ref": {
@@ -161,6 +161,9 @@
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/documents/.+?$",
           "form": {
+            "remoteTypeahead": {
+              "type": "documents"
+            },
             "validation": {
               "messages": {
                 "patternMessage": "Should be in the following format: https://ils.rero.ch/api/documents/<PID>."


### PR DESCRIPTION
Adds a search input in the order line editor to link an order line to a
document, preventing the user to enter a valid API URL.

* Adapts order lines JSON schema.
* Updates order lines JSON schema source string for translation.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#350

## How to test?

- Test document typeahead in order lines editor.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
