### PR TITLE
circulation: fix extend loan API response

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -64,7 +64,7 @@ class LoanState(object):
 
 
 class LoanAction(object):
-    """Class holding all availabe circulation loan actions."""
+    """Class holding all available circulation loan actions."""
 
     REQUEST = 'request'
     CHECKOUT = 'checkout'
@@ -72,7 +72,7 @@ class LoanAction(object):
     VALIDATE = 'validate'
     RECEIVE = 'receive'
     RETURN_MISSING = 'return_missing'
-    EXTEND = 'extend'
+    EXTEND = 'extend_loan'
     CANCEL = 'cancel'
     NO = 'no'
     UPDATE = 'update'


### PR DESCRIPTION
When a loan was extended, the responses doens't include the correct
action name ('extend' instead of 'extend_loan'). This PR fix this
problem.

Closes rero/rero-ils#1256

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
