### PR TITLE
patrons: fix patron CLI creation problem.

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -964,6 +964,7 @@
     "communication_language": "eng"
   },
   {
+    "pid": "50",
     "birth_date": "1927-05-14",
     "city": "New York",
     "email": "reroilstest+leonard@gmail.com",
@@ -982,6 +983,7 @@
     "street": "Central Park"
   },
   {
+    "pid": "51",
     "birth_date": "1930-05-14",
     "city": "Vulcan",
     "email": "reroilstest+spock@gmail.com",
@@ -999,6 +1001,7 @@
     "street": "Illogical street, 44"
   },
   {
+    "pid": "52",
     "barcode": "cypress-1",
     "birth_date": "1931-03-22",
     "city": "Betelgeuse",
@@ -1019,6 +1022,7 @@
     "communication_language": "eng"
   },
   {
+    "pid": "53",
     "barcode": "cypress-2",
     "birth_date": "1932-12-28",
     "city": "Betelgeuse",

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1628,7 +1628,7 @@ RECORDS_REST_FACETS = dict(
     ),
     templates=dict(
         aggs=dict(
-            template_type=dict(
+            type=dict(
                 terms=dict(
                     field='template_type',
                     # This does not take into account
@@ -1648,7 +1648,7 @@ RECORDS_REST_FACETS = dict(
             )
         ),
         filters={
-            _('templates'): and_term_filter('templates'),
+            _('type'): and_term_filter('template_type'),
             _('visibility'): and_term_filter('visibility')
         }
     )
@@ -1796,6 +1796,13 @@ RECORDS_REST_SORT_OPTIONS['items']['issue_expected_date'] = dict(
     fields=['issue.expected_date'], title='Issue expected date',
     default_order='asc'
 )
+# ------ TEMPLATES SORT
+RECORDS_REST_SORT_OPTIONS['templates']['name'] = dict(
+    fields=['name_sort'], title='Template name',
+    default_order='asc'
+)
+RECORDS_REST_DEFAULT_SORT['templates'] = dict(
+    query='bestmatch', noquery='name')
 
 # Detailed View Configuration
 # ===========================

--- a/rero_ils/modules/minters.py
+++ b/rero_ils/modules/minters.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 
 def id_minter(record_uuid, data, provider, pid_key='pid', object_type='rec'):
-    """RERIOLS minter."""
+    """RERO ILS minter."""
     provider = provider.create(
         object_type=object_type,
         object_uuid=record_uuid,

--- a/rero_ils/modules/serializers.py
+++ b/rero_ils/modules/serializers.py
@@ -69,7 +69,7 @@ class JSONSerializer(_JSONSerializer):
 
     def post_process_serialize_search(self, results, pid_fetcher):
         """Post process the search results."""
-        pid_type = pid_fetcher('foo', dict(pid='1')).pid_type
+        pid_type = pid_fetcher(None, dict(pid='1')).pid_type
         results['links'].update({
             'create': url_for('invenio_records_rest.{pid_type}_list'.format(
                         pid_type=pid_type), _external=True

--- a/rero_ils/modules/templates/api.py
+++ b/rero_ils/modules/templates/api.py
@@ -26,15 +26,15 @@ from ..fetchers import id_fetcher
 from ..minters import id_minter
 from ..providers import Provider
 
-# tmpl provider
+# provider
 TemplateProvider = type(
     'TemplateProvider',
     (Provider,),
     dict(identifier=TemplateIdentifier, pid_type='tmpl')
 )
-# tmpl minter
+# minter
 template_id_minter = partial(id_minter, provider=TemplateProvider)
-# tmpl fetcher
+# fetcher
 template_id_fetcher = partial(id_fetcher, provider=TemplateProvider)
 
 
@@ -46,6 +46,10 @@ class TemplatesSearch(IlsRecordsSearch):
 
         index = 'templates'
         doc_types = None
+        fields = ('*', )
+        facets = {}
+
+        default_filter = None
 
 
 class Template(IlsRecord):

--- a/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
@@ -5,7 +5,7 @@
     "max_result_window": 20000
   },
   "mappings": {
-   "date_detection": false,
+    "date_detection": false,
     "numeric_detection": false,
     "properties": {
       "$schema": {
@@ -15,7 +15,11 @@
         "type": "keyword"
       },
       "name": {
-        "type": "text"
+        "type": "text",
+        "copy_to": "name_sort"
+      },
+      "name_sort": {
+        "type": "keyword"
       },
       "description": {
         "type": "text"

--- a/scripts/setup
+++ b/scripts/setup
@@ -292,7 +292,7 @@ eval ${PREFIX} invenio utils reindex -t cipo --yes-i-know --no-info
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 info_msg "- Users: ${DATA_PATH}/users.json"
-eval ${PREFIX} invenio fixtures import_users ${DATA_PATH}/users.json -v
+eval ${PREFIX} invenio fixtures import_users ${DATA_PATH}/users.json -v --dbcommit --reindex
 
 info_msg "- ILL requests: ${DATA_PATH}/ill_request.json"
 eval ${PREFIX} invenio fixtures create_ill_requests -f ${DATA_PATH}/ill_requests.json

--- a/tests/api/test_monitoring_rest.py
+++ b/tests/api/test_monitoring_rest.py
@@ -42,7 +42,7 @@ def test_monitoring_es_db_counts(client):
             'cipo': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'circ_policies'},
             'doc': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'documents'},
             'hold': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'holdings'},
-            'illr': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'ill_requests'}
+            'illr': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'ill_requests'},
             'item': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'items'},
             'itty': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'item_types'},
             'lib': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'libraries'},


### PR DESCRIPTION
Using the CLI `import_users` keeps some pids into the `patron_pid` db
table. This will cause problem to create new user after the setup (using
API or UI. This commit cleans the user creation.
This commit also update template resource facet configuration and ES
mapping (to allow resource name sorting).

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- run `bootstrap` & `setup`
- start the UI (localhost:4200) and create a  new user (role doesn't matter).

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
