### PR TITLE
circulation: allow overriding exception

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_color_content-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_color_content-v0.0.1.json
@@ -15,11 +15,11 @@
         "type": "selectWithSort",
         "options": [
           {
-            "label": "Monochrome",
+            "label": "rdacc:1002",
             "value": "rdacc:1002"
           },
           {
-            "label": "Polychrome",
+            "label": "rdacc:1003",
             "value": "rdacc:1003"
           }
         ],

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -191,6 +191,8 @@ def checkout(item, data):
         transaction_location_pid,
         transaction_user_pid
     """
+    data['override_blocking'] = flask_request.args.get(
+        'override_blocking', False)
     return item.checkout(**data)
 
 

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -149,10 +149,27 @@ def test_checkout_library_limit(
     assert 'error' == data['messages'][0]['type']
     assert 'Checkout denied' in data['messages'][0]['content']
 
+    # try a checkout with 'override_blocking' parameter.
+    #   --> the restriction is no longer checked, the checkout will be success.
+    res, data = postdata(client, 'api_item.checkout', dict(
+        item_pid=item3.pid,
+        patron_pid=patron.pid,
+        transaction_location_pid=loc_public_martigny.pid,
+        transaction_user_pid=librarian_martigny_no_email.pid,
+    ), url_data={'override_blocking': 'true'})
+    assert res.status_code == 200
+    loan3_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
+
     # reset fixtures
-    #   --> checkin both loaned item
+    #   --> checkin three loaned item
     #   --> reset patron_type to original value
     #   --> reset items to original values
+    res, data = postdata(client, 'api_item.checkin', dict(
+        item_pid=item3.pid,
+        pid=loan3_pid,
+        transaction_location_pid=loc_public_martigny.pid,
+        transaction_user_pid=librarian_martigny_no_email.pid,
+    ))
     res, data = postdata(client, 'api_item.checkin', dict(
         item_pid=item2.pid,
         pid=loan2_pid,


### PR DESCRIPTION
Sometimes, restrictions can disallow to execute a circulation operation.
Adding the "override_blocking" parameter to the API url allows to bypass
all restrictions.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
