### PR TITLE
circulation: allows multiple reminders and overdue fees

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -9,9 +9,21 @@
     "allow_checkout": true,
     "checkout_duration": 30,
     "allow_requests": true,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 3,
     "renewal_duration": 30,
     "policy_library_level": false,
@@ -27,10 +39,22 @@
     "allow_checkout": true,
     "checkout_duration": 30,
     "allow_requests": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 3,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 30,
     "policy_library_level": false,
     "is_default": true
@@ -45,10 +69,22 @@
     "allow_checkout": true,
     "checkout_duration": 7,
     "allow_requests": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 1,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 7,
     "policy_library_level": true,
     "is_default": false,
@@ -78,10 +114,22 @@
     "allow_checkout": true,
     "checkout_duration": 14,
     "allow_requests": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 1,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 14,
     "policy_library_level": false,
     "is_default": false,
@@ -114,10 +162,22 @@
     "allow_checkout": true,
     "checkout_duration": 14,
     "allow_requests": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 1,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 14,
     "policy_library_level": false,
     "is_default": false,
@@ -142,10 +202,22 @@
     "allow_checkout": true,
     "checkout_duration": 28,
     "allow_requests": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 3,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 28,
     "policy_library_level": false,
     "is_default": false,
@@ -168,12 +240,24 @@
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
     "allow_checkout": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "checkout_duration": 84,
     "allow_requests": true,
     "number_renewals": 3,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 84,
     "policy_library_level": false,
     "is_default": false,
@@ -372,11 +456,23 @@
       "$ref": "https://ils.rero.ch/api/organisations/3"
     },
     "allow_checkout": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "checkout_duration": 28,
     "allow_requests": true,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "number_renewals": 3,
     "renewal_duration": 30,
     "policy_library_level": false,
@@ -390,12 +486,24 @@
       "$ref": "https://ils.rero.ch/api/organisations/4"
     },
     "allow_checkout": true,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "checkout_duration": 30,
     "allow_requests": true,
     "number_renewals": 3,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
     "renewal_duration": 30,
     "policy_library_level": false,
     "is_default": true

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -14,7 +14,6 @@
   "properties": {
     "$schema": {
       "title": "Schema",
-      "description": "Schema to validate circulation policies records against.",
       "type": "string",
       "minLength": 9,
       "default": "https://ils.rero.ch/schemas/circ_policies/circ_policy-v0.0.1.json"
@@ -26,17 +25,14 @@
     },
     "name": {
       "title": "Circulation policy name",
-      "description": "The name of the circulation policy.",
       "type": "string",
       "minLength": 2
     },
     "description": {
       "title": "Circulation policy description",
-      "description": "The description of the circulation policy.",
       "type": "string"
     },
     "organisation": {
-      "title": "Organisation",
       "type": "object",
       "properties": {
         "$ref": {
@@ -48,53 +44,116 @@
     },
     "allow_checkout": {
       "title": "Allow Checkout",
-      "description": "Checkouts are allowed or not.",
       "type": "boolean",
       "default": true
     },
     "checkout_duration": {
       "title": "Checkout duration in days",
-      "description": "The duration of the checkout in days.",
       "type": "integer",
       "minimum": 0,
       "default": 7
     },
     "allow_requests": {
       "title": "Allow patron requests",
-      "description": "Patron requests are allowed or not.",
       "type": "boolean",
       "default": true
     },
-    "number_of_days_before_due_date": {
-      "title": "Number of days before due date.",
-      "description": "Number of days before due date for sending the due_soon notification.",
-      "type": "integer",
-      "default": 5,
-      "minimum": 0
+    "reminders": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "reminder": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "days_delay",
+            "communication_channel",
+            "template"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "due_soon",
+                "overdue"
+              ]
+            },
+            "days_delay": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "fee_amount": {
+              "type": "number",
+              "multipleOf": 0.01
+            },
+            "communication_channel": {
+              "type": "string",
+              "enum": [
+                "email",
+                "mail"
+              ]
+            },
+            "template": {
+              "type": "string",
+              "minLength": 2
+            }
+          }
+        }
+      }
     },
-    "number_of_days_after_due_date": {
-      "title": "Number of days after due date",
-      "description": "Number of days after due date for sending the first overdue notification.",
-      "type": "integer",
-      "default": 5,
-      "minimum": 1
-    },
-    "reminder_fee_amount": {
-      "title": "The amount of reminder fee",
-      "description": "Overdue amount.",
-      "type": "number",
-      "default": 2.0
+    "overdue_fees": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intervals"
+      ],
+      "properties": {
+        "intervals": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "interval": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "from",
+                "fee_amount"
+              ],
+              "properties": {
+                "from": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "to": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "fee_amount": {
+                  "type": "number",
+                  "minimum": 0,
+                  "multipleOf": 0.01
+                }
+              }
+            }
+          }
+        },
+        "maximum_total_amount": {
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 0.01
+        }
+      }
     },
     "number_renewals": {
       "title": "Maximum number of renewals",
-      "description": "Maximum number of renewals allowed.",
       "type": "integer",
       "minimum": 0,
       "default": 0
     },
     "renewal_duration": {
       "title": "Renewal duration in days",
-      "description": "The duration of the renewal in days.",
       "type": "integer",
       "minimum": 1
     },

--- a/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
@@ -41,14 +41,44 @@
       "number_renewals": {
         "type": "integer"
       },
-      "number_of_days_after_due_date": {
-        "type": "integer"
+      "reminders": {
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "days_delay": {
+            "type": "integer"
+          },
+          "fee_amount": {
+            "type": "float"
+          },
+          "communication_channel": {
+            "type": "keyword"
+          },
+          "template": {
+            "type": "keyword"
+          }
+        }
       },
-      "number_of_days_before_due_date": {
-        "type": "integer"
-      },
-      "reminder_fee_amount": {
-        "type": "float"
+      "overdue_fees": {
+        "properties": {
+          "intervals": {
+            "properties": {
+              "from": {
+                "type": "integer"
+              },
+              "to": {
+                "type": "integer"
+              },
+              "fee_amount": {
+                "type": "float"
+              }
+            }
+          },
+          "maximum_total_amount": {
+            "type": "float"
+          }
+        }
       },
       "renewal_duration": {
         "type": "integer"

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -71,6 +71,8 @@ class Dispatcher:
     @staticmethod
     def send_mail(data):
         """Send the notification by email."""
+        from .api import get_template_to_use
+        from ..loans.api import Loan
         patron = data['loan']['patron']
         # get the recipient email from loan.patron.patron.email
         recipient = patron.get('email')
@@ -80,11 +82,13 @@ class Dispatcher:
                 'Patron (pid: {pid}) does not have an email'.format(
                     pid=patron['pid']))
             return
-        notification_type = data.get('notification_type')
         language = patron['patron']['communication_language']
-        template = 'email/{type}/{lang}.txt'.format(
-            type=notification_type,
-            lang=language
+        notification_type = data.get('notification_type')
+        loan = Loan.get_record_by_pid(data['loan']['pid'])
+        tpl_path = get_template_to_use(loan, notification_type).rstrip('/')
+        template = '{tpl_path}/{language}.txt'.format(
+            tpl_path=tpl_path,
+            language=language
         )
 
         # get the sender email from

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -39,31 +39,26 @@ def process_notifications(verbose=False):
 
 
 @shared_task(ignore_result=True)
-def create_over_and_due_soon_notifications(overdue=True, due_soon=True,
+def create_over_and_due_soon_notifications(late=True, due_soon=True,
                                            process=True, verbose=False):
-    """Creates due soon and overdue notifications."""
+    """Creates due soon and late notifications."""
     no_over_due_loans = 0
     no_due_soon_loans = 0
     if due_soon:
-        due_soon_loans = get_due_soon_loans()
-        for loan in due_soon_loans:
-            loan.create_notification(notification_type='due_soon')
+        for loan in get_due_soon_loans():
+            loan.create_notification(
+                notification_type=Notification.DUE_SOON_NOTIFICATION_TYPE)
             no_due_soon_loans += 1
-    if overdue:
+    if late:
         for loan in get_overdue_loans():
-            loan.create_notification(notification_type='overdue')
+            loan.create_notification(
+                notification_type=Notification.OVERDUE_NOTIFICATION_TYPE)
             no_over_due_loans += 1
 
-    msg = 'loans| overdue: {no_over_due_loans} '\
-        'due soon: {no_due_soon_loans}'.format(
-            no_over_due_loans=no_over_due_loans,
-            no_due_soon_loans=no_due_soon_loans
-        )
-
+    msg = f'loans| late: {no_over_due_loans} due soon: {no_due_soon_loans}'
     if process:
         msg = '{msg}, {process_msg}'.format(
             msg=msg,
             process_msg=process_notifications.run(verbose=verbose)
         )
-
     return msg

--- a/rero_ils/modules/patron_transactions/api.py
+++ b/rero_ils/modules/patron_transactions/api.py
@@ -260,9 +260,10 @@ class PatronTransaction(IlsRecord):
             cls, notification=None, dbcommit=None, reindex=None,
             delete_pid=None):
         """Create a patron transaction from notification."""
-        from ..notifications.api import calculate_overdue_amount
+        from ..notifications.api import calculate_notification_amount
         record = {}
-        if notification.get('notification_type') == 'overdue':
+        total_amount = calculate_notification_amount(notification)
+        if total_amount > 0:  # no need to create transaction if amount <= 0 !
             data = {
                 'notification': {
                     '$ref': get_ref_for_pid('notif', notification.pid)
@@ -276,7 +277,7 @@ class PatronTransaction(IlsRecord):
                         notification.organisation_pid
                     )
                 },
-                'total_amount': calculate_overdue_amount(notification),
+                'total_amount': total_amount,
                 'creation_date': datetime.now(timezone.utc).isoformat(),
                 'type': 'overdue',
                 'status': 'open'

--- a/rero_ils/modules/selfcheck/api.py
+++ b/rero_ils/modules/selfcheck/api.py
@@ -31,8 +31,7 @@ from ..items.api import Item
 from ..items.models import ItemNoteTypes
 from ..libraries.api import Library
 from ..loans.api import Loan, LoanAction, LoanState, \
-    get_loans_by_item_pid_by_patron_pid, get_loans_by_patron_pid, \
-    is_overdue_loan
+    get_loans_by_item_pid_by_patron_pid, get_loans_by_patron_pid
 from ..patron_transactions.api import PatronTransaction
 from ..patrons.api import Patron
 from ...filter import format_date_filter
@@ -187,7 +186,7 @@ def patron_information(barcode, **kwargs):
             if loan['state'] == LoanState.ITEM_ON_LOAN:
                 patron_account_information.get('charged_items').append(
                     item.get('pid'))
-                if is_overdue_loan(loan):
+                if loan.is_loan_overdue():
                     patron_account_information.get('overdue_items')\
                         .append(item.get('pid'))
             elif loan['state'] in [

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -25,8 +25,8 @@ from invenio_circulation.search.api import LoansSearch
 from utils import flush_index, get_json, postdata
 
 from rero_ils.modules.loans.api import Loan, LoanAction, get_overdue_loans
-from rero_ils.modules.notifications.api import NotificationsSearch, \
-    number_of_reminders_sent
+from rero_ils.modules.notifications.api import Notification, \
+    NotificationsSearch, number_of_reminders_sent
 from rero_ils.modules.patron_types.api import PatronType
 from rero_ils.modules.utils import get_ref_for_pid
 
@@ -234,7 +234,8 @@ def test_overdue_limit(
     assert overdue_loans[0].get('pid') == loan_pid
     assert number_of_reminders_sent(loan) == 0
 
-    loan.create_notification(notification_type='overdue')
+    loan.create_notification(
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE)
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     assert number_of_reminders_sent(loan) == 1

--- a/tests/api/notifications/test_notifications_permissions.py
+++ b/tests/api/notifications/test_notifications_permissions.py
@@ -27,9 +27,9 @@ from rero_ils.modules.notifications.permissions import NotificationPermission
 def test_notifications_permissions_api(client, patron_martigny_no_email,
                                        system_librarian_martigny_no_email,
                                        librarian_martigny_no_email,
-                                       notification_overdue_martigny,
-                                       notification_overdue_saxon,
-                                       notification_overdue_sion):
+                                       notification_late_martigny,
+                                       notification_late_saxon,
+                                       notification_late_sion):
     """Test notification permissions api."""
     notif_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -38,17 +38,17 @@ def test_notifications_permissions_api(client, patron_martigny_no_email,
     notif_martigny_permission_url = url_for(
         'api_blueprint.permissions',
         route_name='notifications',
-        record_pid=notification_overdue_martigny.pid
+        record_pid=notification_late_martigny.pid
     )
     notif_saxon_permission_url = url_for(
         'api_blueprint.permissions',
         route_name='notifications',
-        record_pid=notification_overdue_saxon.pid
+        record_pid=notification_late_saxon.pid
     )
     notif_sion_permission_url = url_for(
         'api_blueprint.permissions',
         route_name='notifications',
-        record_pid=notification_overdue_sion.pid
+        record_pid=notification_late_sion.pid
     )
 
     # Not logged
@@ -116,9 +116,9 @@ def test_notifcations_permissions(patron_martigny_no_email,
                                   librarian_martigny_no_email,
                                   system_librarian_martigny_no_email,
                                   org_martigny,
-                                  notification_overdue_sion,
-                                  notification_overdue_martigny,
-                                  notification_overdue_saxon):
+                                  notification_late_sion,
+                                  notification_late_martigny,
+                                  notification_late_saxon):
     """Test notifications permissions class."""
 
     # Anonymous user
@@ -129,9 +129,9 @@ def test_notifcations_permissions(patron_martigny_no_email,
     assert not NotificationPermission.delete(None, {})
 
     # As Patron
-    notif_martigny = notification_overdue_martigny
-    notif_saxon = notification_overdue_saxon
-    notif_sion = notification_overdue_sion
+    notif_martigny = notification_late_martigny
+    notif_saxon = notification_late_saxon
+    notif_sion = notification_late_sion
     with mock.patch(
         'rero_ils.modules.notifications.permissions.current_patron',
         patron_martigny_no_email

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -28,8 +28,8 @@ from invenio_circulation.search.api import LoansSearch
 from utils import flush_index, postdata
 
 from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
-from rero_ils.modules.notifications.api import NotificationsSearch, \
-    number_of_reminders_sent
+from rero_ils.modules.notifications.api import Notification, \
+    NotificationsSearch, number_of_reminders_sent
 from rero_ils.modules.selfcheck.api import authorize_patron, enable_patron, \
     item_information, patron_information, selfcheck_checkin, \
     selfcheck_checkout, selfcheck_login, system_status, \
@@ -140,7 +140,8 @@ def test_patron_information(client, sip2_librarian_martigny_no_email,
     )
     loan = Loan.get_record_by_pid(loan_pid)
     assert loan.is_loan_overdue()
-    loan.create_notification(notification_type='overdue')
+    loan.create_notification(
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE)
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     assert number_of_reminders_sent(loan) == 1
@@ -210,7 +211,8 @@ def test_item_information(client, sip2_librarian_martigny_no_email,
     loan = Loan.get_record_by_pid(loan_pid)
     assert loan['state'] == LoanState.ITEM_ON_LOAN
     assert loan.is_loan_overdue()
-    loan.create_notification(notification_type='overdue')
+    loan.create_notification(
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE)
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     assert number_of_reminders_sent(loan) == 1

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -29,8 +29,8 @@ from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.tasks import clean_obsolete_temporary_item_types
 from rero_ils.modules.loans.api import Loan, LoanAction, get_due_soon_loans, \
     get_overdue_loans
-from rero_ils.modules.notifications.api import NotificationsSearch, \
-    number_of_reminders_sent
+from rero_ils.modules.notifications.api import Notification, \
+    NotificationsSearch, number_of_reminders_sent
 from rero_ils.modules.notifications.tasks import \
     create_over_and_due_soon_notifications
 from rero_ils.modules.patrons.api import Patron
@@ -82,7 +82,8 @@ def test_create_over_and_due_soon_notifications_task(
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
 
-    assert loan.is_notified(notification_type='due_soon')
+    assert loan.is_notified(
+        notification_type=Notification.DUE_SOON_NOTIFICATION_TYPE)
 
     # test overdue notification
     end_date = datetime.now(timezone.utc) - timedelta(days=7)
@@ -96,7 +97,8 @@ def test_create_over_and_due_soon_notifications_task(
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
 
-    assert loan.is_notified(notification_type='overdue')
+    assert loan.is_notified(
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE)
     assert number_of_reminders_sent(loan) == 1
 
     # checkin the item to put it back to it's original state

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -908,9 +908,21 @@
     },
     "allow_checkout": true,
     "checkout_duration": 30,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "allow_requests": true,
     "number_renewals": 3,
     "renewal_duration": 30,
@@ -928,9 +940,21 @@
     "allow_checkout": true,
     "checkout_duration": 15,
     "allow_requests": true,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 1,
     "renewal_duration": 15,
     "is_default": false,
@@ -965,9 +989,21 @@
     "allow_checkout": true,
     "checkout_duration": 7,
     "allow_requests": true,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "number_renewals": 1,
     "renewal_duration": 7,
     "is_default": false,
@@ -998,9 +1034,21 @@
     },
     "allow_checkout": true,
     "checkout_duration": 30,
-    "number_of_days_before_due_date": 5,
-    "number_of_days_after_due_date": 5,
-    "reminder_fee_amount": 2.0,
+    "reminders": [
+      {
+        "type": "due_soon",
+        "days_delay": 5,
+        "communication_channel": "email",
+        "template": "email/due_soon"
+      },
+      {
+        "type": "overdue",
+        "days_delay": 5,
+        "fee_amount": 2.0,
+        "communication_channel": "email",
+        "template": "email/overdue"
+      }
+    ],
     "allow_requests": true,
     "number_renewals": 3,
     "renewal_duration": 30,

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -28,8 +28,8 @@ from utils import flush_index, item_record_to_a_specific_loan_state
 from rero_ils.modules.ill_requests.api import ILLRequest, ILLRequestsSearch
 from rero_ils.modules.items.api import ItemsSearch
 from rero_ils.modules.loans.api import Loan, LoanState
-from rero_ils.modules.notifications.api import NotificationsSearch, \
-    get_availability_notification
+from rero_ils.modules.notifications.api import Notification, \
+    NotificationsSearch, get_notification
 from rero_ils.modules.patron_transactions.api import PatronTransactionsSearch
 from rero_ils.modules.patrons.api import Patron, PatronsSearch
 
@@ -761,8 +761,10 @@ def loan_validated_martigny(
 @pytest.fixture(scope="module")
 def notification_availability_martigny(loan_validated_martigny):
     """Availability notification of martigny."""
-    notification = get_availability_notification(loan_validated_martigny)
-    return notification
+    return get_notification(
+        loan_validated_martigny,
+        notification_type=Notification.AVAILABILITY_NOTIFICATION_TYPE
+    )
 
 
 # ------------ Notifications: dummy notification ----------
@@ -809,26 +811,21 @@ def loan_overdue_martigny(
 
 
 @pytest.fixture(scope="module")
-def notification_overdue_martigny(
-        app,
-        loan_overdue_martigny):
+def notification_late_martigny(app, loan_overdue_martigny):
     """Create an overdue notification for an overdue loan."""
     notification = loan_overdue_martigny.create_notification(
-        notification_type='overdue')
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE
+    )
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     flush_index(PatronTransactionsSearch.Meta.index)
-
     return notification
 
 
 @pytest.fixture(scope="module")
-def patron_transaction_overdue_martigny(
-        app,
-        notification_overdue_martigny):
+def patron_transaction_overdue_martigny(app, notification_late_martigny):
     """Return an overdue patron transaction for an overdue notification."""
-    records = list(notification_overdue_martigny.patron_transactions)
-
+    records = list(notification_late_martigny.patron_transactions)
     return records[0]
 
 
@@ -885,25 +882,21 @@ def loan_overdue_saxon(
 
 
 @pytest.fixture(scope="module")
-def notification_overdue_saxon(
-        app,
-        loan_overdue_saxon):
+def notification_late_saxon(app, loan_overdue_saxon):
     """Create an overdue notification for an overdue loan."""
     notification = loan_overdue_saxon.create_notification(
-        notification_type='overdue')
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE
+    )
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     flush_index(PatronTransactionsSearch.Meta.index)
-
     return notification
 
 
 @pytest.fixture(scope="module")
-def patron_transaction_overdue_saxon(
-        app,
-        notification_overdue_saxon):
+def patron_transaction_overdue_saxon(app, notification_late_saxon):
     """Return an overdue patron transaction for an overdue notification."""
-    records = list(notification_overdue_saxon.patron_transactions)
+    records = list(notification_late_saxon.patron_transactions)
     return records[0]
 
 
@@ -964,25 +957,21 @@ def loan_overdue_sion(
 
 
 @pytest.fixture(scope="module")
-def notification_overdue_sion(
-        app,
-        loan_overdue_sion):
+def notification_late_sion(app, loan_overdue_sion):
     """Create an overdue notification for an overdue loan."""
     notification = loan_overdue_sion.create_notification(
-        notification_type='overdue')
+        notification_type=Notification.OVERDUE_NOTIFICATION_TYPE
+    )
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     flush_index(PatronTransactionsSearch.Meta.index)
-
     return notification
 
 
 @pytest.fixture(scope="module")
-def patron_transaction_overdue_sion(
-        app,
-        notification_overdue_sion):
+def patron_transaction_overdue_sion(app, notification_late_sion):
     """Return an overdue patron transaction for an overdue notification."""
-    records = list(notification_overdue_sion.patron_transactions)
+    records = list(notification_late_sion.patron_transactions)
     return records[0]
 
 


### PR DESCRIPTION
* Updates the `CirculationPolicy` resource JSON schema to allow multiple
  reminders and incremental overdue fees.
* Updates data & fixtures.
* Updates unit test.
* Adapts/improves related code.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
