### PR TITLE
notification: improve notification creation task

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -282,10 +282,15 @@ CELERY_BEAT_SCHEDULE = {
         'enabled': False
     },
     'notification-creation': {
-        'task': ('rero_ils.modules.notifications.tasks'
-                 '.create_over_and_due_soon_notifications'),
+        'task': 'rero_ils.modules.notifications.tasks.create_notifications',
         'schedule': crontab(minute="*/5"),
-        'enabled': False
+        'kwargs': {
+            'types': [
+                Notification.DUE_SOON_NOTIFICATION_TYPE,
+                Notification.OVERDUE_NOTIFICATION_TYPE
+            ]
+        },
+        'enabled': False,
         # TODO: in production set this up once a day
     },
     'claims-creation': {
@@ -2401,11 +2406,16 @@ CIRCULATION_LOAN_TRANSITIONS = {
         ),
     ],
     'PENDING': [
-        dict(dest=LoanState.ITEM_AT_DESK,
-             transition=PendingToItemAtDesk, trigger='validate_request'),
-        dict(dest=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
-             transition=PendingToItemInTransitPickup,
-             trigger='validate_request'),
+        dict(
+            dest=LoanState.ITEM_AT_DESK,
+            transition=PendingToItemAtDesk,
+            trigger='validate_request'
+        ),
+        dict(
+            dest=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
+            transition=PendingToItemInTransitPickup,
+            trigger='validate_request'
+        ),
         dict(
             dest=LoanState.ITEM_ON_LOAN,
             transition=ToItemOnLoan,

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -280,8 +280,8 @@ class Library(IlsRecord):
         )
 
     def count_open(self, start_date=datetime.now(pytz.utc),
-                   end_date=datetime.now(pytz.utc), day_only=False):
-        """Get next open day."""
+                   end_date=datetime.now(pytz.utc)):
+        """Get number of open day between date interval."""
         if isinstance(start_date, str):
             start_date = date_string_to_utc(start_date)
         if isinstance(end_date, str):

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -35,7 +35,8 @@ from ..items.utils import item_pid_to_object
 from ..libraries.api import Library
 from ..loans.api import Loan
 from ..locations.api import Location
-from ..notifications.tasks import create_over_and_due_soon_notifications
+from ..notifications.api import Notification
+from ..notifications.tasks import create_notifications
 from ..patron_transaction_events.api import PatronTransactionEvent
 from ..patron_types.api import PatronType
 from ..patrons.api import Patron, PatronsSearch
@@ -129,9 +130,14 @@ def create_loans(infile, verbose, debug):
                 errors_count = print_message(item_barcode, 'rank_2',
                                              errors_count)
     # create due soon notifications, overdue notifications are auto created.
-    result = create_over_and_due_soon_notifications(overdue=False,
-                                                    process=False,
-                                                    verbose=verbose)
+    result = create_notifications(
+        types=[
+            Notification.DUE_SOON_NOTIFICATION_TYPE,
+            Notification.OVERDUE_NOTIFICATION_TYPE
+        ],
+        process=False,
+        verbose=verbose
+    )
     # block given patron
     for patron_data in to_block:
         barcode = patron_data.get('barcode')

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -83,9 +83,8 @@ class Dispatcher:
                     pid=patron['pid']))
             return
         language = patron['patron']['communication_language']
-        notification_type = data.get('notification_type')
         loan = Loan.get_record_by_pid(data['loan']['pid'])
-        tpl_path = get_template_to_use(loan, notification_type).rstrip('/')
+        tpl_path = get_template_to_use(loan, data).rstrip('/')
         template = '{tpl_path}/{language}.txt'.format(
             tpl_path=tpl_path,
             language=language

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -19,9 +19,14 @@
 
 from __future__ import absolute_import, print_function
 
+from datetime import datetime, timezone
+
 from celery import shared_task
+from flask import current_app
 
 from .api import Notification
+from ..circ_policies.api import OVERDUE_REMINDER_TYPE
+from ..libraries.api import Library
 from ..loans.api import get_due_soon_loans, get_overdue_loans
 
 
@@ -39,26 +44,77 @@ def process_notifications(verbose=False):
 
 
 @shared_task(ignore_result=True)
-def create_over_and_due_soon_notifications(late=True, due_soon=True,
-                                           process=True, verbose=False):
-    """Creates due soon and late notifications."""
-    no_over_due_loans = 0
-    no_due_soon_loans = 0
-    if due_soon:
-        for loan in get_due_soon_loans():
-            loan.create_notification(
-                notification_type=Notification.DUE_SOON_NOTIFICATION_TYPE)
-            no_due_soon_loans += 1
-    if late:
-        for loan in get_overdue_loans():
-            loan.create_notification(
-                notification_type=Notification.OVERDUE_NOTIFICATION_TYPE)
-            no_over_due_loans += 1
+def create_notifications(types=None, tstamp=None, process=True, verbose=True):
+    """Creates requested notifications.
 
-    msg = f'loans| late: {no_over_due_loans} due soon: {no_due_soon_loans}'
+    :param types: an array of notification types to create.
+    :param tstamp: a timestamp to specify when the function is execute. By
+                   default it will be `datetime.now()`.
+    :param process: is the notifications should be processed/sent.
+    :param verbose: is the task should be verbose.
+    """
+    from ..loans.utils import get_circ_policy
+    types = types or []
+    tstamp = tstamp or datetime.now(timezone.utc)
+    logger = current_app.logger
+    notification_counter = {}
+
+    # DUE SOON NOTIFICATIONS
+    if Notification.DUE_SOON_NOTIFICATION_TYPE in types:
+        due_soon_type = Notification.DUE_SOON_NOTIFICATION_TYPE
+        notification_counter[due_soon_type] = 0
+        logger.debug("OVERDUE_NOTIFICATION_CREATION --------------")
+        for loan in get_due_soon_loans(tstamp=tstamp):
+            logger.debug(f'* Loan#{loan.pid} is considerate as \'due_soon\'')
+            loan.create_notification(notification_type=due_soon_type)
+            notification_counter[due_soon_type] += 1
+
+    # OVERDUE NOTIFICATIONS
+    if Notification.OVERDUE_NOTIFICATION_TYPE in types:
+        logger.debug("OVERDUE_NOTIFICATION_CREATION --------------")
+        overdue_type = Notification.OVERDUE_NOTIFICATION_TYPE
+        notification_counter[overdue_type] = 0
+        for loan in get_overdue_loans(tstamp=tstamp):
+            logger.debug(f'* Loan#{loan.pid} is considerate as \'overdue\'')
+            # For each overdue loan, we need to get the 'overdue' reminders
+            # to should be sent from the due_date and the current used date.
+            loan_library = Library.get_record_by_pid(loan.library_pid)
+            open_days = loan_library.count_open(
+                start_date=loan.overdue_date,
+                end_date=tstamp
+            )
+            circ_policy = get_circ_policy(loan)
+            logger.debug(f'  - this loan use the cipo#{circ_policy.pid}')
+            logger.debug(f'  - open days from loans due_date :: {open_days}')
+            reminders = circ_policy.get_reminders(
+                reminder_type=OVERDUE_REMINDER_TYPE,
+                limit=open_days
+            )
+            # For each reminder, try to create it.
+            #   the `create_notification` method will check if the notification
+            #   is already sent. If the notification has already sent, it will
+            #   not be created again
+            for idx, reminder in enumerate(reminders):
+                notification = loan.create_notification(
+                    notification_type=overdue_type,
+                    counter=idx
+                )
+                if notification:
+                    logger.debug(f'  --> Overdue notification#{idx+1} created')
+                    notification_counter[overdue_type] += 1
+                else:
+                    logger.debug(f'  --> Overdue notification#{idx+1} skipped '
+                                 f':: already sent')
+
+    if verbose:
+        logger = current_app.logger
+        logger.info("NOTIFICATIONS CREATION TASK")
+        notification_sum = sum(notification_counter.values())
+        logger.info(f'  * total of {notification_sum} notification(s) created')
+        counters = {k: v for k, v in notification_counter.items() if v > 0}
+        for notif_type, cpt in counters.items():
+            logger.info(f'  +--> {cpt} `{notif_type}` notification(s) created')
+
     if process:
-        msg = '{msg}, {process_msg}'.format(
-            msg=msg,
-            process_msg=process_notifications.run(verbose=verbose)
-        )
-    return msg
+        logger.info(process_notifications.run(verbose=verbose))
+

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -376,6 +376,8 @@ def get_ref_for_pid(module, pid):
     :return: url for record
     """
     configuration = get_endpoint_configuration(module)
+    if module == 'loans':
+        configuration = {'list_route': '/loans/'}
     if configuration and configuration.get('list_route'):
         return '{url}/api{route}{pid}'.format(
             url=get_base_url(),

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -953,6 +953,13 @@
         "fee_amount": 2.0,
         "communication_channel": "email",
         "template": "email/overdue"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 12,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue2"
       }
     ],
     "number_renewals": 1,
@@ -3128,6 +3135,7 @@
     "pid": "notif1",
     "creation_date": "2019-01-09T08:18:22.576291+00:00",
     "notification_type": "availability",
+    "reminder_counter": 0,
     "loan": {
       "$ref": "https://ils.rero.ch/api/loans/x"
     }

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -26,13 +26,12 @@ from invenio_circulation.proxies import current_circulation
 from invenio_circulation.search.api import LoansSearch
 from utils import flush_index, get_mapping
 
-from rero_ils.modules.loans.api import Loan, LoanState, \
-    get_loans_by_patron_pid, get_overdue_loans
+from rero_ils.modules.loans.api import Loan, LoanState, get_loans_by_patron_pid
 from rero_ils.modules.loans.tasks import loan_anonymizer
 from rero_ils.modules.loans.utils import get_default_loan_duration
-from rero_ils.modules.notifications.api import NotificationsSearch
-from rero_ils.modules.notifications.tasks import \
-    create_over_and_due_soon_notifications
+from rero_ils.modules.notifications.api import Notification, \
+    NotificationsSearch
+from rero_ils.modules.notifications.tasks import create_notifications
 from rero_ils.modules.patron_transactions.api import PatronTransaction
 
 
@@ -81,7 +80,7 @@ def test_loan_keep_and_to_anonymize(
         'transaction_location_pid': loc_public_martigny.pid,
         'transaction_user_pid': librarian_martigny_no_email.pid
     }
-    item, actions = item.checkin(**params)
+    item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)
     # item checkedin and has no open events
     assert loan.concluded(loan)
@@ -94,7 +93,7 @@ def test_loan_keep_and_to_anonymize(
     loan = Loan.get_record_by_pid(loan.pid)
     assert loan.concluded(loan)
     assert loan.can_anonymize(loan_data=loan)
-    loan = loan.update(loan, dbcommit=True, reindex=True)
+    loan.update(loan, dbcommit=True, reindex=True)
 
     # test loans with fees
     item, patron, loan = item2_on_loan_martigny_patron_and_loan_on_loan
@@ -104,17 +103,18 @@ def test_loan_keep_and_to_anonymize(
     loan['end_date'] = end_date.isoformat()
     loan.update(loan, dbcommit=True, reindex=True)
 
-    create_over_and_due_soon_notifications()
+    create_notifications(types=[
+        Notification.DUE_SOON_NOTIFICATION_TYPE,
+        Notification.OVERDUE_NOTIFICATION_TYPE
+    ])
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
-    overdue_loans = list(get_overdue_loans())
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
         'transaction_user_pid': librarian_martigny_no_email.pid
     }
-    item, actions = item.checkin(**params)
-
+    item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)
 
     assert not loan.concluded(loan)
@@ -133,7 +133,10 @@ def test_anonymizer_job(
     loan['end_date'] = end_date.isoformat()
     loan.update(loan, dbcommit=True, reindex=True)
 
-    create_over_and_due_soon_notifications()
+    create_notifications(types=[
+        Notification.DUE_SOON_NOTIFICATION_TYPE,
+        Notification.OVERDUE_NOTIFICATION_TYPE
+    ])
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
 
@@ -147,7 +150,7 @@ def test_anonymizer_job(
         'transaction_location_pid': loc_public_martigny.pid,
         'transaction_user_pid': librarian_martigny_no_email.pid
     }
-    item, actions = item.checkin(**params)
+    item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)
     # item checked-in and has no open events
     assert not loan.concluded(loan)


### PR DESCRIPTION
Initially, the task to create notification is only able to create one
DUE_SOON and one OVERDUE notifications. Improves this task to allow it
to all necessary notification not yet sent on a loan.
Adds a new parameter for the task method allowing to simulate the
execution of this task for a given timestamp.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
