### PR TITLE
users: set whether to keep loan history or not

### DIFF
--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -125,6 +125,12 @@
         }
       }
     },
+    "to_anonymize": {
+      "title": "Set loan to be anonymized",
+      "description": "If enabled, loan is set to be anonymized.",
+      "type": "boolean",
+      "default": false
+    },
     "state": {
       "type": "string",
       "title": "State name",

--- a/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
@@ -85,6 +85,9 @@
       "transaction_user_pid": {
         "type": "keyword"
       },
+      "to_anonymize": {
+        "type": "boolean"
+      },
       "organisation": {
         "properties": {
           "pid": {

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -307,6 +307,11 @@ class Patron(IlsRecord):
         user = _datastore.find_user(id=self.get('user_id'))
         return user
 
+    @property
+    def keep_history(self):
+        """Shortcut for user keep history."""
+        return self.get('patron', {}).get('keep_history', True)
+
     def _update_roles(self):
         """Update user roles."""
         db_roles = self.user.roles

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -164,6 +164,7 @@
         "communication_language",
         "expiration_date",
         "libraries",
+        "keep_history",
         "blocked",
         "blocked_note"
       ],
@@ -384,6 +385,12 @@
               "templateOptions.required": "true"
             }
           }
+        },
+        "keep_history": {
+          "title": "Keep circulation history",
+          "description": "When enabled, track of the loan history of the 6 last months will be kept.",
+          "type": "boolean",
+          "default": true
         }
       },
       "form": {

--- a/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
@@ -112,6 +112,9 @@
           "communication_language": {
             "type": "keyword"
           },
+          "keep_history": {
+            "type": "boolean"
+          },
           "subscriptions": {
             "properties": {
               "patron_type": {


### PR DESCRIPTION
A new boolean `keep_history` field is added to patron record to either
maintain circulation transaction history for the last 6 months or to
anonymize the transaction once it is concluded.

A loan is considered concluded if it is in the ITEM_RETURNED or
CANCELLED state and has no open patron transactions (fees).

A new field added to the loan record `to_anonymize` to set the record to
be anonymized.


Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1422?milestone=277700

## Dependencies


## How to test?

./run_tests.sh

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
