### PR TITLE
data: fix responsibilityStatement conversion

### DIFF
--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -1502,14 +1502,14 @@ def build_responsibility_data(responsibility_data):
     for data_std in data_std_items:
         out_data = []
         data_value = remove_trailing_punctuation(
-                        data_std.lstrip(), ',.[]', ':;/-=')
+                        data_std.lstrip(), ',.', ':;/-=')
         if data_value:
             out_data.append({'value': data_value})
             if lang:
                 try:
                     data_lang_value = \
                         remove_trailing_punctuation(
-                            data_lang_items[index].lstrip(), ',.[]', ':;/-=')
+                            data_lang_items[index].lstrip(), ',.', ':;/-=')
                     if not data_lang_value:
                         raise Exception('missing data')
                 except Exception as err:

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -354,6 +354,52 @@ def test_marc21_to_pid():
     assert data.get('pid') is None
 
 
+def test_marc21_to_title_245_with_sufield_c_having_square_bracket():
+    """Test dojson test_marc21_to_title_245_without_246.
+
+    - field 245 with subfields $a $b $c
+    - subfields 245 $a without '='
+    - subfields 245 $c with '[]'
+    - field 246 is not present
+    """
+
+    marc21xml = """
+    <record>
+      <controlfield tag=
+          "008">110729s2011    xx ||| |  ||||00|  |und d</controlfield>
+      <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">R006114538</subfield>
+      </datafield>
+      <datafield ind1="0" ind2="0" tag="245">
+        <subfield code="a">Ma ville en vert :</subfield>
+        <subfield code="b">pour un retour de la nature /</subfield>
+        <subfield code="c">[Robert Klant ... [et al.] ; [Kitty B.]</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get('title') == [
+        {
+            'type': 'bf:Title',
+            'mainTitle': [
+                {'value': 'Ma ville en vert'}
+            ],
+            'subtitle': [
+                {'value': 'pour un retour de la nature'}
+            ],
+        }
+    ]
+    assert data.get('responsibilityStatement') == [
+        [
+            {'value': '[Robert Klant ... [et al.]'}
+        ],
+        [
+            {'value': '[Kitty B.]'}
+        ]
+    ]
+
+
 def test_marc21_to_title_245_with_two_246():
     """Test dojson title with a 245 and two 246.
 


### PR DESCRIPTION
In the build_responsibility_data function, the square brackets [] are no
more considered as trailing punctuation to be removed.

* Closes #1406.

Co-Authored-by: Gianni Pante <gianni.pante@rero.ch>

## Why are you opening this PR?

To fix the issue mentioned above.

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* N/A

## How to test?

see issue description

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
