### PR TITLE
circulation: display ILL request in patron profile

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -36,6 +36,7 @@ from ..api import IlsRecord, IlsRecordError, IlsRecordsIndexer, \
     IlsRecordsSearch
 from ..documents.api import Document
 from ..errors import NoCirculationActionIsPermitted
+from ..ill_requests.api import ILLRequest
 from ..items.models import ItemCirculationAction, ItemStatus
 from ..items.utils import item_pid_to_object
 from ..libraries.api import Library
@@ -488,7 +489,7 @@ def patron_profile(patron):
     """Return formatted loans for patron profile display.
 
     :param patron: the patron resource
-    :return: array of loans, requests, fees and history
+    :return: array of loans, requests, fees, history and ill_requests
     """
     from ..items.api import Item
 
@@ -516,11 +517,9 @@ def patron_profile(patron):
             pickup_location = Location.get_record_by_pid(
                 loan.get('pickup_location_pid'))
             if pickup_location:
-                pickup_location.get('pickup_name')
-                if pickup_location.get('pickup_name'):
-                    loan['pickup_name'] = pickup_location.get('pickup_name')
-                else:
-                    loan['pickup_name'] = pickup_location.get('name')
+                loan['pickup_name'] = pickup_location.get(
+                    'pickup_name', pickup_location.get('name')
+                )
         if loan['state'] == LoanState.ITEM_ON_LOAN:
             can, reasons = item.can(
                 ItemCirculationAction.EXTEND,
@@ -563,10 +562,21 @@ def patron_profile(patron):
         'open': _process_patron_profile_fees(patron, organisation, 'open'),
         'closed': _process_patron_profile_fees(patron, organisation, 'closed')
     }
-    return sorted(loans, key=attrgetter('end_date')),\
+    # ILL request
+    ill_requests = []
+    for request in ILLRequest.get_requests_by_patron_pid(patron_pid):
+        location_pid = request.replace_refs()['pickup_location']['pid']
+        location = Location.get_record_by_pid(location_pid)
+        loc_name = location.get('pickup_name', location.get('name'))
+        request['pickup_location']['name'] = loc_name
+        ill_requests.append(request)
+
+    return \
+        sorted(loans, key=attrgetter('end_date')),\
         sorted(requests, key=attrgetter('rank', 'request_creation_date')),\
         fees,\
-        history
+        history,\
+        ill_requests
 
 
 def _process_patron_profile_fees(patron, organisation, status='open'):

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_ill_requests.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_ill_requests.html
@@ -1,0 +1,116 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2020 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+<div id="history-section" class="row mb-1 align-items-center">
+  <div class="col mr-1 d-none d-lg-block">
+    <div class="row p-2 bg-dark rounded text-light">
+      <div class="col-lg-6">{{ _('Title') }}</div>
+      <div class="col-lg-5">{{ _('Authors') }}</div>
+      <div class="col-lg-1 text-lg-right">{{ _('Status') }}</div>
+    </div>
+  </div>
+</div>
+
+{%- if ill_requests|length > 0 %}
+  {%- for request in ill_requests %}
+    {% set badge_color = {
+         "pending": "secondary",
+         "validated": "success",
+         "denied": "danger",
+         "closed": "light"
+       }[request.status] | default("light") -%}
+    <div class="row mb-1">
+      <div class="col mr-1 p-2 border rounded">
+        <div class="row pl-2 pr-2">
+          <div class="col-lg-6">
+            <button class="pl-0 pt-0 btn btn-toogle" type="button" data-target-id="request-{{ request.pid }}">
+              <i class="fa fa-caret-right pr-0"></i>
+            </button>
+            {{ request.document.title }}
+            </a>
+          </div>
+          <div class="col-lg-5">
+            {{ request.document.authors }}
+          </div>
+          <div class="col-lg-1 text-lg-right">
+            <span class="badge badge-{{ badge_color }} px-2 py-1 font-weight-normal">
+              {{ request.status }}
+            </span>
+          </div>
+        </div>
+
+        <div id="request-{{ request.pid }}" class="mt-1 ng-star-inserted d-none">
+          <h6 class="mt-2 mb-2 ng-star-inserted">{{ _('Details') }}</h6>
+          <section class="col">
+            <div class="row">
+              <div class="col-12 label-title font-weight-bold">{{ _('Document information') }}</div>
+              {%- if request.document.publisher %}
+              <div class="col-md-2 col-sm-4 pl-5"><b>{{ _('Publisher')}}</b></div>
+                <div class="col-md-10 col-sm-8">{{ request.document.publisher }}</div>
+              {%- endif %}
+              {%- if request.document.year %}
+                <div class="col-md-2 col-sm-4 pl-5 font-weight-bold">{{ _('Year')}}</div>
+                <div class="col-md-10 col-sm-8">{{ request.document.year }}</div>
+              {%- endif %}
+              {%- if request.document.identifier %}
+                <div class="col-md-2 col-sm-4 pl-5 font-weight-bold">{{ _('Identifier')}}</div>
+                <div class="col-md-10 col-sm-8">{{ request.document.identifier }}</div>
+              {%- endif %}
+              {%- if request.document.source %}
+                <div class="col-md-2 col-sm-4 pl-5 font-weight-bold">{{ _('Source')}}</div>
+                <div class="col-md-10 col-sm-8">
+                  {{ request.document.source.journal_title }}
+                  {%- if request.document.source.volume or request.document.source.number %}
+                    <span class="pl-3">(
+                      {%- if request.document.source.volume %}Vol.{{ request.document.source.volume }}{%- endif %}
+                      {%- if request.document.source.volume and request.document.source.number %} -- {%- endif %}
+                      {%- if request.document.source.number %}n°.{{ request.document.source.number }}{%- endif %}
+                    )</span>
+                  {%- endif %}
+                </div>
+              {%- endif %}
+              <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Pickup location')}}</div>
+              <div class="col-md-10 col-sm-8">{{ request.pickup_location.name }}</div>
+              <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Is request copy')}}</div>
+              <div class="col-md-10 col-sm-8">
+                <i class="fa fa-{%- if request.is_copy %}check text-success{%- else %}times text-danger{%- endif %}"></i>
+              </div>
+              {%- if request.pages %}
+                <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Pages')}}</div>
+                <div class="col-md-10 col-sm-8">{{ request.pages }}</div>
+              {%- endif %}
+              {%- if request.found_in %}
+                <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Found in')}}</div>
+                <div class="col-md-10 col-sm-8">
+                  <span>({{ request.found_in.source }})</span>
+                  <a href="{{ request.found_in.url }}" target="_blank">{{ request.found_in.url }}</a>
+                </div>
+              {%- endif %}
+              {%- if request.note %}
+                <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Note')}}</div>
+                <div class="col-md-10 col-sm-8"><blockquote>{{ request.note }}</blockquote></div>
+              {%- endif %}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  {%- endfor %}
+{%- else %}
+  <p>{{ _('No request') }}</p>
+{%- endif %}

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -63,6 +63,13 @@
           </a>
         </li>
         <li class="nav-item">
+          <a class="nav-link{% if tab == 'ill_request' %} active{% endif %}" href="#ill_request" data-toggle="tab" id="ill_request-tab" title="{{ _('ILL requests') }}" role="tab"
+            aria-controls="history" aria-selected="false">
+            {{ _('ILL requests') }}
+            <span class="badge badge-light font-weight-normal">{{ ill_requests | length }}</span>
+          </a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link{% if tab == 'personal' %} active{% endif %}" href="#personal-data" data-toggle="tab" id="personal-data-tab"
             title="{{ _('Personal data') }}" role="tab" aria-controls="personal-data" aria-selected="false">
             {{ _('Personal data') }}
@@ -104,6 +111,14 @@
       aria-labelledby="history-tab"
     >
       {% include('rero_ils/_patron_profile_history.html') %}
+    </section>
+    <section
+      class="pl-3 pr-2 tab-pane show py-2{% if tab == 'ill_request' %} active{% endif %}"
+      id="ill_request"
+      role="tabpanel"
+      aria-labelledby="ill_request-tab"
+    >
+      {% include('rero_ils/_patron_profile_ill_requests.html') %}
     </section>
     <section
       class="pl-3 pr-2 tab-pane show py-2{% if tab == 'personal' %} active{% endif %}"

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -152,7 +152,15 @@ def logged_user():
 def profile(viewcode):
     """Patron Profile Page."""
     tab = request.args.get('tab', 'loans')
-    if tab not in ['loans', 'requests', 'fees', 'history', 'personal']:
+    allowed_tabs = [
+        'loans',
+        'requests',
+        'fees',
+        'history',
+        'ill_request',
+        'personal'
+    ]
+    if tab not in allowed_tabs:
         abort(400)
     patron = Patron.get_patron_by_user(current_user)
     if patron is None:
@@ -193,7 +201,7 @@ def profile(viewcode):
         return redirect(url_for(
             'patrons.profile', viewcode=viewcode) + '?tab={0}'.format(tab))
 
-    loans, requests, fees, history = patron_profile(patron)
+    loans, requests, fees, history, ill_requests = patron_profile(patron)
 
     # patron alert list
     #   each alert dictionary key represent an alert category (subscription,
@@ -226,6 +234,7 @@ def profile(viewcode):
         requests=requests,
         fees=fees,
         history=history,
+        ill_requests=ill_requests,
         alerts=alerts,
         viewcode=viewcode,
         tab=tab

--- a/tests/ui/ill_requests/test_ill_requests_api.py
+++ b/tests/ui/ill_requests/test_ill_requests_api.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import, print_function
 
+from rero_ils.modules.ill_requests.api import ILLRequest
+
 
 def test_ill_request_properties(ill_request_martigny, ill_request_sion,
                                 loc_public_martigny_data, org_martigny_data):
@@ -29,3 +31,14 @@ def test_ill_request_properties(ill_request_martigny, ill_request_sion,
     assert ill_request_martigny.get_pickup_location().pid \
         == loc_public_martigny_data['pid']
     assert ill_request_martigny.organisation_pid == org_martigny_data['pid']
+
+
+def test_ill_request_get_request(ill_request_martigny, ill_request_sion,
+                                 patron_martigny_no_email):
+    """Test ill request get_request functions."""
+    assert len(list(ILLRequest.get_requests_by_patron_pid(
+        patron_martigny_no_email.pid, status='pending'
+    ))) == 1
+    assert len(list(ILLRequest.get_requests_by_patron_pid(
+        patron_martigny_no_email.pid, status='denied'
+    ))) == 0

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -32,7 +32,7 @@ def test_patrons_profile(
         client, librarian_martigny_no_email, loan_pending_martigny,
         patron_martigny_no_email, loc_public_martigny,
         item_type_standard_martigny, item_lib_martigny, json_header,
-        circ_policy_short_martigny):
+        circ_policy_short_martigny, ill_request_martigny):
     """Test patron profile."""
     # check redirection
     res = client.get(url_for('patrons.profile'))


### PR DESCRIPTION
Adds a tab into the patron profile to display the requests related to
the current logged patron.

## How to test?

![image](https://user-images.githubusercontent.com/10031585/92739552-4c9c6180-f37d-11ea-93cd-1176928d93db.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
