### PR TITLE
items: improve automatic barcode generation

### DIFF
--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -8,7 +8,6 @@
     "$schema",
     "pid",
     "location",
-    "barcode",
     "item_type",
     "type",
     "document",

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -127,7 +127,6 @@
     },
     "to_anonymize": {
       "title": "Set loan to be anonymized",
-      "description": "If enabled, loan is set to be anonymized.",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
Set the barcode field as not required field. If an item is
created/updated without barcode, the backend will generated a fictive
barcode itself.

Closes rero/rero-ils#1287
Closes rero/rero-ils#1565

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- receive an serial issue in the UI interface (not using quick recieve)
- don't fill the barcode field
- change any other field in the form
- save the item
- check the created item has a fictive barcode ("f-2021....")

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
