### PR TITLE
holdings: exlcude masked holding from public interface

### DIFF
--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -69,9 +69,15 @@ def doc_item_view_method(pid, record, template=None, **kwargs):
     # Use ES to order holdings records
     # Pass directly the ES holdings to the template
     # and create some pipe to process record
+    # return only non-masked holdings records for the public interface.
+    # TODO: this is a temporary implemenation of the masked holdings records.
+    # this functionality will be completed after merging the USs:
+    # US1909: Performance: many items on public document detailed view
+    # US1906: Complete item model
     from ..holdings.api import HoldingsSearch
     query = results = HoldingsSearch()\
-        .filter('term', document__pid=pid.pid_value)
+        .filter('term', document__pid=pid.pid_value) \
+        .filter('term', _masked=False)
     if organisation:
         query = query.filter('term', organisation__pid=organisation.pid)
     results = query\

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -13,14 +13,13 @@
     "document"
   ],
   "propertiesOrder": [
+    "location",
+    "circulation_category",
     "call_number",
     "second_call_number",
-    "circulation_category",
-    "location",
     "holdings_type",
-    "_masked",
-    "vendor",
     "enumerationAndChronology",
+    "patterns",
     "supplementaryContent",
     "index",
     "missing_issues",
@@ -32,7 +31,8 @@
     "completeness",
     "composite_copy_report",
     "notes",
-    "patterns"
+    "vendor",
+    "_masked"
   ],
   "properties": {
     "$schema": {
@@ -53,7 +53,14 @@
     },
     "second_call_number": {
       "title": "Second call number",
-      "type": "string"
+      "type": "string",
+      "hide": true,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     },
     "circulation_category": {
       "title": "Circulation type",
@@ -447,8 +454,9 @@
         }
       },
       "form": {
-        "expressionProperties": {
-          "templateOptions.required": "true"
+        "hide": true,
+        "navigation": {
+          "essential": true
         }
       }
     },
@@ -488,28 +496,53 @@
       "title": "Supplementary content",
       "description": "Textual description of supplementary contents (special issues, etc.).",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     },
     "index": {
       "title": "Indexes",
       "description": "Textual description of the indexes.",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     },
     "missing_issues": {
       "title": "Missing issues",
       "description": "Textual description of the missing issues.",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     },
     "issue_binding": {
       "title": "Number of issues to be bound together",
       "type": "number",
-      "minimum": 0
+      "minimum": 0,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     },
     "notes": {
       "title": "Notes",
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "title": "Note",
@@ -596,6 +629,10 @@
         }
       },
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "validation": {
           "validators": {
             "uniqueValueKeysInObject": {
@@ -622,6 +659,10 @@
         "not_currently_received"
       ],
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "selectWithSort",
         "options": [
           {
@@ -669,6 +710,10 @@
         "other_method_of_acquisition"
       ],
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "selectWithSort",
         "options": [
           {
@@ -729,6 +774,10 @@
       "format": "date",
       "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "datepicker",
         "validation": {
           "messages": {
@@ -752,6 +801,10 @@
         "permanently_retained"
       ],
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "selectWithSort",
         "options": [
           {
@@ -806,6 +859,10 @@
         "not_applicable"
       ],
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "selectWithSort",
         "options": [
           {
@@ -840,6 +897,10 @@
         "composite"
       ],
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "selectWithSort",
         "options": [
           {

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -166,12 +166,24 @@ def organisation_organisation_search_factory(self, search, query_parser=None):
 
 
 def organisation_search_factory(self, search, query_parser=None):
-    """Search factory."""
-    search, urlkwargs = search_factory(self, search)
+    """Search factory with view code parameter.
+
+    Exlcude masked record from public search.
+    """
+    # TODO: this is a temporary implemenation of the masked holdings records.
+    # this functionality will be completed after merging the USs:
+    # US1909: Performance: many items on public document detailed view
+    # US1906: Complete item model
     if current_patron:
         search = search.filter(
             'term', organisation__pid=current_organisation.pid
         )
+    view = request.args.get(
+        'view', current_app.config.get('RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'))
+    search, urlkwargs = search_factory(self, search)
+    if view != current_app.config.get('RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'):
+        search = search.filter('bool', must_not=[Q('term', _masked=True)])
+
     return search, urlkwargs
 
 


### PR DESCRIPTION
Enable longmode for holdings editor, the following
fields are by default displayed for new records:

 * holdings.location
 * holdings.circulation_category
 * holdings.call_number
 * holdings.EnumerationAnyChronology
 * holdings.vendor
 * holdings._masked

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

`note`:  the `masking` functionality will be completed after merging the refactoring of holdings/items
and implementing the `complete item record` user story.

https://tree.taiga.io/project/rero21-reroils/task/1970?kanban-status=1224895

## Dependencies

https://tree.taiga.io/project/rero21-reroils/task/1970?kanban-status=1224895

## How to test?

Only few fields are available when creating new holdings record:

<img width="1336" alt="Screenshot 2021-01-25 at 17 22 07" src="https://user-images.githubusercontent.com/26998238/105733522-ed0cb000-5f31-11eb-85d9-8f10842cb2cc.png">

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
