### PR TITLE
gh-actions: fix wrong label in stale workflow file

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Mark stale issues and pull requests"
+name: "Mark stale issues/PR"
 on:
   workflow_dispatch:
   schedule:
@@ -22,5 +22,5 @@ jobs:
         # Set the label added to the PR marked stale
         stale-pr-label: 'stale'
         # Labels on an issue exempted from being marked as stale
-        exempt-issue-label: ['bug','P: High']
-        exempt-pr-label: ['translations']
+        exempt-issue-labels: 'bug,P: High'
+        exempt-pr-labels: 'translations'


### PR DESCRIPTION
* Adds a trailing 's' to exempt_issue_labels and exempt_pr_labels.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To fix wrong settings labels in the stale.yml file. 

## How to test?

- Check changes.
- The action has been tested on my repo: https://github.com/iGormilhit/rero-ils/actions?query=workflow%3A%22Mark+stale+issues+and+pull+requests%22

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
