### PR TITLE
patrons: fix document title in the fees tab

### DIFF
--- a/rero_ils/modules/patrons/templates/rero_ils/_macro_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/_macro_profile.html
@@ -50,18 +50,11 @@
                     <b>{{ _('Document') }}</b>
                   </div>
                   <div class="col-lg-10 col-sm-10">
-                    {% if fee.document.title and fee.document.title | count == 1 %}
+                    {% if fee.document.title %}
                       <a
                         id="document-{{ fee.document.pid }}"
                         href="{{ url_for('invenio_records_ui.doc', viewcode=viewcode, pid_value=fee.document.pid) }}"
-                      >
-                        {% if fee.document.title[0].mainTitle and fee.document.title[0].mainTitle[0].value %}
-                          {{ fee.document.title[0].mainTitle[0].value }}
-                        {% endif %}
-                        {% if fee.document.title[0].subtitle and fee.document.title[0].subtitle[0].value %}
-                          {{ fee.document.title[0].subtitle[0].value }}
-                        {% endif %}
-                      </a>
+                      >{{ fee.document.title | create_title_text }}</a>
                     {% endif %}
                   </div>
               </div>


### PR DESCRIPTION
Into the patron profile page for 'fees' tab, sometime the document title
linked to a fees was not displayed. This commit improves the management
of document title using the general function `create_title_text` already
used to display the document title into the document detailed view.

Closes rero/rero-ils#1543

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Login as a patron. 
- Go into the patron profile page
- Choose the fees tab
- Check the document title linked to the fee was correctly displayed

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
