### PR TITLE
menu: update the language menu entry

### DIFF
--- a/rero_ils/views.py
+++ b/rero_ils/views.py
@@ -148,6 +148,7 @@ def init_menu_tools():
 def init_menu_lang():
     """Create the header language menu."""
     item = current_menu.submenu('main.menu')
+    ui_language = 'ui_language_{lang}'.format(lang=current_i18n.language)
     # Bug: when you reload the page with register(**kwargs), it failed
     # We so check that 'id' already exists. If yes, do not create again
     # the item.
@@ -155,9 +156,9 @@ def init_menu_lang():
         item,
         endpoint=None,
         text='{icon} <span class="{visible}">{menu}'.format(
-            icon='<i class="fa fa-bars"></i>',
+            icon='<i class="fa fa-language"></i>',
             visible='visible-md-inline visible-lg-inline',
-            menu=_('Menu')
+            menu=_(ui_language)
         ),
         order=0,
         id='language-menu'


### PR DESCRIPTION
In the menu of the public interface, it exists a 'menu' entry. This
entry list all available languages for the application. This commit
renamed the entry menu using the current language and change the icon
linked to this menu entry

Closes rero/rero-ils#1466

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

![image](https://user-images.githubusercontent.com/10031585/100242960-a8ff2e00-2f35-11eb-8cdf-335c4a622c3b.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
