### PR TITLE
holdings: remove extra titles for some fields in editor

### DIFF
--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -55,12 +55,15 @@
       ],
       "properties": {
         "$ref": {
-          "title": "Circulation type URI",
+          "title": "Circulation category URI",
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/item_types/.*?$",
           "form": {
             "remoteOptions": {
               "type": "item_types"
+            },
+            "templateOptions": {
+              "label": ""
             }
           }
         }
@@ -78,7 +81,13 @@
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/locations/.+?$",
           "form": {
-            "fieldMap": "location"
+            "fieldMap": "location",
+            "remoteOptions": {
+              "type": "locations"
+            },
+            "templateOptions": {
+              "label": ""
+            }
           }
         }
       }
@@ -440,14 +449,19 @@
       ],
       "properties": {
         "$ref": {
+          "title": "Vendor URI",
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/vendors/.*?$",
           "form": {
+            "remoteOptions": {
+              "type": "vendors"
+            },
             "expressionProperties": {
               "templateOptions.required": "false"
             },
-            "remoteOptions": {
-              "type": "vendors"
+            "placeholder": "Choose a vendor",
+            "templateOptions": {
+              "label": ""
             }
           }
         }


### PR DESCRIPTION
Fixes a problem when the title of the fields
location, circulation category and electronic_location
where displayed twice in the holdings editor.

Fixes a problem when librarian can not deselect the
vendor field in the holdings editor.

* Closes #1452
* Closes #1451

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1865?kanban-status=1224894



## How to test?

<img width="885" alt="Screenshot 2020-11-18 at 08 54 58" src="https://user-images.githubusercontent.com/26998238/99501256-d23f1d80-297b-11eb-8250-d8ee902b5547.png">



<img width="996" alt="Screenshot 2020-11-18 at 13 21 11" src="https://user-images.githubusercontent.com/26998238/99530189-45a75600-29a1-11eb-9a4c-b2c7d426ca6b.png">

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
