### PR TITLE
holdings: add optional fields for holdings display

### DIFF
--- a/data/patterns.json
+++ b/data/patterns.json
@@ -2,6 +2,20 @@
   {
     "template_name": "quarterly_one_level",
     "rero_control_number": "R003826164",
+    "call_number": "SM af-82",
+    "second_call_number": "EN 4624",
+    "enumerationAndChronology": "No 61(2020)-",
+    "missing_issues": "Hors s\u00e9rie 18 (2020)",
+    "notes": [
+      {
+        "type": "general_note",
+        "content": "3 derniers fascicules en salle de lecture"
+      },
+      {
+        "type": "conservation_note",
+        "content": "3 derni\u00e8res ann\u00e9es"
+      }
+    ],
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
@@ -141,6 +155,21 @@
   {
     "template_name": "quarterly_two_levels",
     "rero_control_number": "R003301493",
+    "second_call_number": "CDU 904(374)",
+    "enumerationAndChronology": "Jg. 20(2020)-",
+    "index": "1 vol. (2020-2021)",
+    "supplementaryContent": "Sonderausgabe \"Teacher's guide\"",
+    "missing_issues": "Hors s\u00e9rie 18 (2020)",
+    "notes": [
+      {
+        "type": "reception_note",
+        "content": "A transmettre \u00e0 Astrid pour d\u00e9pouillement"
+      },
+      {
+        "type": "claim_note",
+        "content": "Contacter M. Filipini, par t\u00e9l\u00e9phone, pour les r\u00e9clamations"
+      }
+    ],
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} Heft {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",

--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -76,15 +76,19 @@
   {% for holding in holdings %}
   {% set items = holding.get_items %}
   {% set number_items = holding.get_items_count_by_holding_pid %}
-  {% if record.harvested or number_items > 0 %}
+  {% if record.harvested or number_items >= 0 %}
   <!-- Card header -->
   <div class="card mt-2">
     <div id="{{ holding.pid }}" class="card-header p-2">
       <div class="row">
         <div class="col-1">
-          <a class="collapse-link" data-toggle="collapse" href="#collapse-{{ holding.pid }}" aria-expanded="false">
-            <i class="fa fa-caret-down fa-lg"></i>
-          </a>
+          {% if number_items > 0 %}
+              <a class="collapse-link" data-toggle="collapse" href="#collapse-{{ holding.pid }}" aria-expanded="false">
+              <i class="fa fa-caret-down fa-lg"></i>
+            </a>
+           {% else %}
+            &nbsp;
+          {% endif %}
         </div>
         <div class="col-10">
           <div class="row">
@@ -95,26 +99,63 @@
               {{ holding|holding_circulation_category }}
             </div>
             <div class="col-sm-2">
-              {% if not record.harvested %}
+              {% if not record.harvested and number_items > 0 %}
                 {{ number_items }} {{ _('items') if number_items > 1 else _('item') }}
               {% else %}
                 &nbsp;
               {% endif %}
             </div>
 
-            <div class="col-sm-2 availability d-none">
+            <div class="col-sm-3 availability{% if number_items > 0 %}d-none{% endif %}">
               {% if not record.harvested %}
-                {% if number_items > 0 %}
-                  <i class="fa fa-circle text-{{ 'success' if holding.available else 'danger' }}"></i>
-                  {{ _('available') if holding.available else _('not available') }}
+                {% if holding.holding_is_serial %}
+                  <i class="fa fa-circle text-warning"></i>
+                  {% if number_items > 0 %}
+                    {{ _('see collections and items')}}
+                  {% else %}
+                    {{ _('no items received')}}
+                  {% endif %}
                 {% else %}
-                  <i class="fa fa-circle text-{{ 'danger' }}"></i> {{ _('not available') }}
+                  {% if number_items > 0 %}
+                    <i class="fa fa-circle text-{{ 'success' if holding.available else 'danger' }}"></i>
+                    {{ _('available') if holding.available else _('not available') }}
+                  {% else %}
+                    <i class="fa fa-circle text-{{ 'danger' }}"></i> {{ _('not available') }}
+                  {% endif %}
                 {% endif %}
               {% else %}
                 &nbsp;
               {% endif %}
             </div>
+
+            <!-- display data for serials holdings -->
+            {% if holding.holding_is_serial %}
+            <div class="row col-sm-12 mt-3">
+            <!-- a line break only for serials holdings -->
+              {% if holding.call_number or holding.second_call_number %}
+                {{ dl(_('Call number'), holding | format_record_call_number ) }}
+              {% endif %}
+              {% if holding.enumerationAndChronology %}
+                {{ dl(_('Available collection'), holding.enumerationAndChronology) }}
+              {% endif %}
+              {% if holding.supplementaryContent %}
+                {{ dl(_('Supplementary content'), holding.supplementaryContent) }}
+              {% endif %}
+              {% if holding.index %}
+                {{ dl(_('Indexes'), holding.index) }}
+              {% endif %}
+              {% if holding.missing_issues %}
+                {{ dl(_('Missing issues'), holding.missing_issues) }}
+              {% endif %}
+              {% if holding|get_note('general_note') %}
+                {{ dl(_('Note'), holding|get_note('general_note')|nl2br) }}
+              {% endif %}
+            </div>
+          {% endif %}
+
           </div>
+         
+          
         </div>
       </div>
     </div>
@@ -147,7 +188,7 @@
               </div>
               <div class="col-sm-2">
                 {% if item.call_number %}
-                  {{ item | format_item_call_number }}
+                  {{ item | format_record_call_number }}
                 {% endif %}
               </div>
               {% set locations = item|item_library_pickup_locations %}

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -132,14 +132,14 @@ def can_request(item):
 
 
 @blueprint.app_template_filter()
-def get_note(item, note_type):
-    """Get a item note by its type.
+def get_note(record, note_type):
+    """Get a note by its type for a given holdings or item.
 
-    :param item: the item to check.
+    :param record: the record to check.
     :param note_type: the type of note to find.
     :return the requested note, None if no corresponding note is found.
     """
-    return item.get_note(note_type)
+    return record.get_note(note_type)
 
 
 @blueprint.app_template_filter()

--- a/rero_ils/modules/holdings/cli.py
+++ b/rero_ils/modules/holdings/cli.py
@@ -122,6 +122,13 @@ def create_patterns(infile, verbose, debug, lazy):
             except IndexError as error:
                 break
         patterns = record.get('patterns')
+        enumerationAndChronology = record.get('enumerationAndChronology')
+        supplementaryContent = record.get('supplementaryContent')
+        index = record.get('index')
+        missing_issues = record.get('missing_issues')
+        notes = record.get('notes')
+        call_number = record.get('call_number')
+        second_call_number = record.get('second_call_number')
         for org_pid in Organisation.get_all_pids():
             circ_category_pid = get_circ_category(org_pid)
             location_pid = get_random_location(org_pid)
@@ -130,6 +137,13 @@ def create_patterns(infile, verbose, debug, lazy):
                 location_pid=location_pid,
                 item_type_pid=circ_category_pid,
                 holdings_type='serial',
+                enumerationAndChronology=enumerationAndChronology,
+                supplementaryContent=supplementaryContent,
+                index=index,
+                missing_issues=missing_issues,
+                notes=notes,
+                call_number=call_number,
+                second_call_number=second_call_number,
                 patterns=patterns)
             # create minimum 3 and max 9 received issues for this holdings
             create_issues_from_holding(holdings_record)

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -14,9 +14,15 @@
   ],
   "propertiesOrder": [
     "call_number",
+    "second_call_number",
     "circulation_category",
     "location",
     "holdings_type",
+    "enumerationAndChronology",
+    "supplementaryContent",
+    "index",
+    "missing_issues",
+    "notes",
     "patterns"
   ],
   "properties": {
@@ -34,8 +40,11 @@
     },
     "call_number": {
       "title": "Call number",
-      "type": "string",
-      "minLength": 4
+      "type": "string"
+    },
+    "second_call_number": {
+      "title": "Second call number",
+      "type": "string"
     },
     "circulation_category": {
       "title": "Circulation type",
@@ -411,6 +420,133 @@
       "form": {
         "expressionProperties": {
           "templateOptions.required": "true"
+        }
+      }
+    },
+    "enumerationAndChronology": {
+      "title": "Available collection",
+      "description": "Textual description of the basic bibliographic unit of the holding.",
+      "type": "string",
+      "minLength": 1
+    },
+    "supplementaryContent": {
+      "title": "Supplementary content",
+      "description": "Textual description of supplementary contents (special issues, etc.).",
+      "type": "string",
+      "minLength": 1
+    },
+    "index": {
+      "title": "Indexes",
+      "description": "Textual description of the indexes.",
+      "type": "string",
+      "minLength": 1
+    },
+    "missing_issues": {
+      "title": "Missing issues",
+      "description": "Textual description of the missing issues.",
+      "type": "string",
+      "minLength": 1
+    },
+    "notes": {
+      "title": "Notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "Note",
+        "propertiesOrder": [
+          "type",
+          "content"
+        ],
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "enum": [
+              "general_note",
+              "staff_note",
+              "conservation_note",
+              "reception_note",
+              "claim_note",
+              "routing_note",
+              "binding_note",
+              "acquisition_note"
+            ],
+            "form": {
+              "type": "selectWithSort",
+              "wrappers": [
+                "form-field-horizontal"
+              ],
+              "options": [
+                {
+                  "label": "general note",
+                  "value": "general_note"
+                },
+                {
+                  "label": "staff note",
+                  "value": "staff_note"
+                },
+                {
+                  "label": "conservation note",
+                  "value": "conservation_note"
+                },
+                {
+                  "label": "reception note",
+                  "value": "reception_note"
+                },
+                {
+                  "label": "claim note",
+                  "value": "claim_note"
+                },
+                {
+                  "label": "routing note",
+                  "value": "routing_note"
+                },
+                {
+                  "label": "binding note",
+                  "value": "binding_note"
+                },
+                {
+                  "label": "acquisition note",
+                  "value": "acquisition_note"
+                }
+              ],
+              "templateOptions": {
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
+              }
+            }
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "maxLength": 2000,
+            "minLength": 3,
+            "form": {
+              "type": "textarea",
+              "templateOptions": {
+                "rows": 3
+              }
+            }
+          }
+        }
+      },
+      "form": {
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "type"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one note per type is allowed"
+          }
         }
       }
     }

--- a/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
@@ -17,6 +17,9 @@
       "call_number": {
         "type": "keyword"
       },
+      "second_call_number": {
+        "type": "keyword"
+      },
       "circulation_category": {
         "properties": {
           "pid": {
@@ -108,6 +111,28 @@
             }
           }
         }
+      },
+      "notes": {
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "content": {
+            "type": "text"
+          }
+        }
+      },
+      "enumerationAndChronology": {
+        "type": "keyword"
+      },
+      "supplementaryContent": {
+        "type": "keyword"
+      },
+      "index": {
+        "type": "keyword"
+      },
+      "missing_issues": {
+        "type": "keyword"
       },
       "_created": {
         "type": "date"

--- a/rero_ils/modules/holdings/models.py
+++ b/rero_ils/modules/holdings/models.py
@@ -40,3 +40,16 @@ class HoldingMetadata(db.Model, RecordMetadataBase):
     """Holding record metadata."""
 
     __tablename__ = 'holding_metadata'
+
+
+class HoldingNoteTypes:
+    """Class to list all holdings possible note types."""
+
+    GENERAL = 'general_note'
+    STAFF = 'staff_note'
+    CONSERVATION = 'conservation_note'
+    RECEPTION = 'reception_note'
+    CLAIM = 'claim_note'
+    ROUTING = 'routing_note'
+    BINDING = 'binding_note'
+    ACQUISITION = 'acquisition_note'

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -66,9 +66,6 @@ class ItemRecord(IlsRecord):
         note_types = [note.get('type') for note in self.get('notes', [])]
         if len(note_types) != len(set(note_types)):
             return _('Can not have multiple notes of same type.')
-        if not self.get('call_number') and self.get('second_call_number'):
-            return _(
-                'Must have a first call number to have a second call number')
 
         return True
 
@@ -183,7 +180,7 @@ class ItemRecord(IlsRecord):
         holding_pid = get_holding_pid_by_doc_location_item_type(
             document_pid, location_pid, item_type_pid, item_record_type)
 
-        # we will NOT create serials holdings for items
+        # we will NOT create serial holdings for items
         if not holding_pid and item_record_type != 'serial':
             holdings_record = create_holding(
                 document_pid=document_pid,

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -61,18 +61,11 @@
     },
     "call_number": {
       "title": "Call number",
-      "type": "string",
-      "minLength": 4,
-      "form": {
-        "expressionProperties": {
-          "templateOptions.required": "field.parent.model.second_call_number !== ''"
-        }
-      }
+      "type": "string"
     },
     "second_call_number": {
       "title": "Second call number",
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "location": {
       "title": "Location",

--- a/rero_ils/modules/items/views.py
+++ b/rero_ils/modules/items/views.py
@@ -157,9 +157,10 @@ def item_availability_text(item):
 
 
 @blueprint.app_template_filter()
-def format_item_call_number(item):
-    """Returns formatted text to display call number for item."""
-    return ' | '.join([
-        item.get('call_number'),
-        item.get('second_call_number')]
-    ) if item.get('second_call_number') else item.get('call_number')
+def format_record_call_number(record):
+    """Returns formatted text to display call number for item or holding."""
+    call_numbers = [
+        record.get('call_number'), record.get('second_call_number')]
+
+    return ' | '.join(
+        call_number for call_number in call_numbers if call_number)

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -219,7 +219,13 @@ def test_create_holdings_with_pattern(
 
     # test will not fail when creating a standard holding for a journal doc.
     holding_lib_martigny_w_patterns_data['holdings_type'] = 'standard'
-    del holding_lib_martigny_w_patterns_data['patterns']
+    # delete serials fields
+    fields = [
+        'enumerationAndChronology', 'notes', 'index', 'missing_issues',
+        'supplementaryContent', 'patterns'
+    ]
+    for field in fields:
+        del holding_lib_martigny_w_patterns_data[field]
     Holding.create(
         data=holding_lib_martigny_w_patterns_data,
         delete_pid=True,

--- a/tests/data/holdings.json
+++ b/tests/data/holdings.json
@@ -225,6 +225,16 @@
       "$ref": "https://ils.rero.ch/api/locations/loc1"
     },
     "holdings_type": "serial",
+    "enumerationAndChronology": "enumerationAndChronology",
+    "supplementaryContent": "supplementaryContent",
+    "index": "index",
+    "missing_issues": "missing_issues",
+    "notes": [
+      {
+        "type": "general_note",
+        "content": "general_note..."
+      }
+    ],
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -25,6 +25,7 @@ from utils import flush_index, get_mapping
 
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.holdings.api import holding_id_fetcher as fetcher
+from rero_ils.modules.items.views import format_record_call_number
 
 
 def test_holding_es_mapping(es, db, holding_lib_martigny,
@@ -63,3 +64,18 @@ def test_holding_create(db, es_clear, document, org_martigny,
     holding = next(search.filter('term', pid=holding.pid).scan())
     holding_record = Holding.get_record_by_pid(holding.pid)
     assert holding_record.organisation_pid == org_martigny.get('pid')
+
+
+def test_holdings_call_number_filter(app):
+    """Test call number format."""
+    holding = {'call_number': 'first_cn'}
+    results = 'first_cn'
+    assert results == format_record_call_number(holding)
+
+    holding = {'call_number': 'first_cn', 'second_call_number': 'second_cn'}
+    results = 'first_cn | second_cn'
+    assert results == format_record_call_number(holding)
+
+    holding = {'second_call_number': 'second_cn'}
+    results = 'second_cn'
+    assert results == format_record_call_number(holding)

--- a/tests/ui/items/test_items_filter.py
+++ b/tests/ui/items/test_items_filter.py
@@ -17,15 +17,19 @@
 
 """Item filters tests."""
 
-from rero_ils.modules.items.views import format_item_call_number
+from rero_ils.modules.items.views import format_record_call_number
 
 
 def test_items_call_number_filter(app):
     """Test call number format."""
     item = {'call_number': '00123'}
     results = '00123'
-    assert results == format_item_call_number(item)
+    assert results == format_record_call_number(item)
 
     item = {'call_number': '00123', 'second_call_number': '00456'}
     results = '00123 | 00456'
-    assert results == format_item_call_number(item)
+    assert results == format_record_call_number(item)
+
+    item = {'second_call_number': '00456'}
+    results = '00456'
+    assert results == format_record_call_number(item)

--- a/tests/unit/test_holdings_jsonschema.py
+++ b/tests/unit/test_holdings_jsonschema.py
@@ -60,78 +60,27 @@ def test_required_patterns_frequency(
             holding, holding_schema)
 
 
-def test_pid(
+def test_holdings_all_jsonschema_keys_values(
         holding_schema, holding_lib_martigny_w_patterns_data):
-    """Test pid for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['pid'] = 25
-        validate(data, holding_schema)
-
-
-def test_call_number(holding_schema,
-                     holding_lib_martigny_w_patterns_data):
-    """Test call_number for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['call_number'] = 25
-        validate(data, holding_schema)
-
-
-def test_document(holding_schema,
-                  holding_lib_martigny_w_patterns_data):
-    """Test document for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['document'] = 25
-        validate(data, holding_schema)
-
-
-def test_circulation_category(
-        holding_schema, holding_lib_martigny_w_patterns_data):
-    """Test circulation_category for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['circulation_category'] = 25
-        validate(data, holding_schema)
-
-
-def test_location(
-        holding_schema, holding_lib_martigny_w_patterns_data):
-    """Test location for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['location'] = 25
-        validate(data, holding_schema)
-
-
-def test_holdings_type(
-        holding_schema, holding_lib_martigny_w_patterns_data):
-    """Test holdings_type for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['holdings_type'] = 1
-        validate(data, holding_schema)
-
-
-def test_patterns(
-        holding_schema, holding_lib_martigny_w_patterns_data):
-    """Test patterns for holding jsonschemas."""
-    validate(holding_lib_martigny_w_patterns_data, holding_schema)
-
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(holding_lib_martigny_w_patterns_data)
-        data['patterns'] = 25
-        validate(data, holding_schema)
+    """Test all keys and values for holdings jsonschema."""
+    record = holding_lib_martigny_w_patterns_data
+    validate(record, holding_schema)
+    validator = [
+        {'key': 'pid', 'value': 25},
+        {'key': 'call_number', 'value': 25},
+        {'key': 'second_call_number', 'value': 25},
+        {'key': 'document', 'value': 25},
+        {'key': 'circulation_category', 'value': 25},
+        {'key': 'location', 'value': 25},
+        {'key': 'holdings_type', 'value': 25},
+        {'key': 'patterns', 'value': 25},
+        {'key': 'enumerationAndChronology', 'value': 25},
+        {'key': 'supplementaryContent', 'value': 25},
+        {'key': 'index', 'value': 25},
+        {'key': 'missing_issues', 'value': 25},
+        {'key': 'notes', 'value': 25}
+    ]
+    for element in validator:
+        with pytest.raises(ValidationError):
+            record[element['key']] = element['value']
+            validate(record, holding_schema)


### PR DESCRIPTION
With this commit, new optional fields are allowed for
the holdings of type serial. The fields are:
- enumerationAndChronology
- supplementaryContent
- index
- missing_issues
- notes

The new field second_call_number is available for
all types of holdings records

Item and holdings call numbers have no minimum character constraint.

Issues with status deleted are not displayed in the public interface.

* Closes #1284
* Removes the condition to have an item second call number only
if first call number exist.
* Adapts tests and fixtures accordingly.
* Adapts the public interface to display the new fields.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/taskboard/sprint-35-106?kanban-status=1224894

## How to test?

`bootstrap` + `setup`
To display a serial holdings with optional field, display the following document in the public interface:
~/global/search/documents?q=R003826164&page=1&size=10

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
