### PR TITLE
template: fix permissions/JSON schema

### DIFF
--- a/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
@@ -41,7 +41,13 @@
     "description": {
       "title": "Description",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "type": "textarea",
+        "templateOptions": {
+          "rows": 3
+        }
+      }
     },
     "organisation": {
       "title": "Organisation",
@@ -75,6 +81,7 @@
         "private"
       ],
       "form": {
+        "fieldMap": "visibility",
         "type": "selectWithSort",
         "wrappers": [
           "form-field-horizontal"
@@ -106,10 +113,7 @@
         "patrons"
       ],
       "form": {
-        "type": "selectWithSort",
-        "wrappers": [
-          "form-field-horizontal"
-        ],
+        "hideExpression": "true",
         "options": [
           {
             "label": "documents",
@@ -127,12 +131,7 @@
             "label": "patrons",
             "value": "patrons"
           }
-        ],
-        "templateOptions": {
-          "selectWithSortOptions": {
-            "order": "label"
-          }
-        }
+        ]
       }
     },
     "data": {

--- a/rero_ils/modules/templates/permissions.py
+++ b/rero_ils/modules/templates/permissions.py
@@ -99,10 +99,12 @@ class TemplatePermission(RecordPermission):
             #   - 'librarian' can only update his own private records
             #     He cannot change the visibility
             elif current_patron.is_librarian:
-                new_template = request.get_json()
-                if new_template is not None and \
-                        record['visibility'] != new_template['visibility']:
+                incoming_record = request.get_json(silent=True) or {}
+                # a librarian cannot change visibility of a template
+                if incoming_record and incoming_record.get('visibility') \
+                   != record.get('visibility'):
                     return False
+                # a librarian can update its own private record
                 elif record.is_private and \
                         record.creator_pid == current_patron.pid:
                     return True


### PR DESCRIPTION
* Fixes templates permissions for update method.
* Fixes JSON schema :
  - user can't update template_type for a template.
  - description field is now displayed as a textarea.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
