### PR TITLE
gh actions: fix wrong yaml format in stale worflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,5 +22,5 @@ jobs:
         # Set the label added to the PR marked stale
         stale-pr-label: 'stale'
         # Labels on an issue exempted from being marked as stale
-        exempt-issue-label: 'bug,P: High'
-        exempt-pr-label: 'translations'
+        exempt-issue-label: ['bug','P: High']
+        exempt-pr-label: ['translations']


### PR DESCRIPTION
* Exempted label should be a well formatted list.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- Fixing an issue with the YAML format: [see warning][1] 

[1]: https://github.com/rero/rero-ils/runs/1701028205?check_suite_focus=true#step:2:1

## How to test?

- Check changed files. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
