### PR TITLE
circulation: add control on circulation operation

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1608,6 +1608,7 @@ RECORDS_REST_FACETS = dict(
             _('library'): and_term_filter('library.pid'),
             _('item_type'): and_term_filter('item_type.pid'),
             _('vendor'): and_term_filter('vendor.pid'),
+            _('status'): and_term_filter('status'),
             _('issue_status'): and_term_filter('issue.status'),
             # to allow multiple filters support, in this case to filter by
             # "late or claimed"
@@ -2304,10 +2305,12 @@ CIRCULATION_ACTIONS_VALIDATION = {
     ],
     ItemCirculationAction.EXTEND: [
         Item.can_extend,
+        Patron.can_extend,
         PatronType.allow_extend
     ],
     ItemCirculationAction.CHECKOUT: [
         Patron.can_checkout,
+        CircPolicy.allow_checkout,
         PatronType.allow_checkout
     ]
 }

--- a/rero_ils/modules/patron_types/api.py
+++ b/rero_ils/modules/patron_types/api.py
@@ -34,8 +34,8 @@ from ..loans.api import LoanState, get_loans_count_by_library_for_patron_pid, \
 from ..minters import id_minter
 from ..patron_transactions.api import PatronTransaction
 from ..patrons.api import Patron, PatronsSearch
-from ..patrons.utils import get_patron_from_arguments
 from ..providers import Provider
+from ..utils import get_patron_from_arguments
 
 # provider
 PatronTypeProvider = type(

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -371,7 +371,7 @@
         },
         "blocked": {
           "title": "Blocking",
-          "description": "A patron with a blocked account cannot request and borrow items, but can still renew and check in items.",
+          "description": "A patron with a blocked account cannot extend, request and borrow items.",
           "type": "boolean"
         },
         "blocked_note": {

--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -28,15 +28,3 @@ def user_has_patron(user=current_user):
     if patron and 'patron' in patron.get('roles'):
         return True
     return False
-
-
-def get_patron_from_arguments(**kwargs):
-    """Try to load a patron from potential arguments."""
-    from .api import Patron
-    required_arguments = ['patron', 'patron_barcode', 'patron_pid', 'loan']
-    if not any(k in required_arguments for k in kwargs):
-        return None
-    return kwargs.get('patron') \
-        or Patron.get_patron_by_barcode(kwargs.get('patron_barcode')) \
-        or Patron.get_record_by_pid(kwargs.get('patron_pid')) \
-        or Patron.get_record_by_pid(kwargs.get('loan').get('patron_pid'))

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -407,3 +407,15 @@ def get_record_class_from_schema_or_pid_type(schema=None, pid_type=None):
         .get('RECORDS_REST_ENDPOINTS')
         .get(pid_type, {}).get('record_class'))
     return record_class
+
+
+def get_patron_from_arguments(**kwargs):
+    """Try to load a patron from potential arguments."""
+    from .patrons.api import Patron
+    required_arguments = ['patron', 'patron_barcode', 'patron_pid', 'loan']
+    if not any(k in required_arguments for k in kwargs):
+        return None
+    return kwargs.get('patron') \
+        or Patron.get_patron_by_barcode(kwargs.get('patron_barcode')) \
+        or Patron.get_record_by_pid(kwargs.get('patron_pid')) \
+        or Patron.get_record_by_pid(kwargs.get('loan').get('patron_pid'))


### PR DESCRIPTION
Closes rero/rero-ils#1470
If a circulation policy disallow checkout operation, the error message
returned was not user friendly. This commit add a check for checkout
operation on cipo; this check return a better error message.

Closes rero/rero-ils#1383
If a patron is blocked for any reasons, this user couldn't extend any
active loan.

Closes rero/rero-ils#1507
Fixes 'status' facet problem on items result list. Despite if user
choose a status to faceting the results, the facet value didn't apply.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
