### PR TITLE
document: canton field only available for switzerland

### DIFF
--- a/rero_ils/jsonschemas/common/cantons-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/cantons-v0.0.1.json
@@ -139,7 +139,8 @@
       ],
       "templateOptions": {
         "cssClass": "col-lg-4"
-      }
+      },
+      "hideExpression": "field.parent.model.country !== 'sz'"
     }
   }
 }


### PR DESCRIPTION
The canton field should only be available when the country 'Switzerland'
was selected in the provisionActitivy country field.

Closes rero/rero-ils#1285

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- In the document editor, play with `country` field into `provisionActivity` section. When 'Switzerland' (sz) is selected the canton field should appears, otherwise the field is hidden.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
