### PR TITLE
patron: add circulation statistic API

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -473,6 +473,23 @@ def get_loans_by_item_pid_by_patron_pid(
     return {}
 
 
+def get_loans_stats_by_patron_pid(patron_pid):
+    """Search loans for patron and aggregate result on loan state.
+
+    :param patron_pid: The patron pid
+    :return: a dict with loans state as key, number of loans as value
+    """
+    agg = A('terms', field='state')
+    search = search_by_patron_item_or_document(patron_pid=patron_pid)
+    search.aggs.bucket('state', agg)
+    search = search[0:0]
+    results = search.execute()
+    stats = {}
+    for result in results.aggregations.state.buckets:
+        stats[result.key] = result.doc_count
+    return stats
+
+
 def get_loans_by_patron_pid(patron_pid, filter_states=[]):
     """Search all loans for patron to the given filter_states.
 

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -406,6 +406,7 @@ class Patron(IlsRecord):
         # a blocked patron can't request any item
         if patron.is_blocked:
             return False, [patron.blocked_message]
+
         return True, []
 
     @classmethod
@@ -426,6 +427,7 @@ class Patron(IlsRecord):
         # a blocked patron can't request any item
         if patron.is_blocked:
             return False, [patron.blocked_message]
+
         return True, []
 
     @classmethod
@@ -685,6 +687,39 @@ class Patron(IlsRecord):
         :returns: True if valid user otherwise false.
         """
         return Patron.record_pid_exists(user_pid)
+
+    def get_circulation_messages(self):
+        """Return messages useful for circulation.
+
+        * check if the user is blocked ?
+        * check if the user reaches the maximum loans limit ?
+
+        :return an array of messages. Each message is a dictionary with a level
+                and a content. The level could be used to filters messages if
+                needed.
+        """
+        from ..patron_types.api import PatronType
+
+        # if patron is blocked - error type message
+        #   if patron is blocked, no need to return any other circulation
+        #   messages !
+        if self.is_blocked:
+            return [{
+                'type': 'error',
+                'content': self.blocked_message
+            }]
+
+        messages = []
+        # check the patron type define limit
+        patron_type = PatronType.get_record_by_pid(self.patron_type_pid)
+        valid, message = patron_type.check_checkout_count_limit(self)
+        if not valid:
+            messages.append({
+                'type': 'error',
+                'content': message
+            })
+
+        return messages
 
 
 class PatronsIndexer(IlsRecordsIndexer):

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -39,7 +39,7 @@ from .utils import user_has_patron
 from ..items.api import Item
 from ..items.utils import item_pid_to_object
 from ..libraries.api import Library
-from ..loans.api import Loan, patron_profile
+from ..loans.api import Loan, get_loans_stats_by_patron_pid, patron_profile
 from ..locations.api import Location
 from ..utils import get_base_url
 from ...permissions import login_and_librarian
@@ -103,6 +103,19 @@ def number_of_patrons():
         s = s.filter('bool', must_not=[Q('term', pid=exclude_pid)])
     response = dict(hits=dict(total=s.count()))
     return jsonify(response)
+
+
+@api_blueprint.route('/<patron_pid>/circulation_informations', methods=['GET'])
+@check_permission
+def patron_circulation_informations(patron_pid):
+    """Get the circulation statistics and info messages about a patron."""
+    patron = Patron.get_record_by_pid(patron_pid)
+    if not patron:
+        abort(404, 'Patron not found')
+    return jsonify({
+        'statistics': get_loans_stats_by_patron_pid(patron_pid),
+        'messages': patron.get_circulation_messages()
+    })
 
 
 blueprint = Blueprint(

--- a/tests/api/loans/test_loans_limits.py
+++ b/tests/api/loans/test_loans_limits.py
@@ -18,8 +18,9 @@
 """Loan Record limits."""
 from copy import deepcopy
 
+from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import postdata
+from utils import get_json, postdata
 
 from rero_ils.modules.loans.api import LoanAction
 from rero_ils.modules.patron_types.api import PatronType
@@ -132,6 +133,17 @@ def test_loans_limits_checkout_library_limits(
     ))
     assert res.status_code == 403
     assert 'Checkout denied' in data['message']
+
+    # check the circulation information API
+    url = url_for(
+        'api_patrons.patron_circulation_informations',
+        patron_pid=patron.pid
+    )
+    res = client.get(url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'error' == data['messages'][0]['type']
+    assert 'Checkout denied' in data['messages'][0]['content']
 
     # reset fixtures
     #   --> checkin both loaned item

--- a/tests/api/patrons/test_patrons_blocked.py
+++ b/tests/api/patrons/test_patrons_blocked.py
@@ -53,6 +53,10 @@ def test_blocked_field_exists(
     assert 'blocked' in data['metadata']['patron']
     assert data['metadata']['patron']['blocked'] is True
 
+    assert patron3_martigny_blocked_no_email.is_blocked
+    note = patron3_martigny_blocked_no_email.patron.get('blocked_note')
+    assert note and note in patron3_martigny_blocked_no_email.blocked_message
+
 
 def test_blocked_field_not_present(
         client,


### PR DESCRIPTION
Adds an API to get patron circulation loan statistics. This API return
the number of loans relate to this patron by state.

Closes rero/rero-ils#1278

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
