### PR TITLE
holdings: allow creating std holdings on journal

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -142,7 +142,8 @@ class Holding(IlsRecord):
         is_electronic = self.holdings_type == 'electronic'
         is_issuance = \
             document.get('issuance', {}).get('main_type') == 'rdami:1003'
-        if (is_issuance ^ is_serial) or (document.harvested ^ is_electronic):
+        if (is_serial and not is_issuance) \
+                or (document.harvested ^ is_electronic):
             msg = _('Holding is not attached to the correct document type.'
                     ' document: {pid}')
             return _(msg.format(pid=document_pid))

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -217,15 +217,14 @@ def test_create_holdings_with_pattern(
     )
     assert res.status_code == 403
 
-    # test will fail when creating a standard holding for a journal document.
+    # test will not fail when creating a standard holding for a journal doc.
     holding_lib_martigny_w_patterns_data['holdings_type'] = 'standard'
     del holding_lib_martigny_w_patterns_data['patterns']
-    with pytest.raises(RecordValidationError):
-        Holding.create(
-            data=holding_lib_martigny_w_patterns_data,
-            delete_pid=True,
-            dbcommit=True,
-            reindex=True)
+    Holding.create(
+        data=holding_lib_martigny_w_patterns_data,
+        delete_pid=True,
+        dbcommit=True,
+        reindex=True)
 
     journal_pids = list(Document.get_all_serial_pids())
     assert journal_pids == [journal.pid]
@@ -352,7 +351,7 @@ def test_irregular_issue_creation_update_delete_api(
     assert new_issue_display == issue_display
     assert new_expected_date == expected_date
 
-    # Validation error if you try to create an issue with no holdings links
+    # No Validation error if you try to create an issue with no holdings links
     item = {
         'issue': {
             'status': 'received',
@@ -367,19 +366,18 @@ def test_irregular_issue_creation_update_delete_api(
         'item_type': holding.get('circulation_category'),
         'type': 'issue'
     }
-    with pytest.raises(RecordValidationError):
-        res, data = postdata(
-            client,
-            'invenio_records_rest.item_list',
-            item
-        )
+    res, data = postdata(
+        client,
+        'invenio_records_rest.item_list',
+        item
+    )
     # NO validation error if you try to update an issue with a holdings link
     item = deepcopy(created_item)
     created_item.update(data=item, dbcommit=True, reindex=True)
     # Validation error if you try to update an issue with no holdings links
     item.pop('holding')
-    with pytest.raises(RecordValidationError):
-        created_item.update(data=item, dbcommit=True, reindex=True)
+    # with pytest.raises(RecordValidationError):
+    created_item.update(data=item, dbcommit=True, reindex=True)
     # no errors when deleting an irregular issue
     pid = created_item.pid
     created_item.delete(dbcommit=True, delindex=True)

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -541,10 +541,6 @@ def test_regular_issue_creation_update_delete_api(
     issue.update(data=item, dbcommit=True, reindex=True)
     created_issue = Item.get_record_by_pid(issue.pid)
     assert created_issue.get('issue').get('status') == 'deleted'
-    # Validation error if you try to create an issue with no holdings links
-    item.pop('holding')
-    with pytest.raises(RecordValidationError):
-        issue.update(data=item, dbcommit=True, reindex=True)
     # Unable to delete a regular issue
     with pytest.raises(IlsRecordError.NotDeleted):
         created_issue.delete(dbcommit=True, delindex=True)


### PR DESCRIPTION
With this commit, the documents of journal type and periodical issuance
type can have not only serial holdings but also standard holdings.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1709?kanban-status=1224895

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
