### PR TITLE
public ui: merge profile menu entries

### DIFF
--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -16,10 +16,10 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #}
-{%- extends 'rero_ils/page.html' %}
+{%- extends 'rero_ils/page_settings.html' %}
 {% from "rero_ils/_macro_profile.html" import build_fees %}
 
-{%- block body %}
+{%- block settings_body %}
 {% include('rero_ils/_patron_profile_head.html') %}
 
 <section>
@@ -38,21 +38,21 @@
   <header>
     <nav>
       <ul class="nav nav-tabs" role="tablist">
-        <li class="nav-item">
+        <li class="nav-item mw-25">
           <a class="nav-link{% if tab == 'loans' %} active{% endif %}" href="#loans" data-toggle="tab" id="loans-tab" title="{{ _('Loans') }}"
             role="tab" aria-controls="loans" aria-selected="true">
             {{ _('Loans') }}
             <span class="badge badge-light font-weight-normal">{{ loans | length }}</span>
           </a>
         </li>
-        <li class="nav-item">
+        <li class="nav-item mw-25">
           <a class="nav-link{% if tab == 'requests' %} active{% endif %}" href="#requests" data-toggle="tab" id="requests-tab" title="{{ _('Requests') }}" role="tab"
             aria-controls="requests" aria-selected="false">
             {{ _('Requests') }}
             <span class="badge badge-light font-weight-normal">{{ requests | length }}</span>
           </a>
         </li>
-         <li class="nav-item">
+         <li class="nav-item mw-25">
           <a class="nav-link{% if tab == 'fees' %} active{% endif %}" href="#fees" data-toggle="tab" id="fees-tab" title="{{ _('Fees') }}" role="tab"
             aria-controls="fees" aria-selected="false">
             {{ _('Fees') }}
@@ -60,7 +60,7 @@
           </a>
         </li>
         {% if record.patron.keep_history %}
-        <li class="nav-item">
+        <li class="nav-item mw-25">
           <a class="nav-link{% if tab == 'history' %} active{% endif %}" href="#history" data-toggle="tab" id="history-tab" title="{{ _('History') }}" role="tab"
             aria-controls="history" aria-selected="false">
             {{ _('History') }}
@@ -68,14 +68,14 @@
           </a>
         </li>
         {% endif %}
-        <li class="nav-item">
+        <li class="nav-item mw-25">
           <a class="nav-link{% if tab == 'ill_request' %} active{% endif %}" href="#ill_request" data-toggle="tab" id="ill_request-tab" title="{{ _('ILL requests') }}" role="tab"
             aria-controls="history" aria-selected="false">
             {{ _('ILL requests') }}
             <span class="badge badge-light font-weight-normal">{{ ill_requests | length }}</span>
           </a>
         </li>
-        <li class="nav-item">
+        <li class="nav-item mw-25">
           <a class="nav-link{% if tab == 'personal' %} active{% endif %}" href="#personal-data" data-toggle="tab" id="personal-data-tab"
             title="{{ _('Personal data') }}" role="tab" aria-controls="personal-data" aria-selected="false">
             {{ _('Personal data') }}
@@ -136,4 +136,4 @@
     </section>
   </article>
 </article>
-{%- endblock body %}
+{%- endblock settings_body %}

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -28,6 +28,7 @@ from flask import Blueprint, abort, current_app, flash, jsonify, \
 from flask_babelex import format_currency
 from flask_babelex import gettext as _
 from flask_babelex import lazy_gettext
+from flask_breadcrumbs import register_breadcrumb
 from flask_login import current_user, login_required
 from flask_menu import register_menu
 from invenio_i18n.ext import current_i18n
@@ -169,10 +170,14 @@ def logged_user():
 @login_required
 @register_menu(
     blueprint,
-    'main.profile.patron_profile',
-    lazy_gettext('%(icon)s Profile', icon='<i class="fa fa-book fa-fw"></i>'),
+    'settings.patron_profile',
+    lazy_gettext('%(icon)s My loans', icon='<i class="fa fa-book fa-fw"></i>'),
     visible_when=user_has_patron,
-    id="my-profile-menu"
+    id="my-profile-menu",
+    order=-1
+)
+@register_breadcrumb(
+    blueprint, 'breadcrumbs.settings.patron_profile', _('Patron Profile')
 )
 def profile(viewcode):
     """Patron Profile Page."""

--- a/rero_ils/theme/assets/scss/rero_ils/styles.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/styles.scss
@@ -39,6 +39,20 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 @import "patrons/profile";
 @import "documents/detailed";
 
+// bootstrap extension
+
+.mw-25 {
+  max-width: 25%;
+}
+
+.mw-50 {
+  max-width: 50%;
+}
+
+.mw-75 {
+  max-width: 75%;
+}
+
 // cover
 .rero-ils-cover-logo {
   width: 10em;

--- a/rero_ils/theme/templates/rero_ils/header.html
+++ b/rero_ils/theme/templates/rero_ils/header.html
@@ -133,8 +133,10 @@
 {{ flashed_messages() }}
 {%- endblock flashmessages %}
 
+{% if False %}
 <div class="container">
   {%- block breadcrumbs %}
   {%- include "rero_ils/breadcrumbs.html" %}
   {%- endblock breadcrumbs %}
 </div>
+{% endif %}

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -273,13 +273,16 @@ def init_menu_profile():
     )
 
     item = current_menu.submenu('main.profile.profile')
+    profile_endpoint = 'invenio_userprofiles.profile'
+    if current_patron and current_patron.is_patron:
+        profile_endpoint = 'patrons.profile'
     rero_register(
         item,
-        endpoint='invenio_userprofiles.profile',
+        endpoint=profile_endpoint,
         visible_when=lambda: current_user.is_authenticated,
         text='{icon} {profile}'.format(
             icon='<i class="fa fa-user"></i>',
-            profile=_('RERO ID')
+            profile=_('My Account')
         ),
         order=1,
         id='profile-menu',


### PR DESCRIPTION
* Removes the RERO ID menu.
* Adds a "My Account" menu, which is the patron profile for patron and
  invenio users for others.
* Removes breadcrumbs in the profile settings view.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
