### PR TITLE
cypress: create scenario A test

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -508,6 +508,7 @@ def patron_profile(patron):
             item.replace_refs()['document']['pid'])
         loan['document'] = document.replace_refs().dumps()
         loan['item_call_number'] = item['call_number']
+        loan['item_barcode'] = item['barcode']
         if loan['state'] == LoanState.ITEM_ON_LOAN:
             loan['overdue'] = loan.is_loan_overdue()
             loan['library_name'] = Library.get_record_by_pid(

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_requests.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_requests.html
@@ -29,7 +29,7 @@
 
 {% if requests|length > 0 %}
   {% for loan in requests %}
-  <div class="row mb-1">
+  <div id="item-{{ loan.item_barcode }}" class="row mb-1">
     <div class="col mr-1 p-2 border rounded{% if loan.state == 'ITEM_AT_DESK' %} border-success{% endif %}">
       <div class="row pl-2 pr-2">
         <div class="col-lg-4">
@@ -37,12 +37,13 @@
             <i class="fa fa-caret-right pr-0"></i>
           </button>
           <a
+            id="item-{{ loan.item_barcode }}-title"
             href="{{ url_for('invenio_records_ui.doc', viewcode=viewcode, pid_value=loan.document.pid) }}"
           >
           {{ loan.document.title[0]._text }}
           </a>
         </div>
-        <div class="col-lg-4">
+        <div id="item-{{ loan.item_barcode }}-pickup-name" class="col-lg-4">
           {{ loan.pickup_name }}
         </div>
         <div class="col-lg-2{% if loan.state == 'ITEM_AT_DESK' %} text-success{% endif %}">
@@ -66,7 +67,7 @@
           <form class="mt-0" action="{{ url_for('patrons.profile') }}" method="POST" name="cancel_request">
             <input type="hidden" name="type" value="cancel">
             <input type="hidden" name="loan_pid" value="{{ loan.pid }}">
-            <button type="submit" class="btn btn-outline-primary mt-1">
+            <button id="item-{{ loan.item_barcode }}-cancel-button" type="submit" class="btn btn-outline-primary mt-1">
               {{ _('Cancel') }}
             </button>
           </form>
@@ -90,7 +91,7 @@
           <div class="col-lg-2 col-sm-4 text-right label-title">
             <b>{{ _('Call number') }}</b>
           </div>
-          <div class="col-lg-10 col-sm-8">
+          <div id="item-{{ loan.item_barcode }}-call-number" class="col-lg-10 col-sm-8">
             {{ loan.item_call_number }}
           </div>
         </div>
@@ -98,7 +99,7 @@
           <div class="col-lg-2 col-sm-4 text-right label-title">
             <b>{{ _('Transaction date') }}</b>
           </div>
-          <div class="col-lg-10 col-sm-8">
+          <div id="item-{{ loan.item_barcode }}-transaction-date" class="col-lg-10 col-sm-8">
             {{ loan.transaction_date|format_date(
               locale=current_i18n.locale.language
             )}}

--- a/tests/e2e/cypress/cypress/fixtures/items.json
+++ b/tests/e2e/cypress/cypress/fixtures/items.json
@@ -1,18 +1,14 @@
 {
   "vulcanDefault": {
+    "code": "VULCAN-BIB",
     "location": "Default location for Vulcan library",
     "pickupName": "Vulcan library",
-    "library": {
-      "$ref": "https://ils.rero.ch/api/libraries/23"
-    },
     "itemTypeUri": "Default"
   },
-  "starfleetDefault": {
+  "starfleetStandardLoan": {
+    "code": "STARFLEET-BIB",
     "location": "Default location for Starfleet library",
     "pickupName": "Starfleet library",
-    "library": {
-      "$ref": "https://ils.rero.ch/api/libraries/22"
-    },
     "itemTypeUri": "Default"
   }
 }

--- a/tests/e2e/cypress/cypress/fixtures/users.json
+++ b/tests/e2e/cypress/cypress/fixtures/users.json
@@ -19,9 +19,7 @@
       "first_name": "Spock",
       "last_name": "Grayson",
       "libraryPid": "23"
-    }
-  },
-  "sysLibrarians": {
+    },
     "leonard": {
       "email": "reroilstest+leonard@gmail.com",
       "first_name": "Leonard",

--- a/tests/e2e/cypress/cypress/integration/circulation/scenario-a.spec.js
+++ b/tests/e2e/cypress/cypress/integration/circulation/scenario-a.spec.js
@@ -1,0 +1,155 @@
+/// <reference types="Cypress" />
+/*
+
+RERO ILS
+Copyright (C) 2020 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+before(function () {
+  cy.fixture('users').then(function (userData) {
+    this.users = userData;
+  });
+  cy.fixture('common').then(function (commonData) {
+    this.common = commonData;
+  });
+  cy.fixture('documents').then(function (documents) {
+    this.documents = documents;
+  });
+  cy.fixture('items').then(function (items) {
+    this.items = items;
+  });
+  this.itemBarcode = 'request-' + cy.getCurrentDateAndHour();
+});
+
+describe('Circulation scenario A: standard loan', function() {
+  /**
+   * DESCRIPTION
+   *
+   * 1. A patron makes a request on an item, to be picked up at ownimg library. The item is on shelf.
+   * 2. A librarian validates the request. The item is at desk.
+   * 3. The item is checked out for patron at owning library.
+   * 4. The item is returned at owning library. Item is on shelf.
+   */
+  before('Login as a professional and create a document and an item', function() {
+    // Create server to watch api requests
+    cy.server();
+    // Open app on frontpage
+    cy.visit('');
+    // Check language and force to english
+    cy.setLanguageToEnglish();
+    // Login as librarian (Leonard)
+    cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
+    // Create a document
+    // Go to document editor
+    cy.goToMenu('create-bibliographic-record-menu-frontpage');
+    // Populate form with simple record
+    cy.populateSimpleRecord(this.documents.book);
+    //Save record
+    cy.saveRecord();
+    // Create an item
+    cy.createItemFromDocumentDetailView(this.itemBarcode, this.items.starfleetStandardLoan);
+  });
+
+  beforeEach('Action to perform before each test', function() {
+    console.log('before each');
+    cy.logout();
+  });
+
+  after('Clean data: remove item and document', function() {
+    // TODO: find a way to preserve cookies (auth) and server after a test
+    cy.server();
+    cy.route({method: 'DELETE', url: '/api/items/*'}).as('deleteItem');
+    cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
+    // Go to document detail view and remove item
+    cy.goToProfessionalDocumentDetailView(this.itemBarcode);
+    cy.get('#item-' + this.itemBarcode + ' [name=buttons] > [name=delete]').click();
+    cy.get('#modal-confirm-button').click();
+    cy.wait('@deleteItem');
+    // Remove document
+    cy.reload(); // Bug: need to reload the page to unable the remove button
+    cy.deleteRecordFromDetailView();
+  });
+
+  it('1. A patron makes a request', function() {
+    /**
+     * James makes a request on item, to be picked up at Starfleet library.
+     */
+    cy.login(this.users.patrons.james.email, this.common.uniquePwd);
+    // Search for the item
+    cy.goToPublicDocumentDetailView(this.itemBarcode);
+    // Request the item
+    cy.get('#' + this.itemBarcode + '-dropdownMenu').click();
+    // Select pickup location (force because menu can go over browser view)
+    cy.get('#' + this.items.starfleetStandardLoan.code).click({force: true});
+    // Go to user profile, directly on requests-tab
+    cy.userProfile('requests-tab');
+    // Check barcode exists and that it's requested
+    cy.get('#item-' + this.itemBarcode + '-call-number').should('contain', this.itemBarcode);
+  });
+
+  it('2. A librarian validates the request', function() {
+    /**
+     * Leonard validates James' request.
+     */
+    cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
+    // Go to requests list
+    cy.goToMenu('requests-menu-frontpage')
+    // Check that the document is present
+    cy.get('table').should('contain', this.itemBarcode)
+    // Enter the barcode and validate
+    cy.get('#search').type(this.itemBarcode).type('{enter}')
+
+    // The item should be marked as available in user profile view
+    // Go to patrons list
+    cy.goToMenu('patrons-menu-frontpage')
+    // Go to James patron profile
+    cy.get('#' + this.users.patrons.james.barcode + '-loans').click()
+    // Click on tab called "To pick up"
+    cy.get('#pick-up-tab').click()
+    // The item should be present
+    cy.get('.content').should('contain', this.itemBarcode)
+  });
+
+  it('3. The item is checked out for patron at owning library', function() {
+    /**
+     * Leonard checks the item out for James in Starfleet library.
+     */
+    cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
+    // Go to circulation search bar
+    cy.goToMenu('circulation-menu-frontpage');
+    // Checkout
+    cy.scanPatronBarcodeThenItemBarcode(this.users.patrons.james, this.itemBarcode);
+    // Item barcode should be present
+    cy.get('#item-' + this.itemBarcode).should('contain', this.itemBarcode);
+  });
+
+  it('4. The item is returned at owning library', function() {
+    /**
+     * The item is returned at Starfleet library and goes on shelf.
+     * Leonard makes the checkin.
+     */
+    cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
+    // Go to circulation search bar
+    cy.goToMenu('circulation-menu-frontpage');
+    // Checkin
+    cy.scanItemBarcode(this.itemBarcode);
+    // CHeck that the item was checked in and that it is on shelf
+    cy.get('#item-' + this.itemBarcode).should('contain', this.itemBarcode);
+    cy.get('#item-' + this.itemBarcode).should('contain', 'on shelf');
+    cy.get('#item-' + this.itemBarcode).should('contain', 'checked in');
+    cy.logout();
+  });
+});

--- a/tests/e2e/cypress/cypress/integration/templates/template-test-request.spec.js
+++ b/tests/e2e/cypress/cypress/integration/templates/template-test-request.spec.js
@@ -79,6 +79,7 @@ describe('Template: librarian request', function() {
     console.log('after');
     // TODO: find a way to preserve cookies (auth) and server after a test
     cy.server();
+    cy.route({method: 'DELETE', url: '/api/items/*'}).as('deleteItem');
     cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
     // Go to item detail view
     cy.goToProfessionalDocumentDetailView(this.itemBarcode);
@@ -90,6 +91,8 @@ describe('Template: librarian request', function() {
     cy.goToProfessionalDocumentDetailView(this.itemBarcode);
     cy.get('#item-' + this.itemBarcode + ' [name=buttons] > [name=delete]').click();
     cy.get('#modal-confirm-button').click();
+    cy.wait('@deleteItem');
+
     // Remove document
     cy.reload(); // Bug: need to reload the page to unable the remove button
     cy.deleteRecordFromDetailView();

--- a/tests/e2e/cypress/cypress/support/circulation.js
+++ b/tests/e2e/cypress/cypress/support/circulation.js
@@ -18,12 +18,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
 // Scan the patron barcode, then the item barcode (this does a checkout)
-Cypress.Commands.add('scanPatronBarcodeThenItemBarcode', (patronBarcode, patron, itemBarcode) => {
+Cypress.Commands.add('scanPatronBarcodeThenItemBarcode', (patron, itemBarcode) => {
   // Enter patron barcode
-  cy.get('#search').type(patronBarcode).type('{enter}');
+  cy.get('#search').type(patron.barcode).type('{enter}');
   // Assert that patron info is displayed
-  cy.get('#patron-last-name').should('contain', patron.lastname);
-  cy.get('#patron-first-name').should('contain', ', ' + patron.firstname);
+  cy.get('#patron-last-name').should('contain', patron.last_name);
+  cy.get('#patron-first-name').should('contain', ', ' + patron.first_name);
   // Enter item barcode for checkout
   cy.get('#search').type(itemBarcode).type('{enter}');
 });

--- a/tests/e2e/cypress/cypress/support/commands.js
+++ b/tests/e2e/cypress/cypress/support/commands.js
@@ -38,7 +38,7 @@ Cypress.Commands.add('setLanguageToEnglish', () => {
     })
   })
   // Wait for the menu to close
-  // TODO: find a better way
+  // TODO: find a better way (same as logout command)
   cy.wait(1000)
 })
 

--- a/tests/e2e/cypress/cypress/support/navigation.js
+++ b/tests/e2e/cypress/cypress/support/navigation.js
@@ -48,21 +48,12 @@ Cypress.Commands.add("goToMenu", (menuId) => {
   cy.get('#' + menuId).click()
 })
 
-Cypress.Commands.add("goToDocumentDetailView", (itemBarcode) => {
+Cypress.Commands.add("goToPublicDocumentDetailView", (itemBarcode) => {
   // Go to homepage
   cy.get('#homepage-logo').click()
-  cy.url(1000).then((url) => {
-    if (url.includes('/professional/')) {
-      // on professional context
-      cy.get('.form-control').clear()
-      cy.get('.form-control').type(itemBarcode).type('{enter}')
-    }
-    else {
-       // on public context
-      cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').clear()
-      cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').type(itemBarcode).type('{enter}')
-    }
-  })
+  // on public context
+  cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').clear()
+  cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').type(itemBarcode).type('{enter}')
   // Use first element
   cy.get('.card-title > a').click()
 })

--- a/tests/e2e/cypress/cypress/support/record.js
+++ b/tests/e2e/cypress/cypress/support/record.js
@@ -24,13 +24,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 Cypress.Commands.add("createItemFromDocumentDetailView", (barcode, item) => {
   // Click on "Add…" button to add an item
   cy.get('.col > .btn').click()
-  // Fill in Item barcode
+  // Fill in the form
   cy.get('#barcode').type(barcode)
-  // Fill in Item Call number with barcode content
   cy.get('#call_number').type(barcode)
-  // Fill in Item Category
+  // Select item type
   cy.get('select').first().select(item.itemTypeUri)
-  // Fill in localisation (could be 0, 1, etc. to select first element from select list)
+  // Select location
   cy.get('select').eq(1).select(item.location)
   // Submit form
   cy.get('.mt-4 > [type="submit"]').click()

--- a/tests/e2e/cypress/cypress/support/user.js
+++ b/tests/e2e/cypress/cypress/support/user.js
@@ -21,6 +21,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 Cypress.Commands.add("logout", () => {
   // click on username
   cy.get('#my-account-menu').click()
+  // Wait for the menu to open
+  // TODO: find a better way (same as setLanguageToEnglish command)
+  cy.wait(1000)
   // then click on Logout link
   cy.get('#logout-menu').click()
 })
@@ -28,6 +31,7 @@ Cypress.Commands.add("logout", () => {
 Cypress.Commands.add("login", (email, password) => {
   // click on "My account"
   cy.get('#my-account-menu').click()
+  cy.wait(1000)
   cy.get('#login-menu').click()
   cy.get('#email').type(email)
   cy.get('#password').type(password)


### PR DESCRIPTION
* Creates scenario A test.
* Adds an id html attribute in patron profile view for element selection
with cypress.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Task 1612 of US1489

## Dependencies

N/A

## How to test?

You need to include rero-ils-ui into rero-ils:

`cd rero-ils-ui`
`npm ci && npm install path/to/ng-core.tgz --no-save`
`npm run pack`

`cd rero-ils`
`poetry run bootstrap -t path/to/rero-ils-ui.tgz`
`poetry run setup`

Then run the server with `FLASK_DEBUG=False poetry run server`, otherwise the test will fail.
Check that `FLASK_DEBUG=False` is not overwritten in invenio.cfg.

`poetry run cypress` installs new version of cypress and runs all the tests.
With a GUI: `cd tests/e2e/cypress`, then `npm run cypress`. Click on the test file to launch it.
Try different browsers.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
