### PR TITLE
data: set several minLength to 1

### DIFF
--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -43,7 +43,7 @@
     "barcode": {
       "title": "Barcode",
       "type": "string",
-      "minLength": 4,
+      "minLength": 1,
       "form": {
         "focus": true,
         "validation": {

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -119,17 +119,17 @@
       "title": "Street",
       "description": "Street and number of the address.",
       "type": "string",
-      "minLength": 3
+      "minLength": 1
     },
     "postal_code": {
       "title": "Postal code",
       "type": "string",
-      "minLength": 4
+      "minLength": 1
     },
     "city": {
       "title": "City",
       "type": "string",
-      "minLength": 3
+      "minLength": 1
     },
     "phone": {
       "title": "Phone number",


### PR DESCRIPTION
For migrating records from Virtua: Sets the
minimum length of the following fields to 1 character:

* patron.city
* patron.postal_code
* patron.street
* item.barcode

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1884?kanban-status=1224895

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
