### PR TITLE
patrons: fix patron creation and modification

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2080,6 +2080,10 @@ SECURITY_SEND_REGISTER_EMAIL = True
 #: Allow users to login without first confirming their email address.
 SECURITY_LOGIN_WITHOUT_CONFIRMATION = False
 
+#: TODO: remove this when the email is sent only if the user has an email
+# address
+SECURITY_SEND_PASSWORD_CHANGE_EMAIL = False
+
 # Misc
 INDEXER_REPLACE_REFS = True
 INDEXER_RECORD_TO_INDEX = 'rero_ils.modules.indexer_utils.record_to_index'

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -80,7 +80,7 @@
       "minLength": 6,
       "form": {
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))"
+          "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian')) || field.parent.model.patron.communication_channel === 'email'"
         },
         "validation": {
           "validators": {


### PR DESCRIPTION
* Fixes patron creation with an existing user account, closes #1454.
* Ensures that when the patron updates his/her email in the RERO ID, the
  modification is synched to the patron record, closes #1458.
* Makes the email required if the communication channel is email, closes #1455.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- To fix issues for the release 0.14.1.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
