### PR TITLE
fixtures: add an organisation for cypress

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -381,5 +381,23 @@
     "renewal_duration": 30,
     "policy_library_level": false,
     "is_default": true
+  },
+  {
+    "pid": "13",
+    "name": "Default",
+    "description": "Default circulation policy.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    },
+    "allow_checkout": true,
+    "checkout_duration": 30,
+    "allow_requests": true,
+    "number_renewals": 3,
+    "number_of_days_before_due_date": 5,
+    "number_of_days_after_due_date": 5,
+    "reminder_fee_amount": 2.0,
+    "renewal_duration": 30,
+    "policy_library_level": false,
+    "is_default": true
   }
 ]

--- a/data/item_types.json
+++ b/data/item_types.json
@@ -88,5 +88,14 @@
       "$ref": "https://ils.rero.ch/api/organisations/3"
     },
     "type": "standard"
+  },
+  {
+    "pid": "11",
+    "name": "Default",
+    "description": "Default item type",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    },
+    "type": "standard"
   }
 ]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -1841,5 +1841,169 @@
         ]
       }
     ]
+  },
+  {
+    "pid": "22",
+    "address": "On board the Enterprise",
+    "code": "ENTERPRISE",
+    "email": "reroilstest+cypress1@gmail.com",
+    "name": "Starfleet library",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    },
+    "opening_hours": [
+      {
+        "day": "monday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "tuesday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "wednesday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "thursday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "friday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "saturday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "sunday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "pid": "23",
+    "address": "Somewhere on Vulcan",
+    "code": "VULCAN",
+    "email": "reroilstest+cypress2@gmail.com",
+    "name": "Vulcan Sciences Academy",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    },
+    "opening_hours": [
+      {
+        "day": "monday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "tuesday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "wednesday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "thursday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "friday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "saturday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "day": "sunday",
+        "is_open": true,
+        "times": [
+          {
+            "start_time": "01:00",
+            "end_time": "23:59"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/data/locations.json
+++ b/data/locations.json
@@ -162,7 +162,7 @@
   {
     "pid": "19",
     "code": "CITA-BIB",
-    "name": "Defaut location for La Citadelle",
+    "name": "Default location for La Citadelle",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/7"
     },
@@ -174,7 +174,7 @@
   {
     "pid": "20",
     "code": "BEAST-BIB",
-    "name": "Defaut location for Beast's Library",
+    "name": "Default location for Beast's Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/8"
     },
@@ -186,7 +186,7 @@
   {
     "pid": "21",
     "code": "DREAM-BIB",
-    "name": "Defaut location for Dream's Library",
+    "name": "Default location for Dream's Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/9"
     },
@@ -198,7 +198,7 @@
   {
     "pid": "22",
     "code": "LUX-BIB",
-    "name": "Defaut location for Lux Foundation Library",
+    "name": "Default location for Lux Foundation Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/10"
     },
@@ -210,7 +210,7 @@
   {
     "pid": "23",
     "code": "HOG-BIB",
-    "name": "Defaut location for Hogwarts Library",
+    "name": "Default location for Hogwarts Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/11"
     },
@@ -222,7 +222,7 @@
   {
     "pid": "24",
     "code": "BABEL-BIB",
-    "name": "Defaut location for Biblioth\u00e8que de Babel",
+    "name": "Default location for Biblioth\u00e8que de Babel",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/12"
     },
@@ -234,7 +234,7 @@
   {
     "pid": "25",
     "code": "ROSE-BIB",
-    "name": "Defaut location for Biblioth\u00e8que de l\u2019abbaye",
+    "name": "Default location for Biblioth\u00e8que de l\u2019abbaye",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/13"
     },
@@ -246,7 +246,7 @@
   {
     "pid": "26",
     "code": "UNI-BIB",
-    "name": "Defaut location for The University's Library",
+    "name": "Default location for The University's Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/14"
     },
@@ -258,7 +258,7 @@
   {
     "pid": "27",
     "code": "CEMETERY-BIB",
-    "name": "Defaut location for Cemetery of Forgotten Books",
+    "name": "Default location for Cemetery of Forgotten Books",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/15"
     },
@@ -270,7 +270,7 @@
   {
     "pid": "28",
     "code": "TRUTH-BIB",
-    "name": "Defaut location for Ministry of Truth",
+    "name": "Default location for Ministry of Truth",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/16"
     },
@@ -282,7 +282,7 @@
   {
     "pid": "29",
     "code": "RIVE-BIB",
-    "name": "Defaut location for Rivendell Library",
+    "name": "Default location for Rivendell Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/17"
     },
@@ -294,7 +294,7 @@
   {
     "pid": "30",
     "code": "MATILDA-BIB",
-    "name": "Defaut location for Matilda's Library",
+    "name": "Default location for Matilda's Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/18"
     },
@@ -306,7 +306,7 @@
   {
     "pid": "31",
     "code": "UNSEEN-BIB",
-    "name": "Defaut location for Unseen University Library",
+    "name": "Default location for Unseen University Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/19"
     },
@@ -318,7 +318,7 @@
   {
     "pid": "32",
     "code": "WAN-BIB",
-    "name": "Defaut location for Wan Shi Tong's Library",
+    "name": "Default location for Wan Shi Tong's Library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/20"
     },
@@ -330,7 +330,7 @@
   {
     "pid": "33",
     "code": "BUFFY-BIB",
-    "name": "Defaut location for Sunnydale High School library",
+    "name": "Default location for Sunnydale High School library",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/21"
     },
@@ -342,12 +342,36 @@
   {
     "pid": "34",
     "code": "JEDI-BIB",
-    "name": "Defaut location for Jedi Archives",
+    "name": "Default location for Jedi Archives",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/6"
     },
     "is_pickup": true,
     "pickup_name": "Jedi Archives",
+    "is_online": false,
+    "allow_request": true
+  },
+  {
+    "pid": "35",
+    "code": "STARFLEET-BIB",
+    "name": "Default location for Starfleet library",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/22"
+    },
+    "is_pickup": true,
+    "pickup_name": "Starfleet library",
+    "is_online": false,
+    "allow_request": true
+  },
+  {
+    "pid": "36",
+    "code": "VULCAN-BIB",
+    "name": "Default location for Vulcan library",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/23"
+    },
+    "is_pickup": true,
+    "pickup_name": "Vulcan library",
     "is_online": false,
     "allow_request": true
   }

--- a/data/organisations.json
+++ b/data/organisations.json
@@ -24,5 +24,13 @@
     "code": "fictive",
     "default_currency": "CHF",
     "current_budget_pid": "5"
+  },
+  {
+    "pid": "4",
+    "address": "The front-end",
+    "name": "Institute of user interface tests",
+    "code": "cypress",
+    "default_currency": "CHF",
+    "current_budget_pid": "6"
   }
 ]

--- a/data/patron_types.json
+++ b/data/patron_types.json
@@ -47,5 +47,13 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/2"
     }
+  },
+  {
+    "pid": "7",
+    "name": "Standard",
+    "description": "Standard patron.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    }
   }
 ]

--- a/data/users.json
+++ b/data/users.json
@@ -913,5 +913,80 @@
     "street": "Ranftweg 1",
     "communication_channel": "email",
     "communication_language": "eng"
+  },
+  {
+    "birth_date": "1927-05-14",
+    "city": "New York",
+    "email": "reroilstest+leonard@gmail.com",
+    "first_name": "Leonard",
+    "roles": [
+      "system_librarian",
+      "librarian"
+    ],
+    "last_name": "McCoy",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/22"
+    },
+    "password": "123456",
+    "phone": "+39324993599",
+    "postal_code": "11101",
+    "street": "Central Park"
+  },
+  {
+    "birth_date": "1930-05-14",
+    "city": "Vulcan",
+    "email": "reroilstest+spock@gmail.com",
+    "first_name": "Spock",
+    "roles": [
+      "librarian"
+    ],
+    "last_name": "Grayson",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/23"
+    },
+    "password": "123456",
+    "phone": "+39324993596",
+    "postal_code": "11102",
+    "street": "Illogical street, 44"
+  },
+  {
+    "barcode": "cypress-1",
+    "birth_date": "1931-03-22",
+    "city": "Betelgeuse",
+    "email": "reroilstest+james@gmail.com",
+    "first_name": "James",
+    "roles": [
+      "patron"
+    ],
+    "last_name": "Kirk",
+    "password": "123456",
+    "patron_type": {
+      "$ref": "https://ils.rero.ch/api/patron_types/7"
+    },
+    "phone": "+41324883598",
+    "postal_code": "4242",
+    "street": "Galaxy street",
+    "communication_channel": "email",
+    "communication_language": "eng"
+  },
+  {
+    "barcode": "cypress-2",
+    "birth_date": "1932-12-28",
+    "city": "Betelgeuse",
+    "email": "reroilstest+nyota@gmail.com",
+    "first_name": "Nyota",
+    "roles": [
+      "patron"
+    ],
+    "last_name": "Uhura",
+    "password": "123456",
+    "patron_type": {
+      "$ref": "https://ils.rero.ch/api/patron_types/7"
+    },
+    "phone": "+41324883123",
+    "postal_code": "4242",
+    "street": "Milky Way street",
+    "communication_channel": "email",
+    "communication_language": "eng"
   }
 ]

--- a/rero_ils/modules/organisations/api.py
+++ b/rero_ils/modules/organisations/api.py
@@ -173,6 +173,12 @@ class Organisation(IlsRecord):
             cannot_delete['links'] = links
         return cannot_delete
 
+    def is_test_organisation(self):
+        """Check if this is a test organisation."""
+        if self.get('code') == 'cypress':
+            return True
+        return False
+
 
 class OrganisationsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""

--- a/rero_ils/templates/rero_ils/frontpage.html
+++ b/rero_ils/templates/rero_ils/frontpage.html
@@ -125,7 +125,9 @@
           <h3>{{ _('Organisations\' catalogues') }}</h3>
           <ul class="list-unstyled">
             {% for org in organisations %}
-            <li><a href="{{ url_for('rero_ils.index_with_view_code', viewcode=org.code) }}">{{ org.name }}</a></li>
+              {% if  not org.is_test_organisation() %}
+                <li><a href="{{ url_for('rero_ils.index_with_view_code', viewcode=org.code) }}">{{ org.name }}</a></li>
+              {% endif %}
             {% endfor %}
           </ul>
         {% else %}

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -78,6 +78,15 @@ def test_view_parameter_exists(client):
     assert result.status_code == 302
 
 
+def test_view_parameter_cypress(client):
+    """Test view parameter with cypress viewcode."""
+    result = client.get(url_for(
+        'rero_ils.index_with_view_code',
+        viewcode='cypress'
+    ))
+    assert result.status_code == 404
+
+
 def test_view_parameter_notfound(client):
     """Test view parameter exception."""
     result = client.get(url_for(


### PR DESCRIPTION
* Adds fixtures for cypress tests (organisation, libraries, librarians,
patrons, locations, patron type, item type and circ policy). This leverages
 the creation of resources needed to test circulation scenarios

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Add fixtures dedicated to cypress tests.

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

N/A

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
