### PR TITLE
notification: create list of template API.

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2271,6 +2271,12 @@ RERO_ILS_ENABLE_OPERATION_LOG = {
     'items': 'item'
 }
 
+# Notification Configuration
+# ===========================
+RERO_ILS_NOTIFICATIONS_ALLOWED_TEMPATE_FILES = [
+    '*.txt',
+    '*.tpl.*'
+]
 
 # Login Configuration
 # ===================

--- a/rero_ils/modules/circ_policies/views.py
+++ b/rero_ils/modules/circ_policies/views.py
@@ -19,13 +19,11 @@
 
 from __future__ import absolute_import, print_function
 
-from functools import wraps
-
 from flask import Blueprint, jsonify
 
 from ..circ_policies.api import CircPolicy
+from ..decorators import check_logged_as_librarian
 from ..patrons.api import current_patron
-from ...permissions import login_and_librarian
 
 blueprint = Blueprint(
     'circ_policies',
@@ -35,20 +33,10 @@ blueprint = Blueprint(
 )
 
 
-def check_permission(fn):
-    """Decorate to check permission access."""
-    @wraps(fn)
-    def decorated_view(*args, **kwargs):
-        """Decorated view."""
-        login_and_librarian()
-        return fn(*args, **kwargs)
-    return decorated_view
-
-
 @blueprint.route('/circ_policies/name/validate/<name>', methods=["GET"])
-@check_permission
+@check_logged_as_librarian
 def name_validate(name):
-    """Circ policy name Validatation."""
+    """Circulation policy name validation."""
     response = {
         'name': None
     }

--- a/rero_ils/modules/decorators.py
+++ b/rero_ils/modules/decorators.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Shared module decorators."""
+
+from functools import wraps
+
+from rero_ils.permissions import login_and_librarian
+
+
+def check_logged_as_librarian(fn):
+    """Decorate to check if the current logged user is logged as librarian.
+
+    If no user is connected: return 401 (unauthorized)
+    If current logged user isn't `librarian`: return 403 (forbidden)
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        login_and_librarian()
+        return fn(*args, **kwargs)
+    return wrapper

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -19,8 +19,6 @@
 
 from __future__ import absolute_import, print_function
 
-from functools import wraps
-
 import click
 from flask import Blueprint, abort, current_app, jsonify, render_template
 from flask import request as flask_request
@@ -43,7 +41,6 @@ from ..locations.api import Location
 from ..organisations.api import Organisation
 from ..patrons.api import Patron, current_patron
 from ..utils import cached, extracted_data_from_ref
-from ...permissions import login_and_librarian
 
 
 def doc_item_view_method(pid, record, template=None, **kwargs):
@@ -104,16 +101,6 @@ api_blueprint = Blueprint(
     'api_documents',
     __name__
 )
-
-
-def check_permission(fn):
-    """Check user permissions."""
-    @wraps(fn)
-    def decorated_view(*args, **kwargs):
-        """Decorated view."""
-        login_and_librarian()
-        return fn(*args, **kwargs)
-    return decorated_view
 
 
 @api_blueprint.route('/cover/<isbn>')

--- a/rero_ils/modules/item_types/views.py
+++ b/rero_ils/modules/item_types/views.py
@@ -19,13 +19,11 @@
 
 from __future__ import absolute_import, print_function
 
-from functools import wraps
-
 from flask import Blueprint, jsonify
 
+from ..decorators import check_logged_as_librarian
 from ..item_types.api import ItemType
 from ..patrons.api import current_patron
-from ...permissions import login_and_librarian
 
 blueprint = Blueprint(
     'item_types',
@@ -35,18 +33,8 @@ blueprint = Blueprint(
 )
 
 
-def check_permission(fn):
-    """Decorate to check permission access."""
-    @wraps(fn)
-    def decorated_view(*args, **kwargs):
-        """Decorated view."""
-        login_and_librarian()
-        return fn(*args, **kwargs)
-    return decorated_view
-
-
 @blueprint.route('/item_types/name/validate/<name>', methods=["GET"])
-@check_permission
+@check_logged_as_librarian
 def name_validate(name):
     """Item type name validation."""
     response = {

--- a/rero_ils/modules/patron_types/views.py
+++ b/rero_ils/modules/patron_types/views.py
@@ -19,13 +19,11 @@
 
 from __future__ import absolute_import, print_function
 
-from functools import wraps
-
 from flask import Blueprint, jsonify
 
+from ..decorators import check_logged_as_librarian
 from ..patron_types.api import PatronType
 from ..patrons.api import current_patron
-from ...permissions import login_and_librarian
 
 blueprint = Blueprint(
     'patron_types',
@@ -35,18 +33,8 @@ blueprint = Blueprint(
 )
 
 
-def check_permission(fn):
-    """Decorate to check permission access."""
-    @wraps(fn)
-    def decorated_view(*args, **kwargs):
-        """Decorated view."""
-        login_and_librarian()
-        return fn(*args, **kwargs)
-    return decorated_view
-
-
 @blueprint.route('/patron_types/name/validate/<name>', methods=["GET"])
-@check_permission
+@check_logged_as_librarian
 def name_validate(name):
     """Patron type name validation."""
     response = {

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -20,7 +20,6 @@
 from __future__ import absolute_import, print_function
 
 import re
-from functools import wraps
 
 from elasticsearch_dsl import Q
 from flask import Blueprint, abort, current_app, flash, jsonify, \
@@ -37,12 +36,12 @@ from werkzeug.utils import redirect
 from .api import Patron, PatronsSearch
 from .permissions import get_allowed_roles_management
 from .utils import user_has_patron
+from ..decorators import check_logged_as_librarian
 from ..items.api import Item
 from ..items.utils import item_pid_to_object
 from ..loans.api import Loan, get_loans_stats_by_patron_pid, patron_profile
 from ..locations.api import Location
 from ..utils import get_base_url
-from ...permissions import login_and_librarian
 
 api_blueprint = Blueprint(
     'api_patrons',
@@ -58,21 +57,8 @@ _EMAIL_REGEX = re.compile(r'email:"\s*(.*?)\s*"')
 _USERNAME_REGEX = re.compile(r'username:"\s*(.*?)\s*"')
 
 
-def check_permission(fn):
-    """Decorate to check permission access.
-
-    The access is allow when the connected user is a librarian.
-    """
-    @wraps(fn)
-    def is_logged_librarian(*args, **kwargs):
-        """Decorated view."""
-        login_and_librarian()
-        return fn(*args, **kwargs)
-    return is_logged_librarian
-
-
 @api_blueprint.route('/count/', methods=['GET'])
-@check_permission
+@check_logged_as_librarian
 def number_of_patrons():
     """Returns the number of patrons matching the query.
 
@@ -106,7 +92,7 @@ def number_of_patrons():
 
 
 @api_blueprint.route('/<patron_pid>/circulation_informations', methods=['GET'])
-@check_permission
+@check_logged_as_librarian
 def patron_circulation_informations(patron_pid):
     """Get the circulation statistics and info messages about a patron."""
     patron = Patron.get_record_by_pid(patron_pid)
@@ -264,7 +250,7 @@ def format_currency_filter(value, currency):
 
 
 @api_blueprint.route('/roles_management_permissions', methods=['GET'])
-@check_permission
+@check_logged_as_librarian
 def get_roles_management_permissions():
     """Get the roles that current logged user could manage."""
     return jsonify({

--- a/tests/api/circ_policies/test_circ_policies_rest.py
+++ b/tests/api/circ_policies/test_circ_policies_rest.py
@@ -178,12 +178,11 @@ def test_circ_policies_post_put_delete(client, org_martigny,
     assert res.status_code == 200
 
 
-@mock.patch('rero_ils.modules.circ_policies.views.login_and_librarian',
+@mock.patch('rero_ils.modules.decorators.login_and_librarian',
             mock.MagicMock())
-def test_circ_policies_name_validate(client, circ_policy_default_martigny):
+def test_circ_policies_name_validate(client):
     """Test policy validation."""
     url = url_for('circ_policies.name_validate', name='Default')
-    circ_policy = circ_policy_default_martigny
 
     class current_patron:
         class organisation:

--- a/tests/api/item_types/test_item_types_rest.py
+++ b/tests/api/item_types/test_item_types_rest.py
@@ -151,13 +151,11 @@ def test_item_types_post_put_delete(client, org_martigny,
     assert res.status_code == 410
 
 
-@mock.patch('rero_ils.modules.item_types.views.login_and_librarian',
+@mock.patch('rero_ils.modules.decorators.login_and_librarian',
             mock.MagicMock())
-def test_item_types_name_validate(client, item_type_standard_martigny):
+def test_item_types_name_validate(client):
     """Test record name validation."""
-
     url = url_for('item_types.name_validate', name='standard')
-
     class current_patron:
         class organisation:
             pid = 'org1'

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -511,3 +511,15 @@ def test_transaction_library_pid(notification_late_martigny,
                                  lib_martigny_data):
     assert notification_late_martigny.transaction_library_pid == \
            lib_martigny_data.get('pid')
+
+
+def test_notification_templates_list(client, librarian_martigny_no_email):
+    """Test notification templates list API."""
+    url = url_for('notifications.list_available_template')
+    res = client.get(url)
+    assert res.status_code == 401
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res = client.get(url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert isinstance(data.get('templates'), list)

--- a/tests/api/patron_types/test_patron_types_rest.py
+++ b/tests/api/patron_types/test_patron_types_rest.py
@@ -153,13 +153,11 @@ def test_patron_types_post_put_delete(client, org_martigny,
     assert res.status_code == 410
 
 
-@mock.patch('rero_ils.modules.patron_types.views.login_and_librarian',
+@mock.patch('rero_ils.modules.decorators.login_and_librarian',
             mock.MagicMock())
-def test_patron_types_name_validate(client, patron_type_children_martigny):
+def test_patron_types_name_validate(client):
     """Test patron type name validation."""
-
     url = url_for('patron_types.name_validate', name='children')
-
     class current_patron:
         class organisation:
             pid = 'org1'


### PR DESCRIPTION
Creates an API entry point to list all templates available for
notification creation. Only template directories containing files
according to the configuration setting will be considerate as valid.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- call `https://localhost:5000/notifications/templates/list` url (logged as librarian/syslib)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
