### PR TITLE
circulation: check in an item with no loans

### DIFF
--- a/tests/ui/circulation/test_actions_checkin.py
+++ b/tests/ui/circulation/test_actions_checkin.py
@@ -51,11 +51,13 @@ def test_checkin_on_item_on_shelf_no_requests(
     params['transaction_library_pid'] = lib_fully.pid
     with pytest.raises(NoCirculationAction):
         item, actions = item_lib_martigny.checkin(**params)
-        assert item.status == ItemStatus.IN_TRANSIT
-    params['transaction_library_pid'] = lib_fully.pid
+    item = Item.get_record_by_pid(item_lib_martigny.pid)
+    assert item.status == ItemStatus.IN_TRANSIT
+    params['transaction_library_pid'] = lib_martigny.pid
     with pytest.raises(NoCirculationAction):
         item, actions = item_lib_martigny.checkin(**params)
-        assert item.status == ItemStatus.IN_TRANSIT
+    item = Item.get_record_by_pid(item_lib_martigny.pid)
+    assert item.status == ItemStatus.ON_SHELF
 
 
 def test_checkin_on_item_on_shelf_with_requests(


### PR DESCRIPTION
Fixes a bug when checking in an on_shelf or in_transit item (with no
loans) that did not receive the correct item status.

* Closes #1334

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
