### PR TITLE
patron_type: implements overdue items restriction

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2255,6 +2255,10 @@ CIRCULATION_ACTIONS_VALIDATION = {
     ],
     ItemCirculationAction.EXTEND: [
         Item.can_extend
+    ],
+    ItemCirculationAction.CHECKOUT: [
+        Patron.can_checkout,
+        PatronType.allow_checkout
     ]
 }
 

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -19,7 +19,6 @@
 
 from copy import deepcopy
 from datetime import datetime, timezone
-from functools import wraps
 
 from flask import current_app
 from invenio_circulation.api import get_loan_for_item
@@ -33,6 +32,8 @@ from invenio_pidstore.errors import PersistentIdentifierError
 from invenio_records_rest.utils import obj_or_import_string
 from invenio_search import current_search
 
+from ..decorators import add_action_parameters_and_flush_indexes, \
+    check_operation_allowed
 from ..models import ItemCirculationAction, ItemStatus
 from ..utils import item_pid_to_object
 from ...api import IlsRecord
@@ -45,49 +46,6 @@ from ...loans.api import Loan, LoanAction, LoanState, \
 from ...locations.api import Location
 from ...patrons.api import Patron
 from ....filter import format_date_filter
-
-
-def add_action_parameters_and_flush_indexes(function):
-    """Add missing action and validate parameters.
-
-    For each circulation action, this method ensures that all required
-    paramters are given. Adds missing parameters if any. Ensures the right
-    loan transition for the given action.
-    """
-    @wraps(function)
-    def wrapper(item, *args, **kwargs):
-        """Executed before loan action."""
-        checkin_loan = None
-        if function.__name__ == 'validate_request':
-            # checks if the given loan pid can be validated
-            item.prior_validate_actions(**kwargs)
-        elif function.__name__ == 'checkin':
-            # the smart checkin requires extra checks/actions before a checkin
-            loan, kwargs = item.prior_checkin_actions(**kwargs)
-            checkin_loan = loan
-        # CHECKOUT: Case where no loan PID
-        elif function.__name__ == 'checkout' and not kwargs.get('pid'):
-            patron_pid = kwargs['patron_pid']
-            item_pid = item.pid
-            request = get_request_by_item_pid_by_patron_pid(
-                item_pid=item_pid, patron_pid=patron_pid)
-            if request:
-                kwargs['pid'] = request.pid
-        elif function.__name__ == 'extend_loan':
-            loan, kwargs = item.prior_extend_loan_actions(**kwargs)
-            checkin_loan = loan
-
-        loan, kwargs = item.complete_action_missing_params(
-                item=item, checkin_loan=checkin_loan, **kwargs)
-        Loan.check_required_params(loan, function.__name__, **kwargs)
-
-        item, action_applied = function(item, loan, *args, **kwargs)
-
-        item.change_status_commit_and_reindex_item(item)
-
-        return item, action_applied
-
-    return wrapper
 
 
 class ItemCirculation(IlsRecord):
@@ -431,16 +389,20 @@ class ItemCirculation(IlsRecord):
             data['transaction_pickup_libraries'] = True
         return data
 
+    @check_operation_allowed(ItemCirculationAction.CHECKOUT)
     @add_action_parameters_and_flush_indexes
     def checkout(self, current_loan, **kwargs):
         """Checkout item to the user."""
         action_params, actions = self.prior_checkout_actions(kwargs)
         loan = Loan.get_record_by_pid(action_params.get('pid'))
-        current_loan = loan or Loan.create(action_params,
-                                           dbcommit=True,
-                                           reindex=True)
+        current_loan = loan or Loan.create(
+            action_params,
+            dbcommit=True,
+            reindex=True
+        )
         loan = current_circulation.circulation.trigger(
-            current_loan, **dict(action_params, trigger='checkout')
+            current_loan,
+            **dict(action_params, trigger='checkout')
         )
         actions.update({LoanAction.CHECKOUT: loan})
         return self, actions
@@ -580,6 +542,7 @@ class ItemCirculation(IlsRecord):
             LoanAction.EXTEND: loan
         }
 
+    @check_operation_allowed(ItemCirculationAction.REQUEST)
     @add_action_parameters_and_flush_indexes
     def request(self, current_loan, **kwargs):
         """Request item for the user and create notifications."""

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -133,14 +133,7 @@ def do_item_jsonify_action(func):
             # Return error 400 when there is a missing required parameter
             abort(400, str(error))
         except CirculationException as error:
-            patron = False
-            # Detect patron details
-            if data.get('patron_pid'):
-                patron = Patron.get_record_by_pid(data.get('patron_pid'))
-            # Add more info in case of blocked patron (for UI)
-            if patron and patron.patron.get('blocked') is True:
-                abort(403, "BLOCKED USER")
-            abort(403, str(error))
+            abort(403, error.description or str(error))
         except NotFound as error:
             raise error
         except exceptions.RequestError as error:
@@ -413,7 +406,7 @@ def can_request(item_pid):
         if not kwargs['library']:
             abort(404, 'Library not found')
 
-    # as to item if the request is possible with these data.
+    # ask to item if the request is possible with these data.
     can, reasons = item.can(ItemCirculationAction.REQUEST, **kwargs)
 
     # check the `reasons_not_request` array. If it's empty, the request is

--- a/rero_ils/modules/items/decorators.py
+++ b/rero_ils/modules/items/decorators.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2020 RERO
+# Copyright (C) 2020 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Decorators about items."""
+
+from functools import wraps
+
+from flask import current_app
+from invenio_circulation.errors import CirculationException
+from invenio_records_rest.utils import obj_or_import_string
+
+from rero_ils.modules.loans.api import Loan, \
+    get_request_by_item_pid_by_patron_pid
+
+
+def add_action_parameters_and_flush_indexes(function):
+    """Add missing action and validate parameters.
+
+    For each circulation action, this method ensures that all required
+    parameters are given. Adds missing parameters if any. Ensures the right
+    loan transition for the given action.
+    """
+    @wraps(function)
+    def wrapper(item, *args, **kwargs):
+        """Executed before loan action."""
+        checkin_loan = None
+        if function.__name__ == 'validate_request':
+            # checks if the given loan pid can be validated
+            item.prior_validate_actions(**kwargs)
+        elif function.__name__ == 'checkin':
+            # the smart checkin requires extra checks/actions before a checkin
+            loan, kwargs = item.prior_checkin_actions(**kwargs)
+            checkin_loan = loan
+        # CHECKOUT: Case where no loan PID
+        elif function.__name__ == 'checkout' and not kwargs.get('pid'):
+            patron_pid = kwargs['patron_pid']
+            item_pid = item.pid
+            request = get_request_by_item_pid_by_patron_pid(
+                item_pid=item_pid, patron_pid=patron_pid)
+            if request:
+                kwargs['pid'] = request.pid
+        elif function.__name__ == 'extend_loan':
+            loan, kwargs = item.prior_extend_loan_actions(**kwargs)
+            checkin_loan = loan
+
+        loan, kwargs = item.complete_action_missing_params(
+                item=item, checkin_loan=checkin_loan, **kwargs)
+        Loan.check_required_params(loan, function.__name__, **kwargs)
+        item, action_applied = function(item, loan, *args, **kwargs)
+        item.change_status_commit_and_reindex_item(item)
+        return item, action_applied
+    return wrapper
+
+
+def check_operation_allowed(action):
+    """Check if a specific action is allowed on an item.
+
+    Check the CIRCULATION_ACTIONS_VALIDATION configuration file and execute
+    function corresponding to the action specified. All function are execute
+    until one return False (action denied) or all actions are successful.
+
+    :param action: the action to check as ItemCirculationAction part.
+    :raise CirculationException if a function disallow the operation.
+    """
+    def inner_function(func):
+        @wraps(func)
+        def decorated_view(*args, **kwargs):
+            actions = current_app.config.get(
+                'CIRCULATION_ACTIONS_VALIDATION', {})
+            for func_name in actions.get(action, []):
+                func_callback = obj_or_import_string(func_name)
+                can, reasons = func_callback(args[0], **kwargs)
+                if not can:
+                    raise CirculationException(description=reasons[0])
+            return func(*args, **kwargs)
+        return decorated_view
+    return inner_function

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -50,9 +50,7 @@ def create_over_and_due_soon_notifications(overdue=True, due_soon=True,
             loan.create_notification(notification_type='due_soon')
             no_due_soon_loans += 1
     if overdue:
-        over_due_loans = get_overdue_loans()
-
-        for loan in over_due_loans:
+        for loan in get_overdue_loans():
             loan.create_notification(notification_type='overdue')
             no_over_due_loans += 1
 

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -68,7 +68,6 @@
       "title": "Amount",
       "description": "Yearly amount due by patrons linked to this patron type.",
       "type": "number",
-      "default": 0,
       "minimum": 0,
       "form": {
         "wrappers": [

--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -20,12 +20,22 @@
 
 from flask_login import current_user
 
-from .api import Patron
-
 
 def user_has_patron(user=current_user):
     """Test if user has a patron."""
+    from .api import Patron
     patron = Patron.get_patron_by_email(email=user.email)
     if patron and 'patron' in patron.get('roles'):
         return True
     return False
+
+
+def get_patron_from_arguments(**kwargs):
+    """Try to load a patron from potential arguments."""
+    from .api import Patron
+    required_arguments = ['patron', 'patron_barcode', 'patron_pid']
+    if not any(k in required_arguments for k in kwargs):
+        return None
+    return kwargs.get('patron') \
+        or Patron.get_patron_by_barcode(kwargs.get('patron_barcode')) \
+        or Patron.get_record_by_pid(kwargs.get('patron_pid'))

--- a/tests/api/loans/test_loans_utils.py
+++ b/tests/api/loans/test_loans_utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests loans utils."""
+from rero_ils.modules.items.utils import item_pid_to_object
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.utils import loan_build_document_ref, \
+    loan_build_item_ref, loan_build_patron_ref
+from rero_ils.modules.utils import get_ref_for_pid
+
+
+def test_loans_build_refs(item_lib_martigny, patron_martigny_no_email,
+                          document):
+    """Test functions buildings refs."""
+
+    # Create "virtual" Loan (not registered)
+    loan = Loan({
+        'item_pid': item_pid_to_object(item_lib_martigny.pid),
+        'document_pid': document.pid,
+        'patron_pid': patron_martigny_no_email.pid
+    })
+
+    assert loan_build_item_ref(None, loan) == \
+        get_ref_for_pid('items', item_lib_martigny.pid)
+    assert loan_build_document_ref(None, loan) == \
+        get_ref_for_pid('doc', document.pid)
+    assert loan_build_patron_ref(None, loan) == \
+        get_ref_for_pid('patrons', patron_martigny_no_email.pid)

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -86,7 +86,7 @@ def test_create_over_and_due_soon_notifications_task(
     loan['end_date'] = end_date.isoformat()
     loan.update(loan, dbcommit=True, reindex=True)
 
-    overdue_loans = get_overdue_loans()
+    overdue_loans = list(get_overdue_loans())
     assert overdue_loans[0].get('pid') == loan_pid
 
     create_over_and_due_soon_notifications()

--- a/tests/ui/circulation/test_loan_utils.py
+++ b/tests/ui/circulation/test_loan_utils.py
@@ -20,7 +20,7 @@
 from copy import deepcopy
 
 import pytest
-from invenio_circulation.errors import RecordCannotBeRequestedError
+from invenio_circulation.errors import CirculationException
 from utils import flush_index, item_record_to_a_specific_loan_state
 
 from rero_ils.modules.api import IlsRecordError
@@ -97,7 +97,7 @@ def test_loan_utils(client, patron_martigny_no_email,
         'transaction_user_pid': librarian_martigny_no_email.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, loan_pending_martigny = item_record_to_a_specific_loan_state(
             item=item_lib_martigny, loan_state=LoanState.PENDING,
             params=params, copy_item=True)


### PR DESCRIPTION
Implements the overdue_items_limit restriction : If a patron type
resource defines an 'overdue_items_limit', patrons with overdue items
can't execute any checkout operation if the limit is reached.
This commit also refactors the 'blocked_patron' restriction.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
