### PR TITLE
users: make the email optional

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -967,7 +967,6 @@
     "pid": "46",
     "birth_date": "2005-02-03",
     "city": "Tenna",
-    "email": "reroilstest+920014@gmail.com",
     "username": "fabiano",
     "first_name": "Fabiano",
     "roles": [

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -338,17 +338,38 @@ class Patron(IlsRecord):
     @classmethod
     def get_patron_by_user(cls, user):
         """Get patron by user."""
-        if hasattr(user, 'email'):
-            return cls.get_patron_by_email(email=user.email)
+        if hasattr(user, 'id'):
+            result = PatronsSearch().filter(
+                'term',
+                user_id=user.id
+            ).source(includes='pid').scan()
+            try:
+                pid = next(result).pid
+            except StopIteration:
+                return None
+            return cls.get_record_by_pid(pid)
 
     @classmethod
-    def get_patron_by_email(cls, email=None):
+    def get_patron_by_email(cls, email):
         """Get patron by email."""
         pid_value = cls.get_pid_by_email(email)
         if pid_value:
             return cls.get_record_by_pid(pid_value)
         else:
             return None
+
+    @classmethod
+    def get_patron_by_username(cls, username):
+        """Get patron by username."""
+        result = PatronsSearch().filter(
+            'term',
+            username=username
+        ).source(includes='pid').scan()
+        try:
+            pid = next(result).pid
+        except StopIteration:
+            return None
+        return cls.get_record_by_pid(pid)
 
     @classmethod
     def get_pid_by_email(cls, email):

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -25,7 +25,6 @@
     "first_name",
     "last_name",
     "birth_date",
-    "email",
     "username",
     "roles"
   ],
@@ -157,6 +156,7 @@
         "barcode",
         "type",
         "communication_channel",
+        "additional_communication_email",
         "communication_language",
         "expiration_date",
         "libraries",
@@ -241,6 +241,7 @@
         },
         "communication_channel": {
           "title": "Communication channel",
+          "description": "For the email channel, the user must have an e-mail. Otherwise, no notifications will be sent.",
           "type": "string",
           "enum": [
             "email",
@@ -258,6 +259,19 @@
                 "value": "mail"
               }
             ]
+          }
+        },
+        "additional_communication_email": {
+          "title": "Additional communication email",
+          "type": "string",
+          "format": "email",
+          "pattern": "^.*@.*\\..*$",
+          "minLength": 6,
+          "form": {
+            "hideExpression": "model.communication_channel === 'email'",
+            "messages": {
+              "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
+            }
           }
         },
         "communication_language": {

--- a/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
@@ -54,6 +54,9 @@
           }
         }
       },
+      "user_id": {
+        "type": "keyword"
+      },
       "street": {
         "type": "text"
       },

--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -25,7 +25,7 @@ from .api import Patron
 
 def user_has_patron(user=current_user):
     """Test if user has a patron."""
-    patron = Patron.get_patron_by_email(email=user.email)
+    patron = Patron.get_patron_by_user(user=user)
     if patron and 'patron' in patron.get('roles'):
         return True
     return False

--- a/tests/api/test_user_authentication.py
+++ b/tests/api/test_user_authentication.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test User Authentication API."""
+from flask import url_for
+from utils import get_json, postdata
+
+
+def test_login(client, patron_sion_no_email):
+    """Test login with several scenarios."""
+
+    # user does not exists
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': 'not@exist.com',
+            'password': ''
+        }
+    )
+    assert res.status_code == 400
+    data = get_json(res)
+    assert data['errors'][0] == dict(
+        field='email', message='USER_DOES_NOT_EXIST')
+
+    # wrong password
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_no_email.get('email'),
+            'password': 'bad'
+        }
+    )
+    assert res.status_code == 400
+    data = get_json(res)
+    assert data['errors'][0] == dict(
+        field='password', message='Invalid password')
+
+    # login by email
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_no_email.get('email'),
+            'password': patron_sion_no_email.get('birth_date')
+        }
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('id')
+    # logout for the next test
+    client.post(url_for('invenio_accounts_rest_auth.logout'))
+
+    # login by username
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_no_email.get('username'),
+            'password': patron_sion_no_email.get('birth_date')
+        }
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('id')
+    # logout for the next test
+    client.post(url_for('invenio_accounts_rest_auth.logout'))
+
+
+def test_login_without_email(client, patron_sion_without_email):
+    """Test login with several scenarios."""
+    # login by username without email
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_without_email.get('username'),
+            'password': patron_sion_without_email.get('birth_date')
+        }
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('id')
+    # logout for the next test
+    client.post(url_for('invenio_accounts_rest_auth.logout'))

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -646,6 +646,27 @@ def patron_sion_no_email(
     return ptrn
 
 
+@pytest.fixture(scope="module")
+@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
+def patron_sion_without_email(
+        app,
+        roles,
+        lib_sion,
+        patron_type_grown_sion,
+        patron_sion_data):
+    """Create Sion patron without sending reset password instruction."""
+    del patron_sion_data['email']
+    patron_sion_data['pid'] = 'ptrn10wthoutemail'
+    patron_sion_data['username'] = 'withoutemail'
+    ptrn = Patron.create(
+        data=patron_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn
+
+
 # ------------ Loans: pending loan ----------
 @pytest.fixture(scope="module")
 def loan_pending_martigny(

--- a/tests/ui/notifications/test_notifications_api.py
+++ b/tests/ui/notifications/test_notifications_api.py
@@ -111,6 +111,7 @@ def test_notification_dispatch(app, mailbox):
             return {'loan': {
                 'pid': 'dummy_notification_loan_pid',
                 'patron': {
+                    'pid': 'dummy_patron_pid',
                     'patron': {
                         'communication_channel': self.communication_channel
                     }

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -184,10 +184,11 @@ def test_get_patron(patron_martigny_no_email):
     assert Patron.get_patron_by_barcode(
         patron.patron.get('barcode')) == patron
     assert not Patron.get_patron_by_barcode('not exists')
+    assert Patron.get_patron_by_user(patron.user) == patron
 
     class user:
-        email = patron.get('email')
-    assert Patron.get_patron_by_user(user) == patron
+        pass
+    assert Patron.get_patron_by_user(user) is None
 
 
 def test_user_librarian_can_delete(librarian_martigny):

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -87,7 +87,7 @@ def test_city(patron_schema, patron_martigny_data_tmp):
         validate(patron_martigny_data_tmp, patron_schema)
 
 
-def test_username_email(patron_schema, patron_martigny_data_tmp):
+def test_username(patron_schema, patron_martigny_data_tmp):
     """Test username for patron jsonschemas."""
     validate(patron_martigny_data_tmp, patron_schema)
     del(patron_martigny_data_tmp['username'])
@@ -117,6 +117,11 @@ def test_email(patron_schema, patron_martigny_data_tmp):
     """Test email for patron jsonschemas."""
     validate(patron_martigny_data_tmp, patron_schema)
 
+    # email is optional
+    del patron_martigny_data_tmp['email']
+    validate(patron_martigny_data_tmp, patron_schema)
+
+    # email with a bad format
     with pytest.raises(ValidationError):
         patron_martigny_data_tmp['email'] = 25
         validate(patron_martigny_data_tmp, patron_schema)


### PR DESCRIPTION
* Makes the email optional.
* Updates the fixtures.
* Updates the user loading script.
* Adds an additionnal notification email for the patron.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Implements: https://tree.taiga.io/project/rero21-reroils/us/1659

## How to test?

- Create a patron without email. Do a checkout. Log with the new user and consult his profile.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
