### PR TITLE
circulation: hide buttons if action isn't available.

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -207,27 +207,38 @@
             {%- endfor %}
 
             <!-- action button : Should be at the end to be render above and be clickabke -->
-            {%- set locations = item|item_library_pickup_locations %}
-            {%- if item|can_request and locations %}
-              <div class="action-buttons">
-                <a href="#" type="button" class="btn btn-primary btn-sm" data-toggle="dropdown" aria-haspopup="true"
-                  aria-expanded="false" id="{{ item.barcode }}-dropdownMenu">
-                  {{ _('Request') }}
-                  <i class="fa fa-caret-down fa-fw"></i>
-                </a>
-                <!-- TODO: Style the dropdown header -->
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu">
-                  <h6 class="dropdown-header">{{ _('Select a Pickup Location') }}</h6>
-                  <div class="dropdown-divider"></div>
-                  {% for location in locations %}
-                  <a class="dropdown-item"
-                    id="{{ location.code }}"
-                    href="{{ url_for('item.patron_request', viewcode=viewcode, item_pid=item.pid, pickup_location_pid=location.pid)}}">
-                    {{ location.pickup_name }}
+            {%- if item|item_and_patron_in_same_organisation %}
+              {%- set can_request, reasons = item|can_request %}
+              {%- set locations = item|item_library_pickup_locations %}
+              {%- if can_request and locations %}
+                <div class="action-buttons">
+                  <a href="#" type="button" class="btn btn-primary btn-sm" data-toggle="dropdown" aria-haspopup="true"
+                    aria-expanded="false" id="{{ item.barcode }}-dropdownMenu">
+                    {{ _('Request') }}
+                    <i class="fa fa-caret-down fa-fw"></i>
                   </a>
-                  {% endfor %}
+                  <!-- TODO: Style the dropdown header -->
+                  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu">
+                    <h6 class="dropdown-header">{{ _('Select a Pickup Location') }}</h6>
+                    <div class="dropdown-divider"></div>
+                    {% for location in locations %}
+                    <a class="dropdown-item"
+                      id="{{ location.code }}"
+                      href="{{ url_for('item.patron_request', viewcode=viewcode, item_pid=item.pid, pickup_location_pid=location.pid)}}">
+                      {{ location.pickup_name }}
+                    </a>
+                    {% endfor %}
+                  </div>
                 </div>
-              </div>
+              {%- elif reasons %}
+                <div class="action-buttons">
+                  <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true" title="{{ reasons | join('<br/>') }}">
+                    <button type="submit" class="btn btn-primary mt-1" disabled>
+                      {{ _('Request') }}
+                    </button>
+                  </span>
+                </div>
+              {%- endif %}
             {%- endif %}
           </div>
        {%- endfor %}

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -549,6 +549,8 @@ def patron_profile(patron):
                 loan=loan
             )
             loan['can_renew'] = can
+            if not can:
+                loan['can_renew_reasons'] = reasons
             loans.append(loan)
         elif loan['state'] in [
                 LoanState.PENDING,

--- a/rero_ils/modules/patron_types/api.py
+++ b/rero_ils/modules/patron_types/api.py
@@ -157,8 +157,8 @@ class PatronType(IlsRecord):
 
         # check fee amount limit
         if not patron_type.check_fee_amount_limit(patron):
-            return False, [_('Checkout denied: the maximal fee amount is '
-                             'reached')]
+            return False, [_('Checkout denied: the maximal overdue fee amount '
+                             'is reached')]
 
         return True, []
 
@@ -185,8 +185,8 @@ class PatronType(IlsRecord):
 
         # check fee amount limit
         if not patron_type.check_fee_amount_limit(patron):
-            return False, [_('Request denied: the maximal fee amount is '
-                             'reached')]
+            return False, [_('Request denied: the maximal overdue fee amount '
+                             'is reached')]
 
         return True, []
 
@@ -213,8 +213,8 @@ class PatronType(IlsRecord):
 
         # check fee amount limit
         if not patron_type.check_fee_amount_limit(patron):
-            return False, [_('Renewal denied: the maximal fee amount is '
-                             'reached')]
+            return False, [_('Renewal denied: the maximal overdue fee amount '
+                             'is reached')]
         return True, []
 
     def get_linked_patron(self):
@@ -302,7 +302,7 @@ class PatronType(IlsRecord):
         if not global_limit:
             return True, None
 
-        # [0] get the stats fr this patron by library
+        # [0] get the stats for this patron by library
         patron_library_stats = get_loans_count_by_library_for_patron_pid(
             patron.pid, [LoanState.ITEM_ON_LOAN])
 

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -104,13 +104,13 @@
           ],
           "properties": {
             "global_limit": {
-              "title": "Global checkout limit",
+              "title": "Number of checkouts in the organisation",
               "description": "The checkout is blocked once the specified checkout number is reached by the patron. This is a global checkout limit.",
               "type": "number",
               "minimum": 1
             },
             "library_limit": {
-              "title": "Default checkout limit by library",
+              "title": "Number of checkouts by library",
               "description": "The checkout is blocked once the specified checkout number is reached by the patron for items of the same owning library. This is the same limit for all libraries.",
               "type": "number",
               "minimum": 1
@@ -181,8 +181,8 @@
           ],
           "properties": {
             "default_value": {
-              "title": "Default fee amount limit",
-              "description": "The checkout, renewal and the request are blocked once the specified fee amount is reached by the patron.",
+              "title": "Fee amount",
+              "description": "The checkout, renewal and the request are blocked once the specified overdue fee amount is reached by the patron.",
               "type": "number",
               "minimum": 0
             }
@@ -194,7 +194,7 @@
             ],
             "templateOptions": {
               "toggle-switch": {
-                "label": "Limit by fee amount"
+                "label": "Limit by overdue fee amount"
               }
             }
           }
@@ -207,7 +207,7 @@
           ],
           "properties": {
             "default_value": {
-              "title": "Default overdue items limit",
+              "title": "Number of overdue items",
               "description": "The checkout, renewal and the request are blocked once the specified number of overdue items is reached by the patron.",
               "type": "number",
               "minimum": 1

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -405,7 +405,7 @@ class Patron(IlsRecord):
 
         # a blocked patron can't request any item
         if patron.is_blocked:
-            return False, [patron.blocked_message]
+            return False, [patron.get_blocked_message()]
 
         return True, []
 
@@ -426,7 +426,7 @@ class Patron(IlsRecord):
 
         # a blocked patron can't request any item
         if patron.is_blocked:
-            return False, [patron.blocked_message]
+            return False, [patron.get_blocked_message()]
 
         return True, []
 
@@ -578,12 +578,16 @@ class Patron(IlsRecord):
         """Shortcut to know if user is blocked."""
         return self.patron.get('blocked', False)
 
-    @property
-    def blocked_message(self):
-        """Get the message in case of patron is blocked."""
+    def get_blocked_message(self, public=False):
+        """Get the message in case of patron is blocked.
+
+        :param public: Is the message is for public interface ?
+        """
+        main = _('Your account is currently blocked.') if public \
+            else _('This patron is currently blocked.')
         if self.is_blocked:
             return '{main} {reason_str}: {reason}'.format(
-                main=_('This patron is currently blocked.'),
+                main=main,
                 reason_str=_('Reason'),
                 reason=self.patron.get('blocked_note')
             )
@@ -688,12 +692,13 @@ class Patron(IlsRecord):
         """
         return Patron.record_pid_exists(user_pid)
 
-    def get_circulation_messages(self):
+    def get_circulation_messages(self, public=False):
         """Return messages useful for circulation.
 
         * check if the user is blocked ?
         * check if the user reaches the maximum loans limit ?
 
+        :param public: is messages are for public interface ?
         :return an array of messages. Each message is a dictionary with a level
                 and a content. The level could be used to filters messages if
                 needed.
@@ -706,27 +711,35 @@ class Patron(IlsRecord):
         if self.is_blocked:
             return [{
                 'type': 'error',
-                'content': self.blocked_message
+                'content': self.get_blocked_message(public)
             }]
 
         messages = []
-        # check the patron type define limit
-        patron_type = PatronType.get_record_by_pid(self.patron_type_pid)
-        valid, message = patron_type.check_checkout_count_limit(self)
-        if not valid:
-            messages.append({
-                'type': 'error',
-                'content': message
-            })
-        # check fee amount limit
-        valid = patron_type.check_fee_amount_limit(self)
-        if not valid:
-            messages.append({
-                'type': 'error',
-                'content': _(
-                    'Transactions denied: the maximal fee amount is reached.')
-            })
-
+        # other messages must be only rendered for the professional interface
+        if not public:
+            # check the patron type define limit
+            patron_type = PatronType.get_record_by_pid(self.patron_type_pid)
+            valid, message = patron_type.check_checkout_count_limit(self)
+            if not valid:
+                messages.append({
+                    'type': 'error',
+                    'content': message
+                })
+            # check fee amount limit
+            if not patron_type.check_fee_amount_limit(self):
+                messages.append({
+                    'type': 'error',
+                    'content': _(
+                        'Transactions denied: the maximal overdue fee amount '
+                        'is reached.')
+                })
+            # check the patron type overdue limit
+            if not patron_type.check_overdue_items_limit(self):
+                messages.append({
+                    'type': 'error',
+                    'content': _('Checkout denied: the maximal number of '
+                                 'overdue items is reached')
+                })
         return messages
 
 

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_loans.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_loans.html
@@ -71,8 +71,8 @@
           {% endif %}
         </div>
         <div class="col-lg-2 text-right">
-          {% if loan.can_renew %}
-          {%- with form = can_renew_form %}
+          {% if loan.can_renew -%}
+            {%- with form = can_renew_form %}
             <form action="{{ url_for('patrons.profile') }}" method="POST" name="can_renew_form">
               <input type="hidden" name="type" value="renew">
               <input type="hidden" name="loan_pid" value="{{ loan.pid }}">
@@ -80,8 +80,14 @@
                 {{ _('Renew') }}
               </button>
             </form>
-          {%- endwith %}
-          {% endif %}
+            {%- endwith %}
+          {%- else -%}
+            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true" title="{{ loan.can_renew_reasons | join('<br/>') }}">
+            <button type="submit" class="btn btn-primary mt-1" disabled>
+              {{ _('Renew') }}
+            </button>
+            </span>
+          {%- endif %}
         </div>
       </div>
       <div id="loan-{{ loan.pid }}" class="mt-1 ng-star-inserted d-none">

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_requests.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_requests.html
@@ -49,7 +49,7 @@
         <div class="col-lg-2{% if loan.state == 'ITEM_AT_DESK' %} text-success{% endif %}">
           {% if loan.state == 'ITEM_AT_DESK' %}
           <i class="fa fa-check"  title="{{ _('item at desk') }}" aria-hidden="true"></i>
-          {{ _('ready') }}
+          {{ _('to pick up') }}
           {% elif loan.state in ['PENDING', 'ITEM_IN_TRANSIT_FOR_PICKUP'] %}
           <i class="fa fa-bullseye"  title="{{ _('pending') }}" aria-hidden="true"></i>
           <!-- TODO: Add expired date and remove "waiting" text

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -23,15 +23,13 @@
 {% include('rero_ils/_patron_profile_head.html') %}
 
 <section>
-  {% for key, data in alerts.items() %}
-    {% for message in data['messages'] %}
-      <div class="alert alert-{{ data['level'] }}" role="alert">{{ message }}</div>
-    {% endfor %}
+  {% for message in messages %}
+    <div class="alert alert-{{ message['type'] }}" role="alert">{{ message['content'] }}</div>
   {% endfor %}
   {% set note=record.notes|selectattr('type', '==', 'public_note')|list|last%}
   {% if note %}
   <div class="alert alert-warning" role="alert">
-    {{note. content.replace('\n', '<br>')|safe}}
+    {{note.content.replace('\n', '<br>')|safe}}
   </div>
   {% endif %}
 </section>

--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -39,4 +39,4 @@ def get_patron_from_arguments(**kwargs):
     return kwargs.get('patron') \
         or Patron.get_patron_by_barcode(kwargs.get('patron_barcode')) \
         or Patron.get_record_by_pid(kwargs.get('patron_pid')) \
-        or Patron.get_record_by_pid(kwargs.get('loan').get('patron_id'))
+        or Patron.get_record_by_pid(kwargs.get('loan').get('patron_pid'))

--- a/rero_ils/static/scss/rero_ils/styles.scss
+++ b/rero_ils/static/scss/rero_ils/styles.scss
@@ -92,6 +92,15 @@ html [type=button] {
   color: $secondary;
 }
 
+button:disabled:hover {
+  cursor: not-allowed;
+}
+
+div.tooltip div.tooltip-inner{
+  text-align: left;
+  max-width: 400px;
+}
+
 /*
  *********************************
 

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -305,7 +305,7 @@ def test_overdue_limit(
         )
     )
     assert res.status_code == 403
-    assert 'maximal fee amount is reached' in data['message']
+    assert 'maximal overdue fee amount is reached' in data['message']
 
     # [2.2] test fee amount limit when we try to request another item
     res, data = postdata(
@@ -320,7 +320,7 @@ def test_overdue_limit(
         )
     )
     assert res.status_code == 403
-    assert 'maximal fee amount is reached' in data['message']
+    assert 'maximal overdue fee amount is reached' in data['message']
 
     # [2.3] test fee amount limit when we try to extend loan
     res, _ = postdata(
@@ -334,7 +334,7 @@ def test_overdue_limit(
     )
 
     assert res.status_code == 403
-    assert 'maximal fee amount is reached' in data['message']
+    assert 'maximal overdue fee amount is reached' in data['message']
 
     # reset the patron_type with default value
     del patron_type['limits']

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -457,14 +457,17 @@ def test_document_can_request_view(
         'rero_ils.modules.documents.views.current_user',
         patron_martigny_no_email.user
     ):
-        assert can_request(item_lib_fully)
-        assert not can_request(item_lib_sion)
+        can, _ = can_request(item_lib_fully)
+        assert can
+        can, _ = can_request(item_lib_sion)
+        assert not can
 
     with mock.patch(
         'rero_ils.modules.documents.views.current_user',
         patron2_martigny_no_email.user
     ):
-        assert not can_request(item_lib_fully)
+        can, _ = can_request(item_lib_fully)
+        assert not can
 
     picks = item_library_pickup_locations(item_lib_fully)
     assert len(picks) == 3

--- a/tests/api/patrons/test_patrons_blocked.py
+++ b/tests/api/patrons/test_patrons_blocked.py
@@ -32,6 +32,7 @@ def test_blocked_field_exists(
         patron3_martigny_blocked_no_email):
     """Test ptrn6 have blocked field present and set to False."""
     login_user_via_session(client, librarian_martigny_no_email.user)
+    patron3 = patron3_martigny_blocked_no_email
 
     # non blocked patron
     non_blocked_patron_url = url_for(
@@ -53,9 +54,9 @@ def test_blocked_field_exists(
     assert 'blocked' in data['metadata']['patron']
     assert data['metadata']['patron']['blocked'] is True
 
-    assert patron3_martigny_blocked_no_email.is_blocked
-    note = patron3_martigny_blocked_no_email.patron.get('blocked_note')
-    assert note and note in patron3_martigny_blocked_no_email.blocked_message
+    assert patron3.is_blocked
+    note = patron3.patron.get('blocked_note')
+    assert note and note in patron3.get_blocked_message()
 
 
 def test_blocked_field_not_present(

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -53,8 +53,8 @@ def test_item_can_request(
     )
     assert res.status_code == 401
 
-    result = can_request(item_lib_martigny)
-    assert not result
+    can, _ = can_request(item_lib_martigny)
+    assert not can
 
     login_user_via_session(client, librarian_martigny_no_email.user)
     # valid test


### PR DESCRIPTION
If the patron can't operate an action due to circulation restrictions
(patron blocked, patron type limits, ...), circulation buttons should be
hide. In the patron profile view, adds warning/error messages depending
of patron restrictions.

Closes rero/rero-ils#1357
Closes rero/rero-ils#1356

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## How to test?

![image](https://user-images.githubusercontent.com/10031585/97972358-ad1bae00-1dc4-11eb-9285-3bcbd1b85e28.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
