### PR TITLE
tests: force npm version for github actions

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -16,6 +16,11 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - name: Setup node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+
     - name: Docker compose up
       run: docker-compose up -d
 


### PR DESCRIPTION
* Uses `actions/setup-node@v1` to force the npm version for all github
actions tests.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
