### PR TITLE
patron: fix patron profile for dispute event

### DIFF
--- a/rero_ils/modules/patrons/static/scss/rero_ils/patrons_profile.scss
+++ b/rero_ils/modules/patrons/static/scss/rero_ils/patrons_profile.scss
@@ -97,6 +97,19 @@
               width: 100%;
             }
           }
+          blockquote {
+            font-style: italic;
+            margin: 0;
+            &:before, &:after {
+	            color: #AAA;
+            }
+            &:before {
+	            content: '“ ';
+	          }
+            &:after {
+	            content: ' ”';
+	          }
+          }
         }
         .force-display {
           display: block !important;

--- a/rero_ils/modules/patrons/templates/rero_ils/_macro_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_macro_profile.html
@@ -113,35 +113,38 @@
                     )}}
                   </div>
                   <div class="col-lg-9 event-content">
-                      <div class="row">
-                        <div class="col-lg-10 col-sm-10 d-inline-block text-truncate label">
-                          {{ _(event.type) }} [{{ _(event.subtype) }}]
-                        </div>
-                        <div class="col-lg-2 col-sm-2 amount">
-                          <span
-                            class="badge badge-{% if event.type == 'payment' %}success{% else %}danger{% endif %}">
+                    <div class="row {% if event.type == 'dispute' %}event-highlight{% endif %}">
+                      <div class="col-lg-10 col-sm-10 d-inline-block text-truncate label">
+                        {{ _(event.type) }} {% if event.subtype %} [{{ _(event.subtype) }}] {% endif %}
+                      </div>
+                      <div class="col-lg-2 col-sm-2 amount">
+                        {%- if event.amount %}
+                          <span class="badge badge-{% if event.type == 'payment' %}success{% else %}danger{% endif %}">
                             {{ event.amount | format_currency(event.currency) }}
                           </span>
-                        </div>
+                        {%- endif %}
                       </div>
+                    </div>
+                    {%- if event.note %}
                       <div class="row">
                         <div class="col-lg-2 col-sm-1 label-title">
-                          {% if 'note' in event %}
-                            <i class="fa fa-comment-o pr-1" title="{{ _('Note') }}"></i>
-                          {% endif %}
-                          {% if event.library %}
-                            <i class="fa fa-map-marker pr-1" title="{{ _('Library') }}"></i>
-                          {% endif %}
+                          <i class="fa fa-comment-o pr-1" title="{{ _('Note') }}"></i>
                         </div>
                         <div class="col-lg-10 col-sm-11">
-                          {% if event.note %}
-                            {{ event.note }}
-                          {% endif %}
-                          {% if event.library %}
-                            {{ event.library.name }}
-                          {% endif %}
+                          <blockquote>{{ event.note }}</blockquote>
                         </div>
-                    </div>
+                      </div>
+                    {%- endif %}
+                    {%- if event.library %}
+                      <div class="row">
+                        <div class="col-lg-2 col-sm-1 label-title">
+                          <i class="fa fa-map-marker pr-1" title="{{ _('Library') }}"></i>
+                        </div>
+                        <div class="col-lg-10 col-sm-11">
+                          {{ event.library.name }}
+                        </div>
+                      </div>
+                    {%- endif %}
                   </div>
                 </div>
             </div>

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -244,7 +244,8 @@ def profile(viewcode):
 @blueprint.app_template_filter('format_currency')
 def format_currency_filter(value, currency):
     """Format currency with current locale."""
-    return format_currency(value, currency)
+    if value:
+        return format_currency(value, currency)
 
 
 @api_blueprint.route('/roles_management_permissions', methods=['GET'])

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -26,6 +26,7 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, to_relative_url
 
 from rero_ils.modules.loans.api import Loan, LoanState
+from rero_ils.modules.patrons.views import format_currency_filter
 
 
 def test_patrons_profile(
@@ -146,3 +147,10 @@ def test_patrons_blocked_user_profile(
     assert res.status_code == 200
     # The profile displays the patron a blocked account message.
     assert "Your account is currently blocked." in res.get_data(as_text=True)
+
+
+def test_patron_format_currency_filter(app):
+    """Test format currency filter."""
+    assert format_currency_filter(3, 'EUR') == '€3.00'
+    assert format_currency_filter(4.5, 'CHF') == 'CHF4.50'
+    assert format_currency_filter(None, 'EUR') is None


### PR DESCRIPTION
When a patron has some fees containing at least one 'dispute' event, the
server crash because ii tries to convert the amount of dispute (always
none) to a decimal number. This PR fix this problem checking if the
event to display has a valid 'amount' attribute. This PR also fixes some
small HTML problems on the patron profile.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

Closes rero/rero-ils#1272

## How to test?

- Log in as admin. Go in professional view to place a dispute event on Simonetta patron account.
- Logout
- Log in as Simonetta. Display your patron profile to view the dispute event.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
