### PR TITLE
editor: adapt JSON schema form options

### DIFF
--- a/rero_ils/jsonschemas/common/cantons-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/cantons-v0.0.1.json
@@ -138,7 +138,7 @@
         }
       ],
       "templateOptions": {
-        "cssClass": "col-lg-4"
+        "itemCssClass": "col-lg-4"
       },
       "hideExpression": "field.parent.model.country !== 'sz'"
     }

--- a/rero_ils/jsonschemas/common/countries-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/countries-v0.0.1.json
@@ -1919,7 +1919,7 @@
         }
       ],
       "templateOptions": {
-        "cssClass": "col-lg-4"
+        "itemCssClass": "col-lg-4"
       }
     }
   }

--- a/rero_ils/jsonschemas/common/languages-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/languages-v0.0.1.json
@@ -2434,7 +2434,7 @@
         }
       ],
       "templateOptions": {
-        "cssClass": "col-lg-6"
+        "itemCssClass": "col-lg-6"
       }
     }
   },
@@ -2537,7 +2537,7 @@
     ],
     "form": {
       "templateOptions": {
-        "cssClass": "col-lg-6"
+        "itemCssClass": "col-lg-6"
       },
       "hide": true
     }
@@ -2554,7 +2554,7 @@
     ],
     "form": {
       "templateOptions": {
-        "cssClass": "row"
+        "containerCssClass": "row"
       }
     },
     "properties": {
@@ -2564,7 +2564,7 @@
         "minLength": 1,
         "form": {
           "templateOptions": {
-            "cssClass": "col-lg-6"
+            "itemCssClass": "col-lg-6"
           }
         }
       },
@@ -2578,7 +2578,7 @@
     "type": "object",
     "form": {
       "templateOptions": {
-        "cssClass": "row"
+        "containerCssClass": "row"
       }
     },
     "propertiesOrder": [
@@ -2595,7 +2595,7 @@
         "minLength": 1,
         "form": {
           "templateOptions": {
-            "cssClass": "col-lg-12"
+            "itemCssClass": "col-lg-12"
           },
           "focus": true
         }

--- a/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
+++ b/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
@@ -133,9 +133,6 @@
       "default": "in progress",
       "form": {
         "type": "selectWithSort",
-        "wrappers": [
-          "form-field-horizontal"
-        ],
         "options": [
           {
             "value": "in_progress",
@@ -165,9 +162,6 @@
       "form": {
         "type": "datepicker",
         "placeholder": "Select a date",
-        "wrappers": [
-          "form-field"
-        ],
         "validation": {
           "messages": {
             "patternMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
@@ -202,9 +196,6 @@
             ],
             "form": {
               "type": "selectWithSort",
-              "wrappers": [
-                "form-field-horizontal"
-              ],
               "options": [
                 {
                   "value": "shipping_and_handling",

--- a/rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json
+++ b/rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json
@@ -61,9 +61,6 @@
       ],
       "form": {
         "type": "selectWithSort",
-        "wrappers": [
-          "form-field"
-        ],
         "options": [
           {
             "label": "course",
@@ -75,6 +72,9 @@
           }
         ],
         "templateOptions": {
+          "wrappers": [
+            "form-field"
+          ],
           "selectWithSortOptions": {
             "order": "label"
           }
@@ -92,6 +92,9 @@
         "required": [
           "name"
         ],
+        "propertiesOrder": [
+          "name"
+        ],
         "properties": {
           "name": {
             "title": "Name",
@@ -101,11 +104,13 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         },
         "hideExpression": "field.parent.model.collection_type !== 'course'",
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.collection_type === 'course'"
+          "templateOptions.required": "true"
         }
       }
     },
@@ -129,7 +134,9 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         }
       }
     },
@@ -212,7 +219,9 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         }
       }
     },
@@ -241,7 +250,9 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         }
       }
     },

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -138,9 +138,11 @@
       "type": "boolean",
       "default": false,
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_abstract-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_abstract-v0.0.1.json
@@ -16,10 +16,7 @@
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_book_format-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_book_format-v0.0.1.json
@@ -23,13 +23,15 @@
         "72\u00ba",
         "96\u00ba",
         "128\u00ba"
-      ]
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
+      }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_color_content-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_color_content-v0.0.1.json
@@ -26,15 +26,13 @@
         "templateOptions": {
           "selectWithSortOptions": {
             "order": "label"
-          }
+          },
+          "cssClass": "w-md-50"
         }
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json
@@ -45,9 +45,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_identifiedby-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_identifiedby-v0.0.1.json
@@ -24,7 +24,7 @@
           }
         ],
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "itemCssClass": "col-lg-4"
         }
       }
     },
@@ -35,7 +35,7 @@
       "minLength": 1,
       "form": {
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "itemCssClass": "col-lg-4"
         }
       }
     },
@@ -48,7 +48,7 @@
   "form": {
     "hide": true,
     "templateOptions": {
-      "cssClass": "col-lg-12"
+      "itemCssClass": "col-lg-12"
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
@@ -23,9 +23,11 @@
       "default": "bf:Organisation",
       "const": "bf:Organisation",
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "preferred_name": {
@@ -35,7 +37,7 @@
       "form": {
         "placeholder": "Example: M\u00fcller, Hans",
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -52,7 +54,7 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "col-lg-12"
+          "itemCssClass": "col-lg-12"
         }
       }
     },
@@ -63,7 +65,7 @@
       "default": false,
       "form": {
         "templateOptions": {
-          "cssClass": "col-lg-12"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -74,7 +76,7 @@
       "form": {
         "placeholder": "Example: Lausanne",
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -85,7 +87,7 @@
       "form": {
         "placeholder": "Example: 4",
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -97,7 +99,7 @@
       "form": {
         "placeholder": "Example: 1989",
         "templateOptions": {
-          "cssClass": "col-lg-4"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -107,7 +109,7 @@
   },
   "form": {
     "templateOptions": {
-      "cssClass": "row"
+      "containerCssClass": "row"
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation_link-v0.0.1.json
@@ -18,9 +18,11 @@
       "default": "bf:Organisation",
       "const": "bf:Organisation",
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "$ref": {
@@ -33,14 +35,14 @@
           "enableGroupField": true
         },
         "templateOptions": {
-          "cssClass": "col-lg-12"
+          "itemCssClass": "col-lg-12"
         }
       }
     }
   },
   "form": {
     "templateOptions": {
-      "cssClass": "row"
+      "containerCssClass": "row"
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
@@ -23,9 +23,11 @@
       "default": "bf:Person",
       "const": "bf:Person",
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "preferred_name": {
@@ -35,7 +37,7 @@
       "form": {
         "placeholder": "Example: M\u00fcller, Hans",
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -47,7 +49,7 @@
       "form": {
         "placeholder": "Example: 1955",
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -59,7 +61,7 @@
       "form": {
         "placeholder": "Example: 2012",
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -70,7 +72,7 @@
       "form": {
         "placeholder": "Example: physicist",
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -82,7 +84,7 @@
       "form": {
         "placeholder": "Example: XXIII",
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -93,7 +95,7 @@
       "minLength": 1,
       "form": {
         "templateOptions": {
-          "cssClass": "col-lg-6"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -103,7 +105,7 @@
   },
   "form": {
     "templateOptions": {
-      "cssClass": "row"
+      "containerCssClass": "row"
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person_link-v0.0.1.json
@@ -18,9 +18,11 @@
       "default": "bf:Person",
       "const": "bf:Person",
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "$ref": {
@@ -33,14 +35,14 @@
           "enableGroupField": true
         },
         "templateOptions": {
-          "cssClass": "col-lg-12"
+          "itemCssClass": "col-lg-12"
         }
       }
     }
   },
   "form": {
     "templateOptions": {
-      "cssClass": "row"
+      "containerCssClass": "row"
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_role-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_role-v0.0.1.json
@@ -757,7 +757,7 @@
       }
     ],
     "templateOptions": {
-      "cssClass": "col-lg-6"
+      "itemCssClass": "col-lg-6"
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_copyright_date-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_copyright_date-v0.0.1.json
@@ -9,14 +9,14 @@
       "pattern": "^([\u00a9\u2117]\\s)?\\d{4}.*",
       "minLength": 4,
       "form": {
-        "placeholder": "Example: \u00a9 2010"
+        "placeholder": "Example: \u00a9 2010",
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_dimensions-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_dimensions-v0.0.1.json
@@ -9,16 +9,16 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: 22 cm"
+        "placeholder": "Example: 22 cm",
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
       }
     },
     "form": {
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_duration-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_duration-v0.0.1.json
@@ -9,14 +9,14 @@
       "type": "string",
       "minLength": 2,
       "form": {
-        "placeholder": "Example: 1h50"
+        "placeholder": "Example: 1h50",
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_edition_statement-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_edition_statement-v0.0.1.json
@@ -38,9 +38,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_electronic_locator-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_electronic_locator-v0.0.1.json
@@ -24,10 +24,16 @@
           "placeholder": "Example: https://www.rero.ch/",
           "type": "string",
           "format": "uri",
+          "pattern": "^(ftps?|https?)://.*$",
           "minLength": 7,
           "form": {
             "templateOptions": {
-              "cssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12"
+            },
+            "validation": {
+              "messages": {
+                "patternMessage": "Should be a valid URL format."
+              }
             }
           }
         },
@@ -67,7 +73,7 @@
               }
             ],
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -223,7 +229,7 @@
               }
             ],
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -242,22 +248,19 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12"
             }
           }
         }
       },
       "form": {
         "templateOptions": {
-          "cssClass": "row"
+          "containerCssClass": "row"
         }
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json
@@ -11,7 +11,7 @@
       },
       "hide": true,
       "templateOptions": {
-        "cssClass": "editor-max-width editor-title"
+        "cssClass": "w-md-50"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
@@ -137,7 +137,7 @@
               }
             ],
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -148,7 +148,7 @@
           "minLength": 1,
           "form": {
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -160,7 +160,7 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -172,7 +172,7 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-4"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -184,7 +184,7 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -196,7 +196,7 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-4"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -212,14 +212,14 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-4"
+              "itemCssClass": "col-lg-6"
             }
           }
         }
       },
       "form": {
         "templateOptions": {
-          "cssClass": "row"
+          "containerCssClass": "row"
         }
       }
     },
@@ -227,9 +227,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_illustrative_content-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_illustrative_content-v0.0.1.json
@@ -13,10 +13,7 @@
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_issuance-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_issuance-v0.0.1.json
@@ -45,7 +45,7 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-6"
+                "itemCssClass": "col-lg-6"
               }
             }
           },
@@ -56,15 +56,17 @@
             "default": "rdami:1001",
             "const": "rdami:1001",
             "form": {
-              "wrappers": [
-                "hide"
-              ]
+              "templateOptions": {
+                "wrappers": [
+                  "hide"
+                ]
+              }
             }
           }
         },
         "form": {
           "templateOptions": {
-            "cssClass": "row"
+            "containerCssClass": "row"
           }
         }
       },
@@ -105,7 +107,7 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-6"
+                "itemCssClass": "col-lg-6"
               }
             }
           },
@@ -116,15 +118,17 @@
             "default": "rdami:1002",
             "const": "rdami:1002",
             "form": {
-              "wrappers": [
-                "hide"
-              ]
+              "templateOptions": {
+                "wrappers": [
+                  "hide"
+                ]
+              }
             }
           }
         },
         "form": {
           "templateOptions": {
-            "cssClass": "row"
+            "containerCssClass": "row"
           }
         }
       },
@@ -165,7 +169,7 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-6"
+                "itemCssClass": "col-lg-6"
               }
             }
           },
@@ -176,15 +180,17 @@
             "default": "rdami:1003",
             "const": "rdami:1003",
             "form": {
-              "wrappers": [
-                "hide"
-              ]
+              "templateOptions": {
+                "wrappers": [
+                  "hide"
+                ]
+              }
             }
           }
         },
         "form": {
           "templateOptions": {
-            "cssClass": "row"
+            "containerCssClass": "row"
           }
         }
       },
@@ -220,7 +226,7 @@
                 }
               ],
               "templateOptions": {
-                "cssClass": "col-lg-6"
+                "itemCssClass": "col-lg-6"
               }
             }
           },
@@ -231,23 +237,20 @@
             "default": "rdami:1004",
             "const": "rdami:1004",
             "form": {
-              "wrappers": [
-                "hide"
-              ]
+              "templateOptions": {
+                "wrappers": [
+                  "hide"
+                ]
+              }
             }
           }
         },
         "form": {
           "templateOptions": {
-            "cssClass": "row"
+            "containerCssClass": "row"
           }
         }
       }
-    ],
-    "form": {
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
-    }
+    ]
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json
@@ -25,9 +25,11 @@
             "bf:Language"
           ],
           "form": {
-            "wrappers": [
-              "hide"
-            ],
+            "templateOptions": {
+              "wrappers": [
+                "hide"
+              ]
+            },
             "options": [
               {
                 "label": "bf:Language",
@@ -42,13 +44,8 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "row"
+          "containerCssClass": "row"
         }
-      }
-    },
-    "form": {
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json
@@ -41,7 +41,7 @@
               }
             ],
             "templateOptions": {
-              "cssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12"
             }
           }
         },
@@ -51,14 +51,14 @@
           "minLength": 1,
           "form": {
             "templateOptions": {
-              "cssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12"
             }
           }
         }
       },
       "form": {
         "templateOptions": {
-          "cssClass": "row"
+          "containerCssClass": "row"
         }
       }
     },
@@ -66,9 +66,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_part_of-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_part_of-v0.0.1.json
@@ -68,7 +68,7 @@
                     }
                   },
                   "templateOptions": {
-                    "cssClass": "col-lg-6"
+                    "itemCssClass": "col-lg-6"
                   }
                 }
               },
@@ -78,7 +78,7 @@
                 "minimum": 1,
                 "form": {
                   "templateOptions": {
-                    "cssClass": "col-lg-6"
+                    "itemCssClass": "col-lg-6"
                   }
                 }
               },
@@ -88,7 +88,7 @@
                 "minimum": 1,
                 "form": {
                   "templateOptions": {
-                    "cssClass": "col-lg-6"
+                    "itemCssClass": "col-lg-6"
                   }
                 }
               },
@@ -104,14 +104,14 @@
                     }
                   },
                   "templateOptions": {
-                    "cssClass": "col-lg-6"
+                    "itemCssClass": "col-lg-6"
                   }
                 }
               }
             },
             "form": {
               "templateOptions": {
-                "cssClass": "row"
+                "containerCssClass": "row"
               }
             }
           }
@@ -122,9 +122,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_production_method-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_production_method-v0.0.1.json
@@ -112,14 +112,14 @@
             "label": "rdapm:1021",
             "value": "rdapm:1021"
           }
-        ]
+        ],
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
       }
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
@@ -66,7 +66,7 @@
               }
             ],
             "templateOptions": {
-              "cssClass": "col-lg-4"
+              "itemcCssClass": "col-lg-4"
             }
           }
         },
@@ -94,9 +94,11 @@
                 "default": "bf:Place",
                 "readOnly": true,
                 "form": {
-                  "wrappers": [
-                    "hide"
-                  ]
+                  "templateOptions": {
+                    "wrappers": [
+                      "hide"
+                    ]
+                  }
                 }
               },
               "country": {
@@ -108,14 +110,14 @@
             },
             "form": {
               "templateOptions": {
-                "cssClass": "row"
+                "containerCssClass": "row"
               }
             }
           },
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12"
             }
           }
         },
@@ -161,7 +163,7 @@
                     }
                   ],
                   "templateOptions": {
-                    "cssClass": "col-lg-4"
+                    "itemCssClass": "col-lg-4"
                   }
                 }
               },
@@ -175,25 +177,25 @@
                 },
                 "form": {
                   "templateOptions": {
-                    "cssClass": "col-lg-8"
+                    "itemCssClass": "col-lg-8"
                   }
                 }
               },
               "form": {
                 "templateOptions": {
-                  "cssClass": "col-lg-6"
+                  "itemCssClass": "col-lg-6"
                 }
               }
             },
             "form": {
               "templateOptions": {
-                "cssClass": "row"
+                "containerCssClass": "row"
               }
             }
           },
           "form": {
             "templateOptions": {
-              "cssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12"
             }
           }
         },
@@ -204,7 +206,7 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },
@@ -219,7 +221,7 @@
               "templateOptions.required": "model.type === 'bf:Publication'"
             },
             "templateOptions": {
-              "cssClass": "col-lg-4"
+              "itemCssClass": "col-lg-4"
             }
           }
         },
@@ -232,20 +234,15 @@
           "form": {
             "hide": true,
             "templateOptions": {
-              "cssClass": "col-lg-4"
+              "itemCssClass": "col-lg-4"
             }
           }
         }
       },
       "form": {
         "templateOptions": {
-          "cssClass": "row"
+          "containerCssClass": "row"
         }
-      }
-    },
-    "form": {
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_responsibility_statement-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_responsibility_statement-v0.0.1.json
@@ -16,9 +16,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json
@@ -87,9 +87,6 @@
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   },
@@ -106,7 +103,7 @@
       ],
       "form": {
         "templateOptions": {
-          "cssClass": "row"
+          "containerCssClass": "row"
         }
       },
       "properties": {
@@ -117,7 +114,7 @@
           "form": {
             "placeholder": "Example: vol.3",
             "templateOptions": {
-              "cssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6"
             }
           }
         },

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -7,15 +7,17 @@
     "items": {
       "title": "Subject",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
+      }
     },
     "form": {
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_title-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_title-v0.0.1.json
@@ -44,7 +44,7 @@
               }
             ],
             "templateOptions": {
-              "cssClass": "editor-max-width"
+              "cssClass": "w-md-50"
             }
           }
         },
@@ -104,11 +104,6 @@
             "hide": true
           }
         }
-      }
-    },
-    "form": {
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_titles_proper-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_titles_proper-v0.0.1.json
@@ -7,15 +7,17 @@
     "items": {
       "title": "Proper title",
       "type": "string",
-      "minLength": 2
+      "minLength": 2,
+      "form": {
+        "templateOptions": {
+          "cssClass": "w-md-50"
+        }
+      }
     },
     "form": {
       "hide": true,
       "navigation": {
         "essential": true
-      },
-      "templateOptions": {
-        "cssClass": "editor-title"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_translated_from-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_translated_from-v0.0.1.json
@@ -8,10 +8,7 @@
       "$ref": "https://ils.rero.ch/schemas/common/languages-v0.0.1.json#/language"
     },
     "form": {
-      "hide": true,
-      "templateOptions": {
-        "cssClass": "editor-title"
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_types-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_types-v0.0.1.json
@@ -874,7 +874,7 @@
     "form": {
       "hide": true,
       "templateOptions": {
-        "cssClass": "editor-title"
+        "cssClass": "w-md-50"
       }
     }
   }

--- a/rero_ils/modules/ebooks/dojson/contrib/marc21/model.py
+++ b/rero_ils/modules/ebooks/dojson/contrib/marc21/model.py
@@ -530,7 +530,7 @@ def marc21_electronicLocator(self, key, value):
     """Get electronic locator."""
     indicator2 = key[4]
     electronic_locator = {}
-    url = utils.force_list(value.get('u'))[0]
+    url = utils.force_list(value.get('u'))[0].strip()
     subfield_3 = value.get('3')
     if subfield_3:
         subfield_3 = utils.force_list(subfield_3)[0]

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -131,7 +131,15 @@
           "uri": {
             "title": "URI",
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "pattern": "^(ftps?|https?)://.*$",
+            "form": {
+              "validation": {
+                "messages": {
+                  "patternMessage": "Should be a valid URL format."
+                }
+              }
+            }
           },
           "source": {
             "title": "Source",
@@ -150,9 +158,11 @@
         "serial"
       ],
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "patterns": {
@@ -457,9 +467,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -582,9 +589,6 @@
             ],
             "form": {
               "type": "selectWithSort",
-              "wrappers": [
-                "form-field-horizontal"
-              ],
               "options": [
                 {
                   "label": "general_note",

--- a/rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json
+++ b/rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json
@@ -174,32 +174,17 @@
         "title": {
           "type": "string",
           "title": "Title",
-          "minLength": 3,
-          "form": {
-            "wrappers": [
-              "form-field-horizontal"
-            ]
-          }
+          "minLength": 3
         },
         "authors": {
           "type": "string",
           "title": "Authors",
-          "minLength": 3,
-          "form": {
-            "wrappers": [
-              "form-field-horizontal"
-            ]
-          }
+          "minLength": 3
         },
         "publisher": {
           "type": "string",
           "title": "Publisher",
-          "minLength": 3,
-          "form": {
-            "wrappers": [
-              "form-field-horizontal"
-            ]
-          }
+          "minLength": 3
         },
         "year": {
           "type": "string",
@@ -210,20 +195,12 @@
               "messages": {
                 "patternMessage": "Should be in the following format: YYYY (2020)."
               }
-            },
-            "wrappers": [
-              "form-field-horizontal"
-            ]
+            }
           }
         },
         "identifier": {
           "type": "string",
-          "title": "Identifier",
-          "form": {
-            "wrappers": [
-              "form-field-horizontal"
-            ]
-          }
+          "title": "Identifier"
         },
         "source": {
           "type": "object",
@@ -244,42 +221,30 @@
               "form": {
                 "expressionProperties": {
                   "templateOptions.required": "false"
-                },
-                "wrappers": [
-                  "form-field-horizontal"
-                ]
+                }
               }
             },
             "volume": {
               "type": "string",
               "title": "Volume",
               "form": {
-                "wrappers": [
-                  "form-field-horizontal"
-                ],
                 "templateOptions": {
-                  "cssClass": "col-md-3 p-0"
+                  "itemCssClass": "col-md-3 p-0"
                 }
               }
             },
             "number": {
               "type": "string",
-              "title": "Number",
-              "form": {
-                "wrappers": [
-                  "form-field-horizontal"
-                ],
-                "templateOptions": {
-                  "cssClass": "col-md-3 p-0"
-                }
-              }
+              "title": "Number"
             }
           }
         }
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         }
       }
     },
@@ -290,10 +255,7 @@
         "hideExpression": "model.copy === false",
         "expressionProperties": {
           "templateOptions.required": "model.copy === true"
-        },
-        "wrappers": [
-          "form-field-horizontal"
-        ]
+        }
       }
     },
     "found_in": {
@@ -323,10 +285,16 @@
           "title": "URL",
           "placeholder": "Example: https://www.rero.ch/",
           "format": "uri",
+          "pattern": "^(ftps?|https?)://.*$",
           "minLength": 7,
           "form": {
             "expressionProperties": {
               "templateOptions.required": "field.parent.model.source !== undefined && field.parent.model.source !== ''"
+            },
+            "validation": {
+              "messages": {
+                "patternMessage": "Should be a valid URL format."
+              }
             }
           }
         }
@@ -386,7 +354,9 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         },
         "validation": {
           "validators": {

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -234,9 +234,11 @@
       ],
       "default": "standard",
       "form": {
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "issue": {
@@ -301,9 +303,11 @@
           "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
           "form": {
             "type": "datepicker",
-            "wrappers": [
-              "form-field"
-            ],
+            "templateOptions": {
+              "wrappers": [
+                "form-field"
+              ]
+            },
             "validation": {
               "messages": {
                 "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
@@ -332,9 +336,11 @@
           "type": "boolean",
           "default": true,
           "form": {
-            "wrappers": [
-              "hide"
-            ]
+            "templateOptions": {
+              "wrappers": [
+                "hide"
+              ]
+            }
           }
         },
         "claims_count": {
@@ -389,9 +395,11 @@
             "value": "excluded"
           }
         ],
-        "wrappers": [
-          "hide"
-        ]
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        }
       }
     },
     "holding": {
@@ -420,6 +428,7 @@
     "notes": {
       "title": "Notes",
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "title": "Note",
@@ -532,10 +541,6 @@
       "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
       "form": {
         "type": "datepicker",
-        "wrappers": [
-          "toggle-switch",
-          "form-field"
-        ],
         "templateOptions": {
           "hideLabel": true,
           "wrappers": [

--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -249,42 +249,13 @@
                   "weekly",
                   "monthly",
                   "yearly"
-                ],
-                "form": {
-                  "type": "selectWithSort",
-                  "wrappers": [
-                    "form-field-horizontal"
-                  ],
-                  "templateOptions": {
-                    "selectWithSortOptions": {
-                      "order": "label"
-                    }
-                  },
-                  "options": [
-                    {
-                      "label": "daily",
-                      "value": "daily"
-                    },
-                    {
-                      "label": "weekly",
-                      "value": "weekly"
-                    },
-                    {
-                      "label": "monthly",
-                      "value": "monthly"
-                    },
-                    {
-                      "label": "yearly",
-                      "value": "yearly"
-                    }
-                  ]
-                }
-              },
-              "data": {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                }
+                ]
+              }
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "integer"
               }
             }
           }

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -185,11 +185,12 @@
         }
       },
       "form": {
-        "wrappers": [
-          "toggle-switch"
-        ],
+        "hideExpression": "field.parent.model.allow_request === false",
         "templateOptions": {
           "label": "",
+          "wrappers": [
+            "toggle-switch"
+          ],
           "toggle-switch": {
             "label": "Restrict pickup to",
             "description": "If enabled, restrict pickup to specific pickup locations."

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -70,11 +70,11 @@
       "type": "number",
       "minimum": 0,
       "form": {
-        "wrappers": [
-          "toggle-switch",
-          "form-field"
-        ],
         "templateOptions": {
+          "wrappers": [
+            "toggle-switch",
+            "form-field"
+          ],
           "toggle-switch": {
             "label": "Yearly subscription",
             "description": "Activation of subscription fees for patrons linked to this type."
@@ -162,11 +162,11 @@
             }
           },
           "form": {
-            "wrappers": [
-              "toggle-switch",
-              "form-field"
-            ],
             "templateOptions": {
+              "wrappers": [
+                "toggle-switch",
+                "form-field"
+              ],
               "toggle-switch": {
                 "label": "Limit by checkouts"
               }
@@ -188,11 +188,11 @@
             }
           },
           "form": {
-            "wrappers": [
-              "toggle-switch",
-              "form-field"
-            ],
             "templateOptions": {
+              "wrappers": [
+                "toggle-switch",
+                "form-field"
+              ],
               "toggle-switch": {
                 "label": "Limit by overdue fee amount"
               }
@@ -214,11 +214,11 @@
             }
           },
           "form": {
-            "wrappers": [
-              "toggle-switch",
-              "form-field"
-            ],
             "templateOptions": {
+              "wrappers": [
+                "toggle-switch",
+                "form-field"
+              ],
               "toggle-switch": {
                 "label": "Limit by overdue items"
               }

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -8,6 +8,7 @@
     "first_name",
     "last_name",
     "birth_date",
+    "user_id",
     "email",
     "username",
     "street",
@@ -396,7 +397,9 @@
       "form": {
         "hideExpression": "!field.parent.model.roles.some(v => v === 'patron')",
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         }
       }
     },
@@ -528,7 +531,9 @@
       },
       "form": {
         "templateOptions": {
-          "cssClass": "editor-title"
+          "wrappers": [
+            "card"
+          ]
         },
         "validation": {
           "validators": {

--- a/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
@@ -110,9 +110,11 @@
         "patrons"
       ],
       "form": {
-        "wrappers": [
-          "hide"
-        ],
+        "templateOptions": {
+          "wrappers": [
+            "hide"
+          ]
+        },
         "options": [
           {
             "label": "documents",

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -56,7 +56,15 @@
       "title": "Website",
       "type": "string",
       "format": "uri",
-      "minLength": 4
+      "pattern": "^(ftps?|https?)://.*$",
+      "minLength": 4,
+      "form": {
+        "validation": {
+          "messages": {
+            "patternMessage": "Should be a valid URL format."
+          }
+        }
+      }
     },
     "note": {
       "title": "Note",

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -426,7 +426,7 @@ def prepare_jsonschema(schema):
     return schema
 
 
-@blueprint.route('/schemaform/<document_type>')
+@blueprint.route('/schemas/<document_type>')
 def schemaform(document_type):
     """Return schema and form options for the editor."""
     doc_type = document_type

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -148,7 +148,7 @@ then
   info_msg "Install RERO-ILS-UI from tgz: ${tgz_file}"
   npm install --no-save --only=prod --no-fund --no-audit  "${tgz_file}" --prefix "${static_folder}"
 else
-  npm install --no-save --only=prod --no-fund --no-audit  @rero/rero-ils-ui@0.11.1 --prefix "${static_folder}"
+  npm install --no-save --only=prod --no-fund --no-audit  @rero/rero-ils-ui@0.12.0 --prefix "${static_folder}"
 fi
 
 # build the web assets

--- a/tests/e2e/cypress/cypress/integration/editor/document/create-simple-document.spec.js
+++ b/tests/e2e/cypress/cypress/integration/editor/document/create-simple-document.spec.js
@@ -46,7 +46,7 @@ describe('Create a document', function() {
   });
 
   it('Creates a document with only essential fields', function() {
-    cy.intercept('/schemaform/documents').as('documentSchemaform');
+    cy.intercept('/schemas/documents').as('documentSchemaform');
     // Go to document editor
     cy.visit('/professional/records/documents/new');
     // Populate form with simple record

--- a/tests/e2e/cypress/cypress/integration/templates/templates-test.spec.js
+++ b/tests/e2e/cypress/cypress/integration/templates/templates-test.spec.js
@@ -37,7 +37,7 @@ describe('Templates: Create and use template for a document', function() {
     cy.login(this.users.librarians.spock.email, this.common.uniquePwd)
     cy.intercept('GET', '**/professional/records/document**)').as('documentEditor');
     cy.intercept('POST', '/api/templates/').as('createTemplate');
-    cy.intercept('GET', '/schemaform/documents').as('getDocumentSchemaform');
+    cy.intercept('GET', '/schemas/documents').as('getDocumentSchemaform');
   });
 
   after('Delete resources and logout', function() {


### PR DESCRIPTION
* Adapts the JSONSchema form options for a new ng-core editor version.
* Changes the schemaform url to schemas to be more compliant with other
  RERO application.
* Closes #1426.
* Closes #1423.
* Closes #1366.
* Closes rero/rero-ils#1598.
* Closes rero/rero-ils#1604.
* Closes rero/rero-ils#1601.
* Closes rero/rero-ils#1425.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Dependencies

* https://github.com/rero/rero-ils-ui/pull/503
* rero/ng-core#338


## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [x] Cypress tests successful?
