### PR TITLE
notes: allow notes of short size

### DIFF
--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -569,7 +569,7 @@
             "type": "string",
             "title": "Content",
             "maxLength": 2000,
-            "minLength": 3,
+            "minLength": 1,
             "form": {
               "type": "textarea",
               "templateOptions": {

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -400,7 +400,7 @@
             "type": "string",
             "title": "Content",
             "maxLength": 2000,
-            "minLength": 3,
+            "minLength": 1,
             "form": {
               "type": "textarea",
               "templateOptions": {

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -502,7 +502,7 @@
             "type": "string",
             "title": "Content",
             "maxLength": 2000,
-            "minLength": 3,
+            "minLength": 1,
             "form": {
               "type": "textarea",
               "templateOptions": {


### PR DESCRIPTION
Sets the note minimum length of holdings, patron and item to 1 instead
of 3 characters, to allow libraries to use notes as codes for some
internal uses cases.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1880?kanban-status=1224895

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

You can not add holdings/patron/item notes  of size `1`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
