### PR TITLE
documents: add to index some holdings fields

### DIFF
--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -744,6 +744,24 @@
               }
             }
           },
+          "call_number": {
+            "type": "text"
+          },
+          "second_call_number": {
+            "type": "text"
+          },
+          "index": {
+            "type": "text"
+          },
+          "enumerationAndChronology": {
+            "type": "text"
+          },
+          "supplementaryContent": {
+            "type": "text"
+          },
+          "notes": {
+            "type": "text"
+          },
           "items": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
The following holdings fields are now indexed in the document index in
order to allow search requests on holdings data:

* holdings.call_number
* holdings.second_call_number
* holdings.index
* holdings.enumerationAndChronology
* holdings.supplementaryContent
* holdings.notes

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1969?kanban-status=1224895

## How to test?

- now you can locate a document by searching for its holdings.enumerationAndChronology or any other fields listed above.
<img width="864" alt="Screenshot 2021-01-21 at 17 15 44" src="https://user-images.githubusercontent.com/26998238/105380666-72305600-5c0e-11eb-9a5b-372fc99e94e0.png">

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
