### PR TITLE
patrons: fix subscriptions renewal problem.

### DIFF
--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -20,7 +20,6 @@
 from datetime import datetime
 from functools import partial
 
-from elasticsearch_dsl import Q
 from flask import current_app
 from flask_login import current_user
 from flask_security.confirmable import confirm_user
@@ -426,8 +425,7 @@ class Patron(IlsRecord):
         """Get patrons linked to patron_type that haven't any subscription."""
         query = PatronsSearch() \
             .filter('term', patron__type__pid=patron_type_pid) \
-            .filter('bool', must_not=[
-                Q('exists', field="patron__subscriptions")])
+            .exclude('exists', field='patron.subscriptions')
         for res in query.source('pid').scan():
             yield Patron.get_record_by_pid(res.pid)
 

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -114,9 +114,9 @@ def test_patron_has_valid_subscriptions(
     patron_sion.add_subscription(patron_type_grown_sion, start, end)
     # !! As `add_subscription` use the method `Patron.update`, then the signal
     #    `after_record_update` are send by invenio_records and the patron
-    #    listener `reate_subscription_patron_transaction` is called. This
+    #    listener `create_subscription_patron_transaction` is called. This
     #    listener found that user doesn't have any subscription and add a valid
-    #    one for this patron. So after `add_subscription` call, i just removed
+    #    one for this patron. So after `add_subscription` call, I just removed
     #    the valid subscription created.
     del patron_sion['patron']['subscriptions'][1]
     assert not patron_sion.has_valid_subscription


### PR DESCRIPTION
The method to retrieve patrons without valid subscriptions doesn't
works as expected. Each day, a new subscription will be added for all
patrons linked to patron_type requiring a subscription, even if they
have a valid one.
This commit fixes this problem.

Closes rero/rero-ils#1317

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
