### PR TITLE
document: fix call number display.

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -137,7 +137,7 @@
           {%- set call_number = item | format_record_call_number -%}
             {%- if call_number %}
             <dt class="offset-1 col-lg-2 col-sm-3">{{ _('Call number') }}</dt>
-            <dd class="col-lg-10 col-sm-9">{{ item | format_record_call_number }}</dd>
+            <dd class="col-lg-9 col-sm-8">{{ item | format_record_call_number }}</dd>
             {%- endif %}
             {%- set collections = item.pid|in_collection %}
             {%- if collections|length > 0 %}


### PR DESCRIPTION
In the 'get' tab from document detailed view, the item call number was
included into a too large column. It caused a display problem because
label and data were splitted in two separate lines.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
