### PR TITLE
items: use temporary item_type for circulation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -888,6 +888,7 @@ WTForms = "*"
 reference = "647dd97880e2105948071b041286f318bf2628f7"
 type = "git"
 url = "https://github.com/rero/flask-wiki.git"
+
 [[package]]
 category = "main"
 description = "Simple integration of Flask and WTForms."
@@ -900,6 +901,17 @@ version = "0.14.3"
 Flask = "*"
 WTForms = "*"
 itsdangerous = "*"
+
+[[package]]
+category = "main"
+description = "Let your Python tests travel through time"
+name = "freezegun"
+optional = false
+python-versions = ">=3.5"
+version = "1.1.0"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
 
 [[package]]
 category = "main"
@@ -1026,7 +1038,7 @@ optional = true
 version = ">=1.2.5,<1.3.0"
 
 [package.dependencies.invenio-db]
-extras = ["versioning", "postgresql"]
+extras = ["postgresql", "versioning"]
 optional = true
 version = ">=1.0.8,<1.1.0"
 
@@ -1300,6 +1312,7 @@ tests = ["invenio-app (>=1.2.3)", "invenio-jsonschemas (>=1.0.1)", "mock (>=1.3.
 reference = "d8c96352d55f8a5a72303c66bd06b46fc022c579"
 type = "git"
 url = "https://github.com/inveniosoftware/invenio-circulation.git"
+
 [[package]]
 category = "main"
 description = "Invenio configuration loader."
@@ -1502,6 +1515,7 @@ tests = ["check-manifest (>=0.35)", "coverage (>=4.3.4)", "isort (4.2.2)", "mock
 reference = "fe55e095a8e78b36cfad875f752f2facc2908bae"
 type = "git"
 url = "https://github.com/inveniosoftware/invenio-oaiharvester.git"
+
 [[package]]
 category = "main"
 description = "Invenio module that implements OAI-PMH server."
@@ -1781,6 +1795,7 @@ tests = ["check-manifest (>=0.35)", "coverage (>=4.5.3)", "invenio-app (>=1.2.3)
 reference = "88f4db624d8c6da3b1f7debb38a06ec88031e40c"
 type = "git"
 url = "https://github.com/inveniosoftware-contrib/invenio-sip2.git"
+
 [[package]]
 category = "main"
 description = "Invenio standard theme."
@@ -1833,6 +1848,7 @@ tests = ["pytest-invenio (>=1.4.0)"]
 reference = "d7fafc33068df24a7a9ef34836587f15c45ca96d"
 type = "git"
 url = "https://github.com/rero/invenio-userprofiles.git"
+
 [[package]]
 category = "main"
 description = "IPython: Productive Interactive Computing"
@@ -3082,7 +3098,7 @@ test = ["pytest"]
 [[package]]
 category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
+marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" and (python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\")"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
@@ -3296,7 +3312,7 @@ version = "0.12.0"
 [[package]]
 category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
+marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" and (python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\")"
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -3310,8 +3326,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 sip2 = ["invenio-sip2"]
 
 [metadata]
-content-hash = "0694b5d53655009bbc984942706cad4a1d8b09f8c7fe5aa28478b60bdb969a8c"
-lock-version = "1.0"
+content-hash = "b8ad4768e2e91c51e6323382887087e903a09e8e8a9f5129ffbe8e895dee40cc"
 python-versions = ">= 3.6, <3.8"
 
 [metadata.files]
@@ -3411,11 +3426,13 @@ cffi = [
     {file = "cffi-1.14.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb"},
     {file = "cffi-1.14.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d"},
     {file = "cffi-1.14.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01"},
     {file = "cffi-1.14.4-cp37-cp37m-win32.whl", hash = "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e"},
     {file = "cffi-1.14.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35"},
     {file = "cffi-1.14.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d"},
     {file = "cffi-1.14.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b"},
     {file = "cffi-1.14.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e"},
     {file = "cffi-1.14.4-cp38-cp38-win32.whl", hash = "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d"},
     {file = "cffi-1.14.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375"},
     {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
@@ -3453,6 +3470,7 @@ click-repl = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.3.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fabeeb121735d47d8eab8671b6b031ce08514c86b7ad8f7d5490a7b6dcd6267d"},
@@ -3653,6 +3671,10 @@ Flask-Wiki = []
 flask-wtf = [
     {file = "Flask-WTF-0.14.3.tar.gz", hash = "sha256:d417e3a0008b5ba583da1763e4db0f55a1269d9dd91dcc3eb3c026d3c5dbd720"},
     {file = "Flask_WTF-0.14.3-py2.py3-none-any.whl", hash = "sha256:57b3faf6fe5d6168bda0c36b0df1d05770f8e205e18332d0376ddb954d17aef2"},
+]
+freezegun = [
+    {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
+    {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
 ]
 ftfy = [
     {file = "ftfy-5.8.tar.gz", hash = "sha256:51c7767f8c4b47d291fcef30b9625fb5341c06a31e6a3b627039c706c42f3720"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ invenio-sip2 = {git = "https://github.com/inveniosoftware-contrib/invenio-sip2.g
 flask-cors = ">3.0.8"
 celery = ">=5.0.0"
 cryptography = ">3.2"
+freezegun = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 ## Python packages development dependencies (order matters)

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -134,7 +134,6 @@ I18N_LANGUAGES = [
 # this parameter using the 'default_currency' field
 RERO_ILS_DEFAULT_CURRENCY = 'CHF'
 
-
 # Base templates
 # ==============
 #: Global base template.
@@ -184,8 +183,7 @@ THEME_SETTINGS_TEMPLATE = SETTINGS_TEMPLATE
 #: Template for error pages.
 THEME_ERROR_TEMPLATE = 'rero_ils/page_error.html'
 # External CSS for each organisation customization
-RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT = \
-    'https://resources.rero.ch/ils/test/css/'
+RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT = 'https://resources.rero.ch/ils/test/css/'
 #: Template for including a tracking code for web analytics.
 THEME_TRACKINGCODE_TEMPLATE = 'rero_ils/trackingcode.html'
 THEME_JAVASCRIPT_TEMPLATE = 'rero_ils/javascript.html'
@@ -291,6 +289,12 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute=0, hour=6),  # Every day at 06:00 UTC,
         'enabled': False
     },
+    'clear_obsolete_temporary_item_types': {
+        'task': ('rero_ils.modules.items.tasks'
+                 '.clean_obsolete_temporary_item_types'),
+        'schedule': crontab(minute=15, hour=2),  # Every day at 02:15 UTC,
+        'enabled': False
+    },
     'anonymize-loans': {
         'task': ('rero_ils.modules.loans.tasks'
                  '.loan_anonymizer'),
@@ -300,7 +304,7 @@ CELERY_BEAT_SCHEDULE = {
     'clear_and_renew_subscriptions': {
         'task': ('rero_ils.modules.patrons.tasks'
                  '.task_clear_and_renew_subscriptions'),
-        'schedule': crontab(minute='2', hour='2'),
+        'schedule': crontab(minute=2, hour=2),  # Every day at 02:02 UTC,
         'enabled': False
     }
     # 'mef-harvester': {

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -267,7 +267,7 @@ class CircPolicy(IlsRecord):
         cipo = cls.provide_circ_policy(
             library_pid,
             patron.patron_type_pid,
-            item.item_type_pid
+            item.item_type_circulation_category_pid
         )
         if not cipo.get('allow_requests', False):
             return False, ["Circulation policy disallows the operation."]
@@ -296,7 +296,7 @@ class CircPolicy(IlsRecord):
         cipo = cls.provide_circ_policy(
             library_pid,
             patron.patron_type_pid,
-            item.item_type_pid
+            item.item_type_circulation_category_pid
         )
         if not cipo.get('allow_checkout', False):
             return False, ["Circulation policy disallows the operation."]

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -417,7 +417,6 @@ class ItemCirculation(ItemRecord):
                 new_end_date = new_end_date.astimezone()\
                     .replace(microsecond=0).isoformat()
                 action_params['end_date'] = new_end_date
-
         loan = current_circulation.circulation.trigger(
             current_loan,
             **dict(action_params, trigger='checkout')
@@ -1041,7 +1040,7 @@ class ItemCirculation(ItemRecord):
         cipo = CircPolicy.provide_circ_policy(
             item.library_pid,
             patron.patron_type_pid,
-            item.item_type_pid
+            item.item_type_circulation_category_pid
         )
         extension_count = loan.get('extension_count', 0)
         if not (cipo.get('number_renewals', 0) > 0 and
@@ -1064,7 +1063,7 @@ class ItemCirculation(ItemRecord):
         circ_policy = CircPolicy.provide_circ_policy(
             self.library_pid,
             patron_type_pid,
-            self.item_type_pid
+            self.item_type_circulation_category_pid
         )
         data = {
             'action_validated': True,

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -363,6 +363,26 @@ class ItemRecord(IlsRecord):
         return item_type_pid
 
     @property
+    def temporary_item_type_pid(self):
+        """Shortcut for temporary item type pid."""
+        tmp_item_type = self.get('temporary_item_type', {})
+        if tmp_item_type:
+            end_date = tmp_item_type.get('end_date')
+            # check if the temporary item_type.end_date is over. If yes, return
+            # None
+            if end_date:
+                now_date = pytz.utc.localize(datetime.now())
+                end_date = date_string_to_utc(end_date)
+                if now_date > end_date:
+                    return None
+            return extracted_data_from_ref(tmp_item_type.get('$ref'))
+
+    @property
+    def item_type_circulation_category_pid(self):
+        """Shortcut to find the best item_type to use for circulation."""
+        return self.temporary_item_type_pid or self.item_type_pid
+
+    @property
     def item_record_type(self):
         """Shortcut for item type, whether a standard or an issue record."""
         return self.get('type')

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -340,7 +340,7 @@ def item(item_barcode):
         circ_policy = CircPolicy.provide_circ_policy(
             item.library_pid,
             patron.patron_type_pid,
-            item.item_type_pid
+            item.item_type_circulation_category_pid
         )
         new_actions = []
         # If circulation policy doesn't allow checkout operation no need to

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -148,7 +148,7 @@
       }
     },
     "item_type": {
-      "title": "Circulation category of the item",
+      "title": "Circulation category",
       "type": "object",
       "required": [
         "$ref"
@@ -176,7 +176,7 @@
       }
     },
     "temporary_item_type": {
-      "title": "Temporary circulation category of the item",
+      "title": "Temporary circulation category",
       "description": "Apply a temporary item circulation category for this item. If specified, this circulation category overrides the default category.",
       "type": "object",
       "propertiesOrder": [
@@ -201,7 +201,7 @@
           }
         },
         "end_date": {
-          "title": "End date",
+          "title": "Deletion date",
           "type": "string",
           "format": "date",
           "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
@@ -220,6 +220,7 @@
         "templateOptions": {
           "cssClass": "editor-title"
         },
+        "hide": true,
         "navigation": {
           "essential": true
         }

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -263,7 +263,7 @@ def create_loan(barcode, transaction_type, loanable_items, verbose=False,
             circ_policy = CircPolicy.provide_circ_policy(
                 item.library_pid,
                 requested_patron.patron_type_pid,
-                item.item_type_pid
+                item.item_type_circulation_category_pid
             )
             if circ_policy.get('allow_requests'):
                 item.request(

--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -33,7 +33,6 @@ from ..utils import get_ref_for_pid
 def get_circ_policy(loan):
     """Return a circ policy for loan."""
     item = Item.get_record_by_pid(loan.item_pid)
-    holding_circulation_category = item.holding_circulation_category_pid
     library_pid = loan.library_pid
     patron = Patron.get_record_by_pid(loan.get('patron_pid'))
     patron_type_pid = patron.patron_type_pid
@@ -41,7 +40,7 @@ def get_circ_policy(loan):
     result = CircPolicy.provide_circ_policy(
         library_pid,
         patron_type_pid,
-        holding_circulation_category
+        item.temporary_item_type_pid or item.holding_circulation_category_pid
     )
     return result
 

--- a/rero_ils/modules/notifications/utils.py
+++ b/rero_ils/modules/notifications/utils.py
@@ -61,7 +61,7 @@ def _build_notification_email_context(loan, item, location):
     library = pickup_location.get_library()
     ctx['pickup_location']['library'] = library
     ctx['item']['item_type'] = \
-        ItemType.get_record_by_pid(item.item_type_pid)
+        ItemType.get_record_by_pid(item.item_type_circulation_category_pid)
     titles = [title for title in ctx['document'].get('title', [])
               if title['type'] == 'bf:Title']
     ctx['document']['title_text'] = \

--- a/tests/api/circulation/test_temporary_item_type.py
+++ b/tests/api/circulation/test_temporary_item_type.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests circulation operation for item with temporary item_type."""
+from datetime import datetime, timedelta
+
+import ciso8601
+from invenio_accounts.testutils import login_user_via_session
+from utils import postdata
+
+from rero_ils.modules.circ_policies.api import CircPolicy
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.utils import get_ref_for_pid
+
+
+def test_checkout_temporary_item_type(
+        client,
+        librarian_martigny_no_email,
+        lib_martigny,
+        loc_public_martigny,
+        patron_martigny_no_email,
+        item_lib_martigny,
+        item_type_on_site_martigny,
+        circ_policy_short_martigny,
+        circ_policy_default_martigny):
+    """Test checkout or item with temporary item_types"""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item = item_lib_martigny
+    assert item.status == ItemStatus.ON_SHELF
+
+    # test basic behavior
+    cipo_used = CircPolicy.provide_circ_policy(
+        lib_martigny.pid,
+        patron_martigny_no_email.patron_type_pid,
+        item.item_type_circulation_category_pid
+    )
+    assert cipo_used == circ_policy_short_martigny
+
+    # add a temporary_item_type on item
+    #   due to this change, the cipo used during circulation operation should
+    #   be different from the first cipo found.
+    item['temporary_item_type'] = {
+        '$ref': get_ref_for_pid('itty', item_type_on_site_martigny.pid)
+    }
+    item = item.update(data=item, dbcommit=True, reindex=True)
+    cipo_tmp_used = CircPolicy.provide_circ_policy(
+        lib_martigny.pid,
+        patron_martigny_no_email.patron_type_pid,
+        item.item_type_circulation_category_pid
+    )
+    assert cipo_tmp_used == circ_policy_default_martigny
+
+    delta = timedelta(cipo_tmp_used.get('checkout_duration'))
+    expected_date = datetime.now() + delta
+    expected_dates = [expected_date, lib_martigny.next_open(expected_date)]
+    expected_dates = [d.strftime('%Y-%m-%d') for d in expected_dates]
+
+    # try a checkout and check the transaction end_date is related to the cipo
+    # corresponding to the temporary item_type
+    params = dict(
+        item_pid=item.pid,
+        patron_pid=patron_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_location_pid=loc_public_martigny.pid
+    )
+    res, data = postdata(client, 'api_item.checkout', params)
+    assert res.status_code == 200
+    transaction_end_date = data['action_applied']['checkout']['end_date']
+    transaction_end_date = ciso8601.parse_datetime(transaction_end_date).date()
+    transaction_end_date = transaction_end_date.strftime('%Y-%m-%d')
+    assert transaction_end_date in expected_dates
+
+    # reset the item to orignal value
+    del item['temporary_item_type']
+    item.update(data=item, dbcommit=True, reindex=True)


### PR DESCRIPTION
If a temporary item_type is defined and valid on an item, it must be
used for circulation operation (checkout, extend, renew).

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
