### PR TITLE
users: allow to edit keep_history setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ jsonpickle = "*"
 ciso8601 = "*"
 # TODO: to be removed when the thumbnail will be refactored
 angular-gettext-babel= ">=0.1"
-invenio-userprofiles = {git = "https://github.com/rero/invenio-userprofiles.git", tag = "reroprofile"}
+invenio-userprofiles = {git = "https://github.com/rero/invenio-userprofiles.git", tag = "baa-add-keep-history"}
 
 ## Additionnal constraints on python modules
 # solves fixture 'celery_config' not found

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -203,7 +203,7 @@ class Loan(IlsRecord):
         # set the field to_anonymize
         to_anonymize = False
         data['to_anonymize'] = \
-            cls.can_anonymize(data) and not data.get('to_anonymize')
+            cls.can_anonymize(loan_data=data) and not data.get('to_anonymize')
 
         record = super(Loan, cls).create(
             data=data, id_=id_, delete_pid=delete_pid, dbcommit=dbcommit,
@@ -214,7 +214,7 @@ class Loan(IlsRecord):
         """Update loan record."""
         self._loan_build_org_ref(data)
         # set the field to_anonymize
-        if Loan.can_anonymize(data) and not self.get('to_anonymize'):
+        if Loan.can_anonymize(loan_data=data) and not self.get('to_anonymize'):
             data['to_anonymize'] = True
         super(Loan, self).update(data, dbcommit, reindex)
         return self
@@ -477,7 +477,7 @@ class Loan(IlsRecord):
         return loan_age.days
 
     @classmethod
-    def can_anonymize(cls, loan_data):
+    def can_anonymize(cls, loan_data=None, patron_data=None):
         """Check if a loan can be anonymized and excluded from loan searches.
 
         Loan can be anonymized if:
@@ -489,12 +489,14 @@ class Loan(IlsRecord):
         old and new version of the loan.
 
         :param loan_data: the loan to check.
+        :param patron_data: the patron to check.
         :return True|False.
         """
         if cls.concluded(loan_data) and cls.age(loan_data) > 6*365/12:
             return True
-        keep_history = Patron.get_record_by_pid(
-            loan_data.get('patron_pid')).keep_history
+        if not patron_data:
+            patron_data = Patron.get_record_by_pid(loan_data.get('patron_pid'))
+        keep_history = patron_data.get('patron', {}).get('keep_history')
         return not keep_history and cls.concluded(loan_data)
 
 
@@ -887,7 +889,7 @@ def get_non_anonymized_loans(patron_pid=None, org_pid=None):
         .filter('terms', state=[LoanState.CANCELLED, LoanState.ITEM_RETURNED])\
         .source(['pid'])
     if patron_pid:
-        search = search.filter('term', patron__pid=patron_pid)
+        search = search.filter('term', patron_pid=patron_pid)
     if org_pid:
         search = search.filter('term', organisation__pid=org_pid)
     for record in search.scan():
@@ -895,19 +897,21 @@ def get_non_anonymized_loans(patron_pid=None, org_pid=None):
 
 
 def anonymize_loans(
-        patron_pid=None, org_pid=None, dbcommit=False, reindex=False):
+        patron_pid=None, patron_data=None, org_pid=None,
+        dbcommit=False, reindex=False):
     """Anonymise loans.
 
     :param dbcommit - commit the changes in the db after the creation.
     :param reindex - index the record after the creation.
     :param patron_pid: optional parameter to filter by patron_pid.
     :param org_pid: optional parameter to filter by organisation.
+    :param patron_data: patron data to check.
     :return: loans.
     """
     counter = 0
     for loan in get_non_anonymized_loans(
             patron_pid=patron_pid, org_pid=org_pid):
-        if Loan.can_anonymize(loan):
+        if Loan.can_anonymize(loan_data=loan, patron_data=patron_data):
             loan.anonymize(loan, dbcommit=dbcommit, reindex=reindex)
             counter += 1
     return counter

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -387,10 +387,10 @@
           }
         },
         "keep_history": {
-          "title": "Keep circulation history",
-          "description": "When enabled, track of the loan history of the 6 last months will be kept.",
+          "title": "Keep history",
+          "description": "If enabled, the loan history is saved for a maximum of six months. It is visible to the user and the library staff.",
           "type": "boolean",
-          "default": true
+          "default": false
         }
       },
       "form": {

--- a/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html
@@ -18,29 +18,124 @@
 #}
 {% from 'rero_ils/macros/macro.html' import dl %}
 
-<h4 class="text-secondary border-bottom mt-3 pb-1">{{ _('Personal details') }}</h4>
+<div id="patronrecord-section" class="row mb-1 align-items-center">
+  <div class="col mr-1 d-none d-lg-block">
+    <div class="row p-2 bg-dark rounded text-light">
+      <div class="col-lg-9">{{ _('Personal details') }}</div>
+    </div>
+  </div>
+</div>
 
-<dl class="row">
-  {% if record.username %}
-  <dt class="col-lg-3">{{_('Username')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.username }}</dd>
-  {% endif %}
-  <dt class="col-lg-3">{{_('Street')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.street }}</dd>
-  <dt class="col-lg-3">{{_('City')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.postal_code }} {{ record.city }}</dd>
-  <dt class="col-lg-3">{{_('Phone')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.phone }}</dd>
-  {% if record.email %}
-  <dt class="col-lg-3">{{_('Email')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.email }}</dd>
-  {% endif %}
-  <dt class="col-lg-3">{{_('Patron number')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.patron.barcode }}</dd>
-  <dt class="col-lg-3">{{_('Account expiration')}}:</dt>
-  <dd class="col-lg-9 mb-0">{{ record.patron.expiration_date | format_date(
-      date_format='medium',
-      time_format=None,
-      locale=current_i18n.locale.language
-    )}}</dd>
-</dl>
+
+<div class="row mb-1">
+  <div class="col mr-1 p-2 border rounded">
+    {% if record.username %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Username')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.username }}
+      </div>
+    </div>
+    {% endif %}
+    {% if record.street %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Street')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.street }}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if record.city %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('City')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.postal_code }} {{ record.city }}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if record.phone %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Phone')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.phone }}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if record.email %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Email')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.email }}
+      </div>
+    </div>
+    {% endif %}
+
+
+    {% if record.patron.barcode %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Patron number')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.patron.barcode }}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if record.patron.expiration_date %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Account expiration')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        {{ record.patron.expiration_date | format_date(
+       date_format='medium',
+       time_format=None,
+       locale=current_i18n.locale.language
+     )}}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if record.patron.barcode %}
+    <div class="row pl-2 pr-2">
+      <div class="col-lg-3 font-weight-bold">
+        {{_('Keep history')}}:
+        </a>
+      </div>
+      <div class="col-lg-9">
+        <i class="fa fa-circle mr- text-{{ 'success' if record.patron.keep_history else 'danger' }}"></i>
+        {% if record.patron.keep_history %}
+            {{_('Keep history')}}<br>
+            {{_('The loan history is saved for a maximum of six months. It is visible to you and the library staff.')}}
+          {%- else %}
+            {{_('Discard history')}}<br>
+            {{_('The loan history is not saved.')}}
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+
+  </div>
+</div>
+<a href="/account/settings/profile/" class="btn btn-primary mt-1">Edit</a>

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -59,6 +59,7 @@
             <span class="badge badge-danger font-weight-normal">{{ fees.open.total_amount | format_currency(fees.open.currency) }}</span>
           </a>
         </li>
+        {% if record.patron.keep_history %}
         <li class="nav-item">
           <a class="nav-link{% if tab == 'history' %} active{% endif %}" href="#history" data-toggle="tab" id="history-tab" title="{{ _('History') }}" role="tab"
             aria-controls="history" aria-selected="false">
@@ -66,6 +67,7 @@
             <span class="badge badge-light font-weight-normal">{{ history | length }}</span>
           </a>
         </li>
+        {% endif %}
         <li class="nav-item">
           <a class="nav-link{% if tab == 'ill_request' %} active{% endif %}" href="#ill_request" data-toggle="tab" id="ill_request-tab" title="{{ _('ILL requests') }}" role="tab"
             aria-controls="history" aria-selected="false">

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2871,7 +2871,8 @@
         "$ref": "https://ils.rero.ch/api/patron_types/ptty1"
       },
       "communication_channel": "email",
-      "communication_language": "eng"
+      "communication_language": "eng",
+      "keep_history": true
     },
     "notes": [
       {

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -75,7 +75,7 @@ def test_loan_keep_and_to_anonymize(
     """Test anonymize and keep loan based on open transactions."""
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     assert not loan.concluded(loan)
-    assert not loan.can_anonymize(loan)
+    assert not loan.can_anonymize(loan_data=loan)
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
@@ -85,7 +85,7 @@ def test_loan_keep_and_to_anonymize(
     loan = Loan.get_record_by_pid(loan.pid)
     # item checkedin and has no open events
     assert loan.concluded(loan)
-    assert not loan.can_anonymize(loan)
+    assert not loan.can_anonymize(loan_data=loan)
 
     patron['patron']['keep_history'] = False
     patron.update(patron, dbcommit=True, reindex=True)
@@ -93,13 +93,13 @@ def test_loan_keep_and_to_anonymize(
     # when the patron asks to anonymise history the can_anonymize is true
     loan = Loan.get_record_by_pid(loan.pid)
     assert loan.concluded(loan)
-    assert loan.can_anonymize(loan)
+    assert loan.can_anonymize(loan_data=loan)
     loan = loan.update(loan, dbcommit=True, reindex=True)
 
     # test loans with fees
     item, patron, loan = item2_on_loan_martigny_patron_and_loan_on_loan
     assert not loan.concluded(loan)
-    assert not loan.can_anonymize(loan)
+    assert not loan.can_anonymize(loan_data=loan)
     end_date = datetime.now(timezone.utc) - timedelta(days=7)
     loan['end_date'] = end_date.isoformat()
     loan.update(loan, dbcommit=True, reindex=True)
@@ -118,7 +118,7 @@ def test_loan_keep_and_to_anonymize(
     loan = Loan.get_record_by_pid(loan.pid)
 
     assert not loan.concluded(loan)
-    assert not loan.can_anonymize(loan)
+    assert not loan.can_anonymize(loan_data=loan)
 
 
 def test_anonymizer_job(
@@ -138,7 +138,7 @@ def test_anonymizer_job(
     flush_index(LoansSearch.Meta.index)
 
     assert not loan.concluded(loan)
-    assert not loan.can_anonymize(loan)
+    assert not loan.can_anonymize(loan_data=loan)
 
     patron['patron']['keep_history'] = True
     patron.update(patron, dbcommit=True, reindex=True)
@@ -151,7 +151,7 @@ def test_anonymizer_job(
     loan = Loan.get_record_by_pid(loan.pid)
     # item checked-in and has no open events
     assert not loan.concluded(loan)
-    assert not loan.can_anonymize(loan)
+    assert not loan.can_anonymize(loan_data=loan)
 
     msg = loan_anonymizer(dbcommit=True, reindex=True)
     assert msg == 'number_of_loans_anonymized: 0'


### PR DESCRIPTION
* Adds the `keep_history` field to the list of fields editable by the
user in the RERO ID form.
* Adds an 'edit' button to allow user to edit his profile from the
Personal data tab.
* Anonymizes loans once the patron sets the field keep_history to false.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?


## How to test?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
