### PR TITLE
holdings: fix is_serial definition

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -121,8 +121,8 @@ class Holding(IlsRecord):
     def extended_validation(self, **kwargs):
         """Add additional record validation.
 
-        Ensures that holdings of type serials are created only on
-        journal documents i.e. serial mode_of_issuance main_type of documents.
+        Ensures that holdings of type standard are created only on
+        non journal documents.
 
         Ensures that holdings of type electronic are created only on
         ebooks documents i.e. harvested documents.
@@ -153,8 +153,6 @@ class Holding(IlsRecord):
                 return _(
                     'Must have next expected date for regular frequencies.')
         is_electronic = self.holdings_type == 'electronic'
-        is_issuance = \
-            document.get('issuance', {}).get('main_type') == 'rdami:1003'
         if (document.harvested ^ is_electronic):
             msg = _('Electronic Holding is not attached to the correct \
                     document type. document: {pid}')
@@ -182,11 +180,7 @@ class Holding(IlsRecord):
     @property
     def is_serial(self):
         """Shortcut to check if holding is a serial holding record."""
-        document = Document.get_record_by_pid(self.document_pid).dumps()
-        is_serial = self.holdings_type == 'serial'
-        is_issuance = \
-            document.get('issuance', {}).get('main_type') == 'rdami:1003'
-        return is_serial and is_issuance
+        return self.holdings_type == 'serial'
 
     @property
     def holding_is_serial(self):

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -156,7 +156,7 @@
       }
     },
     "patterns": {
-      "title": "Serial configuration",
+      "title": "Predictions",
       "type": "object",
       "required": [
         "values",
@@ -176,7 +176,7 @@
       "additionalProperties": false,
       "properties": {
         "template": {
-          "title": "Issue display template",
+          "title": "Template",
           "description": "This template define how a prediction is displayed. i.e. year 2020; vol.1, iss. 4. It should contains the variable field between {{}} with the corresponding pattern and level name.",
           "type": "string",
           "minLength": 3,
@@ -496,7 +496,13 @@
       "title": "Available collection",
       "description": "Textual description of the basic bibliographic unit of the holding.",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "type": "textarea",
+        "templateOptions": {
+          "rows": 2
+        }
+      }
     },
     "supplementaryContent": {
       "title": "Supplementary content",

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -205,7 +205,7 @@ def test_create_holdings_with_pattern(
         post_entrypoint,
         holding_lib_martigny_data
     )
-    assert res.status_code == 403
+    assert res.status_code == 201
 
     holding_lib_martigny_data['patterns'] = \
         pattern_yearly_one_level_data['patterns']
@@ -216,7 +216,7 @@ def test_create_holdings_with_pattern(
         post_entrypoint,
         holding_lib_martigny_data
     )
-    assert res.status_code == 403
+    assert res.status_code == 201
 
     # test will not fail when creating a standard holding for a journal doc.
     holding_lib_martigny_w_patterns_data['holdings_type'] = 'standard'


### PR DESCRIPTION
Previously, a holdings is considered of type serial
if it is attached to document of type journal. With
this commit, if the holdings has the holdings_type =
serial, it is considered a serial holdings.

* Adapts units testing
* Shortens the title of the holdings fields, template and patterns
* Makes the fields EnumerationAndChronolgy as textarea

Co-Authored-by: Aly Badr <aly.badr@rero.ch>


