### PR TITLE
items: inherit holdings first call_number

### DIFF
--- a/rero_ils/modules/collections/api.py
+++ b/rero_ils/modules/collections/api.py
@@ -70,8 +70,15 @@ class Collection(IlsRecord):
         :param self: self
         :return: list of items linked to collection
         """
-        return [Item.get_record_by_pid(item['pid']) for
-                item in self.replace_refs().get('items', [])]
+        items = []
+        for item in self.replace_refs().get('items', []):
+            item = Item.get_record_by_pid(item['pid'])
+            # inherit holdings call number when possible
+            issue_call_number = item.issue_inherited_first_call_number
+            if issue_call_number:
+                item['call_number'] = issue_call_number
+            items.append(item)
+        return items
 
 
 class CollectionsIndexer(IlsRecordsIndexer):

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -361,6 +361,10 @@ class Holding(IlsRecord):
             item = Item.get_record_by_pid(item_pid)
             if not item.issue_status or \
                     item.issue_status == ItemIssueStatus.RECEIVED:
+                # inherit holdings first call# for issues with no 1st call#.
+                issue_call_number = item.issue_inherited_first_call_number
+                if issue_call_number:
+                    item['call_number'] = issue_call_number
                 yield item
 
     def get_number_of_items(self):

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -361,6 +361,18 @@ class ItemRecord(IlsRecord):
         return circulation_category_pid
 
     @property
+    def issue_inherited_first_call_number(self):
+        """Get issue inherited first call number.
+
+        For item of type issue, when the issue first call number is missing,
+        it returns the parent holdings first call number if exists.
+        """
+        from ...holdings.api import Holding
+        if self.get('type') == 'issue' and not self.get('call_number'):
+            return Holding.get_record_by_pid(
+                self.holding_pid).get('call_number')
+
+    @property
     def location_pid(self):
         """Shortcut for item location pid."""
         location_pid = None

--- a/rero_ils/modules/items/serializers/csv.py
+++ b/rero_ils/modules/items/serializers/csv.py
@@ -27,7 +27,7 @@ from invenio_records_rest.serializers.csv import CSVSerializer, Line
 from rero_ils.filter import format_date_filter
 from rero_ils.modules.documents.api import search_document_by_pid
 from rero_ils.modules.documents.utils import title_format_text_head
-from rero_ils.modules.items.api import search_active_loans_for_item
+from rero_ils.modules.items.api import Item, search_active_loans_for_item
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.utils import get_i18n_supported_languages
 
@@ -84,6 +84,11 @@ class ItemCSVSerializer(CSVSerializer):
         language = kwargs.get('language')
 
         record = record_hit['_source']
+        # inherit holdings call number when possible
+        item = Item(record)
+        issue_call_number = item.issue_inherited_first_call_number
+        if issue_call_number:
+            record['call_number'] = issue_call_number
         item_pid = pid.pid_value
 
         # process location

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -631,6 +631,12 @@ def patron_profile(patron):
         if item == {}:
             # loans for deleted items are temporarily skipped.
             continue
+
+        # inherit holdings call number when possible
+        issue_call_number = item.issue_inherited_first_call_number
+        if issue_call_number:
+            item['call_number'] = issue_call_number
+
         document = Document.get_record_by_pid(
             item.replace_refs()['document']['pid'])
         loan['document'] = document.replace_refs().dumps()

--- a/rero_ils/modules/notifications/utils.py
+++ b/rero_ils/modules/notifications/utils.py
@@ -44,6 +44,12 @@ def _build_notification_email_context(loan, item, location):
         loan.get('pickup_location_pid')
     )
     patron = Patron.get_record_by_pid(loan.patron_pid)
+
+    # inherit holdings call number when possible
+    issue_call_number = item.issue_inherited_first_call_number
+    if issue_call_number:
+        item['call_number'] = issue_call_number
+
     ctx = {
         'loan': loan.replace_refs().dumps(),
         'item': item.replace_refs().dumps(),

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -64,6 +64,8 @@ def test_holding_create(db, es_clear, document, org_martigny,
     holding = next(search.filter('term', pid=holding.pid).scan())
     holding_record = Holding.get_record_by_pid(holding.pid)
     assert holding_record.organisation_pid == org_martigny.get('pid')
+    # holdings does not exist
+    assert not Holding.get_holdings_type_by_holding_pid('toto')
 
 
 def test_holdings_call_number_filter(app):

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -82,7 +82,13 @@ def test_patterns_quarterly_one_level(holding_lib_martigny_w_patterns):
 def test_receive_regular_issue(holding_lib_martigny_w_patterns):
     """Test holdings receive regular issues."""
     holding = holding_lib_martigny_w_patterns
+    assert holding.holding_is_serial
     issue = holding.receive_regular_issue(dbcommit=True, reindex=True)
+    # test holdings call number inheriting
+    assert issue.issue_inherited_first_call_number == \
+        holding.get('call_number')
+    assert list(holding.get_items)[0].get('pid') == issue.pid
+
     assert issue.location_pid == holding.location_pid
     assert issue.item_type_pid == holding.circulation_category_pid
     assert issue.document_pid == holding.document_pid


### PR DESCRIPTION
For items of type `issue`, the parent holdings first call_number is
displayed when the item has no first call_number. This call number is
inherited in the following screens in the public interface:

* Document details view.
* Patron profile: loans, requests, history tabs.
* Collection details view.
*  Late issues and inventory CSV exports.
* Generated notifications.

* Closes #1288.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1896?kanban-status=1224894

## Dependencies


## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
