### PR TITLE
transactions: fix paid fees still opened

### DIFF
--- a/tests/api/test_patron_payments_rest.py
+++ b/tests/api/test_patron_payments_rest.py
@@ -46,7 +46,7 @@ def test_patron_payment(
     del payment['pid']
     payment['type'] = 'payment'
     payment['subtype'] = 'cash'
-    payment['amount'] = 1.00
+    payment['amount'] = 0.54
     payment['operator'] = {'$ref': get_ref_for_pid(
         'patrons', librarian_martigny_no_email.pid)}
     res, _ = postdata(
@@ -56,13 +56,13 @@ def test_patron_payment(
     )
     assert res.status_code == 201
     transaction = PatronTransaction.get_record_by_pid(transaction.pid)
-    assert transaction.total_amount == calculated_amount - 1.00
+    assert transaction.total_amount == 1.46
     assert transaction.status == 'open'
 
     # full payment
     payment['type'] = 'payment'
     payment['subtype'] = 'cash'
-    payment['amount'] = transaction.total_amount
+    payment['amount'] = 1.46
     res, _ = postdata(
         client,
         post_entrypoint,


### PR DESCRIPTION
The bit representation of real number
(https://en.wikipedia.org/wiki/IEEE_754) cause problem with arithmetic
operation on them (10-9.54 = 0.460000000000085). This commit fixes this
problem by multiplying transaction amount by 100 and cast them into
integer when arithmetic operations are done.

Closes rero/rero-ils#1373

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
