### PR TITLE
ill_request: fix form validation problem

### DIFF
--- a/rero_ils/filter.py
+++ b/rero_ils/filter.py
@@ -24,6 +24,7 @@ import dateparser
 from babel.dates import format_date, format_datetime, format_time
 from flask import current_app
 from invenio_i18n.ext import current_i18n
+from markupsafe import Markup
 
 
 def format_date_filter(
@@ -87,3 +88,12 @@ def jsondumps(data):
 def text_to_id(text):
     """Text to id."""
     return re.sub(r'\W', '', text)
+
+
+def empty_data(data, replacement_string='No data'):
+    """Return default string if no data."""
+    if data:
+        return data
+    else:
+        msg = '<em class="no-data">{0}</em>'.format(replacement_string)
+        return Markup(msg)

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -48,7 +48,8 @@ from .patrons.listener import create_subscription_patron_transaction, \
     enrich_patron_data, update_from_profile
 from .persons.listener import enrich_persons_data
 from .persons.receivers import publish_api_harvested_records
-from ..filter import format_date_filter, jsondumps, text_to_id, to_pretty_json
+from ..filter import empty_data, format_date_filter, jsondumps, text_to_id, \
+    to_pretty_json
 
 
 class REROILSAPP(object):
@@ -72,6 +73,7 @@ class REROILSAPP(object):
             app.add_template_filter(to_pretty_json, name='tojson_pretty')
             app.add_template_filter(text_to_id, name='text_to_id')
             app.add_template_filter(jsondumps, name='jsondumps')
+            app.add_template_filter(empty_data, name='empty_data')
             app.jinja_env.add_extension('jinja2.ext.do')
             self.register_signals(app)
 

--- a/rero_ils/modules/ill_requests/forms.py
+++ b/rero_ils/modules/ill_requests/forms.py
@@ -118,14 +118,22 @@ class ILLRequestSourceForm(FlaskForm):
         description=_('Library catalog name')
     )
     url = URLField(
-        validators=[
-            validators.Optional(),
-            validators.URL()
-        ],
         description=_('Link of the document'),
         render_kw={'placeholder': 'https://...'}
-
     )
+
+    def validate(self):
+        """Custom validation for this form."""
+        if self.url.data:
+            self.origin.validators = [
+                validators.DataRequired()
+            ]
+        if self.origin.data:
+            self.url.validators = [
+                validators.DataRequired(),
+                validators.URL()
+            ]
+        return super().validate()
 
 
 class ILLRequestForm(FlaskForm):
@@ -180,7 +188,7 @@ class ILLRequestForm(FlaskForm):
                 'title': self.document.title.data,
                 'authors': self.document.authors.data,
                 'publisher': self.document.publisher.data,
-                'year': str(self.document.year.data),
+                'year': str(self.document.year.data or ''),
                 'identifier': self.document.identifier.data,
                 'source': {
                     'journal_title': self.document.source.journal_title.data,
@@ -198,6 +206,7 @@ class ILLRequestForm(FlaskForm):
             },
             'note': self.note.data
         })
+
         # if we put 'copy' in the dict before the dict cleaning and if 'copy'
         # is set to 'No', then it will be removed by `remove_empties_from_dict`
         # So we need to add it after the cleaning

--- a/rero_ils/modules/ill_requests/templates/rero_ils/_macro_form.html
+++ b/rero_ils/modules/ill_requests/templates/rero_ils/_macro_form.html
@@ -32,12 +32,12 @@
     {% do kwargs.update({'aria-describedby': helpBlockId}) %}
     {{ field(**kwargs)|safe }}
     {%- if field.description %}
-      <small id="{{ helpBlockId }}" class="form-text text-muted">{{ field.description|safe }}</small>
+      <small id="{{ helpBlockId }}" class="form-text text-muted">{{ _(field.description)|safe }}</small>
     {%- endif %}
     {%- if field.errors %}
     <ul class="list-unstyled invalid-feedback">
       {%- for error in field.errors %}
-        <li><i class="fa fa-exclamation-circle"></i> {{ error }}</li>
+        <li><i class="fa fa-exclamation-circle"></i> {{ _(error) }}</li>
       {%- endfor %}
     </ul>
     {%- endif %}
@@ -59,7 +59,7 @@
          </span>
        {%- endfor %}
        {%- if field.description %}
-         <small id="{{ helpBlockId }}" class="form-text text-muted">{{ field.description|safe }}</small>
+         <small id="{{ helpBlockId }}" class="form-text text-muted">{{ _(field.description)|safe }}</small>
        {%- endif %}
      </div>
    </div>
@@ -85,7 +85,7 @@
 {% macro render_field_label(field) %}
 
     <label class="col-md-2 col-sm-4 col-form-label{%- if field.flags.required %} required{% endif %}">
-      {{ field.label }}
+      {{ _(field.label.text) }}
     </label>
 {% endmacro %}
 

--- a/rero_ils/modules/ill_requests/templates/rero_ils/ill_request_form.html
+++ b/rero_ils/modules/ill_requests/templates/rero_ils/ill_request_form.html
@@ -21,6 +21,12 @@
 {% from "rero_ils/_macro_form.html" import render_field, render_simple_field %}
 
 {%- block body %}
+  <div class="alert alert-warning my-4" role="alert">
+    <h4 class="alert-heading">Caution !</h4>
+    <hr>
+    <p class="mb-0">A well detailed request is more likely to be satisfied</p>
+  </div>
+
   <form action="{{ url_for('ill_requests.ill_request_form') }}" method="POST" class="form" role="form" novalidate>
     {{ form.hidden_tag() }}
     {%- if form.csrf_token and form.csrf_token.errors %}
@@ -36,7 +42,7 @@
       {{ render_field(form.document.year) }}
       {{ render_field(form.document.identifier) }}
       <div class="form-group row">
-        <label class="col-md-2 col-sm-4 col-form-label">{{ form.document.source.label }}</label>
+        <label class="col-md-2 col-sm-4 col-form-label">{{ _(form.document.source.label.text) }}</label>
         <div class="col-md-6 col-sm-4">{{ render_simple_field(form.document.source.journal_title) }}</div>
         <div class="col-md-2 col-sm-2">{{ render_simple_field(form.document.source.volume) }}</div>
         <div class="col-md-2 col-sm-2">{{ render_simple_field(form.document.source.number) }}</div>
@@ -47,7 +53,7 @@
       {{ render_field(form.request_copy) }}
       {{ render_field(form.pages) }}
       <div class="form-group row">
-        <label class="col-md-2 col-sm-4 col-form-label">{{ form.source.label }}</label>
+        <label class="col-md-2 col-sm-4 col-form-label">{{ _(form.source.label.text) }}</label>
         <div class="col-md-2 col-sm-1">{{ render_simple_field(form.source.origin) }}</div>
         <div class="col-md-8 col-sm-7">{{ render_simple_field(form.source.url) }}</div>
       </div>

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -512,7 +512,7 @@ def patron_profile(patron):
         document = Document.get_record_by_pid(
             item.replace_refs()['document']['pid'])
         loan['document'] = document.replace_refs().dumps()
-        loan['item_call_number'] = item['call_number']
+        loan['item_call_number'] = item.get('call_number')
         loan['item_barcode'] = item['barcode']
         if loan['state'] == LoanState.ITEM_ON_LOAN:
             loan['overdue'] = loan.is_loan_overdue()
@@ -611,12 +611,12 @@ def _process_patron_profile_fees(patron, organisation, status='open'):
             item_pid = Loan.get_record_by_pid(transaction.loan.pid)\
                 .get('item_pid')
             item = Item.get_record_by_pid(item_pid.get('value'))
-            transaction['item_call_number'] = item['call_number']
-        if (transaction.status == 'closed'):
+            transaction['item_call_number'] = item.get('call_number')
+        if transaction.status == 'closed':
             transaction.total_amount = PatronTransactionEvent\
                 .get_initial_amount_transaction_event(transaction.pid)
         transaction['events'] = []
-        if (transaction.type == 'overdue'):
+        if transaction.type == 'overdue':
             transaction['document'] = Document.get_record_by_pid(
                 transaction.document.pid)
             transaction['loan'] = Loan.get_record_by_pid(transaction.loan.pid)
@@ -625,7 +625,7 @@ def _process_patron_profile_fees(patron, organisation, status='open'):
             event['currency'] = Organisation\
                 .get_record_by_pid(event.organisation.pid)\
                 .get('default_currency')
-            if ('library' in event):
+            if 'library' in event:
                 event.library = Library\
                     .get_record_by_pid(event.library.pid)
             transaction['events'].append(event)

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_ill_requests.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_ill_requests.html
@@ -86,11 +86,9 @@
               {%- endif %}
               <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Pickup location')}}</div>
               <div class="col-md-10 col-sm-8">{{ request.pickup_location.name }}</div>
-              <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Is request copy')}}</div>
-              <div class="col-md-10 col-sm-8">
-                <i class="fa fa-{%- if request.is_copy %}check text-success{%- else %}times text-danger{%- endif %}"></i>
-              </div>
-              {%- if request.pages %}
+              <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Scope')}}</div>
+              <div class="col-md-10 col-sm-8">{{ _('Copy') if request.copy else _('Loan') }}</div>
+              {%- if request.pages and request.copy %}
                 <div class="col-md-2 col-sm-4 font-weight-bold">{{ _('Pages')}}</div>
                 <div class="col-md-10 col-sm-8">{{ request.pages }}</div>
               {%- endif %}

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_loans.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_loans.html
@@ -102,7 +102,7 @@
             <b>{{ _('Call number') }}</b>
           </div>
           <div class="col-lg-10 col-sm-8">
-            {{ loan.item_call_number }}
+            {{ loan.item_call_number | empty_data(_('Call number unavailable')) }}
           </div>
         </div>
       </section>

--- a/rero_ils/static/scss/rero_ils/styles.scss
+++ b/rero_ils/static/scss/rero_ils/styles.scss
@@ -87,6 +87,10 @@ html [type=button] {
   font-weight: bold;
 }
 
+.no-data {
+  color: $secondary;
+}
+
 /*
  *********************************
 

--- a/tests/ui/test_filters.py
+++ b/tests/ui/test_filters.py
@@ -17,8 +17,8 @@
 
 """Jinja2 filters tests."""
 
-from rero_ils.filter import format_date_filter, jsondumps, text_to_id, \
-    to_pretty_json
+from rero_ils.filter import empty_data, format_date_filter, jsondumps, \
+    text_to_id, to_pretty_json
 
 
 def test_date_filter_format_timestamp_en(app):
@@ -109,3 +109,10 @@ def test_to_pretty():
 def test_text_to_id():
     """Test text to id."""
     assert 'LoremIpsum' == text_to_id('Lorem Ipsum')
+
+
+def test_empty_data():
+    """Test empty data."""
+    assert 'data' == empty_data('data')
+    substitution_text = 'no data available'
+    assert substitution_text in empty_data(None, substitution_text)


### PR DESCRIPTION
When user submit the ill request form with some values, either the
server return an error either bad data are saved into the request :
  * no date selected --> 'None' string was saved.
  * found_in.source specified and no url --> server error
  * invalid URL in found_in.url --> server error

This commit also fixes some bugs due t item call_number that is now not
required. Introducing a new Jinja filter to display an custom message if
no data is available.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- When creating an ill_request, test the form with "source" and "url" fields.
- Create an ill_request with no year.
- Display the checkout tab in the patron detail view for Simnetta. The item "Art passions" detail will display a substitution text for call number field

![image](https://user-images.githubusercontent.com/10031585/96459082-fcd57380-1221-11eb-8f2c-7d9f98b15da3.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
