### PR TITLE
holdings: attach serials to non-serials documents

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -131,8 +131,6 @@ class Holding(IlsRecord):
         frequency the next_expected_date should be given.
 
         :return: False if
-            - document type is not journal and holding type is serial.
-            - document type is journal and holding type is not serial.
             - document type is ebook and holding type is not electronic.
             - document type is not ebook and holding type is electronic.
             - holding type is serial and the next_expected_date
@@ -157,10 +155,9 @@ class Holding(IlsRecord):
         is_electronic = self.holdings_type == 'electronic'
         is_issuance = \
             document.get('issuance', {}).get('main_type') == 'rdami:1003'
-        if (is_serial and not is_issuance) \
-                or (document.harvested ^ is_electronic):
-            msg = _('Holding is not attached to the correct document type.'
-                    ' document: {pid}')
+        if (document.harvested ^ is_electronic):
+            msg = _('Electronic Holding is not attached to the correct \
+                    document type. document: {pid}')
             return _(msg.format(pid=document_pid))
         # the enumeration and chronology optional fields are only allowed for
         # serial holdings

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -62,8 +62,6 @@ class ItemRecord(IlsRecord):
         if not holding:
             return _('Holding does not exist: {pid}.'.format(pid=holding_pid))
         is_serial = holding.holdings_type == 'serial'
-        if is_serial and self.get('type') == 'standard':
-            return _('Standard item can not attached to a journal.')
         issue = self.get('issue', {})
         if issue and self.get('type') == 'standard':
             return _('Standard item can not have a issue field.')


### PR DESCRIPTION
    * Allows to:
        * Attach holdings of serial type to any type of document.
        * Attach holdings of standard type to document of type journal.
        * Attach items of standard type to holdings of type serial.
* Closes #1612

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1883?kanban-status=1224895

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
