### PR TITLE
serials: manage serial claims

### DIFF
--- a/data/patterns.json
+++ b/data/patterns.json
@@ -19,7 +19,7 @@
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "next_expected_date": "2020-03-01",
+      "next_expected_date": "2010-03-01",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
@@ -60,7 +60,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1013",
-      "next_expected_date": "2020-01-02",
+      "next_expected_date": "2010-01-02",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
@@ -92,7 +92,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} Edition {{first_chronology.level_1}}",
       "frequency": "rdafr:1013",
-      "next_expected_date": "2020-06-01",
+      "next_expected_date": "2010-06-01",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
@@ -124,7 +124,7 @@
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1014",
-      "next_expected_date": "2020-03-03",
+      "next_expected_date": "2010-03-03",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
@@ -188,7 +188,7 @@
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} Heft {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "next_expected_date": "2020-09-01",
+      "next_expected_date": "2010-09-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -227,7 +227,7 @@
     "patterns": {
       "template": "ann\u00e9e {{first_chronology.level_1}} no {{first_enumeration.level_1}} {{second_chronology.level_2}} {{second_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "next_expected_date": "2020-03-20",
+      "next_expected_date": "2010-03-20",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
@@ -285,7 +285,7 @@
     "patterns": {
       "template": "N\u02da {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "next_expected_date": "2020-03-20",
+      "next_expected_date": "2010-03-20",
       "values": [
         {
           "name": "first_enumeration",
@@ -321,7 +321,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1007",
-      "next_expected_date": "2020-01-15",
+      "next_expected_date": "2010-01-15",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
@@ -364,7 +364,7 @@
     "patterns": {
       "template": "Ann\u00e9e {{first_enumeration.level_1}} no {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "next_expected_date": "2020-06-01",
+      "next_expected_date": "2010-06-01",
       "max_number_of_claims": 3,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,

--- a/data/vendors.json
+++ b/data/vendors.json
@@ -316,59 +316,5 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/3"
     }
-  },
-  {
-    "pid": "19",
-    "name": "Flourish and Blotts Bookseller",
-    "website": "http://www.flourishandblotts.com",
-    "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor7@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
-    "currency": "EUR",
-    "vat_rate": 20,
-    "organisation": {
-      "$ref": "https://ils.rero.ch/api/organisations/1"
-    }
-  },
-  {
-    "pid": "20",
-    "name": "Flourish and Blotts Bookseller",
-    "website": "http://www.flourishandblotts.com",
-    "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor7@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
-    "currency": "EUR",
-    "vat_rate": 20,
-    "organisation": {
-      "$ref": "https://ils.rero.ch/api/organisations/2"
-    }
-  },
-  {
-    "pid": "21",
-    "name": "Flourish and Blotts Bookseller",
-    "website": "http://www.flourishandblotts.com",
-    "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor7@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
-    "currency": "EUR",
-    "vat_rate": 20,
-    "organisation": {
-      "$ref": "https://ils.rero.ch/api/organisations/3"
-    }
   }
 ]

--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -74,7 +74,7 @@
   </a>
   {%- endif %}
   {%- for holding in holdings %}
-  {% set items = holding.get_items %}
+  {% set items = holding.get_items | sort(attribute='enumerationAndChronology', reverse=True) %}
   {% set number_items = holding.get_items_count_by_holding_pid %}
   {% if record.harvested or number_items >= 0 %}
   <!-- Card header -->

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -45,6 +45,7 @@ from ..organisations.api import Organisation
 from ..providers import Provider
 from ..utils import extracted_data_from_ref, get_ref_for_pid, \
     get_schema_for_resource
+from ..vendors.api import Vendor
 
 # holing provider
 HoldingProvider = type(
@@ -224,6 +225,33 @@ class Holding(IlsRecord):
         for item_pid in Item.get_items_pid_by_holding_pid(self.pid):
             items.append(Item.get_record_by_pid(item_pid))
         return Holding.isAvailable(items)
+
+    @property
+    def max_number_of_claims(self):
+        """Shortcut to return the max_number_of_claims."""
+        return self.get('patterns', {}).get('max_number_of_claims')
+
+    @property
+    def days_before_first_claim(self):
+        """Shortcut to return the days_before_first_claim."""
+        return self.get('patterns', {}).get('days_before_first_claim')
+
+    @property
+    def days_before_next_claim(self):
+        """Shortcut to return the days_before_next_claim."""
+        return self.get('patterns', {}).get('days_before_next_claim')
+
+    @property
+    def vendor_pid(self):
+        """Shortcut for vendor pid of the holding."""
+        return self.replace_refs().get('vendor', {}).get('pid')
+
+    @property
+    def vendor(self):
+        """Shortcut to return the vendor record."""
+        if self.vendor_pid:
+            return Vendor.get_record_by_pid(self.vendor_pid)
+        return None
 
     @property
     def notes(self):

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -18,6 +18,7 @@
     "circulation_category",
     "location",
     "holdings_type",
+    "vendor",
     "enumerationAndChronology",
     "supplementaryContent",
     "index",
@@ -142,6 +143,9 @@
         "frequency"
       ],
       "propertiesOrder": [
+        "max_number_of_claims",
+        "days_before_first_claim",
+        "days_before_next_claim",
         "template",
         "frequency",
         "next_expected_date",
@@ -449,11 +453,19 @@
     "vendor": {
       "title": "Vendor",
       "type": "object",
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Vendor URI",
           "type": "string",
-          "pattern": "^https://ils.rero.ch/api/vendors/.*?$"
+          "pattern": "^https://ils.rero.ch/api/vendors/.*?$",
+          "form": {
+            "remoteOptions": {
+              "type": "vendors"
+            }
+          }
         }
       }
     },

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -26,7 +26,6 @@ from invenio_search import current_search
 
 from .circulation import ItemCirculation
 from .issue import ItemIssue
-from .record import ItemRecord
 from ..models import ItemIdentifier, ItemMetadata
 from ..utils import item_pid_to_object
 from ...api import IlsRecordError, IlsRecordsIndexer, IlsRecordsSearch
@@ -88,7 +87,7 @@ class ItemsSearch(IlsRecordsSearch):
         current_search.flush_and_refresh(cls.Meta.index)
 
 
-class Item(ItemRecord, ItemCirculation, ItemIssue):
+class Item(ItemCirculation, ItemIssue):
     """Item class."""
 
     minter = item_id_minter

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -32,11 +32,11 @@ from invenio_pidstore.errors import PersistentIdentifierError
 from invenio_records_rest.utils import obj_or_import_string
 from invenio_search import current_search
 
+from .record import ItemRecord
 from ..decorators import add_action_parameters_and_flush_indexes, \
     check_operation_allowed
 from ..models import ItemCirculationAction, ItemStatus
 from ..utils import item_pid_to_object
-from ...api import IlsRecord
 from ...circ_policies.api import CircPolicy
 from ...documents.api import Document
 from ...errors import NoCirculationAction
@@ -48,7 +48,7 @@ from ...patrons.api import Patron
 from ....filter import format_date_filter
 
 
-class ItemCirculation(IlsRecord):
+class ItemCirculation(ItemRecord):
     """Item circulation class."""
 
     statuses = {

--- a/rero_ils/modules/items/api/issue.py
+++ b/rero_ils/modules/items/api/issue.py
@@ -17,10 +17,15 @@
 
 """API for manipulating the item issue."""
 
-from ...api import IlsRecord
+from datetime import datetime, timezone
+
+import ciso8601
+
+from .record import ItemRecord
+from ..models import ItemIssueStatus
 
 
-class ItemIssue(IlsRecord):
+class ItemIssue(ItemRecord):
     """Item issue class."""
 
     @property
@@ -47,3 +52,199 @@ class ItemIssue(IlsRecord):
     def issue_status_date(self):
         """Shortcut for issue status date."""
         return self.get('issue', {}).get('status_date')
+
+    @property
+    def claims_count(self):
+        """Shortcut for the issue claims_count."""
+        return self.get('issue', {}).get('claims_count', 0)
+
+    @claims_count.setter
+    def claims_count(self, claims_count):
+        self.setdefault('issue', {}).setdefault('claims_count', 0)
+        self['issue']['claims_count'] = claims_count
+
+    @property
+    def vendor_pid(self):
+        """Shortcut for vendor pid if exists."""
+        from ...holdings.api import Holding
+        if self.holding_pid:
+            holding = Holding.get_record_by_pid(self.holding_pid)
+            vendor = holding.vendor
+            if vendor:
+                return vendor.pid
+
+    @classmethod
+    def get_issues_pids_by_status(cls, issue_status, holdings_pid=None):
+        """Return issues pids by status optionally filtered by holdings_pid.
+
+        :param holdings_pid: the holdings pid. If none, return all late issues.
+        :param issue_status: the issue status.
+        :return a generator of issues pid.
+        """
+        from . import ItemsSearch
+        query = ItemsSearch() \
+            .filter('term', issue__status=issue_status) \
+            .filter('term', type='issue')
+        if holdings_pid:
+            query = query.filter('term', holding__pid=holdings_pid)
+        results = query\
+            .params(preserve_order=True) \
+            .sort({'_created': {'order': 'asc'}}) \
+            .source(['pid']).scan()
+        for hit in results:
+            yield hit.pid
+
+    @classmethod
+    def get_issues_by_status(cls, issue_status, holdings_pid=None):
+        """Return all issues by status optionally filtered for a holdings pid.
+
+        :param holdings_pid: the holdings pid. If none, return all late issues.
+        :return a generator of Item.
+        """
+        from . import Item
+        for pid in cls.get_issues_pids_by_status(
+                issue_status, holdings_pid=holdings_pid):
+            yield Item.get_record_by_pid(pid)
+
+    @classmethod
+    def get_late_serial_holdings_pids(cls):
+        """Return pids for all late holdings.
+
+        The holdings is considered late if the it is of type serial and the
+        next expected date has passed (greater than current datetime).
+
+        :return a generator of holdings pid.
+        """
+        from ...holdings.api import HoldingsSearch
+        current_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        query = HoldingsSearch() \
+            .filter('term', holdings_type='serial') \
+            .filter('range',
+                    patterns__next_expected_date={'lte': current_date})
+        results = query\
+            .params(preserve_order=True) \
+            .sort({'_created': {'order': 'asc'}}) \
+            .source(['pid']).scan()
+        for hit in results:
+            yield hit.pid
+
+    @classmethod
+    def receive_next_late_expected_issues(cls, dbcommit=False, reindex=False):
+        """Receive the next late expected issue for all holdings.
+
+        :param reindex: reindex record by record.
+        :param dbcommit: commit record to database.
+
+        :return a count of created issues.
+        """
+        from ...holdings.api import Holding
+        created_issues = 0
+        pids = cls.get_late_serial_holdings_pids()
+        for pid in pids:
+            holding = Holding.get_record_by_pid(pid)
+            issue = holding.receive_regular_issue(
+                dbcommit=dbcommit, reindex=reindex)
+            issue['issue']['status'] = ItemIssueStatus.LATE
+            issue = issue.update(issue, dbcommit=dbcommit, reindex=reindex)
+            created_issues += 1
+        return created_issues
+
+    @classmethod
+    def _process_issue_claim(
+            cls, issue, claims_count, claims_days, modified_issues,
+            dbcommit=False, reindex=False):
+        """Process issue for a new claim.
+
+        :param issue: the issue item record.
+        :param claims_days: claims days parameter to compare with issue age.
+        :param modified_issues: counter to count modified issues.
+        :param reindex: reindex the records.
+        :param dbcommit: commit record to database.
+        :param claims_count: current claim count for this issue.
+
+        :return a count of modified issues.
+        """
+        days = cls._get_issue_status_age(issue)
+        if days >= claims_days:
+            cls._update_issue_status_claims_count(
+                issue, claims_count,
+                dbcommit=dbcommit, reindex=reindex)
+            modified_issues += 1
+        return modified_issues
+
+    @classmethod
+    def _get_issue_status_age(cls, issue):
+        """Return the age of an issue.
+
+        It compares the issue status date with the current timestamp
+
+        :param issue: the issue item record.
+        :return the issue status age in days.
+        """
+        issue_status_date = ciso8601.parse_datetime(
+            issue.issue_status_date)
+        return (datetime.now(timezone.utc) - issue_status_date).days
+
+    @classmethod
+    def _update_issue_status_claims_count(
+            cls, issue, claims_count, dbcommit=False,
+            reindex=False):
+        """Update issue status and claims count.
+
+        It compares the issue status date with the current timestamp
+
+        :param issue: the issue item record.
+        :param claims_count: the current claims_count from the issue.
+        :param reindex: reindex the records.
+        :param dbcommit: commit record to database.
+        """
+        issue['issue']['status'] = ItemIssueStatus.CLAIMED
+        issue.claims_count += 1
+        issue = issue.update(
+            issue, dbcommit=dbcommit, reindex=reindex)
+
+    @classmethod
+    def create_first_and_next_claims(
+            cls, claim_type=None, dbcommit=False, reindex=False):
+        """Claim the late and claimed issues for all holdings.
+
+        :param claim_type: if first, it creates the first claim for the late
+        issues. if value is next, it creates the next claim for the claimed
+        issues.
+        :param reindex: reindex the records.
+        :param dbcommit: commit record to database.
+
+        :return a count of modified issues.
+        """
+        from ...holdings.api import Holding
+
+        modified_issues = 0
+        issues = []
+
+        if claim_type == 'first':
+            issue_status = ItemIssueStatus.LATE
+        elif claim_type == 'next':
+            issue_status = ItemIssueStatus.CLAIMED
+        if issue_status:
+            issues = cls.get_issues_by_status(issue_status=issue_status)
+
+        for issue in issues:
+            email = None
+            holding = Holding.get_record_by_pid(issue.holding_pid)
+            vendor = holding.vendor
+            if vendor:
+                email = vendor.order_email
+            max_number_of_claims = holding.max_number_of_claims
+            if email and max_number_of_claims and \
+                    max_number_of_claims > issue.claims_count:
+                if issue.claims_count == 0 and holding.days_before_first_claim:
+                    modified_issues = cls._process_issue_claim(
+                        issue, issue.claims_count,
+                        holding.days_before_first_claim,
+                        modified_issues, dbcommit=dbcommit, reindex=reindex)
+                elif issue.claims_count and holding.days_before_next_claim:
+                    modified_issues = cls._process_issue_claim(
+                        issue, issue.claims_count,
+                        holding.days_before_next_claim,
+                        modified_issues, dbcommit=dbcommit, reindex=reindex)
+        return modified_issues

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -244,6 +244,12 @@
               "hide"
             ]
           }
+        },
+        "claims_count": {
+          "title": "Issue claims count",
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
         }
       },
       "form": {

--- a/rero_ils/modules/items/listener.py
+++ b/rero_ils/modules/items/listener.py
@@ -42,3 +42,8 @@ def enrich_item_data(sender, json=None, record=None, index=None,
             'pid': lib_pid
         }
         json['available'] = item.available
+        # add vendor name
+        if item.vendor_pid:
+            json['vendor'] = {
+                'pid': item.vendor_pid
+            }

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -101,6 +101,9 @@
           },
           "status_date": {
             "type": "date"
+          },
+          "claims_count": {
+            "type": "integer"
           }
         }
       },
@@ -133,6 +136,13 @@
       },
       "acquisition_date": {
         "type": "date"
+      },
+      "vendor": {
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          }
+        }
       },
       "_created": {
         "type": "date"

--- a/rero_ils/modules/items/serializers/json.py
+++ b/rero_ils/modules/items/serializers/json.py
@@ -24,6 +24,7 @@ from rero_ils.modules.item_types.api import ItemType
 from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.serializers import JSONSerializer
+from rero_ils.modules.vendors.api import Vendor
 
 
 class ItemsJSONSerializer(JSONSerializer):
@@ -58,11 +59,17 @@ class ItemsJSONSerializer(JSONSerializer):
             loc = Location.get_record_by_pid(loc_term.get('key'))
             loc_term['name'] = loc.get('name')
 
-        # Add library name
+        # Add item type name
         for item_type_term in results.get('aggregations', {}).get(
                 'item_type', {}).get('buckets', []):
             item_type = ItemType.get_record_by_pid(item_type_term.get('key'))
             item_type_term['name'] = item_type.get('name')
+
+        # Add vendor name
+        for vendor_term in results.get('aggregations', {}).get(
+                'vendor', {}).get('buckets', []):
+            vendor = Vendor.get_record_by_pid(vendor_term.get('key'))
+            vendor_term['name'] = vendor.get('name')
 
         return super(
             ItemsJSONSerializer, self).post_process_serialize_search(

--- a/rero_ils/modules/items/tasks.py
+++ b/rero_ils/modules/items/tasks.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Celery tasks for item records."""
+
+from __future__ import absolute_import, print_function
+
+from celery import shared_task
+
+from .api import Item
+
+
+@shared_task
+def process_late_claimed_issues(
+    expected_issues_to_late=True, create_first_claim=True,
+        create_next_claim=True, dbcommit=False, reindex=False):
+    """Job to manage serials claims.
+
+    Receives the next late expected issue for all holdings.
+    Creates the first and next claims for a late or claimed issues
+
+    :param expected_issues_to_late: by default creates late issues.
+    :param create_first_claim: by default creates first claims.
+    :param create_next_claim: by default creates next claims.
+    :param reindex: reindex the records.
+    :param dbcommit: commit record to database.
+
+    :return a count of modified and created issues.
+    """
+    expected_issues_to_late_count = 0
+    create_first_claim_count = 0
+    create_next_claim_count = 0
+
+    if expected_issues_to_late:
+        expected_issues_to_late_count = Item.receive_next_late_expected_issues(
+            dbcommit=dbcommit, reindex=reindex)
+    if create_first_claim:
+        create_first_claim_count = Item.create_first_and_next_claims(
+            claim_type='first', dbcommit=dbcommit, reindex=reindex)
+    if create_next_claim:
+        create_next_claim_count = Item.create_first_and_next_claims(
+            claim_type='next', dbcommit=dbcommit, reindex=reindex)
+
+    msg = 'expected_issues_to_late: {expected_issues_to_late_count} '\
+        'create_first_claim: {create_first_claim_count} '\
+        'create_next_claim: {create_next_claim_count} '.format(
+            expected_issues_to_late_count=expected_issues_to_late_count,
+            create_first_claim_count=create_first_claim_count,
+            create_next_claim_count=create_next_claim_count
+        )
+
+    return msg

--- a/rero_ils/modules/vendors/api.py
+++ b/rero_ils/modules/vendors/api.py
@@ -67,6 +67,19 @@ class Vendor(IlsRecord):
         }
     }
 
+    @property
+    def order_email(self):
+        """Shortcut for vendor order email.
+
+        if the order email does not exist, it returns the default contact email
+        """
+        vendor = self.replace_refs()
+        if vendor:
+            return vendor.get(
+                'order_contact', vendor.get(
+                    'default_contact', {})).get('email')
+        return None
+
     def get_number_of_acq_orders(self):
         """Get number of acquisition orders."""
         return AcqOrdersSearch().filter(

--- a/scripts/setup
+++ b/scripts/setup
@@ -440,7 +440,7 @@ then
     info_msg "Start OAI harvesting asynchrone"
     eval ${PREFIX} invenio oaiharvester harvest -n ebooks -q -k
 else
-    eval ${PREFIX} invenio scheduler enable_tasks -n bulk-indexer -n notification-creation -n accounts -n clear_and_renew_subscriptions -v
+    eval ${PREFIX} invenio scheduler enable_tasks -n bulk-indexer -n claims-creation -n notification-creation -n accounts -n clear_and_renew_subscriptions -v
     info_msg "For ebooks harvesting run:"
     msg "\tinvenio oaiharvester harvest -n ebooks -a max=100 -q"
 fi

--- a/setup.py
+++ b/setup.py
@@ -298,6 +298,7 @@ setup(
             'notifications = rero_ils.modules.notifications.tasks',
             'patrons = rero_ils.modules.patrons.tasks',
             'rero_ils_collections = rero_ils.modules.collections.tasks',
+            'claims = rero_ils.modules.items.tasks',
         ],
         'invenio_records.jsonresolver': [
             'acq_accounts = rero_ils.modules.acq_accounts.jsonresolver',

--- a/tests/data/holdings.json
+++ b/tests/data/holdings.json
@@ -224,6 +224,9 @@
     "location": {
       "$ref": "https://ils.rero.ch/api/locations/loc1"
     },
+    "vendor": {
+      "$ref": "https://ils.rero.ch/api/vendors/vndr1"
+    },
     "holdings_type": "serial",
     "enumerationAndChronology": "enumerationAndChronology",
     "supplementaryContent": "supplementaryContent",
@@ -239,7 +242,7 @@
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
       "next_expected_date": "2020-03-01",
-      "max_number_of_claims": 3,
+      "max_number_of_claims": 2,
       "days_before_first_claim": 7,
       "days_before_next_claim": 7,
       "values": [

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -669,7 +669,8 @@ def holding_lib_martigny_w_patterns_data(holdings):
 @pytest.fixture(scope="module")
 def holding_lib_martigny_w_patterns(
     app, journal, holding_lib_martigny_w_patterns_data,
-        loc_public_martigny, item_type_standard_martigny):
+        loc_public_martigny, item_type_standard_martigny,
+        vendor_martigny):
     """Create holding of martigny library with patterns."""
     holding = Holding.create(
         data=holding_lib_martigny_w_patterns_data,

--- a/tests/ui/holdings/test_serial_claims.py
+++ b/tests/ui/holdings/test_serial_claims.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Serial claims tests."""
+
+from __future__ import absolute_import, print_function
+
+from datetime import datetime, timedelta, timezone
+
+from rero_ils.modules.items.api import Item
+from rero_ils.modules.items.models import ItemIssueStatus
+from rero_ils.modules.items.tasks import process_late_claimed_issues
+
+
+def test_late_expected_and_claimed_issues(
+         holding_lib_martigny_w_patterns, holding_lib_sion_w_patterns):
+    """Test automatic change of late expected issues status to late
+    and automatic change to claimed when issue is due"""
+    martigny = holding_lib_martigny_w_patterns
+    sion = holding_lib_sion_w_patterns
+
+    def count_issues(holding):
+        """Get holdings issues counts.
+
+        output format: [late_issues_count, claimed_issues_count]
+        """
+        late_issues = len(list(Item.get_issues_by_status(
+            issue_status=ItemIssueStatus.LATE, holdings_pid=holding.pid)))
+        claimed_issues = len(list(Item.get_issues_by_status(
+            issue_status=ItemIssueStatus.CLAIMED, holdings_pid=holding.pid)))
+        return [late_issues, claimed_issues]
+
+    # these two holdings has no late or claimed issues
+    assert count_issues(martigny) == [0, 0]
+    assert count_issues(sion) == [0, 0]
+
+    # for these holdings records, the next expected date is already passed
+    # system will receive the issue and change its status to late
+    process_late_claimed_issues(dbcommit=True, reindex=True)
+
+    assert count_issues(martigny) == [1, 0]
+    assert count_issues(sion) == [1, 0]
+
+    # create a second late issue for martigny and no more for sion
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)
+                 ).strftime('%Y-%m-%d')
+    tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)
+                ).strftime('%Y-%m-%d')
+    sion['patterns']['next_expected_date'] = tomorrow
+    sion.update(sion, dbcommit=True, reindex=True)
+
+    martigny['patterns']['next_expected_date'] = yesterday
+    martigny.update(martigny, dbcommit=True, reindex=True)
+
+    process_late_claimed_issues(dbcommit=True, reindex=True)
+
+    assert count_issues(martigny) == [2, 0]
+    assert count_issues(sion) == [1, 0]
+
+    # test the claiming process
+
+    # create a first claim for an issue and the claim_counts will increment
+    late_issue = list(Item.get_issues_by_status(
+        issue_status=ItemIssueStatus.LATE, holdings_pid=martigny.pid))[0]
+    late_issue['issue']['status_date'] = \
+        (datetime.now(timezone.utc) - timedelta(
+            days=martigny.days_before_first_claim + 1)).isoformat()
+    late_issue.update(late_issue, dbcommit=True, reindex=True)
+
+    assert late_issue.claims_count == 0
+
+    process_late_claimed_issues(
+        create_next_claim=False, dbcommit=True, reindex=True)
+
+    assert count_issues(martigny) == [1, 1]
+    assert count_issues(sion) == [1, 0]
+    late_issue = Item.get_record_by_pid(late_issue.pid)
+    assert late_issue.claims_count == 1
+
+    # create the next claim for an issue and the claim_counts will increment
+    process_late_claimed_issues(dbcommit=True, reindex=True)
+
+    assert count_issues(martigny) == [1, 1]
+    late_issue = Item.get_record_by_pid(late_issue.pid)
+    assert late_issue.claims_count == 2
+
+    # No more claims will be generated because the max claims reached
+    process_late_claimed_issues(dbcommit=True, reindex=True)
+
+    assert count_issues(martigny) == [1, 1]
+    late_issue = Item.get_record_by_pid(late_issue.pid)
+    assert late_issue.claims_count == 2

--- a/tests/unit/test_holdings_jsonschema.py
+++ b/tests/unit/test_holdings_jsonschema.py
@@ -78,7 +78,8 @@ def test_holdings_all_jsonschema_keys_values(
         {'key': 'supplementaryContent', 'value': 25},
         {'key': 'index', 'value': 25},
         {'key': 'missing_issues', 'value': 25},
-        {'key': 'notes', 'value': 25}
+        {'key': 'notes', 'value': 25},
+        {'key': 'vendor', 'value': 25}
     ]
     for element in validator:
         with pytest.raises(ValidationError):

--- a/tests/unit/test_items_jsonschema.py
+++ b/tests/unit/test_items_jsonschema.py
@@ -36,58 +36,31 @@ def test_required(item_schema, item_lib_martigny_data_tmp):
         validate({}, item_schema)
 
 
-def test_pid(item_schema, item_lib_martigny_data_tmp):
-    """Test pid for item jsonschemas."""
-    validate(item_lib_martigny_data_tmp, item_schema)
-
-    with pytest.raises(ValidationError):
-        item_lib_martigny_data_tmp['pid'] = 25
-        validate(item_lib_martigny_data_tmp, item_schema)
-
-
-def test_type(item_schema, item_lib_martigny_data_tmp):
-    """Test type for item jsonschemas."""
-    validate(item_lib_martigny_data_tmp, item_schema)
-
-    with pytest.raises(ValidationError):
-        item_lib_martigny_data_tmp['type'] = 25
-        validate(item_lib_martigny_data_tmp, item_schema)
-
-
-def test_barcode(item_schema, item_lib_martigny_data_tmp):
-    """Test barcode for item jsonschemas."""
-    validate(item_lib_martigny_data_tmp, item_schema)
-
-    with pytest.raises(ValidationError):
-        item_lib_martigny_data_tmp['barcode'] = 2
-        validate(item_lib_martigny_data_tmp, item_schema)
-
-
-def test_call_number(item_schema, item_lib_martigny_data_tmp):
-    """Test call_number for item jsonschemas."""
-    validate(item_lib_martigny_data_tmp, item_schema)
-
-    with pytest.raises(ValidationError):
-        item_lib_martigny_data_tmp['callNumber'] = 25
-        validate(item_lib_martigny_data_tmp, item_schema)
-
-
-def test_location(item_schema, item_lib_martigny_data_tmp):
-    """Test location for item jsonschemas."""
-    validate(item_lib_martigny_data_tmp, item_schema)
-
-    with pytest.raises(ValidationError):
-        item_lib_martigny_data_tmp['location'] = 25
-        validate(item_lib_martigny_data_tmp, item_schema)
-
-
-def test_item_type(item_schema, item_lib_martigny_data_tmp):
-    """Test location for item jsonschemas."""
-    validate(item_lib_martigny_data_tmp, item_schema)
-
-    with pytest.raises(ValidationError):
-        item_lib_martigny_data_tmp['item_type_pid'] = 25
-        validate(item_lib_martigny_data_tmp, item_schema)
+def test_item_all_jsonschema_keys_values(
+        item_schema, item_lib_martigny_data_tmp):
+    """Test all keys and values for item jsonschema."""
+    record = item_lib_martigny_data_tmp
+    validate(record, item_schema)
+    validator = [
+        {'key': 'pid', 'value': 25},
+        {'key': 'type', 'value': 25},
+        {'key': 'barcode', 'value': 25},
+        {'key': 'call_number', 'value': 25},
+        {'key': 'second_call_number', 'value': 25},
+        {'key': 'item_type', 'value': 25},
+        {'key': 'location', 'value': 25},
+        {'key': 'enumerationAndChronology', 'value': 25},
+        {'key': 'document', 'value': 25},
+        {'key': 'type', 'value': 25},
+        {'key': 'issue', 'value': 25},
+        {'key': 'status', 'value': 25},
+        {'key': 'holding', 'value': 25},
+        {'key': 'organisation', 'value': 25}
+    ]
+    for element in validator:
+        with pytest.raises(ValidationError):
+            record[element['key']] = element['value']
+            validate(record, item_schema)
 
 
 def test_item_notes(item_schema, item_lib_martigny_data_tmp):


### PR DESCRIPTION
Adds a daily job to:

1. Change the issue status to LATE for all expected
issues when the expected date is passed.

2. Change the issue status to CLAIMED for LATE issues
when the corresponding holdings record has a valid vendor
with an email address and max_number_of_claims is not reached.

2.1. Change the issue status to CLAIMED for all LATE
issues when the days_for_first_claim is passed.

2.2. Increment the claims_count field for all CLAIMED
 issue if the days_for_next_claim passed.

The job is scheduled to run every midnight.

* Improves inheritance between the Item, ItemIssue classes.
* Closes #1437
* Closes #1435
* Create tests and fixtures accordingly.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1834?kanban-status=1224894

## How to test?

`bootstap + setup`

- run manually the job (it is scheduled for execution every midnight):
```
poetry run console
from rero_ils.modules.items.tasks import 
process_late_claimed_issues(dbcommit=True, reindex=True)
exit
```
connect as sys_librarian to web interface and see claimed issues in any of the journals.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
