### PR TITLE
cypress: create test for collections

### DIFF
--- a/tests/e2e/cypress/cypress/fixtures/collections.json
+++ b/tests/e2e/cypress/cypress/fixtures/collections.json
@@ -1,0 +1,44 @@
+{
+  "course": {
+    "collection_id": "CRS 1",
+    "title": "Course number 1",
+    "collection_type": "course",
+    "teachers": [
+      {
+        "name": "Pr. Smith, John"
+      }
+    ],
+    "libraries": [
+      {
+        "$ref": "https://ils.rero.ch/api/libraries/22"
+      }
+    ],
+    "description": "List of items for course 1",
+    "subjects": [
+      {
+        "name": "Anne Nonyme"
+      },
+      {
+        "name": "geographic"
+      }
+    ],
+    "start_date": "2020-09-01",
+    "end_date": "2020-12-31",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    },
+    "published": true
+  },
+  "exhibition": {
+    "collection_id": "Expo 1",
+    "title": "Expo \u2013 The Number 1",
+    "collection_type": "exhibition",
+    "description": "List of items for the exhibition",
+    "start_date": "2020-10-01",
+    "end_date": "2021-06-30",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/4"
+    },
+    "published": true
+  }
+}

--- a/tests/e2e/cypress/cypress/integration/application/test-login-logout.spec.js
+++ b/tests/e2e/cypress/cypress/integration/application/test-login-logout.spec.js
@@ -1,0 +1,82 @@
+/// <reference types="Cypress" />
+/*
+
+RERO ILS
+Copyright (C) 2020 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+before(function () {
+  cy.fixture('users').then(function (userData) {
+    this.users = userData;
+  });
+  cy.fixture('common').then(function (commonData) {
+    this.common = commonData;
+  });
+});
+
+describe('Login and logout', function() {
+  before('Go to frontpage', function() {
+    cy.visit('/lang/en');
+  });
+
+  beforeEach('Add description if needed', function() {
+    // Preserve authentication information between the tests
+    Cypress.Cookies.preserveOnce('session');
+  });
+
+  after('Logout', function() {
+    cy.logout();
+  });
+
+  it('Login as a librarian', function() {
+    // Login
+    cy.get('#my-account-menu').click();
+    cy.wait(1000);
+    cy.get('#login-menu').click();
+    // Fill the form and submit
+    cy.get('#email').type(this.users.librarians.leonard.email);
+    cy.get('#password').type(this.common.uniquePwd);
+    cy.get('form[name="login_user_form"]').submit();
+    // Check that the user is logged
+    cy.get('#my-account-menu').should('contain', this.users.librarians.leonard.initials);
+    // Check professional interface access
+    cy.visit('/professional');
+    cy.get('body').should('contain','RERO ILS administration');
+  });
+
+  it('Logout', function() {
+    // Click on username
+    cy.get('#my-account-menu').click()
+    // Wait for the menu to open
+    cy.wait(1000)
+    // Click on logout
+    cy.get('#logout-menu').click();
+    // Check that the user is logged out
+    cy.get('body').should('contain','My account');
+  });
+
+  it('Login as a patron', function() {
+    cy.get('#my-account-menu').click();
+    cy.wait(1000);
+    cy.get('#login-menu').click();
+    // Fill the form
+    cy.get('#email').type(this.users.patrons.james.email);
+    cy.get('#password').type(this.common.uniquePwd);
+    cy.get('form[name="login_user_form"]').submit();
+    // Check that the user is logged
+    cy.get('#my-account-menu').should('contain', this.users.patrons.james.initials);
+  });
+});

--- a/tests/e2e/cypress/cypress/integration/circulation/scenario-a.spec.js
+++ b/tests/e2e/cypress/cypress/integration/circulation/scenario-a.spec.js
@@ -46,15 +46,11 @@ describe('Circulation scenario A: standard loan', function() {
   before('Login as a professional and create a document and an item', function() {
     // Create server to watch api requests
     cy.server();
-    // Open app on frontpage
-    cy.visit('');
-    // Check language and force to english
-    cy.setLanguageToEnglish();
     // Login as librarian (Leonard)
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Create a document
     // Go to document editor
-    cy.goToMenu('create-bibliographic-record-menu-frontpage');
+    cy.visit('/professional/records/documents/new');
     // Populate form with simple record
     cy.populateSimpleRecord(this.documents.book);
     //Save record
@@ -69,7 +65,7 @@ describe('Circulation scenario A: standard loan', function() {
   });
 
   after('Clean data: remove item and document', function() {
-    // TODO: find a way to preserve cookies (auth) and server after a test
+    cy.logout();
     cy.server();
     cy.route({method: 'DELETE', url: '/api/items/*'}).as('deleteItem');
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
@@ -106,7 +102,8 @@ describe('Circulation scenario A: standard loan', function() {
      */
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Go to requests list
-    cy.goToMenu('requests-menu-frontpage')
+    cy.get('#user-services-menu').click();
+    cy.get('#requests-menu').click();
     // Check that the document is present
     cy.get('table').should('contain', this.itemBarcode)
     // Enter the barcode and validate
@@ -114,7 +111,8 @@ describe('Circulation scenario A: standard loan', function() {
 
     // The item should be marked as available in user profile view
     // Go to patrons list
-    cy.goToMenu('users-menu-frontpage')
+    cy.get('#user-services-menu').click();
+    cy.get('#users-menu').click();
     // Go to James patron profile
     cy.get('#' + this.users.patrons.james.barcode + '-loans').click()
     // Click on tab called "To pick up"
@@ -129,7 +127,8 @@ describe('Circulation scenario A: standard loan', function() {
      */
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Go to circulation search bar
-    cy.goToMenu('circulation-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#circulation-menu').click();
     // Checkout
     cy.scanPatronBarcodeThenItemBarcode(this.users.patrons.james, this.itemBarcode);
     // Item barcode should be present
@@ -143,13 +142,13 @@ describe('Circulation scenario A: standard loan', function() {
      */
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Go to circulation search bar
-    cy.goToMenu('circulation-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#circulation-menu').click();
     // Checkin
     cy.scanItemBarcode(this.itemBarcode);
     // CHeck that the item was checked in and that it is on shelf
     cy.get('#item-' + this.itemBarcode).should('contain', this.itemBarcode);
     cy.get('#item-' + this.itemBarcode).should('contain', 'on shelf');
     cy.get('#item-' + this.itemBarcode).should('contain', 'checked in');
-    cy.logout();
   });
 });

--- a/tests/e2e/cypress/cypress/integration/circulation/scenario-b.spec.js
+++ b/tests/e2e/cypress/cypress/integration/circulation/scenario-b.spec.js
@@ -46,15 +46,11 @@ describe('Circulation scenario B: standard loan with transit', function() {
    * 6. The item is received at owning library and goes on shelf.
    */
   before('Login as a professional and create a document and an item', function() {
-    // Open app on frontpage
-    cy.visit('');
-    // Check language and force to english
-    cy.setLanguageToEnglish();
     // Login as librarian (Leonard)
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Create a document
     // Go to document editor
-    cy.goToMenu('create-bibliographic-record-menu-frontpage');
+    cy.visit('/professional/records/documents/new');
     // Populate form with simple record
     cy.populateSimpleRecord(this.documents.book);
     //Save record
@@ -69,7 +65,7 @@ describe('Circulation scenario B: standard loan with transit', function() {
   });
 
   after('Clean data: remove item and document', function() {
-    // TODO: find a way to preserve cookies (auth) and server after a test
+    cy.logout();
     cy.server();
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Go to document detail view and remove item
@@ -106,7 +102,8 @@ describe('Circulation scenario B: standard loan with transit', function() {
     // Login as librarian (Leonard)
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Go to requests list
-    cy.goToMenu('requests-menu-frontpage')
+    cy.get('#user-services-menu').click();
+    cy.get('#requests-menu').click();
     // Check that the document is present
     cy.get('table').should('contain', this.itemBarcode);
     // Enter the barcode and validate
@@ -122,7 +119,8 @@ describe('Circulation scenario B: standard loan with transit', function() {
     // Login as librarian
     cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
     // Go to checkin view
-    cy.goToMenu('circulation-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#circulation-menu').click();
     // Enter item barcode for receive
     cy.get('#search').type(this.itemBarcode).type('{enter}');
     // Check that the item has been received
@@ -135,7 +133,8 @@ describe('Circulation scenario B: standard loan with transit', function() {
     // Login as librarian
     cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
     // Go to checkin view
-    cy.goToMenu('circulation-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#circulation-menu').click();
     // Checkout
     cy.scanPatronBarcodeThenItemBarcode(james, this.itemBarcode)
     // Check that the checkout has been done
@@ -148,7 +147,8 @@ describe('Circulation scenario B: standard loan with transit', function() {
     // Login as librarian
     cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
     // Go to checkin view
-    cy.goToMenu('circulation-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#circulation-menu').click();
     // Checkin
     cy.scanItemBarcode(this.itemBarcode);
     // Check that the checkin has been done
@@ -164,7 +164,8 @@ describe('Circulation scenario B: standard loan with transit', function() {
     // Login as librarian
     cy.adminLogin(this.users.librarians.leonard.email, this.common.uniquePwd);
     // Go to checkin view
-    cy.goToMenu('circulation-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#circulation-menu').click();
     // Receive
     cy.scanItemBarcode(this.itemBarcode);
     // Check that the item has been received
@@ -172,6 +173,5 @@ describe('Circulation scenario B: standard loan with transit', function() {
     // Check that the item is on shelf
     cy.get('#item-' + this.itemBarcode + ' [name="circ-info"] [name="status"]')
     .should('contain', 'on shelf');
-    cy.logout();
   });
 });

--- a/tests/e2e/cypress/cypress/integration/collections/test-collections.spec.js
+++ b/tests/e2e/cypress/cypress/integration/collections/test-collections.spec.js
@@ -1,0 +1,76 @@
+/// <reference types="Cypress" />
+/*
+
+RERO ILS
+Copyright (C) 2020 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+before(function () {
+  cy.fixture('users').then(function (userData) {
+    this.users = userData;
+  });
+  cy.fixture('common').then(function (commonData) {
+    this.common = commonData;
+  });
+  cy.fixture('collections').then(function (collections) {
+    this.collections = collections;
+  });
+});
+
+describe('Collections', function() {
+  /**
+   * DESCRIPTION
+   *
+   */
+  before('Login as a professional', function() {
+    // Login as librarian (Leonard)
+    cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('session');
+  });
+
+  after('Clean data: remove collection', function() {
+    // Delete collection and confirm
+    cy.get('#detail-delete-button').click();
+    cy.get('#modal-confirm-button').click();
+    cy.logout();
+  });
+
+  it('Create a course', function() {
+    let course = this.collections.course;
+    // Go to collection list
+    cy.get('#user-services-menu').click();
+    cy.get('#collections-menu').click();
+    // Click add button
+    cy.get('#search-add-button').click();
+    // Fill in the form
+    cy.fillCollectionEditor(course);
+    // Check the course
+    cy.checkCollection(course);
+  });
+
+  it('Edit a collection to change it as an exhibition', function() {
+    let exhibition = this.collections.exhibition;
+    // Go to editor
+    cy.get('#detail-edit-button').click();
+    // Fill in the form
+    cy.fillCollectionEditor(exhibition);
+    // Check the exhibition
+    cy.checkCollection(exhibition);
+  });
+});

--- a/tests/e2e/cypress/cypress/integration/editor/document/create-simple-document.spec.js
+++ b/tests/e2e/cypress/cypress/integration/editor/document/create-simple-document.spec.js
@@ -32,10 +32,6 @@ before(function () {
 describe('Document editor', function() {
   before('Login as a professional and create an item', function() {
     this.spock = this.users.librarians.spock;
-    //Open app on frontpage
-    cy.visit('');
-    // Check language and force to english
-    cy.setLanguageToEnglish();
     // Login as librarian
     cy.adminLogin(this.spock.email, this.common.uniquePwd);
   });
@@ -43,11 +39,12 @@ describe('Document editor', function() {
   after('Clean data: remove document', function() {
     // Delete record
     cy.deleteRecordFromDetailView();
+    cy.logout();
   });
 
   it('Creates a document with only essential fields', function() {
     // Go to document editor
-    cy.goToMenu('create-bibliographic-record-menu-frontpage');
+    cy.visit('/professional/records/documents/new');
     // Populate form with simple record
     cy.populateSimpleRecord(this.documents.book);
     //Save record

--- a/tests/e2e/cypress/cypress/integration/examples/empty-template.spec.js.disabled
+++ b/tests/e2e/cypress/cypress/integration/examples/empty-template.spec.js.disabled
@@ -1,0 +1,55 @@
+/// <reference types="Cypress" />
+/*
+
+RERO ILS
+Copyright (C) 2020 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+before(function () {
+  // Run once before all
+  // Use to load fixtures and set variable needed in all tests
+  cy.fixture('users').then(function (userData) {
+    this.users = userData;
+  });
+  cy.fixture('common').then(function (commonData) {
+    this.common = commonData;
+  });
+});
+
+describe('Describe test suite here', function() {
+  // Run once before all tests in the block
+  // These steps are not part of the test, but need to be done in order to have
+  // the app in the right state to run the test
+  before('Login and prepare app for tests', function() {
+
+  });
+
+  beforeEach('Add description if needed', function() {
+    // Preserve authentication information between the tests
+    Cypress.Cookies.preserveOnce('session');
+  });
+
+  afterEach('Add description if needed', function() {
+  });
+
+  after('Clean data: ...', function() {
+
+  });
+
+  it('Describe the test here', function() {
+
+  });
+});

--- a/tests/e2e/cypress/cypress/integration/examples/example-test-request.spec.js
+++ b/tests/e2e/cypress/cypress/integration/examples/example-test-request.spec.js
@@ -42,7 +42,6 @@ describe('Template: librarian request', function() {
   // the app in the right state to run the test
   before('Login as a professional and create an item', function() {
     console.log('before');
-    Cypress.Cookies.debug(true);
     // Create server to watch api requests
     cy.server();
     // Open app on frontpage
@@ -53,7 +52,8 @@ describe('Template: librarian request', function() {
     cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
     // Create a document
     // Go to document editor
-    cy.goToMenu('create-bibliographic-record-menu-frontpage');
+    cy.get('#catalog-menu').click();
+    cy.get('#create-bibliographic-record-menu').click();
     // Populate form with simple record
     cy.populateSimpleRecord(this.documents.book);
     //Save record
@@ -65,6 +65,8 @@ describe('Template: librarian request', function() {
   // Runs before each test in the block
   beforeEach('Action to perform before each test', function() {
     console.log('before each');
+    // Preserve authentication information between the tests
+    Cypress.Cookies.preserveOnce('session');
   });
 
   // Runs after each test in the block
@@ -74,13 +76,10 @@ describe('Template: librarian request', function() {
 
   // Run after all tests in the block
   // Is used to restore data as they were before the test
-  // TODO: use token and API rest calls
   after('Clean data: remove request, item and document', function() {
     console.log('after');
-    // TODO: find a way to preserve cookies (auth) and server after a test
     cy.server();
     cy.route({method: 'DELETE', url: '/api/items/*'}).as('deleteItem');
-    cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
     // Go to item detail view
     cy.goToProfessionalDocumentDetailView(this.itemBarcode);
     cy.get('#item-' + this.itemBarcode + ' div a[name=barcode]').click();
@@ -93,8 +92,9 @@ describe('Template: librarian request', function() {
     cy.get('#modal-confirm-button').click();
     cy.wait('@deleteItem');
     // Remove document
-    cy.reload(); // Bug: need to reload the page to unable the remove button
+    cy.reload(); // Bug: need to reload the page to enable the remove button
     cy.deleteRecordFromDetailView();
+    cy.logout();
   });
 
   // First test
@@ -112,17 +112,15 @@ describe('Template: librarian request', function() {
     cy.get('#item-' + this.itemBarcode + ' div a[name=barcode]').click({force:true});
     // Check that the request has been done
     cy.get('.card').should('contain', this.users.patrons.james.barcode);
-    cy.logout();
   });
 
   // Second test
   it('Second test: check the request in admin patron profile view', function() {
     console.log('second test');
-    cy.adminLogin(this.users.librarians.spock.email, this.common.uniquePwd);
-    cy.goToMenu('users-menu-frontpage');
+    cy.get('#user-services-menu').click();
+    cy.get('#users-menu').click();
     cy.get('#' + this.users.patrons.james.barcode + '-loans').click();
     cy.get('#pending-tab').click();
     cy.get('admin-main.ng-star-inserted > :nth-child(2)').should('contain', this.itemBarcode);
-    cy.logout();
   });
 });

--- a/tests/e2e/cypress/cypress/support/collection.js
+++ b/tests/e2e/cypress/cypress/support/collection.js
@@ -1,0 +1,77 @@
+/// <reference types="Cypress" />
+/*
+
+RERO ILS
+Copyright (C) 2020 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+/**
+ * Create collection
+ */
+Cypress.Commands.add("createCollection", (collection) => {
+  // Go to collection list
+  cy.get('#user-services-menu').click();
+  cy.get('#collections-menu').click();
+  // Click add button
+  cy.get('#search-add-button').click();
+  // Fill in the form
+  cy.fillCollectionEditor(collection);
+});
+
+/**
+ * Edit collection from detailed view
+ */
+Cypress.Commands.add("editCollection", (collection) => {
+  // Go to editor
+  cy.get('#detail-edit-button').click();
+  // Fill in the form
+  cy.fillCollectionEditor(collection);
+});
+
+/**
+ * Fill collection editor
+ */
+Cypress.Commands.add("fillCollectionEditor", (collection) => {
+  // Fill in the form
+  cy.get('#collection_type').select(collection.collection_type);
+  cy.get('#start_date').clear();
+  cy.get('#start_date').type(collection.start_date);
+  cy.get('body').click(); // Leave datepicker
+  cy.get('#end_date').clear();
+  cy.get('#end_date').type(collection.end_date);
+  cy.get('body').click(); // Leave datepicker
+  cy.get('#title').clear();
+  cy.get('#title').type(collection.title);
+  cy.get('#collection_id').clear();
+  cy.get('#collection_id').type(collection.collection_id);
+  if (collection.teachers) {
+    cy.get('#teachers-0-name').clear();
+    cy.get('#teachers-0-name').type(collection.teachers[0].name);
+  }
+  cy.get('#editor-save-button').click();
+});
+
+/**
+ * Check collection in detailed view
+ */
+Cypress.Commands.add("checkCollection", (collection) => {
+  cy.get('.d-inline').should('contain', collection.title);
+  cy.get('#collection-type').should('contain', collection.collection_type);
+  if (collection.teachers) {
+    cy.get('#collection #teacher').should('contain', collection.teachers[0].name);
+  }
+});
+

--- a/tests/e2e/cypress/cypress/support/index.js
+++ b/tests/e2e/cypress/cypress/support/index.js
@@ -15,12 +15,14 @@
 
 // Import commands.js using ES2015 syntax:
 import './api'
-import './commands'
-import './utils'
 import './circulation'
-import './user'
+import './collection'
+import './commands'
+import './commands'
 import './navigation'
 import './record'
+import './user'
+import './utils'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/tests/e2e/cypress/cypress/support/navigation.js
+++ b/tests/e2e/cypress/cypress/support/navigation.js
@@ -29,28 +29,10 @@ Cypress.Commands.add("userProfile", (tabId) => {
   }
 })
 
-// Go to a specific menu from professional homepage
-// menuId: `id=` attribute content
-Cypress.Commands.add("goToMenu", (menuId) => {
-  // Go to professional homepage
-  cy.get('#homepage-logo').click()
-  // if already on professional, do nothing
-  cy.url().then((url) => {
-    if (!url.includes('/professional/')) {
-      cy.get('#my-account-menu').click()
-      cy.get('#professional-interface-menu').click()
-    }
-  })
-
-  // Check we're on admin page
-  cy.url(1000).should('include', '/professional/')
-  // Click on 'menuTitle' from Catalog menu
-  cy.get('#' + menuId).click()
-})
-
 Cypress.Commands.add("goToPublicDocumentDetailView", (itemBarcode) => {
   // Go to homepage
-  cy.get('#homepage-logo').click()
+  cy.visit('');
+  cy.setLanguageToEnglish();
   // on public context
   cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').clear()
   cy.get('.d-none > main-search-bar > .flex-grow-1 > .rero-ils-autocomplete > .form-control').type(itemBarcode).type('{enter}')

--- a/tests/e2e/cypress/cypress/support/record.js
+++ b/tests/e2e/cypress/cypress/support/record.js
@@ -32,7 +32,7 @@ Cypress.Commands.add("createItemFromDocumentDetailView", (barcode, item) => {
   // Select location
   cy.get('select').eq(1).select(item.location)
   // Submit form
-  cy.get('.mt-4 > [type="submit"]').click()
+  cy.get('#editor-save-button').click()
   // Assert that the item has been created
   cy.get('.main-content').should('contain', barcode)
 })

--- a/tests/e2e/cypress/cypress/support/user.js
+++ b/tests/e2e/cypress/cypress/support/user.js
@@ -17,34 +17,30 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
-// Logout
+
 Cypress.Commands.add("logout", () => {
-  // click on username
-  cy.get('#my-account-menu').click()
-  // Wait for the menu to open
-  // TODO: find a better way (same as setLanguageToEnglish command)
-  cy.wait(1000)
-  // then click on Logout link
-  cy.get('#logout-menu').click()
-})
+  cy.visit('/signout');
+  cy.contains('My account');
+});
 
 Cypress.Commands.add("login", (email, password) => {
-  // click on "My account"
-  cy.get('#my-account-menu').click()
-  cy.wait(1000)
-  cy.get('#login-menu').click()
-  cy.get('#email').type(email)
-  cy.get('#password').type(password)
-  cy.get('form[name="login_user_form"]').submit()
-})
+  cy.request({
+    method: 'POST',
+    url: '/api/login',
+    followRedirect: false,
+    body: {
+      'email': email,
+      'password': password
+    }
+  }).then(() => {
+    cy.visit('/lang/en'); // this forces the language to englis and preserves it even while using cy.visit
+    cy.get('body').should('contain', 'RERO ID');
+  });
+});
 
 // Login to professional interface
 Cypress.Commands.add("adminLogin", (email, password) => {
-  cy.login(email, password)
-  // set language to english BEFORE going to professional interface
-  cy.setLanguageToEnglish()
-  // go to professional interface
-  cy.get('#my-account-menu').click()
-  cy.get('#professional-interface-menu').click()
-  cy.url(60000).should('include', '/professional/')
- })
+  cy.login(email, password);
+  cy.visit('/professional');
+  cy.get('body').should('contain', 'RERO ILS administration');
+ });


### PR DESCRIPTION
* Creates e2e tests for collections.
* Replaces 'goToMenu' custom command in order not to go to the frontpage
  each time we navigate in the app.
* Adds an empty template to re-use for test creation.
* Adds cookies preservation to keep authentication information between tests.
* Changes login and logout commands in order to use API calls instead of
UI actions.
* Adds a test for login and logout (UI actions).
* Allows language preservation in professional interface.
* Closes #1220.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To create cypress tests for the collections.
To improve existing tests.

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* https://github.com/rero/rero-ils-ui/pull/404

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
