### PR TITLE
document: identify deleted contribution records

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -34,14 +34,14 @@ jobs:
       with:
         version: 1.0.10
 
-    - name: Use Cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/pypoetry/virtualenvs
-          ~/.npm
-        key: ${{ runner.os }}-pip-venv-${{ hashFiles('**/poetry.lock') }}
+    # - name: Use Cache
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: |
+    #       ~/.cache/pip
+    #       ~/.cache/pypoetry/virtualenvs
+    #       ~/.npm
+    #     key: ${{ runner.os }}-pip-venv-${{ hashFiles('**/poetry.lock') }}
 
     - name: Bootstrap
       if: ${{ matrix.dependencies == 'dev' }}

--- a/data/pid_dependencies.json
+++ b/data/pid_dependencies.json
@@ -22,8 +22,8 @@
     ]
   },
   {
-    "name": "document",
-    "filename": "documents_big.json"
+    "name": "pickup_location",
+    "filename": "locations.json"
   },
   {
     "name": "item_type",
@@ -40,6 +40,15 @@
     "dependencies": [
       {
         "name": "organisation"
+      },
+      {
+        "name": "library_exceptions",
+        "optional": "True",
+        "sublist": [
+          {
+            "name": "library"
+          }
+        ]
       }
     ]
   },
@@ -64,10 +73,42 @@
       },
       {
         "name": "library",
-        "ref": "libraries",
         "optional": "True"
       }
     ]
+  },
+  {
+    "name": "vendor",
+    "filename": "vendors.json",
+    "dependencies": [
+      {
+        "name": "organisation"
+      }
+    ]
+  },
+  {
+    "name": "patron",
+    "filename": "users.json",
+    "dependencies": [
+      {
+        "name": "library",
+        "optional": "True"
+      },
+      {
+        "name": "patron",
+        "optional": "True",
+        "sublist": [
+          {
+            "name": "patron_type",
+            "optional": "True"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "document",
+    "filename": "documents_big.json"
   },
   {
     "name": "holding",
@@ -93,13 +134,121 @@
         "name": "location"
       },
       {
-        "name": "item_type"
-      },
-      {
         "name": "document"
       },
       {
-        "name": "holding"
+        "name": "item_type"
+      },
+      {
+        "name": "holding",
+        "optional": "True"
+      },
+      {
+        "name": "organisation",
+        "optional": "True"
+      }
+    ]
+  },
+  {
+    "name": "patterns",
+    "filename": "patterns.json"
+  },
+  {
+    "name": "budget",
+    "filename": "budgets.json",
+    "dependencies": [
+      {
+        "name": "organisation",
+        "optional": "True"
+      }
+    ]
+  },
+  {
+    "name": "collection",
+    "filename": "collections.json",
+    "dependencies": [
+      {
+        "name": "librarie",
+        "ref": "libraries",
+        "optional": "True"
+      },
+      {
+        "name": "item",
+        "ref": "items",
+        "optional": "True"
+      },
+      {
+        "name": "organisation"
+      }
+    ]
+  },
+  {
+    "name": "acq_account",
+    "filename": "acq_accounts.json",
+    "dependencies": [
+      {
+        "name": "budget"
+      },
+      {
+        "name": "library"
+      },
+      {
+        "name": "organisation",
+        "optional": "True"
+      }
+    ]
+  },
+  {
+    "name": "template",
+    "filename": "templates.json",
+    "dependencies": [
+      {
+        "name": "organisation"
+      },
+      {
+        "name": "creator",
+        "ref": "patron"
+      }
+    ]
+  },
+  {
+    "name": "loan",
+    "filename": "loans.json",
+    "dependencies": [
+      {
+        "name": "item",
+        "optional": "True"
+      },
+      {
+        "name": "patron",
+        "optional": "True"
+      },
+      {
+        "name": "document",
+        "optional": "True"
+      },
+      {
+        "name": "organisation",
+        "optional": "True"
+      }
+    ]
+  },
+  {
+    "name": "local_field",
+    "filename": "local_fields.json",
+    "dependencies": [
+      {
+        "name": "organisation",
+        "optional": "True"
+      },
+      {
+        "name": "parent",
+        "optional": "True",
+        "refs": {
+          "document": "documents",
+          "item": "items",
+          "holding": "holdings"
+        }
       }
     ]
   }

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -428,6 +428,9 @@ RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY = librarian_delete_permission_fac
 REST_MIMETYPE_QUERY_ARG_NAME = 'format'
 """Name of the query argument to specify the mimetype wanted for the output."""
 
+MAX_RESULT_WINDOW = 20000
+"""max result window for ES, must be the same in json mapping files."""
+
 RECORDS_REST_ENDPOINTS = dict(
     coll=dict(
         pid_type='coll',
@@ -458,7 +461,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route='/collections/<pid(coll, record_class='
         '"rero_ils.modules.collections.api:Collection"):pid_value>',
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:view_search_collection_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=CollectionPermission),
@@ -519,7 +522,7 @@ RECORDS_REST_ENDPOINTS = dict(
         #     },
         # ),
         default_media_type='application/json',
-        max_result_window=5000000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:view_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=DocumentPermission),
@@ -568,7 +571,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route='/ill_requests/<pid(illr, record_class='
         '"rero_ils.modules.ill_requests.api:ILLRequest"):pid_value>',
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:loans_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=ILLRequestPermission),
@@ -621,7 +624,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/items/<pid(item, record_class='
                     '"rero_ils.modules.items.api:Item"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=ItemPermission),
@@ -663,7 +666,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/item_types/<pid(itty, record_class='
                     '"rero_ils.modules.item_types.api:ItemType"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=ItemTypePermission),
@@ -705,7 +708,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/holdings/<pid(hold, record_class='
                     '"rero_ils.modules.holdings.api:Holding"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=HoldingPermission),
@@ -747,7 +750,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route='/local_fields/<pid(lofi, record_class='
         '"rero_ils.modules.local_fields.api:LocalField"):pid_value>',
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=LocalFieldPermission),
@@ -789,7 +792,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/patrons/<pid(ptrn, record_class='
                     '"rero_ils.modules.patrons.api:Patron"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=PatronPermission),
@@ -835,7 +838,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.patron_transactions.api:'
                     'PatronTransaction"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:patron_transactions_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=PatronTransactionPermission),
@@ -882,7 +885,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.patron_transaction_events.api:'
                     'PatronTransactionEvent"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:patron_transactions_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list',
@@ -940,7 +943,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.patron_types.api:'
                     'PatronType"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=PatronTypePermission),
@@ -984,7 +987,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.organisations.api:'
                     'Organisation"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp=('rero_ils.query:'
                             'organisation_organisation_search_factory'),
         list_permission_factory_imp=lambda record: record_permission_factory(
@@ -1027,7 +1030,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/libraries/<pid(lib, record_class='
                     '"rero_ils.modules.libraries.api:Library"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=LibraryPermission),
@@ -1069,7 +1072,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/locations/<pid(loc, record_class='
                     '"rero_ils.modules.locations.api:Location"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=LocationPermission),
@@ -1111,7 +1114,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/contributions/<pid(cont, record_class='
                     '"rero_ils.modules.contributions.api:Contribution"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:contribution_view_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=ContributionPermission),
@@ -1154,7 +1157,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.circ_policies.api:'
                     'CircPolicy"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=CirculationPolicyPermission),
@@ -1198,7 +1201,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.notifications.api:'
                     'Notification"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=NotificationPermission),
@@ -1240,7 +1243,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/vendors/<pid(vndr, record_class='
                     '"rero_ils.modules.vendors.api:Vendor"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=VendorPermission),
@@ -1287,7 +1290,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.acq_accounts.api:'
                     'AcqAccount"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:acq_accounts_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=AcqAccountPermission),
@@ -1329,7 +1332,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/budgets/<pid(budg, record_class='
                     '"rero_ils.modules.budgets.api:Budget"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=BudgetPermission),
@@ -1374,7 +1377,7 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route=('/acq_orders/<pid(acor, record_class='
                     '"rero_ils.modules.acq_orders.api:AcqOrder"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=AcqOrderPermission),
@@ -1419,7 +1422,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.acq_order_lines.api:'
                     'AcqOrderLine"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=AcqOrderLinePermission),
@@ -1468,7 +1471,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.acq_invoices.api:'
                     'AcquisitionInvoice"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=AcqInvoicePermission),
@@ -1511,7 +1514,7 @@ RECORDS_REST_ENDPOINTS = dict(
                     '"rero_ils.modules.templates.api:'
                     'Template"):pid_value>'),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:templates_search_factory',
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=TemplatePermission),
@@ -2282,7 +2285,7 @@ CIRCULATION_REST_ENDPOINTS = dict(
         item_route='/loans/<{0}:pid_value>'.format(
             _LOANID_CONVERTER),
         default_media_type='application/json',
-        max_result_window=10000,
+        max_result_window=20000,
         error_handlers=dict(),
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=LoanPermission),

--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -181,10 +181,10 @@ def error_print(*args):
 
 
 def make_year(date):
-    """Test if string is integer and between -9999 to 9999."""
+    """Test if string is integer and between 1000 to 9999."""
     try:
         int_date = int(date)
-        if int_date >= -9999 and int_date < 9999:
+        if int_date >= 1000 and int_date < 9999:
             return int_date
     except:
         pass

--- a/rero_ils/modules/acq_accounts/mappings/v7/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/mappings/v7/acq_accounts/acq_account-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/acq_invoices/mappings/v7/acq_invoices/acq_invoice-v0.0.1.json
+++ b/rero_ils/modules/acq_invoices/mappings/v7/acq_invoices/acq_invoice-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/acq_order_lines/mappings/v7/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/mappings/v7/acq_order_lines/acq_order_line-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/budgets/mappings/v7/budgets/budget-v0.0.1.json
+++ b/rero_ils/modules/budgets/mappings/v7/budgets/budget-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/collections/mappings/v7/collections/collection-v0.0.1.json
+++ b/rero_ils/modules/collections/mappings/v7/collections/collection-v0.0.1.json
@@ -1,7 +1,7 @@
 {
   "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 0,
+    "number_of_shards": 8,
+    "number_of_replicas": 1,
     "max_result_window": 20000
   },
   "mappings": {

--- a/rero_ils/modules/contributions/jsonschemas/contributions/contribution-v0.0.1.json
+++ b/rero_ils/modules/contributions/jsonschemas/contributions/contribution-v0.0.1.json
@@ -80,6 +80,10 @@
     "idref": {
       "title": "IdRef authorities",
       "type": "object"
+    },
+    "deleted": {
+      "title": "Deletion date",
+      "type": "string"
     }
   }
 }

--- a/rero_ils/modules/contributions/mappings/v7/contributions/contribution-v0.0.1.json
+++ b/rero_ils/modules/contributions/mappings/v7/contributions/contribution-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000,
     "analysis": {
@@ -358,6 +358,9 @@
       },
       "organisations": {
         "type": "keyword"
+      },
+      "deleted": {
+        "type": "date"
       },
       "_created": {
         "type": "date"

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000,
     "analysis": {

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -630,13 +630,13 @@ def get_holding_pid_by_doc_location_item_type(
 def get_holdings_by_document_item_type(
         document_pid, item_type_pid):
     """Returns holding locations for document/item type."""
-    results = HoldingsSearch().filter(
-        'term',
-        document__pid=document_pid
-    ).filter(
-        'term',
-        circulation_category__pid=item_type_pid
-    ).source(['pid']).scan()
+    results = HoldingsSearch() \
+        .params(preserve_order=True)\
+        .filter('term', document__pid=document_pid) \
+        .filter('term', circulation_category__pid=item_type_pid) \
+        .sort({'pid': {"order": "asc"}}) \
+        .source(['pid']) \
+        .scan()
     return [Holding.get_record_by_pid(result.pid) for result in results]
 
 

--- a/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/ill_requests/mappings/v7/ill_requests/ill_request-v0.0.1.json
+++ b/rero_ils/modules/ill_requests/mappings/v7/ill_requests/ill_request-v0.0.1.json
@@ -1,7 +1,7 @@
 {
   "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 0,
+    "number_of_shards": 8,
+    "number_of_replicas": 1,
     "max_result_window": 20000
   },
   "mappings": {

--- a/rero_ils/modules/item_types/mappings/v7/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/mappings/v7/item_types/item_type-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -240,8 +240,10 @@ class ItemRecord(IlsRecord):
     def get_items_pid_by_holding_pid(cls, holding_pid):
         """Returns item pids from holding pid."""
         from . import ItemsSearch
-        results = ItemsSearch()\
-            .filter('term', holding__pid=holding_pid)\
+        results = ItemsSearch() \
+            .params(preserve_order=True)\
+            .filter('term', holding__pid=holding_pid) \
+            .sort({'pid': {"order": "asc"}}) \
             .source(['pid']).scan()
         for item in results:
             yield item.pid

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000,
     "analysis": {

--- a/rero_ils/modules/libraries/mappings/v7/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/mappings/v7/libraries/library-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/local_fields/mappings/v7/local_fields/local_field-v0.0.1.json
+++ b/rero_ils/modules/local_fields/mappings/v7/local_fields/local_field-v0.0.1.json
@@ -1,7 +1,7 @@
 {
   "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 0,
+    "number_of_shards": 8,
+    "number_of_replicas": 1,
     "max_result_window": 20000
   },
   "mappings": {

--- a/rero_ils/modules/locations/mappings/v7/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/mappings/v7/locations/location-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/notifications/mappings/v7/notifications/notification-v0.0.1.json
+++ b/rero_ils/modules/notifications/mappings/v7/notifications/notification-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/organisations/mappings/v7/organisations/organisation-v0.0.1.json
+++ b/rero_ils/modules/organisations/mappings/v7/organisations/organisation-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/patron_transaction_events/mappings/v7/patron_transaction_events/patron_transaction_event-v0.0.1.json
+++ b/rero_ils/modules/patron_transaction_events/mappings/v7/patron_transaction_events/patron_transaction_event-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/patron_transactions/mappings/v7/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/mappings/v7/patron_transactions/patron_transaction-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/patron_types/mappings/v7/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/mappings/v7/patron_types/patron_type-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
@@ -1,7 +1,7 @@
 {
   "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 0,
+    "number_of_shards": 8,
+    "number_of_replicas": 1,
     "max_result_window": 20000
   },
   "mappings": {

--- a/rero_ils/modules/vendors/mappings/v7/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/mappings/v7/vendors/vendor-v0.0.1.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "number_of_shards": 1,
+    "number_of_shards": 8,
     "number_of_replicas": 1,
     "max_result_window": 20000
   },

--- a/scripts/setup
+++ b/scripts/setup
@@ -87,6 +87,7 @@ DONT_STOP=""
 PREFIX=""
 ES_MAPPING=false
 ENQUEUE=""
+INDEX_PARALLEL=0
 # Permit user to set it with system var. Default is true.
 ENABLE_WARNINGS=${ENABLE_WARNINGS:=true}
 
@@ -99,7 +100,7 @@ if [[ -z "${VIRTUAL_ENV}" ]]; then
 fi
 
 # options may be followed by one colon to indicate they have a required argument
-if ! options=$(getopt -o dCsbclptmwkD: -l deployment,contributions,create_items_holdings_small,create_items_holdings_big,lazy,pursue,time,es-mapping,warnings,enqueue,data_path: -- "$@")
+if ! options=$(getopt -o dCsbclptmwkD:i: -l deployment,contributions,create_items_holdings_small,create_items_holdings_big,lazy,pursue,time,es-mapping,warnings,enqueue,data_path:index_parallel: -- "$@")
 then
     # something went wrong, getopt will put out an error message for us
     exit 1
@@ -143,6 +144,10 @@ do
       ;;
     -D|--data_path)
       DATA_PATH=$2
+      shift
+      ;;
+    -i|--index_parallel)
+      INDEX_PARALLEL=$2
       shift
       ;;
     (--) shift; break;;
@@ -289,6 +294,14 @@ eval ${PREFIX} invenio utils reindex -t ptty --yes-i-know --no-info
 info_msg "- Circulation policies: ${DATA_PATH}/circulation_policies.json ${CREATE_LAZY} ${DONT_STOP}"
 eval ${PREFIX} invenio fixtures create --pid_type cipo ${DATA_PATH}/circulation_policies.json --append ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio utils reindex -t cipo --yes-i-know --no-info
+
+info_msg "Acquisition vendors: ${DATA_PATH}/vendors.json ${CREATE_LAZY} ${DONT_STOP}"
+eval ${PREFIX} invenio fixtures create --pid_type vndr ${DATA_PATH}/vendors.json --append  ${CREATE_LAZY} ${DONT_STOP}
+eval ${PREFIX} invenio utils reindex -t vndr --yes-i-know --no-info
+
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 info_msg "- Users: ${DATA_PATH}/users.json"
@@ -325,6 +338,9 @@ then
     eval ${PREFIX} invenio fixtures create --pid_type cont --schema 'http://ils.rero.ch/schemas/contributions/contribution-v0.0.1.json' ${CONTRIBUTIONS} --append ${CREATE_LAZY} ${DONT_STOP}
     info_msg "Indexing Contributions:"
     eval ${PREFIX} invenio utils reindex -t cont --yes-i-know --no-info
+    if [ ${INDEX_PARALLEL} -gt 0 ]; then
+        eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+    fi
     eval ${PREFIX} invenio utils runindex --raise-on-error
 else
     info_msg "- Contributions from MEF: ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE}"
@@ -361,6 +377,9 @@ fi
 info_msg "- Holdings: ${HOLDINGS} ${CREATE_LAZY} ${DONT_STOP}"
 eval ${PREFIX} invenio fixtures create --pid_type hold --schema 'http://ils.rero.ch/schemas/holdings/holding-v0.0.1.json' ${HOLDINGS} --append ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio utils reindex -t hold --yes-i-know --no-info
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 info_msg "- Items: ${ITEMS} ${CREATE_LAZY} ${DONT_STOP}"
@@ -368,27 +387,29 @@ eval ${PREFIX} invenio fixtures create --pid_type item --schema 'http://ils.rero
 
 # index items
 eval ${PREFIX} invenio utils reindex -t item --yes-i-know --no-info
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 # index documents
 eval ${PREFIX} invenio utils reindex -t doc --yes-i-know --no-info
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 # index contributions
 # We have to reindex contributions to get the oraganisations pids indexed correctly.
 eval ${PREFIX} invenio utils reindex -t cont --yes-i-know --no-info
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 info_msg "- Local fields ${DATA_PATH}/local_fields.json ${CREATE_LAZY} ${DONT_STOP}"
 eval ${PREFIX} invenio fixtures create --pid_type lofi ${DATA_PATH}/local_fields.json --append ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio utils reindex -t lofi --yes-i-know --no-info
-eval ${PREFIX} invenio utils runindex --raise-on-error
-
-# create vendors
-info_msg "Acquisition vendors: ${DATA_PATH}/vendors.json ${CREATE_LAZY} ${DONT_STOP}"
-eval ${PREFIX} invenio fixtures create --pid_type vndr ${DATA_PATH}/vendors.json --append  ${CREATE_LAZY} ${DONT_STOP}
-eval ${PREFIX} invenio utils reindex -t vndr --yes-i-know --no-info
-eval ${PREFIX} invenio utils runindex --raise-on-error
 
 # create serials patterns
 info_msg "Serials patterns: ${DATA_PATH}/patterns.json"
@@ -414,6 +435,9 @@ info_msg "Resource templates:"
 eval ${PREFIX} invenio fixtures create --pid_type tmpl ${DATA_PATH}/templates.json --append  ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio utils reindex -t tmpl --yes-i-know --no-info
 
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 
 # create circulation transactions

--- a/tests/api/test_external_services.py
+++ b/tests/api/test_external_services.py
@@ -39,10 +39,14 @@ def test_documents_get(client, document):
         for contribution in data.get('contribution', []):
             agent = {}
             for item in contribution['agent']:
-                if not item.startswith('authorized_access_point'):
+                if item == 'authorized_access_point':
+                    agent['preferred_name'] = contribution['agent'][item]
+                elif not item.startswith('authorized_access_point_'):
                     agent[item] = contribution['agent'][item]
             contribution['agent'] = agent
             contributions.append(contribution)
+
+        data.pop('sort_title', None)
         return data
 
     item_url = url_for('invenio_records_rest.doc_item', pid_value='doc1')
@@ -65,12 +69,11 @@ def test_documents_get(client, document):
     res = client.get(list_url)
     assert res.status_code == 200
     data = get_json(res)
-    document = document.replace_refs()
-
     data_clean = clean_authorized_access_point(
         data['hits']['hits'][0]['metadata']
     )
-    assert document.replace_refs().dumps() == data_clean
+    document = document.replace_refs().dumps()
+    assert document == data_clean
 
     list_url = url_for('invenio_records_rest.doc_list', q="Vincent Berthe")
     res = client.get(list_url)

--- a/tests/ui/holdings/test_holdings_item.py
+++ b/tests/ui/holdings/test_holdings_item.py
@@ -77,8 +77,8 @@ def test_holding_item_links(client, holding_lib_martigny, item_lib_martigny,
     assert holding_circulation_category(holding_lib_martigny) == 'standard'
     holdings = get_holdings_by_document_item_type(
         document.pid, item_type_standard_martigny.pid)
-    assert holding_lib_martigny.pid == holdings[0].get('pid')
-    assert list(holding_lib_martigny.get_items)[0].get('pid') == \
+    assert holding_lib_martigny.pid == holdings[1].get('pid')
+    assert list(holding_lib_martigny.get_items)[1].get('pid') == \
         item_lib_martigny.pid
 
     holding_lib_martigny.delete_from_index()


### PR DESCRIPTION
* Adds a deletion_date field to JSON schema and mapping in order to track when
  a MEF contribution record is deleted.
* Changes `max_result_window` to 20000 as in config.py.
* Changes `number_of_shards` to 8 for better ES performance.
* Changes `number_of_replicas` to 1 for better ES performance and redundancy.
* Implements lazy loading for patrons fixtures.
* Adds sorting to `get_items_pid_by_holding_pid` so we always get the same order.
* Adds sorting to `get_holdings_by_document_item_type` so we always get the same order.
* Creates vendor fixtures before document fixtures in setup because
  documents have $ref's to vendors.
* Implements parallel indexing during setup.
* Corrects `data/pid_dependencies.json` used for pid dependency checking.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
