### PR TITLE
public ui: improve displayed information

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -1251,7 +1251,7 @@ class ItemCirculation(IlsRecord):
         """Get availability for item."""
         return self.item_has_active_loan_or_request() == 0
 
-    def get_item_end_date(self, format='short'):
+    def get_item_end_date(self, format='short', time_format='medium'):
         """Get item due date for a given item."""
         loan = get_loan_for_item(item_pid_to_object(self.pid))
         if loan:
@@ -1259,7 +1259,7 @@ class ItemCirculation(IlsRecord):
             due_date = format_date_filter(
                 end_date,
                 date_format=format,
-                time_format=None,
+                time_format=time_format,
                 locale=current_i18n.locale.language,
             )
             return due_date

--- a/rero_ils/modules/items/views.py
+++ b/rero_ils/modules/items/views.py
@@ -132,7 +132,7 @@ def item_availability_text(item):
     else:
         text = ''
         if item.status == ItemStatus.ON_LOAN:
-            due_date = item.get_item_end_date(format='short')
+            due_date = item.get_item_end_date(format='short', time_format=None)
             text = '{msg} {date}'.format(
                 msg=_('due until'),
                 date=due_date)

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_head.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_head.html
@@ -20,16 +20,7 @@
   <div class="rero-ils-person-icon col-sm-2 col-lg-1">
     <i class="fa fa-user fa-5x"></i>
   </div>
-  <hgroup class="col-sm-10 col-lg-11 align-self-end">
+  <hgroup class="col-sm-10 col-lg-11 align-self-center">
     <h1 class="mb-0">{{ record.first_name }} {{ record.last_name }}</h1>
-    {% if record.birth_date %}
-      <p>
-        <b>{{ _('Date of birth') }}:</b> {{ record.birth_date | format_date(
-          date_format='medium',
-          time_format=None,
-          locale=current_i18n.locale.language
-        )}}
-      </p>
-    {% endif %}
   </hgroup>
 </header>

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html
@@ -35,7 +35,7 @@
   <dt class="col-lg-3">{{_('Email')}}:</dt>
   <dd class="col-lg-9 mb-0">{{ record.email }}</dd>
   {% endif %}
-  <dt class="col-lg-3">{{_('Barcode')}}:</dt>
+  <dt class="col-lg-3">{{_('Patron number')}}:</dt>
   <dd class="col-lg-9 mb-0">{{ record.patron.barcode }}</dd>
   <dt class="col-lg-3">{{_('Account expiration')}}:</dt>
   <dd class="col-lg-9 mb-0">{{ record.patron.expiration_date | format_date(

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -337,7 +337,7 @@ def test_item_holding_document_availability(
         'rero_ils.modules.items.api.circulation.current_i18n',
         current_i18n
     ):
-        end_date = item.get_item_end_date()
+        end_date = item.get_item_end_date(time_format=None)
         assert item_availability_text(item) == 'due until ' + end_date
 
     """


### PR DESCRIPTION
In the public interface, when an item is "on loan" the due date
displayed contains the time. The time information isn't necessary to be
displayed.

The birth date should not be displayed in the patron profile view in the
public interface.

Closes rero/rero-ils#1398
Closes rero/rero-ils#1386
Closes rero/rero-ils#1385

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
