### PR TITLE
documents: group holdings by libraries

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1900,6 +1900,7 @@ indexes = [
     'collections',
     'contributions',
     'documents',
+    'holdings',
     'items',
     'item_types',
     'ill_requests',
@@ -1963,6 +1964,15 @@ RECORDS_REST_SORT_OPTIONS['circ_policies']['name'] = dict(
 )
 RECORDS_REST_DEFAULT_SORT['circ_policies'] = dict(
     query='bestmatch', noquery='name')
+
+# ------ HOLDINGS SORT
+RECORDS_REST_SORT_OPTIONS['holdings']['library_location'] = dict(
+    fields=['library.pid', 'location.pid'],
+    title='Holdings library location sort',
+    default_order='asc'
+)
+RECORDS_REST_DEFAULT_SORT['holdings'] = dict(
+    query='bestmatch', noquery='library_location')
 
 # ------ ITEM TYPES SORT
 RECORDS_REST_SORT_OPTIONS['item_types']['name'] = dict(

--- a/rero_ils/modules/documents/templates/rero_ils/_anonymous_button.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_anonymous_button.html
@@ -1,8 +1,7 @@
-/*
+{# -*- coding: utf-8 -*-
 
   RERO ILS
   Copyright (C) 2020 RERO
-  Copyright (C) 2020 UCLouvain
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -16,29 +15,13 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-*/
-
-.item-row {
-  position: relative;
-  & + & {
-    margin-top: 2rem;
-    padding-top: 1rem;
-    &:before {
-      position: absolute;
-      content: "";
-      border-top: 1px solid #CCC;
-      height: 1px;
-      width: 96%;
-      left: 2%;
-      top: 0;
-    }
-  }
-  dd {
-    margin-bottom: 0.1rem;
-  }
-  .action-buttons {
-     position: absolute;
-     top: 0;
-     right: 1rem;
-  }
-}
+#}
+{%- if current_user.is_anonymous %}
+<a
+  class="btn btn-primary btn-sm"
+  href="{{ url_for_security('login') + "
+  ?next=" + request.path }}"
+>
+  <i class="fa fa-sign-in"></i> {{ _('Log in (to see request options)') }}
+</a>
+{%- endif %}

--- a/rero_ils/modules/documents/templates/rero_ils/_document_online.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_document_online.html
@@ -1,0 +1,60 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+{% if accesses|length > 0 %}
+<div class="card mb-2">
+  <!-- Card header -->
+  <div id="online_access" class="card-header p-2">
+    <div class="row">
+      <div class="col-1">
+        <a class="collapse-link" data-toggle="collapse" href="#collapse-access" aria-expanded="false">
+          <i class="fa fa-caret-down fa-lg"></i>
+        </a>
+      </div>
+      <div class="col-10">
+            {{ _("Online") }}
+      </div>
+    </div>
+  </div>
+  <!-- Card body -->
+  <div id="collapse-access" class="collapse show" role="tabpanel">
+    <div class="card-body p-2">
+      {% for access in accesses %}
+      <div class="row my-2">
+        <div class="col-12">
+          <div class="row">
+            <div class="col-sm-1">
+              &nbsp;
+            </div>
+            <div class="col-sm-2">
+              {{ access.type }}
+            </div>
+            <div class="col-sm-9">
+              <a class="rero-ils-external-link" href={{ access.url }}>{{ access.content }}</a>
+              {% if access.public_note %}
+                ({{ access.public_note }})
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -21,49 +21,8 @@
 
 {% set accesses = record|get_accesses %}
 {% if accesses|length > 0 or holdings %}
-  <!-- ACCESS -->
-  {% if accesses|length > 0 %}
-  <div class="card mb-2">
-    <!-- Card header -->
-    <div id="online_access" class="card-header p-2">
-      <div class="row">
-        <div class="col-1">
-          <a class="collapse-link" data-toggle="collapse" href="#collapse-access" aria-expanded="false">
-            <i class="fa fa-caret-down fa-lg"></i>
-          </a>
-        </div>
-        <div class="col-10">
-              {{ _("Online") }}
-        </div>
-      </div>
-    </div>
-    <!-- Card body -->
-    <div id="collapse-access" class="collapse show" role="tabpanel">
-      <div class="card-body p-2">
-        {% for access in accesses %}
-        <div class="row my-2">
-          <div class="col-12">
-            <div class="row">
-              <div class="col-sm-1">
-                &nbsp;
-              </div>
-              <div class="col-sm-2">
-                {{ access.type }}
-              </div>
-              <div class="col-sm-9">
-                <a class="rero-ils-external-link" href={{ access.url }}>{{ access.content }}</a>
-                {% if access.public_note %}
-                  ({{ access.public_note }})
-                {% endif %}
-              </div>
-            </div>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-  </div>
-  {% endif %}
+  <!-- ONLINE -->
+  {% include('rero_ils/_document_online.html') %}
 
   <!-- Holdings -->
   {%- if holdings %}
@@ -174,13 +133,12 @@
         <!-- display items -->
         {%- if number_items > 0 %}
         {%- for item in items %}
-          <div id="{{ item.barcode }}-detail" class="row item-row">
+          <div id="{{ item.barcode }}-detail" class="row item-row mt-2">
+          {%- set call_number = item | format_record_call_number -%}
+            {%- if call_number %}
             <dt class="offset-1 col-lg-2 col-sm-3">{{ _('Call number') }}</dt>
-            <dd class="col-lg-3 col-sm-3">{{ item | format_record_call_number }}</dd>
-            <dd class="col-lg-6 col-sm-5">
-              <i class="fa fa-circle text-{{ 'success' if item.available else 'danger' }}"></i>
-              {{ item|item_availability_text }}
-            </dd>
+            <dd class="col-lg-10 col-sm-9">{{ item | format_record_call_number }}</dd>
+            {%- endif %}
             {%- set collections = item.pid|in_collection %}
             {%- if collections|length > 0 %}
               <dt class="offset-1 col-lg-2 col-sm-3">{{ _('Temporary location') }}</dt>
@@ -206,40 +164,16 @@
               <dd class="col-lg-9 col-sm-8">{{ note.get('content') | nl2br | safe }}</dd>
             {%- endfor %}
 
-            <!-- action button : Should be at the end to be render above and be clickabke -->
-            {%- if item|item_and_patron_in_same_organisation %}
-              {%- set can_request, reasons = item|can_request %}
-              {%- set locations = item|item_library_pickup_locations %}
-              {%- if can_request and locations %}
-                <div class="action-buttons">
-                  <a href="#" type="button" class="btn btn-primary btn-sm" data-toggle="dropdown" aria-haspopup="true"
-                    aria-expanded="false" id="{{ item.barcode }}-dropdownMenu">
-                    {{ _('Request') }}
-                    <i class="fa fa-caret-down fa-fw"></i>
-                  </a>
-                  <!-- TODO: Style the dropdown header -->
-                  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu">
-                    <h6 class="dropdown-header">{{ _('Select a Pickup Location') }}</h6>
-                    <div class="dropdown-divider"></div>
-                    {% for location in locations %}
-                    <a class="dropdown-item"
-                      id="{{ location.code }}"
-                      href="{{ url_for('item.patron_request', viewcode=viewcode, item_pid=item.pid, pickup_location_pid=location.pid)}}">
-                      {{ location.pickup_name }}
-                    </a>
-                    {% endfor %}
-                  </div>
-                </div>
-              {%- elif reasons %}
-                <div class="action-buttons">
-                  <span class="d-inline-block mt-1" tabindex="0" data-toggle="tooltip" data-html="true" title="{{ reasons | join('<br/>') }}">
-                    <button type="submit" class="btn btn-primary" disabled>
-                      {{ _('Request') }}
-                    </button>
-                  </span>
-                </div>
-              {%- endif %}
-            {%- endif %}
+            <dt class="offset-1 col-lg-2 col-sm-3">{{ _('Status') }}</dt>
+            <dd class="col-lg-9 col-sm-8">
+              <i
+                class="fa fa-circle text-{{ 'success' if item.available else 'danger' }}"
+              ></i>
+              {{ item|item_availability_text }}
+            </dd>
+            {% with class = 'offset-1' %}
+              {% include('rero_ils/_request_button.html') %}
+            {% endwith %}
           </div>
        {%- endfor %}
        {%- endif %}

--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get_book.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get_book.html
@@ -1,0 +1,85 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2020 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+<!-- Holdings -->
+{%- if holdings %}
+
+<!-- User login -->
+{% include 'rero_ils/_anonymous_button.html' %}
+
+<div class="container">
+{%- for holding in holdings %}
+{% set items = holding.get_items | sort(attribute='enumerationAndChronology', reverse=True) %}
+  {%- for item in items %}
+  <div id="{{ item.barcode }}-detail" class="row item-row mt-2">
+    <dt class="col-lg-2 col-sm-3">{{ _('Location') }}</dt>
+    <dd class="col-lg-10 col-sm-9">
+      {{ holding|holding_location }}
+    </dd>
+
+    {%- set call_number = item | format_record_call_number -%}
+    {%- if call_number %}
+      <dt class="col-lg-2 col-sm-3">{{ _('Call number') }}</dt>
+      <dd class="col-lg-10 col-sm-9">{{ call_number }}</dd>
+    {%- endif %}
+
+    {%- if item.get('enumerationAndChronology') %}
+      <dt class="col-lg-2 col-sm-3">{{ _('Unit') }}</dt>
+      <dd class="col-lg-10 col-sm-9">
+        {{ item.get('enumerationAndChronology') }}
+      </dd>
+    {%- endif %}
+
+    <dt class="col-lg-2 col-sm-3">{{ _('Barcode') }}</dt>
+    <dd class="col-lg-10 col-sm-9">{{ item.barcode }}</dd>
+
+    {%- set public_notes = item|get_public_notes %}
+    {%- for note in public_notes %}
+    <dt class="col-lg-2 col-sm-3">{{ _(note.get('type')) }}</dt>
+    <dd class="col-lg-10 col-sm-9">{{ note.get('content') | nl2br | safe }}</dd>
+    {%- endfor %}
+    {%- set collections = item.pid|in_collection %}
+    {%- if collections|length > 0 %}
+    <dt class="col-lg-2 col-sm-3">{{ _('Temporary location') }}</dt>
+    <dd class="col-lg-10 col-sm-9">
+      {%- for collection in collections %}
+        {%- if collection.published %}
+        <a
+          href="{{ url_for('invenio_records_ui.coll', viewcode=viewcode, pid_value=collection.pid) }}"
+        >
+          {{ collection.title }}{{ '' if loop.last else '; ' }}
+        </a>
+        {%- endif %}
+      {%- endfor %}
+    </dd>
+    {%- endif %}
+
+    <dt class="col-lg-2 col-sm-3">{{ _('Status') }}</dt>
+    <dd class="col-lg-10 col-sm-9">
+      <i
+        class="fa fa-circle text-{{ 'success' if item.available else 'danger' }}"
+      ></i>
+      {{ item|item_availability_text }}
+    </dd>
+
+    {% include('rero_ils/_request_button.html') %}
+  </div>
+  {%- endfor %}
+{%- endfor %}
+</div>
+{%- endif %}

--- a/rero_ils/modules/documents/templates/rero_ils/_request_button.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_request_button.html
@@ -1,0 +1,70 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2020 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+<!-- action button : Should be at the end to be rendered above and be clickable -->
+{%- if item|item_and_patron_in_same_organisation %}
+  {%- set can_request, reasons = item|can_request %}
+  {%- set locations = item|item_library_pickup_locations %}
+  {%- if can_request and locations %}
+    <dd class="{% if class %}{{ class }} {% endif %}col-lg-12 col-sm-12 mt-2">
+      <a
+        href="#"
+        type="button"
+        class="btn btn-primary btn-mini"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+        id="{{ item.barcode }}-dropdownMenu"
+      >
+        {{ _('Request') }}
+        <i class="fa fa-caret-down fa-fw"></i>
+      </a>
+      <div
+        class="dropdown-menu dropdown-menu-left"
+        aria-labelledby="dropdownMenu"
+      >
+        <h6 class="dropdown-header">{{ _('Select a Pickup Location') }}</h6>
+        <div class="dropdown-divider"></div>
+        {% for location in locations %}
+        <a
+          class="dropdown-item"
+          id="{{ location.code }}"
+          href="{{ url_for('item.patron_request', viewcode=viewcode, item_pid=item.pid, pickup_location_pid=location.pid)}}"
+        >
+          {{ location.pickup_name }}
+        </a>
+        {% endfor %}
+      </div>
+    </dd>
+    {%- elif reasons %}
+    <dd class="col-lg-12 col-sm-12 mt-2">
+      <span
+        class="d-inline-block"
+        tabindex="0"
+        data-toggle="tooltip"
+        data-html="true"
+        title="{{ reasons | join('<br/>') }}"
+      >
+        <button type="submit" class="btn btn-primary btn-mini" disabled>
+          {{ _('Request') }}
+          <i class="fa fa-caret-down fa-fw"></i>
+        </button>
+      </span>
+    </dd>
+  {%- endif %}
+{%- endif %}

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -118,13 +118,6 @@
     <header>
       <nav>
         <ul class="nav nav-tabs" role="tablist">
-          <li class="nav-item" title="{{ _('No holdings') }}">
-            <a class="nav-link disabled" href="#documents-get" data-toggle="tab"
-               id="documents-get-tab" title="{{ _('Get') }}" role="tab"
-               aria-controls="documents-get" aria-selected="true">
-              <i class="fa fa-list-ul"></i> {{ _('Get') }}
-            </a>
-          </li>
           <li class="nav-item">
             <a class="nav-link active" href="#documents-description" data-toggle="tab"
                id="documents-description-tab" title="{{ _('Description') }}" role="tab"
@@ -164,7 +157,11 @@
     </header>
     <article class="tab-content">
       <section class="tab-pane show active p-4" id="documents-get" role="tabpanel" aria-labelledby="documents-get-tab">
-        {% include('rero_ils/_documents_get.html') %}
+        {%- if record.type == 'book' %}
+          {% include('rero_ils/_documents_get_book.html') %}
+        {%- else %}
+          {% include('rero_ils/_documents_get.html') %}
+        {%- endif %}
       </section>
       <section class="tab-pane row" id="documents-description" role="tabpanel" aria-labelledby="documents-description-tab">
         {% include('rero_ils/_documents_description.html') %}

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -331,6 +331,11 @@ class ItemRecord(IlsRecord):
         return self.get('status', '')
 
     @property
+    def enumerationAndChronology(self):
+        """Shortcut for item enumarationAndChronology."""
+        return self.get('enumerationAndChronology', '')
+
+    @property
     def item_type_pid(self):
         """Shortcut for item type pid."""
         item_type_pid = None

--- a/rero_ils/modules/local_fields/jsonschemas/local_fields/local_field-v0.0.1.json
+++ b/rero_ils/modules/local_fields/jsonschemas/local_fields/local_field-v0.0.1.json
@@ -45,7 +45,7 @@
       ],
       "properties": {
         "$ref": {
-          "title": "Patron type URI",
+          "title": "Parent URI",
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/documents|items|holdings/.*?$"
         }

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -134,7 +134,7 @@ def logged_user():
         organisation_pid = patron.organisation_pid
         patron = patron.replace_refs()
         patron = patron.dumps()
-        for index, library in enumerate(patron.get('libraries')):
+        for index, library in enumerate(patron.get('libraries', [])):
             data = {
                 'pid': library['pid'],
                 'organisation': {

--- a/rero_ils/theme/assets/scss/rero_ils/styles.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/styles.scss
@@ -147,3 +147,18 @@ div.tooltip div.tooltip-inner{
   background-color: $red;
   color: white;
 }
+
+
+/*
+ *********************************
+
+         BUTTON
+
+ ********************************
+*/
+.btn-mini {
+  padding: .25rem .35rem .25rem .45rem;
+  font-size: .875rem;
+  line-height: 1.3;
+  border-radius: .2rem;
+}


### PR DESCRIPTION
The layout of the book type no longer shows the holdings structure.
The buttons have been aligned vertically below the data.

* Closes #1399.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Check book layout and serial layout.
- Check order (sort by library pid and location pid)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
