### PR TITLE
permissions: fix error message for users

### DIFF
--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -89,10 +89,10 @@ def can_access_professional_view(func):
             return current_app.login_manager.unauthorized()
         else:
             patron = Patron.get_patron_by_user(current_user)
-            if patron.is_librarian or patron.is_system_librarian:
-                return func(*args, **kwargs)
-            else:
+            if not patron or (not patron.is_librarian and
+                              not patron.is_system_librarian):
                 abort(403)
+            return func(*args, **kwargs)
     return decorated_view
 
 


### PR DESCRIPTION
When a user that doesn't have the patron, librarian or system librarian
role, the message "Permission required" is displayed instead of
"Internal server error".

* Closes #1508

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
