### PR TITLE
users: allows the 2nd email to be the only one

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -1053,7 +1053,7 @@
       "type": {
         "$ref": "https://ils.rero.ch/api/patron_types/5"
       },
-      "communication_channel": "email",
+      "communication_channel": "mail",
       "communication_language": "ita"
     }
   },

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -80,7 +80,7 @@
       "minLength": 6,
       "form": {
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian')) || field.parent.model.patron.communication_channel === 'email'"
+          "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian')) || (field.parent.model.patron.communication_channel === 'email' && !field.parent.model.patron.additional_communication_email)"
         },
         "validation": {
           "validators": {
@@ -246,7 +246,7 @@
         },
         "communication_channel": {
           "title": "Communication channel",
-          "description": "For the email channel, the user must have an e-mail. Otherwise, no notifications will be sent.",
+          "description": "For the email channel, the user must have an e-mail or an additional e-mail.",
           "type": "string",
           "enum": [
             "email",

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -357,7 +357,9 @@ def test_patrons_post_without_email(client, lib_martigny,
     # Create record / POST
     del patron_data['pid']
     del patron_data['email']
-    # patron_data['email'] = 'test_librarian@rero.ch'
+    patron_data['patron']['communication_channel'] = 'mail'
+    patron_data['patron'][
+        'additional_communication_email'] = 'test@rero.ch'
     patron_data['username'] = 'test_patron'
 
     res, _ = postdata(

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -658,6 +658,7 @@ def patron_sion_without_email(
     del patron_sion_data['email']
     patron_sion_data['pid'] = 'ptrn10wthoutemail'
     patron_sion_data['username'] = 'withoutemail'
+    patron_sion_data['patron']['communication_channel'] = 'mail'
     ptrn = Patron.create(
         data=patron_sion_data,
         delete_pid=False,

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -173,8 +173,19 @@ def test_patron_create_without_email(app, roles, patron_type_children_martigny,
     # no data has been created
     mailbox.clear()
 
-    # create a patron without email
     del patron_martigny_data_tmp['email']
+
+    # comminication channel require at least one email
+    patron_martigny_data_tmp['patron']['communication_channel'] = 'email'
+    with pytest.raises(RecordValidationError):
+        ptrn = Patron.create(
+            patron_martigny_data_tmp,
+            dbcommit=True,
+            delete_pid=True
+        )
+
+    # create a patron without email
+    patron_martigny_data_tmp['patron']['communication_channel'] = 'mail'
     ptrn = Patron.create(
         patron_martigny_data_tmp,
         dbcommit=True,


### PR DESCRIPTION
* Makes the main address email optional if patron communication channel
  is email and the additional address email is defined.
* Adds a backend custom validation for this specific case.
* Closes #1499.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
