### PR TITLE
circulation: fix 'cancel request' with multiple requests

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -547,14 +547,15 @@ class ItemCirculation(IlsRecord):
             # CANCEL_REQUEST_5_1_2: when item at desk with pending loan, cancel
             # the loan triggers an automatic validation of first pending loan.
             actions_to_execute['validate_first_pending'] = True
-        elif loan['state'] == LoanState.PENDING and (
-            LoanState.ITEM_AT_DESK in loans_list or
-            LoanState.ITEM_ON_LOAN in loans_list or
-            LoanState.ITEM_IN_TRANSIT_FOR_PICKUP in loans_list or
-            LoanState.ITEM_IN_TRANSIT_TO_HOUSE in loans_list
-        ):
-            # CANCEL_REQUEST_2_2, CANCEL_REQUEST_3_2, CANCEL_REQUEST_4_2,
-            # CANCEL_REQUEST_5_2:
+        elif loan['state'] == LoanState.PENDING and \
+                any(state in loans_list for state in [
+                LoanState.ITEM_AT_DESK,
+                LoanState.ITEM_ON_LOAN,
+                LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
+                LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
+                LoanState.PENDING]):
+            # CANCEL_REQUEST_1_2, CANCEL_REQUEST_2_2, CANCEL_REQUEST_3_2,
+            # CANCEL_REQUEST_4_2 CANCEL_REQUEST_5_2:
             # canceling a pending loan does not affect the other active loans.
             actions_to_execute['cancel_loan'] = True
 

--- a/tests/ui/circulation/test_actions_cancel_request.py
+++ b/tests/ui/circulation/test_actions_cancel_request.py
@@ -29,7 +29,8 @@ from rero_ils.modules.loans.api import Loan, LoanState
 
 def test_cancel_request_on_item_on_shelf(
         item_lib_martigny, item_on_shelf_martigny_patron_and_loan_pending,
-        loc_public_martigny, librarian_martigny_no_email):
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
     """Test cancel request on an on_shelf item."""
     # the following tests the circulation action CANCEL_REQUEST_1_1
     # on_shelf item with no pending requests, not possible to cancel a request.
@@ -42,6 +43,17 @@ def test_cancel_request_on_item_on_shelf(
     # on_shelf item with pending requests, cancel a pending loan is possible.
     # the item remains on_shelf
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
+    # add request for another patron
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    # cancel request
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,


### PR DESCRIPTION
* Allows the cancellation of a request when there are several requests
on the item.
* Closes #1303.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

To close mentioned issue.

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

N/A

## How to test?

See issue description

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
