### PR TITLE
operation_logs: capture operation after record creation

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1561,7 +1561,7 @@ RECORDS_REST_ENDPOINTS = dict(
         record_class='rero_ils.modules.operation_logs.api:OperationLog',
         list_route='/operation_logs/',
         item_route='/operation_logs/<pid(oplg, record_class='
-        '"rero_ils.modules.operation_logs.api:UpdaetLog"):pid_value>',
+        '"rero_ils.modules.operation_logs.api:OperationLog"):pid_value>',
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
@@ -2220,6 +2220,14 @@ RECORDS_JSON_SCHEMA = {
     'oplg': '/operation_logs/operation_log-v0.0.1.json',
     'vndr': '/vendors/vendor-v0.0.1.json',
 }
+
+# Operation Log Configuration
+# ===================
+# Keep history of peration logs for the following resources
+RERO_ILS_ENABLE_OPERATION_LOG = [
+    'documents', 'items', 'holdings'
+]
+ 
 
 # Login Configuration
 # ===================

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -43,6 +43,7 @@ from .items.listener import enrich_item_data
 from .loans.listener import enrich_loan_data, listener_loan_state_changed
 from .locations.listener import enrich_location_data
 from .notifications.listener import enrich_notification_data
+from .operation_logs.listener import create_operation_log_record
 from .patron_transaction_events.listener import \
     enrich_patron_transaction_event_data
 from .patron_transactions.listener import enrich_patron_transaction_data
@@ -150,6 +151,8 @@ class REROILSAPP(object):
 
         after_record_insert.connect(create_subscription_patron_transaction)
         after_record_update.connect(create_subscription_patron_transaction)
+        
+        after_record_insert.connect(create_operation_log_record)
 
         loan_state_changed.connect(listener_loan_state_changed, weak=False)
 

--- a/rero_ils/modules/operation_logs/jsonresolver.py
+++ b/rero_ils/modules/operation_logs/jsonresolver.py
@@ -26,10 +26,10 @@ from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 def operation_log_resolver(pid):
     """Resolver for operation_log record."""
     persist_id = PersistentIdentifier.get('oplg', pid)
-    if persistent_id.status == PIDStatus.REGISTERED:
-        return dict(pid=persistent_id.pid_value)
+    if persist_id.status == PIDStatus.REGISTERED:
+        return dict(pid=persist_id.pid_value)
     current_app.logger.error(
         'Operation logs resolver error: /api/operation_logs/{pid} {persist_id}'
-        .format(pid=pid, persistent_id=persistent_id)
+        .format(pid=pid, persistent_id=persist_id)
     )
     raise Exception('unable to resolve')

--- a/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
+++ b/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
@@ -60,7 +60,7 @@
       "type": "string",
       "format": "date-time"
     },
-    "type": {
+    "operation": {
       "title": "Operation type",
       "type": "string",
       "enum": [
@@ -69,7 +69,7 @@
       ]
     },
     "organisation": {
-      "title": "Organisation",
+      "title": "User organisation",
       "type": "object",
       "properties": {
         "$ref": {

--- a/rero_ils/modules/operation_logs/listener.py
+++ b/rero_ils/modules/operation_logs/listener.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Signals connector for Operation log."""
+
+from datetime import datetime, timezone
+
+from flask import current_app
+
+from .api import OperationLog
+from ..patrons.api import current_patron
+from ..utils import extracted_data_from_ref, get_ref_for_pid
+
+
+def create_operation_log_record(sender, record=None, *args, **kwargs):
+    """Create an operation log entry after record creation and update.
+
+    Checks if the record is configured to keep logs of its creation and update.
+    If enabled, a new operation log entry will be added. Method is called after
+    record creation or update by connecting to signals'after_record_insert'
+    and 'after_record_update'.
+
+    :param record: the record being created.
+    """
+    if record.get('$schema'):
+        resource_name = extracted_data_from_ref(
+            record.get('$schema'), data='resource')
+        if resource_name in current_app.config.get(
+            'RERO_ILS_ENABLE_OPERATION_LOG'):
+            oplg = {
+                'date': datetime.now(timezone.utc).isoformat(),
+                'record': {'$ref': get_ref_for_pid(
+                    record.provider.pid_type, record.get('pid'))},
+                'operation': 'create'
+            }
+            if current_patron:
+                oplg['user'] = {
+                    '$ref': get_ref_for_pid('ptrn', current_patron.pid)}
+                oplg['user_name'] = current_patron.formatted_name
+                oplg['organisation'] = {
+                    '$ref': get_ref_for_pid('org', current_patron.organisation_pid)}
+            else:
+                oplg['user_name'] = 'system'
+            OperationLog.create(oplg)

--- a/rero_ils/modules/operation_logs/mappings/v7/operation_logs/operation_log-v0.0.1.json
+++ b/rero_ils/modules/operation_logs/mappings/v7/operation_logs/operation_log-v0.0.1.json
@@ -50,7 +50,7 @@
       "date": {
         "type": "date"
       },
-      "type": {
+      "operation": {
         "type": "keyword"
       },
       "_created": {

--- a/rero_ils/modules/operation_logs/permissions.py
+++ b/rero_ils/modules/operation_logs/permissions.py
@@ -17,7 +17,6 @@
 
 """Permissions of Operation log."""
 
-from rero_ils.modules.organisations.api import current_organisation
 from rero_ils.modules.patrons.api import current_patron
 from rero_ils.modules.permissions import RecordPermission
 
@@ -33,8 +32,11 @@ class OperationLogPermission(RecordPermission):
         :param record: Record to check.
         :return: "True" if action can be done.
         """
-        # List operation logs allowed only for staff members (lib, sys_lib)
-        return current_patron and current_patron.is_librarian
+        # all users may list operation_log records.
+        # TODO: check with group PO here.
+        if not current_patron:
+            return False
+        return True
 
     @classmethod
     def read(cls, user, record):
@@ -44,13 +46,11 @@ class OperationLogPermission(RecordPermission):
         :param record: Record to check.
         :return: "True" if action can be done.
         """
+        # all users may read operation_log records.
+        # TODO: check with group PO here.
         if not current_patron:
             return False
-        # only staff members (lib, sys_lib) are allowed to read
-        if not current_patron.is_librarian:
-            return False
-        # For staff users, they can read only own organisation
-        return current_organisation['pid'] == record.organisation_pid
+        return True
 
     @classmethod
     def create(cls, user, record=None):

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -152,6 +152,9 @@ def logged_user():
                 'RERO_ILS_CONTRIBUTIONS_LABEL_ORDER', {}),
             'contributionSources': current_app.config.get(
                 'RERO_ILS_CONTRIBUTIONS_SOURCES', []
+            ),
+            'operation_logs': current_app.config.get(
+                'RERO_ILS_ENABLE_OPERATION_LOG', []
             )
         }
     }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3440,5 +3440,15 @@
       }
     ],
     "published": true
+  },
+  "oplg1": {
+    "$schema": "https://ils.rero.ch/schemas/operation_logs/ioperation_log-v0.0.1.json",
+    "pid": "oplg1",
+    "record": {
+      "$ref": "https://ils.rero.ch/api/items/item4"
+    },
+    "operation": "create",
+    "user_name": "created_user",
+    "date": "2021-01-21T09:51:52.879533+00:00"
   }
 }

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -1005,3 +1005,10 @@ def local_field_sion(
         reindex=True)
     flush_index(LocalFieldsSearch.Meta.index)
     return local_field
+
+# --- OPERATION LOGS
+@pytest.fixture(scope="module")
+def operation_log_1_data(data):
+    """Load operation log record."""
+    return deepcopy(data.get('oplg1'))
+

--- a/tests/ui/test_monitoring.py
+++ b/tests/ui/test_monitoring.py
@@ -48,7 +48,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
         '      0     loc          0                  locations          0',
         '      0    lofi          0               local_fields          0',
         '      0   notif          0              notifications          0',
-        '      0    oplg          0             operation_logs          0',
+        '      1    oplg          1             operation_logs          0',
         '      0     org          0              organisations          0',
         '      0    ptre          0  patron_transaction_events          0',
         '      0    ptrn          0                    patrons          0',
@@ -70,7 +70,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
     doc_pid = doc.pid
     assert mon.get_db_count('doc') == 1
     assert mon.get_es_count('documents') == 0
-    assert mon.check() == {'doc': {'db_es': 1}}
+    assert mon.check() == {'doc': {'db_es': 1}, 'oplg': {'db_es': 1}}
     assert mon.missing('doc') == {'DB': [], 'ES': ['doc3'], 'ES duplicate': []}
     assert mon.info() == {
         'acac': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'acq_accounts'},
@@ -91,7 +91,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
         'loc': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'locations'},
         'lofi': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'local_fields'},
         'notif': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'notifications'},
-        'oplg': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'operation_logs'},
+        'oplg': {'db': 1, 'db-es': 1, 'es': 0, 'index': 'operation_logs'},
         'org': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'organisations'},
         'ptre': {'db': 0, 'db-es': 0, 'es': 0,
                  'index': 'patron_transaction_events'},
@@ -111,7 +111,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
     res = runner.invoke(es_db_counts_cli, ['-m'], obj=script_info)
     assert res.output.split('\n') == cli_output + [
         'doc: pids missing in ES:',
-        'doc3',
+        'doc3', 'oplg: pids missing in ES:', '1',
         ''
     ]
 
@@ -121,10 +121,10 @@ def test_monitoring(app, document_sion_items_data, script_info):
     doc.reindex()
     flush_index(DocumentsSearch.Meta.index)
     assert mon.get_es_count('documents') == 1
-    assert mon.check() == {}
+    assert mon.check() == {'oplg': {'db_es': 1}}
     assert mon.missing('doc') == {'DB': [], 'ES': [], 'ES duplicate': []}
     doc.delete(dbcommit=True)
     assert mon.get_db_count('doc') == 0
     assert mon.get_es_count('documents') == 1
-    assert mon.check() == {'doc': {'db_es': -1}}
+    assert mon.check() == {'doc': {'db_es': -1}, 'oplg': {'db_es': 1}}
     assert mon.missing('doc') == {'DB': ['doc3'], 'ES': [], 'ES duplicate': []}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -224,3 +224,13 @@ def ill_request_schema(monkeypatch):
         'rero_ils.modules.ill_requests.jsonschemas',
         '/ill_requests/ill_request-v0.0.1.json')
     return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture()
+def operation_log_schema(monkeypatch):
+    """Operation log Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.operation_logs.jsonschemas',
+        'operation_logs/operation_log-v0.0.1.json'
+    )
+    return get_schema(monkeypatch, schema_in_bytes)

--- a/tests/unit/test_operation_logs_jsonschema.py
+++ b/tests/unit/test_operation_logs_jsonschema.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Operation log JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_required(operation_log_schema, operation_log_1_data):
+    """Test required for operation log jsonschemas."""
+    validate(operation_log_1_data, operation_log_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, operation_log_schema)
+
+
+def test_operation_log_all_jsonschema_keys_values(
+        operation_log_schema, operation_log_1_data):
+    """Test all keys and values for operation log jsonschema."""
+    record = operation_log_1_data
+    validate(record, operation_log_schema)
+    validator = [
+        {'key': 'pid', 'value': 25},
+        {'key': 'operation', 'value': 25},
+        {'key': 'record', 'value': 25},
+        {'key': 'date', 'value': 25},
+        {'key': 'organisation', 'value': 25},
+        {'key': 'user', 'value': 25},
+        {'key': 'user_name', 'value': 25}
+    ]
+    for element in validator:
+        with pytest.raises(ValidationError):
+            record[element['key']] = element['value']
+            validate(record, operation_log_schema)


### PR DESCRIPTION
* Adds configuration to enable the capture of operation by resource.
* Renames field operation_log.type to operation_log.operation.
* Adds listener to add operation_log after record creation.
* Adds units testing.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

Additional commit will be added to complete this work, this is only to
allow @Garfield-fr to start the UI development.

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
