### PR TITLE
serials: manage late issues

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 from builtins import classmethod
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
 
 from dateutil.relativedelta import relativedelta
@@ -323,10 +323,11 @@ class Holding(IlsRecord):
 
     @property
     def get_items(self):
-        """Return items of holding record."""
+        """Return standard items and received issues for a holding record."""
         for item_pid in Item.get_items_pid_by_holding_pid(self.pid):
             item = Item.get_record_by_pid(item_pid)
-            if item.issue_status != ItemIssueStatus.DELETED:
+            if not item.issue_status or \
+                    item.issue_status == ItemIssueStatus.RECEIVED:
                 yield item
 
     def get_number_of_items(self):
@@ -508,7 +509,8 @@ class Holding(IlsRecord):
         """Prepare the issue record before creating the item."""
         data = {
             'issue': {
-                'status': 'received',
+                'status': ItemIssueStatus.RECEIVED,
+                'status_date': datetime.now(timezone.utc).isoformat(),
                 'received_date': datetime.now().strftime('%Y-%m-%d'),
                 'expected_date': expected_date,
                 'regular': True

--- a/rero_ils/modules/items/api/issue.py
+++ b/rero_ils/modules/items/api/issue.py
@@ -42,3 +42,8 @@ class ItemIssue(IlsRecord):
     def issue_is_regular(self):
         """Shortcut for issue is regular."""
         return self.get('issue', {}).get('regular', True)
+
+    @property
+    def issue_status_date(self):
+        """Shortcut for issue status date."""
+        return self.get('issue', {}).get('status_date')

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -16,7 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """API for manipulating item records."""
-import datetime
+from datetime import datetime, timezone
 
 from flask_babelex import gettext as _
 
@@ -94,6 +94,7 @@ class ItemRecord(IlsRecord):
         :param reindex: boolean to reindex the record or not.
         :return: The updated item record.
         """
+        data = self._set_issue_status_date(data)
         data = self._prepare_item_record(data=data, mode='update')
         super(ItemRecord, self).update(data, dbcommit, reindex)
         # TODO: some item updates do not require holding re-linking
@@ -112,6 +113,20 @@ class ItemRecord(IlsRecord):
         data = generate_item_barcode(data=data)
         super(ItemRecord, self).replace(data, dbcommit, reindex)
         return self
+
+    @classmethod
+    def _set_issue_status_date(cls, data):
+        """Set the status date to current timestamp for an issue.
+
+        :param data: The record to update.
+        :return: The updated record.
+        """
+        status = data.get('issue', {}).get('status')
+        item = cls.get_record_by_pid(data.pid)
+        if status and item and status != item.issue_status:
+            data['issue']['status_date'] = \
+                datetime.now(timezone.utc).isoformat()
+        return data
 
     @classmethod
     def _increment_next_prediction_for_holding(
@@ -420,6 +435,6 @@ class ItemRecord(IlsRecord):
         """
         acquisition_date = self.get('acquisition_date')
         if acquisition_date:
-            return datetime.datetime.strptime(
-                acquisition_date, '%Y-%m-%d') < datetime.datetime.now()
+            return datetime.strptime(
+                acquisition_date, '%Y-%m-%d') < datetime.now()
         return False

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -170,6 +170,7 @@
           "default": "received",
           "enum": [
             "received",
+            "late",
             "claimed",
             "deleted"
           ],
@@ -181,6 +182,10 @@
                 "value": "received"
               },
               {
+                "label": "late",
+                "value": "late"
+              },
+              {
                 "label": "claimed",
                 "value": "claimed"
               },
@@ -190,6 +195,11 @@
               }
             ]
           }
+        },
+        "status_date": {
+          "format": "date-time",
+          "title": "Status date",
+          "type": "string"
         },
         "received_date": {
           "format": "date",

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -98,6 +98,9 @@
           },
           "status": {
             "type": "keyword"
+          },
+          "status_date": {
+            "type": "date"
           }
         }
       },

--- a/rero_ils/modules/items/models.py
+++ b/rero_ils/modules/items/models.py
@@ -60,6 +60,7 @@ class ItemIssueStatus:
     RECEIVED = 'received'
     CLAIMED = 'claimed'
     DELETED = 'deleted'
+    LATE = 'late'
 
 
 class ItemCirculationAction:

--- a/tests/api/collections/test_collections_api.py
+++ b/tests/api/collections/test_collections_api.py
@@ -19,6 +19,7 @@
 
 
 from rero_ils.modules.collections.api import Collection
+from rero_ils.modules.items.models import ItemStatus
 
 
 def test_get_items(document, item_type_standard_martigny,
@@ -40,7 +41,7 @@ def test_get_items(document, item_type_standard_martigny,
                 '$ref': 'https://ils.rero.ch/api/organisations/org1'
             },
             'pid': 'item1',
-            'status': 'on_shelf',
+            'status': ItemStatus.ON_SHELF,
             'type': 'standard'},
         {'$schema': 'https://ils.rero.ch/schemas/items/item-v0.0.1.json',
             'barcode': '8712133',
@@ -53,7 +54,7 @@ def test_get_items(document, item_type_standard_martigny,
                 '$ref': 'https://ils.rero.ch/api/organisations/org1'
             },
             'pid': 'item5',
-            'status': 'on_shelf',
+            'status': ItemStatus.ON_SHELF,
             'type': 'standard'
          }
     ]

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -32,6 +32,7 @@ from rero_ils.modules.documents.api import Document
 from rero_ils.modules.errors import RecordValidationError
 from rero_ils.modules.holdings.api import Holding
 from rero_ils.modules.items.api import Item
+from rero_ils.modules.items.models import ItemIssueStatus, ItemStatus
 from rero_ils.modules.utils import get_ref_for_pid, get_schema_for_resource
 
 
@@ -169,7 +170,7 @@ def test_receive_regular_issue_api(
     item = {
         'issue': {
             'regular': True,
-            'status': 'received',
+            'status': ItemIssueStatus.RECEIVED,
             'expected_date': datetime.now().strftime('%Y-%m-%d'),
             'received_date': datetime.now().strftime('%Y-%m-%d')
         },
@@ -325,13 +326,13 @@ def test_irregular_issue_creation_update_delete_api(
     login_user_via_session(client, librarian_martigny_no_email.user)
     item = {
         'issue': {
-            'status': 'received',
+            'status': ItemIssueStatus.RECEIVED,
             'received_date': datetime.now().strftime('%Y-%m-%d'),
             'expected_date': datetime.now().strftime('%Y-%m-%d'),
             'regular': False
         },
         'enumerationAndChronology': 'irregular_issue',
-        'status': 'on_shelf',
+        'status': ItemStatus.ON_SHELF,
         'holding': {'$ref': get_ref_for_pid('hold', holding.pid)},
         '$schema': get_schema_for_resource(Item),
         'location': holding.get('location'),
@@ -360,13 +361,13 @@ def test_irregular_issue_creation_update_delete_api(
     # No Validation error if you try to create an issue with no holdings links
     item = {
         'issue': {
-            'status': 'received',
+            'status': ItemIssueStatus.RECEIVED,
             'received_date': datetime.now().strftime('%Y-%m-%d'),
             'expected_date': datetime.now().strftime('%Y-%m-%d'),
             'regular': False
         },
         'enumerationAndChronology': 'irregular_issue',
-        'status': 'on_shelf',
+        'status': ItemStatus.ON_SHELF,
         'location': holding.get('location'),
         'document': holding.get('document'),
         'item_type': holding.get('circulation_category'),

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 from utils import get_mapping
 
 from rero_ils.modules.items.api import Item, ItemsSearch, item_id_fetcher
+from rero_ils.modules.items.models import ItemIssueStatus, ItemStatus
 from rero_ils.modules.items.utils import item_location_retriever, \
     item_pid_to_object
 
@@ -108,10 +109,10 @@ def test_item_extended_validation(client, holding_lib_martigny_w_patterns):
         'holding': {
             '$ref': 'https://ils.rero.ch/api/holdings/holding5'
         },
-        'status': 'on_shelf',
+        'status': ItemStatus.ON_SHELF,
         'enumerationAndChronology': 'irregular_issue',
         'issue': {
-            'status': 'received',
+            'status': ItemIssueStatus.RECEIVED,
             'received_date': datetime.now().strftime('%Y-%m-%d'),
             'expected_date': datetime.now().strftime('%Y-%m-%d'),
             'regular': False


### PR DESCRIPTION
A new late status is added to the issue JSON schema
to manage claims.

The system now saves the creation date of the issue status.
If an issue changes its status, the field
item.issue.status_date is set to current timestamp.

In the public interface, only the received issues
are shown.

* Tests are updated accordingly.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1544?milestone=275632

## Dependencies

My PR depends on the following `rero-ils`'s PR(s):

`reroils.v0.14`

## How to test?
1-`bootstrap + setup`
2- in the pro interface locate the journal `Art passions : [revue d'art et de culture]`.
3- edit any of its issues and move it to the status `late` instead of `received`
4- go to the public interface, and display the same journal. you should not find the issue displayed there.
5- using the `~/api/items/xx`, you can see the new field `item.issue.status_date` is well set to the timestamp of the step 5



## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
