### PR TITLE
test: fix test in house

### DIFF
--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -146,7 +146,16 @@
           "day": {
             "title": "Day",
             "description": "Weekday.",
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
           },
           "is_open": {
             "title": "Is open",

--- a/tests/api/circulation/test_temporary_item_type.py
+++ b/tests/api/circulation/test_temporary_item_type.py
@@ -84,6 +84,6 @@ def test_checkout_temporary_item_type(
     transaction_end_date = transaction_end_date.strftime('%Y-%m-%d')
     assert transaction_end_date in expected_dates
 
-    # reset the item to orignal value
+    # reset the item to original value
     del item['temporary_item_type']
     item.update(data=item, dbcommit=True, reindex=True)


### PR DESCRIPTION
Fixes the test 'test_less_than_one_day_checkout'. If the test was
executed when the library is closed, the test failed ; So to fix this
problem, we freeze the transaction date to an opening day/hour.

Fixes the function `library.next_open()` function. This function didn't
care about hour/minutes.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
