### PR TITLE
patrons: manage patrons without e-mail

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -967,7 +967,6 @@
     "pid": "46",
     "birth_date": "2005-02-03",
     "city": "Tenna",
-    "email": "reroilstest+920014@gmail.com",
     "username": "fabiano",
     "first_name": "Fabiano",
     "roles": [

--- a/rero_ils/accounts_views.py
+++ b/rero_ils/accounts_views.py
@@ -17,13 +17,21 @@
 
 """Invenio Account custom views."""
 
-from flask import current_app
+from flask import after_this_request, current_app
+from flask import request as flask_request
+from invenio_accounts.utils import change_user_password
+from invenio_accounts.views.rest import \
+    ChangePasswordView as BaseChangePasswordView
 from invenio_accounts.views.rest import LoginView as CoreLoginView
-from invenio_accounts.views.rest import use_kwargs
+from invenio_accounts.views.rest import _commit, use_args, use_kwargs
 from invenio_userprofiles.models import UserProfile
+from marshmallow import Schema, fields
 from sqlalchemy.orm.exc import NoResultFound
-from webargs import ValidationError, fields
+from webargs import ValidationError, fields, validate
 from werkzeug.local import LocalProxy
+
+from .modules.patrons.api import Patron, current_patron
+from .modules.patrons.permissions import PatronPermission
 
 current_datastore = LocalProxy(
     lambda: current_app.extensions['security'].datastore)
@@ -65,3 +73,68 @@ class LoginView(CoreLoginView):
         self.verify_login(user, **kwargs)
         self.login_user(user)
         return self.success_response(user)
+
+
+class PasswordPassword(Schema):
+    """Args validation when a user want to change his password."""
+
+    password = fields.String(
+        validate=[validate.Length(min=6, max=128)])
+    new_password = fields.String(
+        required=True, validate=[validate.Length(min=6, max=128)])
+
+
+class UsernamePassword(Schema):
+    """Args validation when a professional change a password for a user."""
+
+    username = fields.String(
+        validate=[validate.Length(min=1, max=128)])
+    new_password = fields.String(
+        required=True, validate=[validate.Length(min=6, max=128)])
+
+
+def make_password_schema(request):
+    """Select the right args validation depending on the context."""
+    # Filter based on 'fields' query parameter
+    fields = request.args.get('fields', None)
+    only = fields.split(',') if fields else None
+    # Respect partial updates for PATCH requests
+    partial = request.method == 'PATCH'
+    if request.json.get('username'):
+        return UsernamePassword(only=only,
+                                partial=partial, context={"request": request})
+
+    # Add current request to the schema's context
+    return PasswordPassword(only=only,
+                            partial=partial, context={"request": request})
+
+
+class ChangePasswordView(BaseChangePasswordView):
+    """View to change the user password."""
+
+    def verify_permission(self, username, **args):
+        """Check permissions.
+
+        Check if the current user can change a password for an other user.
+        """
+        patron = Patron.get_patron_by_username(username)
+        if not PatronPermission.can_create(current_patron, patron, patron):
+            return current_app.login_manager.unauthorized()
+
+    def change_password_for_user(self, username, new_password, **kwargs):
+        """Perform change password for a specific user."""
+        after_this_request(_commit)
+        patron = Patron.get_patron_by_username(username)
+        change_user_password(user=patron.user,
+                             password=new_password)
+
+    @use_args(make_password_schema)
+    def post(self, args):
+        """Change user password."""
+        if flask_request.json.get('username'):
+            self.verify_permission(**args)
+            self.change_password_for_user(**args)
+        else:
+            self.verify_password(**args)
+            self.change_password(**args)
+        return self.success_response()

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -246,7 +246,7 @@ ACCOUNTS_REST_AUTH_VIEWS = {
     "register": "invenio_accounts.views.rest:RegisterView",
     "forgot_password": "invenio_accounts.views.rest:ForgotPasswordView",
     "reset_password": "invenio_accounts.views.rest:ResetPasswordView",
-    "change_password": "invenio_accounts.views.rest:ChangePasswordView",
+    "change_password": "rero_ils.accounts_views:ChangePasswordView",
     "send_confirmation":
         "invenio_accounts.views.rest:SendConfirmationEmailView",
     "confirm_email": "invenio_accounts.views.rest:ConfirmEmailView",
@@ -1774,6 +1774,9 @@ RERO_ILS_QUERY_BOOSTING = {
         'publicationYearText': 2,
         'freeFormedPublicationDate': 2,
         'subjects.*': 2
+    },
+    'patrons': {
+        'barcode': 3
     }
 }
 

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -60,7 +60,7 @@ class IlsRecordError:
     class PidChange(Exception):
         """IlsRecord pid change."""
 
-    class PidAlradyUsed(Exception):
+    class PidAlreadyUsed(Exception):
         """IlsRecord pid already used."""
 
     class PidDoesNotExist(Exception):
@@ -161,15 +161,14 @@ class IlsRecord(Record):
                 from .utils import get_schema_for_resource
                 data['$schema'] = get_schema_for_resource(type)
         pid = data.get('pid')
-        if delete_pid:
-            if pid:
-                del data['pid']
+        if delete_pid and pid:
+            del data['pid']
         else:
             if pid:
                 test_rec = cls.get_record_by_pid(pid)
                 if test_rec is not None:
-                    raise IlsRecordError.PidAlradyUsed(
-                        'PidAlradyUsed {pid_type} {pid} {uuid}'.format(
+                    raise IlsRecordError.PidAlreadyUsed(
+                        'PidAlreadyUsed {pid_type} {pid} {uuid}'.format(
                             pid_type=cls.provider.pid_type,
                             pid=test_rec.pid,
                             uuid=test_rec.id

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -170,7 +170,7 @@
         },
         "validation": {
           "messages": {
-            "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
+            "patternMessage": "The email is not valid."
           }
         }
       }

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -270,6 +270,9 @@ class Patron(IlsRecord):
                     password=hash_password(birth_date),
                     profile=dict(), active=True)
                 db.session.add(user)
+            else:
+                if user.email != data.get('email'):
+                    user.email = data.get('email')
             # update all common fields
             for field in cls.profile_fields:
                 # date field need conversion

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -339,17 +339,38 @@ class Patron(IlsRecord):
     @classmethod
     def get_patron_by_user(cls, user):
         """Get patron by user."""
-        if hasattr(user, 'email'):
-            return cls.get_patron_by_email(email=user.email)
+        if hasattr(user, 'id'):
+            result = PatronsSearch().filter(
+                'term',
+                user_id=user.id
+            ).source(includes='pid').scan()
+            try:
+                pid = next(result).pid
+            except StopIteration:
+                return None
+            return cls.get_record_by_pid(pid)
 
     @classmethod
-    def get_patron_by_email(cls, email=None):
+    def get_patron_by_email(cls, email):
         """Get patron by email."""
         pid_value = cls.get_pid_by_email(email)
         if pid_value:
             return cls.get_record_by_pid(pid_value)
         else:
             return None
+
+    @classmethod
+    def get_patron_by_username(cls, username):
+        """Get patron by username."""
+        result = PatronsSearch().filter(
+            'term',
+            username=username
+        ).source(includes='pid').scan()
+        try:
+            pid = next(result).pid
+        except StopIteration:
+            return None
+        return cls.get_record_by_pid(pid)
 
     @classmethod
     def get_pid_by_email(cls, email):

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -26,6 +26,7 @@
     "last_name",
     "birth_date",
     "username",
+    "user_id",
     "roles"
   ],
   "properties": {
@@ -75,7 +76,7 @@
       "title": "Email",
       "type": "string",
       "format": "email",
-      "pattern": "^.*@.*\\..*$",
+      "pattern": "^.*@.*\\..+$",
       "minLength": 6,
       "form": {
         "validation": {
@@ -113,7 +114,7 @@
     },
     "street": {
       "title": "Street",
-      "description": "Street and number of the address, separated by a coma.",
+      "description": "Street and number of the address.",
       "type": "string",
       "minLength": 3
     },
@@ -265,10 +266,10 @@
           "title": "Additional communication email",
           "type": "string",
           "format": "email",
-          "pattern": "^.*@.*\\..*$",
+          "pattern": "^.*@.*\\..+$",
           "minLength": 6,
           "form": {
-            "hideExpression": "model.communication_channel === 'email'",
+            "hideExpression": "field.parent.model && field.parent.model.communication_channel !== 'email'",
             "messages": {
               "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
             }

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -25,7 +25,6 @@
     "first_name",
     "last_name",
     "birth_date",
-    "email",
     "username",
     "roles"
   ],
@@ -157,6 +156,7 @@
         "barcode",
         "type",
         "communication_channel",
+        "additional_communication_email",
         "communication_language",
         "expiration_date",
         "libraries",
@@ -241,6 +241,7 @@
         },
         "communication_channel": {
           "title": "Communication channel",
+          "description": "For the email channel, the user must have an e-mail. Otherwise, no notifications will be sent.",
           "type": "string",
           "enum": [
             "email",
@@ -258,6 +259,19 @@
                 "value": "mail"
               }
             ]
+          }
+        },
+        "additional_communication_email": {
+          "title": "Additional communication email",
+          "type": "string",
+          "format": "email",
+          "pattern": "^.*@.*\\..*$",
+          "minLength": 6,
+          "form": {
+            "hideExpression": "model.communication_channel === 'email'",
+            "messages": {
+              "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
+            }
           }
         },
         "communication_language": {

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -79,6 +79,9 @@
       "pattern": "^.*@.*\\..+$",
       "minLength": 6,
       "form": {
+        "expressionProperties": {
+          "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))"
+        },
         "validation": {
           "validators": {
             "valueAlreadyExists": {
@@ -87,7 +90,7 @@
             }
           },
           "messages": {
-            "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>.",
+            "patternMessage": "The email is not valid.",
             "alreadyTakenMessage": "This email is already taken."
           }
         }
@@ -270,8 +273,10 @@
           "minLength": 6,
           "form": {
             "hideExpression": "field.parent.model && field.parent.model.communication_channel !== 'email'",
-            "messages": {
-              "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
+            "validation": {
+              "messages": {
+                "patternMessage": "The email is not valid."
+              }
             }
           }
         },
@@ -417,7 +422,7 @@
     },
     "roles": {
       "title": "Role",
-      "description": "Define the roles of the user.",
+      "description": "Define the roles of the user. Please do not remove existing user role, this can have unintended side effects.",
       "type": "array",
       "uniqueItems": true,
       "minItems": 1,

--- a/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
@@ -54,6 +54,9 @@
           }
         }
       },
+      "user_id": {
+        "type": "keyword"
+      },
       "street": {
         "type": "text"
       },

--- a/rero_ils/modules/patrons/permissions.py
+++ b/rero_ils/modules/patrons/permissions.py
@@ -61,7 +61,19 @@ class PatronPermission(RecordPermission):
         """Create permission check.
 
         :param user: Logged user.
-        :param record: Record to check.
+        :param record: pre-existing Record to check.
+        :return: True is action can be done.
+        """
+        incoming_record = request.get_json(silent=True) or {}
+        return cls.can_create(user, record, incoming_record)
+
+    @classmethod
+    def can_create(cls, user, record, incoming_record):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param record: pre-existing Record to check.
+        :param record: new incoming Record data.
         :return: True is action can be done.
         """
         # only staff members (lib, sys_lib) can create patrons ...
@@ -75,7 +87,6 @@ class PatronPermission(RecordPermission):
                     return True
                 # librarian user has some restrictions...
                 if current_patron.is_librarian:
-                    incoming_record = request.get_json(silent=True) or {}
                     # a librarian cannot manage a system_librarian patron
                     if 'system_librarian' in incoming_record.get('roles', [])\
                        or 'system_librarian' in record.get('roles', []):

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_ill_requests.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_ill_requests.html
@@ -38,7 +38,7 @@
       <div class="col mr-1 p-2 border rounded">
         <div class="row pl-2 pr-2">
           <div class="col-lg-6">
-            <button class="pl-0 pt-0 btn btn-toogle" type="button" data-target-id="request-{{ request.pid }}">
+            <button class="pl-0 pt-0 btn btn-toogle" type="button" data-target-id="ill-request-{{ request.pid }}">
               <i class="fa fa-caret-right pr-0"></i>
             </button>
             {{ request.document.title }}
@@ -54,7 +54,7 @@
           </div>
         </div>
 
-        <div id="request-{{ request.pid }}" class="mt-1 ng-star-inserted d-none">
+        <div id="ill-request-{{ request.pid }}" class="mt-1 ng-star-inserted d-none">
           <h6 class="mt-2 mb-2 ng-star-inserted">{{ _('Details') }}</h6>
           <section class="col">
             <div class="row">

--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -24,7 +24,7 @@ from flask_login import current_user
 def user_has_patron(user=current_user):
     """Test if user has a patron."""
     from .api import Patron
-    patron = Patron.get_patron_by_email(email=user.email)
+    patron = Patron.get_patron_by_user(user=user)
     if patron and 'patron' in patron.get('roles'):
         return True
     return False

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -151,7 +151,7 @@
           "title": "Email",
           "type": "string",
           "format": "email",
-          "pattern": "^.*@.*\\..*$",
+          "pattern": "^.*@.*\\..+$",
           "minLength": 6,
           "form": {
             "validation": {
@@ -213,7 +213,7 @@
           "title": "Email",
           "type": "string",
           "format": "email",
-          "pattern": "^.*@.*\\..*$",
+          "pattern": "^.*@.*\\..+$",
           "minLength": 6,
           "form": {
             "validation": {

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -156,7 +156,7 @@
           "form": {
             "validation": {
               "messages": {
-                "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
+                "patternMessage": "The email is not valid."
               }
             }
           }
@@ -218,7 +218,7 @@
           "form": {
             "validation": {
               "messages": {
-                "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
+                "patternMessage": "The email is not valid."
               }
             }
           }

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -28,7 +28,8 @@ from invenio_access.permissions import Permission
 from .modules.patrons.api import Patron
 
 request_item_permission = Permission(RoleNeed('patron'))
-librarian_permission = Permission(RoleNeed('librarian'))
+librarian_permission = Permission(
+    RoleNeed('librarian'), RoleNeed('system_librarian'))
 admin_permission = Permission(RoleNeed('admin'))
 editor_permission = Permission(RoleNeed('editor'), RoleNeed('admin'))
 

--- a/rero_ils/templates/rero_ils/forgot_password.html
+++ b/rero_ils/templates/rero_ils/forgot_password.html
@@ -24,30 +24,35 @@
 
 {% block panel %}
 {%- with form = forgot_password_form %}
-    <div class="card text-center m-4">
-      <h3 class="card-title my-4">{{_('Reset Password')}}</h3>
-      <div class="card-body">
-      {%- if messages %}
-      {%- for category, message in messages %}
-        <p>{{ message }}</p>
-      {%- endfor %}
-      {%- else %}
-      <p class="text-left">{{_('Enter your email address below and we will send you a link to reset your password.')}}</p>
-      <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
+<div class="card text-center m-4">
+  <h3 class="card-title my-4">{{_('Reset Password')}}</h3>
+  <div class="card-body">
+    {%- if messages %}
+    {%- for category, message in messages %}
+    <p>{{ message }}</p>
+    {%- endfor %}
+    {%- else %}
+    <p class="text-left">{{_('Enter your email address below and we will send you a link to reset your password.')}}</p>
+    <div class="alert alert-warning" role="alert">
+      {{_('If you are registered without email, please contact your library.')}}
+    </div>
+    <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
       {{ form.hidden_tag() }}
-      {{ render_field(form.email, icon="fa fa-user", autofocus=True) }}
+      {{ render_field(form.email, icon="fa fa-user", autofocus=True, placeholder=_("email")) }}
       <button type="submit" class="btn btn-primary btn-lg btn-block">{{_('Reset Password')}}</button>
-      </form>
-      {%- endif %}
-    </div>
-
-    {# contents of this if-block can be always shown after mattupstate/flask-security#291 is released. #}
-    {%- if current_user.is_anonymous %}
-    <div class="card-footer">
-        <h4 class="text-muted my-2"><a href="{{url_for('security.login')}}">{{_('Log In')}}</a>{% if security.registerable %} {{_('or')}} <a href="{{url_for('security.register')}}">{{_('Sign Up')}}</a>{% endif %}</h4>
-    </div>
+    </form>
     {%- endif %}
   </div>
+
+  {# contents of this if-block can be always shown after mattupstate/flask-security#291 is released. #}
+  {%- if current_user.is_anonymous %}
+  <div class="card-footer">
+    <h4 class="text-muted my-2"><a
+        href="{{url_for('security.login')}}">{{_('Log In')}}</a>{% if security.registerable %} {{_('or')}} <a
+        href="{{url_for('security.register')}}">{{_('Sign Up')}}</a>{% endif %}</h4>
+  </div>
+  {%- endif %}
+</div>
 </div>
 {%- endwith %}
 {% endblock panel %}

--- a/scripts/setup
+++ b/scripts/setup
@@ -292,7 +292,7 @@ eval ${PREFIX} invenio utils reindex -t cipo --yes-i-know --no-info
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 info_msg "- Users: ${DATA_PATH}/users.json"
-eval ${PREFIX} invenio fixtures import_users ${DATA_PATH}/users.json -v
+eval ${PREFIX} invenio fixtures import_users ${DATA_PATH}/users.json -v --append
 
 info_msg "- ILL requests: ${DATA_PATH}/ill_request.json"
 eval ${PREFIX} invenio fixtures create_ill_requests -f ${DATA_PATH}/ill_requests.json

--- a/tests/api/test_user_authentication.py
+++ b/tests/api/test_user_authentication.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test User Authentication API."""
+from flask import url_for
+from utils import get_json, postdata
+
+
+def test_login(client, patron_sion_no_email):
+    """Test login with several scenarios."""
+
+    # user does not exists
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': 'not@exist.com',
+            'password': ''
+        }
+    )
+    assert res.status_code == 400
+    data = get_json(res)
+    assert data['errors'][0] == dict(
+        field='email', message='USER_DOES_NOT_EXIST')
+
+    # wrong password
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_no_email.get('email'),
+            'password': 'bad'
+        }
+    )
+    assert res.status_code == 400
+    data = get_json(res)
+    assert data['errors'][0] == dict(
+        field='password', message='Invalid password')
+
+    # login by email
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_no_email.get('email'),
+            'password': patron_sion_no_email.get('birth_date')
+        }
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('id')
+    # logout for the next test
+    client.post(url_for('invenio_accounts_rest_auth.logout'))
+
+    # login by username
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_no_email.get('username'),
+            'password': patron_sion_no_email.get('birth_date')
+        }
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('id')
+    # logout for the next test
+    client.post(url_for('invenio_accounts_rest_auth.logout'))
+
+
+def test_login_without_email(client, patron_sion_without_email):
+    """Test login with several scenarios."""
+    # login by username without email
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.login',
+        {
+            'email': patron_sion_without_email.get('username'),
+            'password': patron_sion_without_email.get('birth_date')
+        }
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('id')
+    # logout for the next test
+    client.post(url_for('invenio_accounts_rest_auth.logout'))

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2767,8 +2767,7 @@
     "username": "simonetta",
     "phone": "+41324993585",
     "roles": [
-      "system_librarian",
-      "librarian"
+      "system_librarian"
     ],
     "patron": {
       "expiration_date": "2023-10-07",

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -646,6 +646,27 @@ def patron_sion_no_email(
     return ptrn
 
 
+@pytest.fixture(scope="module")
+@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
+def patron_sion_without_email(
+        app,
+        roles,
+        lib_sion,
+        patron_type_grown_sion,
+        patron_sion_data):
+    """Create Sion patron without sending reset password instruction."""
+    del patron_sion_data['email']
+    patron_sion_data['pid'] = 'ptrn10wthoutemail'
+    patron_sion_data['username'] = 'withoutemail'
+    ptrn = Patron.create(
+        data=patron_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn
+
+
 # ------------ Loans: pending loan ----------
 @pytest.fixture(scope="module")
 def loan_pending_martigny(

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -42,7 +42,7 @@ def test_document_create(db, document_data_tmp):
     assert fetched_pid.pid_value == '1'
     assert fetched_pid.pid_type == 'doc'
 
-    with pytest.raises(IlsRecordError.PidAlradyUsed):
+    with pytest.raises(IlsRecordError.PidAlreadyUsed):
         new_doc = Document.create(doc)
 
 

--- a/tests/ui/notifications/test_notifications_api.py
+++ b/tests/ui/notifications/test_notifications_api.py
@@ -111,6 +111,7 @@ def test_notification_dispatch(app, mailbox):
             return {'loan': {
                 'pid': 'dummy_notification_loan_pid',
                 'patron': {
+                    'pid': 'dummy_patron_pid',
                     'patron': {
                         'communication_channel': self.communication_channel
                     }

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -184,10 +184,11 @@ def test_get_patron(patron_martigny_no_email):
     assert Patron.get_patron_by_barcode(
         patron.patron.get('barcode')) == patron
     assert not Patron.get_patron_by_barcode('not exists')
+    assert Patron.get_patron_by_user(patron.user) == patron
 
     class user:
-        email = patron.get('email')
-    assert Patron.get_patron_by_user(user) == patron
+        pass
+    assert Patron.get_patron_by_user(user) is None
 
 
 def test_user_librarian_can_delete(librarian_martigny):

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -164,6 +164,59 @@ def test_patron_create(app, roles, lib_martigny, librarian_martigny_data_tmp,
     ds.delete_user(user)
 
 
+def test_patron_create_without_email(app, roles, patron_type_children_martigny,
+                                     patron_martigny_data_tmp, mailbox):
+    """Test Patron creation without an email."""
+    del patron_martigny_data_tmp['email']
+
+    # no data has been created
+    mailbox.clear()
+    # assert User.query.count() == 0
+    # assert UserProfile.query.count() == 0
+
+    ptrn = Patron.create(
+        patron_martigny_data_tmp,
+        dbcommit=True,
+        delete_pid=True
+    )
+    user = User.query.filter_by(id=ptrn.get('user_id')).first()
+    assert user
+    assert not user.email
+    assert user == ptrn.user
+    assert user.active
+    assert len(mailbox) == 0
+
+    patron_martigny_data_tmp['email'] = 'test@test.ch'
+    ptrn.replace(
+        data=patron_martigny_data_tmp,
+        dbcommit=True
+    )
+    assert user == ptrn.user
+    assert user.email == patron_martigny_data_tmp['email']
+    assert user.active
+    assert len(mailbox) == 0
+
+    patron_martigny_data_tmp['email'] = 'test@test1.ch'
+    ptrn.replace(
+        data=patron_martigny_data_tmp,
+        dbcommit=True
+    )
+    assert user == ptrn.user
+    assert user.email == patron_martigny_data_tmp['email']
+    assert user.active
+    assert len(mailbox) == 0
+
+    del patron_martigny_data_tmp['email']
+    ptrn.replace(
+        data=patron_martigny_data_tmp,
+        dbcommit=True
+    )
+    assert user == ptrn.user
+    assert not user.email
+    assert user.active
+    assert len(mailbox) == 0
+
+
 def test_patron_organisation_pid(org_martigny, patron_martigny_no_email,
                                  librarian_martigny_no_email):
     """Test organisation pid has been added during the indexing."""

--- a/tests/ui/test_api.py
+++ b/tests/ui/test_api.py
@@ -130,7 +130,7 @@ def test_ilsrecord(app, es_default_index, ils_record, ils_record_2):
         delete_pid=True
     )
     assert record_created_pid.pid == '1'
-    with pytest.raises(IlsRecordError.PidAlradyUsed):
+    with pytest.raises(IlsRecordError.PidAlreadyUsed):
         RecordTest.create(
             data=ils_record,
             dbcommit=True,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import, print_function
 
+from copy import deepcopy
+
 import pytest
 from pkg_resources import resource_string
 from utils import get_schema
@@ -156,6 +158,15 @@ def patron_schema(monkeypatch):
         '/patrons/patron-v0.0.1.json'
     )
     return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture(scope="function")
+def patron_martigny_data_tmp_with_id(patron_martigny_data_tmp):
+    """Load Martigny patron data scope function with a mocked user_id."""
+    patron = deepcopy(patron_martigny_data_tmp)
+    # mock the user_id which is add by the Patron API.
+    patron['user_id'] = 100
+    return patron
 
 
 @pytest.fixture()

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -24,166 +24,166 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
 
-def test_required(patron_schema, patron_martigny_data_tmp):
+def test_required(patron_schema, patron_martigny_data_tmp_with_id):
     """Test required for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
         validate({}, patron_schema)
-        validate(patron_martigny_data_tmp, patron_schema)
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_pid(patron_schema, patron_martigny_data_tmp):
+def test_pid(patron_schema, patron_martigny_data_tmp_with_id):
     """Test pid for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['pid'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['pid'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_first_name(patron_schema, patron_martigny_data_tmp):
+def test_first_name(patron_schema, patron_martigny_data_tmp_with_id):
     """Test first_name for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['first_name'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['first_name'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_last_name(patron_schema, patron_martigny_data_tmp):
+def test_last_name(patron_schema, patron_martigny_data_tmp_with_id):
     """Test last_name for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['last_name'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['last_name'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_street(patron_schema, patron_martigny_data_tmp):
+def test_street(patron_schema, patron_martigny_data_tmp_with_id):
     """Test street for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['street'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['street'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_postal_code(patron_schema, patron_martigny_data_tmp):
+def test_postal_code(patron_schema, patron_martigny_data_tmp_with_id):
     """Test postal_code for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['postal_code'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['postal_code'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_city(patron_schema, patron_martigny_data_tmp):
+def test_city(patron_schema, patron_martigny_data_tmp_with_id):
     """Test city for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['city'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['city'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_username(patron_schema, patron_martigny_data_tmp):
+def test_username(patron_schema, patron_martigny_data_tmp_with_id):
     """Test username for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
-    del(patron_martigny_data_tmp['username'])
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
+    del(patron_martigny_data_tmp_with_id['username'])
     with pytest.raises(ValidationError):
-        validate(patron_martigny_data_tmp, patron_schema)
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_barcode(patron_schema, patron_martigny_data_tmp):
+def test_barcode(patron_schema, patron_martigny_data_tmp_with_id):
     """Test barcode for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['patron']['barcode'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['patron']['barcode'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_birth_date(patron_schema, patron_martigny_data_tmp):
+def test_birth_date(patron_schema, patron_martigny_data_tmp_with_id):
     """Test birth date for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['birth_date'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['birth_date'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_email(patron_schema, patron_martigny_data_tmp):
+def test_email(patron_schema, patron_martigny_data_tmp_with_id):
     """Test email for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     # email is optional
-    del patron_martigny_data_tmp['email']
-    validate(patron_martigny_data_tmp, patron_schema)
+    del patron_martigny_data_tmp_with_id['email']
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     # email with a bad format
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['email'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['email'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_phone(patron_schema, patron_martigny_data_tmp):
+def test_phone(patron_schema, patron_martigny_data_tmp_with_id):
     """Test phone for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['phone'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['phone'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_patron_type(patron_schema, patron_martigny_data_tmp):
+def test_patron_type(patron_schema, patron_martigny_data_tmp_with_id):
     """Test patron_type for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['patron_type_pid'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['patron_type_pid'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_roles(patron_schema, patron_martigny_data_tmp):
+def test_roles(patron_schema, patron_martigny_data_tmp_with_id):
     """Test roles for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['roles'] = 'text'
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['roles'] = 'text'
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_blocked(patron_schema, patron_martigny_data_tmp):
+def test_blocked(patron_schema, patron_martigny_data_tmp_with_id):
     """Test blocked field for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     # blocked is a boolean field, should fail with everything except boolean
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['patron']['blocked'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['patron']['blocked'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['patron']['blocked'] = 'text'
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['patron']['blocked'] = 'text'
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     # Should pass with boolean
-    patron_martigny_data_tmp['patron']['blocked'] = False
-    validate(patron_martigny_data_tmp, patron_schema)
+    patron_martigny_data_tmp_with_id['patron']['blocked'] = False
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_blocked_note(patron_schema, patron_martigny_data_tmp):
+def test_blocked_note(patron_schema, patron_martigny_data_tmp_with_id):
     """Test blocked_note field for patron jsonschemas."""
-    validate(patron_martigny_data_tmp, patron_schema)
+    validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     # blocked_note is text field. Should fail except with text.
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['patron']['blocked_note'] = 25
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['patron']['blocked_note'] = 25
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
     with pytest.raises(ValidationError):
-        patron_martigny_data_tmp['patron']['blocked_note'] = True
-        validate(patron_martigny_data_tmp, patron_schema)
+        patron_martigny_data_tmp_with_id['patron']['blocked_note'] = True
+        validate(patron_martigny_data_tmp_with_id, patron_schema)
 
-    patron_martigny_data_tmp['patron']['blocked_note'] = 'Lost card'
-    validate(patron_martigny_data_tmp, patron_schema)
+    patron_martigny_data_tmp_with_id['patron']['blocked_note'] = 'Lost card'
+    validate(patron_martigny_data_tmp_with_id, patron_schema)

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -87,7 +87,7 @@ def test_city(patron_schema, patron_martigny_data_tmp):
         validate(patron_martigny_data_tmp, patron_schema)
 
 
-def test_username_email(patron_schema, patron_martigny_data_tmp):
+def test_username(patron_schema, patron_martigny_data_tmp):
     """Test username for patron jsonschemas."""
     validate(patron_martigny_data_tmp, patron_schema)
     del(patron_martigny_data_tmp['username'])
@@ -117,6 +117,11 @@ def test_email(patron_schema, patron_martigny_data_tmp):
     """Test email for patron jsonschemas."""
     validate(patron_martigny_data_tmp, patron_schema)
 
+    # email is optional
+    del patron_martigny_data_tmp['email']
+    validate(patron_martigny_data_tmp, patron_schema)
+
+    # email with a bad format
     with pytest.raises(ValidationError):
         patron_martigny_data_tmp['email'] = 25
         validate(patron_martigny_data_tmp, patron_schema)


### PR DESCRIPTION
## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/us/1659?milestone=275632

## Dependencies

https://github.com/rero/rero-ils-ui/pull/411

## How to test?

- Test all features described in the US. "fabiano" has no email anymore.
- This should also close
  - https://github.com/rero/rero-ils/issues/1340
  - https://github.com/rero/rero-ils/issues/1382
  - https://github.com/rero/rero-ils/issues/1381
  - https://github.com/rero/rero-ils/issues/1364

## Fixes needed after the tests:

* Renames `PidAlradyUsed` to `PidAlreadyUsed` exception.
* Changes the email validation message in several resources.
* Fixes update email value from the professional user editor.
* Adds a `append` option to the user creation script. This force to
  increment the PID counter and avoid error for new patron creation.
* Make the user email required when the librarian or system librarian
  role is enable.
* Fixes details document information display in the ILL requests of the
  patron profile.

Implements: https://tree.taiga.io/project/rero21-reroils/us/1659

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
