### PR TITLE
patrons: adapt cypress tests after renaming

### DIFF
--- a/tests/e2e/cypress/cypress/integration/circulation/scenario-a.spec.js
+++ b/tests/e2e/cypress/cypress/integration/circulation/scenario-a.spec.js
@@ -114,7 +114,7 @@ describe('Circulation scenario A: standard loan', function() {
 
     // The item should be marked as available in user profile view
     // Go to patrons list
-    cy.goToMenu('patrons-menu-frontpage')
+    cy.goToMenu('users-menu-frontpage')
     // Go to James patron profile
     cy.get('#' + this.users.patrons.james.barcode + '-loans').click()
     // Click on tab called "To pick up"

--- a/tests/e2e/cypress/cypress/integration/templates/template-test-request.spec.js
+++ b/tests/e2e/cypress/cypress/integration/templates/template-test-request.spec.js
@@ -119,7 +119,7 @@ describe('Template: librarian request', function() {
   it('Second test: check the request in admin patron profile view', function() {
     console.log('second test');
     cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
-    cy.goToMenu('patrons-menu-frontpage');
+    cy.goToMenu('users-menu-frontpage');
     cy.get('#' + this.users.patrons.james.barcode + '-loans').click();
     cy.get('#pending-tab').click();
     cy.get('admin-main.ng-star-inserted > :nth-child(2)').should('contain', this.itemBarcode);


### PR DESCRIPTION
* Updates cypress tests after replacing 'Patrons' with 'Users' in UI.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Task 1755 of US1590

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* https://github.com/rero/rero-ils-ui/pull/381

## How to test?

* needs bootstrap with rero-ils-ui's PR
* needs data in db
* `FLASK_DEBUG=False poetry run server`
* `poetry run cypress`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
