### PR TITLE
CI: fix github actions

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: 3.6
 
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.2
+      uses: snok/install-poetry@v1.1.1
       with:
         version: 1.0.10
 


### PR DESCRIPTION
* Fixes poetry install in github actions.

Unable to process command '##[add-path]/home/runner/.poetry/bin' successfully.
The `add-path` command is disabled. Please upgrade to using Environment Files or
opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS`
environment variable to `true`. For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
