### PR TITLE
document: fix internal server error when display view

### DIFF
--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -120,12 +120,13 @@ def can_request(item):
     """Check if the current user can request a given item."""
     if current_user.is_authenticated:
         patron = Patron.get_patron_by_user(current_user)
-        can, _ = item.can(
-            ItemCirculationAction.REQUEST,
-            patron=patron,
-            library=Library.get_record_by_pid(patron.library_pid)
-        )
-        return can
+        if patron and patron.is_patron:
+            can, _ = item.can(
+                ItemCirculationAction.REQUEST,
+                patron=patron,
+                library=Library.get_record_by_pid(patron.library_pid)
+            )
+            return can
     return False
 
 


### PR DESCRIPTION
When user is self registered and loggeg in, the user cannot access to document detail display.
that's raise en internal server error.

* Adapts `can_request` jinja filter.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which issue does it fix?
https://github.com/rero/rero-ils/issues/1255

## How to test?

1. Go to the registration form and create a new account, you will receive a validation email
2. validate your account by clicking link in the email
3. Log in with your new account on rero-ils
4. Do a search and click on a document
5. You can view the detail of the document.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
