### PR TITLE
cipo: remove `allow_checkout` field

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -6,7 +6,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": true,
     "checkout_duration": 30,
     "allow_requests": true,
     "reminders": [
@@ -36,7 +35,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/2"
     },
-    "allow_checkout": true,
     "checkout_duration": 30,
     "allow_requests": true,
     "reminders": [
@@ -66,7 +64,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": true,
     "checkout_duration": 7,
     "allow_requests": true,
     "reminders": [
@@ -111,7 +108,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": true,
     "checkout_duration": 14,
     "allow_requests": true,
     "reminders": [
@@ -159,7 +155,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": true,
     "checkout_duration": 14,
     "allow_requests": true,
     "reminders": [
@@ -199,7 +194,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": true,
     "checkout_duration": 28,
     "allow_requests": true,
     "reminders": [
@@ -239,7 +233,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": true,
     "reminders": [
       {
         "type": "due_soon",
@@ -311,7 +304,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": false,
     "allow_requests": false,
     "policy_library_level": false,
     "is_default": false,
@@ -341,7 +333,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": false,
     "allow_requests": false,
     "policy_library_level": false,
     "is_default": false,
@@ -395,7 +386,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
     },
-    "allow_checkout": false,
     "allow_requests": false,
     "policy_library_level": false,
     "is_default": false,
@@ -425,7 +415,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/2"
     },
-    "allow_checkout": false,
     "allow_requests": false,
     "policy_library_level": false,
     "is_default": false,
@@ -455,7 +444,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/3"
     },
-    "allow_checkout": true,
     "reminders": [
       {
         "type": "due_soon",
@@ -485,7 +473,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/4"
     },
-    "allow_checkout": true,
     "reminders": [
       {
         "type": "due_soon",

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2240,7 +2240,7 @@ RERO_ILS_ENABLE_OPERATION_LOG = {
     'holdings': 'hold',
     'items': 'item'
 }
- 
+
 
 # Login Configuration
 # ===================
@@ -2524,7 +2524,7 @@ CIRCULATION_ACTIONS_VALIDATION = {
     ],
     ItemCirculationAction.CHECKOUT: [
         Patron.can_checkout,
-        CircPolicy.allow_checkout,
+        CircPolicy.can_checkout,
         PatronType.allow_checkout
     ]
 }

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -295,6 +295,11 @@ class CircPolicy(IlsRecord):
         return cannot_delete
 
     @property
+    def allow_checkout(self):
+        """Shortcut to know if circulation policy allow checkout."""
+        return 'checkout_duration' in self
+
+    @property
     def due_soon_interval_days(self):
         """Get number of days to check if loan is considerate as due_soon."""
         reminder = [r for r in self.get('reminders', [])
@@ -376,7 +381,7 @@ class CircPolicy(IlsRecord):
         return True, []
 
     @classmethod
-    def allow_checkout(cls, item, **kwargs):
+    def can_checkout(cls, item, **kwargs):
         """Check if the cipo corresponding to item/patron allow request.
 
         :param item : the item to check
@@ -400,7 +405,7 @@ class CircPolicy(IlsRecord):
             patron.patron_type_pid,
             item.item_type_circulation_category_pid
         )
-        if not cipo.get('allow_checkout', False):
+        if not cipo.allow_checkout:
             return False, ["Circulation policy disallows the operation."]
         return True, []
 

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -42,11 +42,6 @@
         }
       }
     },
-    "allow_checkout": {
-      "title": "Allow Checkout",
-      "type": "boolean",
-      "default": true
-    },
     "checkout_duration": {
       "title": "Checkout duration in days",
       "type": "integer",

--- a/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
@@ -29,9 +29,6 @@
           }
         }
       },
-      "allow_checkout": {
-        "type": "boolean"
-      },
       "checkout_duration": {
         "type": "integer"
       },

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -1074,12 +1074,12 @@ class ItemCirculation(ItemRecord):
             if not can:
                 data['action_validated'] = False
         if action == 'checkout':
-            if not circ_policy.get('allow_checkout'):
+            if not circ_policy.allow_checkout:
                 data['action_validated'] = False
 
         if action == 'receive':
             if (
-                    circ_policy.get('allow_checkout') and
+                    circ_policy.allow_checkout and
                     loan['state'] ==
                     LoanState.ITEM_IN_TRANSIT_FOR_PICKUP and
                     loan.get('patron_pid') == patron_pid

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -345,7 +345,7 @@ def item(item_barcode):
         new_actions = []
         # If circulation policy doesn't allow checkout operation no need to
         # perform special check describe below.
-        if circ_policy.get('allow_checkout', False):
+        if circ_policy.allow_checkout:
             for action in item_dumps.get('actions', []):
                 if action == 'checkout':
                     if item.number_of_requests() > 0:

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -366,10 +366,8 @@ def get_loanable_items(patron_type_pid):
                 patron_type_pid,
                 item.holding_circulation_category_pid
             )
-            if (
-                    circ_policy.get('allow_checkout') and
-                    circ_policy.get('allow_requests')
-            ):
+            if (circ_policy.allow_checkout and
+               circ_policy.get('allow_requests')):
                 if not item.number_of_requests():
                     # exclude the first 16 items of the 3rd organisation
                     barcode = item.get('barcode')

--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -75,7 +75,7 @@ def get_default_loan_duration(loan, initial_loan):
     #  trigger an HTTP 403 response for the frontend, thanks to
     #  loan_satisfy_circ_policies.
 
-    if policy.get('allow_checkout') is True:
+    if policy.allow_checkout:
         due_date_eve = now + timedelta(days=policy.get(
             'checkout_duration')) - timedelta(days=1)
         next_open_date = library.next_open(date=due_date_eve)
@@ -136,8 +136,7 @@ def loan_satisfy_circ_policies(loan):
     """Validate the loan duration."""
     # Validate the loan duration
     policy = get_circ_policy(loan)
-    return loan['end_date'] > loan['start_date'] and \
-        policy.get('allow_checkout')
+    return loan['end_date'] > loan['start_date'] and policy.allow_checkout
 
 
 def is_item_available_for_checkout(item_pid):

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -984,7 +984,9 @@ def test_item_possible_actions(client, item_lib_martigny,
         'itty1'
     )
 
-    circ_policy['allow_checkout'] = False
+    original_checkout_duration = circ_policy.get('checkout_duration')
+    if original_checkout_duration is not None:
+        del circ_policy['checkout_duration']
     circ_policy.update(
         circ_policy,
         dbcommit=True,
@@ -1003,10 +1005,11 @@ def test_item_possible_actions(client, item_lib_martigny,
     actions = data.get('metadata').get('item').get('actions')
     assert 'checkout' not in actions
 
-    circ_policy['allow_checkout'] = True
+    if original_checkout_duration is not None:
+        circ_policy['checkout_duration'] = original_checkout_duration
     circ_policy.update(
         circ_policy,
         dbcommit=True,
         reindex=True
     )
-    assert circ_policy['allow_checkout']
+    assert circ_policy.allow_checkout

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -906,7 +906,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org1"
     },
-    "allow_checkout": true,
     "checkout_duration": 30,
     "reminders": [
       {
@@ -937,7 +936,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org1"
     },
-    "allow_checkout": true,
     "checkout_duration": 15,
     "allow_requests": true,
     "reminders": [
@@ -993,7 +991,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org1"
     },
-    "allow_checkout": true,
     "checkout_duration": 7,
     "allow_requests": true,
     "reminders": [
@@ -1039,7 +1036,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org2"
     },
-    "allow_checkout": true,
     "checkout_duration": 30,
     "reminders": [
       {
@@ -1070,7 +1066,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org1"
     },
-    "allow_checkout": false,
     "allow_requests": false,
     "policy_library_level": false,
     "is_default": false
@@ -1083,7 +1078,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org2"
     },
-    "allow_checkout": false,
     "allow_requests": false,
     "policy_library_level": false,
     "is_default": false
@@ -1096,7 +1090,6 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org1"
     },
-    "allow_checkout": true,
     "checkout_duration": 0,
     "allow_requests": false,
     "policy_library_level": false,

--- a/tests/e2e/cypress/cypress/fixtures/cipo.json
+++ b/tests/e2e/cypress/cypress/fixtures/cipo.json
@@ -3,7 +3,6 @@
     "organisation_pid": 4,
     "name": "On site",
     "allow_requests": false,
-    "allow_checkout": true,
     "checkout_duration": 0,
     "policy_library_level": false,
     "is_default": false
@@ -13,7 +12,6 @@
     "name":"Extended",
     "description":"Extended loan (3 months).",
     "allow_requests":true,
-    "allow_checkout":true,
     "checkout_duration":84,
     "number_of_days_after_due_date":5,
     "number_of_days_before_due_date":5,
@@ -29,7 +27,6 @@
     "name":"Default",
     "description":"Default circulation policy.",
     "allow_requests":true,
-    "allow_checkout":true,
     "checkout_duration":30,
     "number_of_days_after_due_date":5,
     "number_of_days_before_due_date":5,
@@ -44,7 +41,6 @@
     "name":"No checkout",
     "description":"Ebooks circulation policy.",
     "allow_requests":false,
-    "allow_checkout":false,
     "policy_library_level":false,
     "is_default":false
   }

--- a/tests/e2e/cypress/cypress/support/cipo.js
+++ b/tests/e2e/cypress/cypress/support/cipo.js
@@ -35,7 +35,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       "name": (cipo.name + nameSuffix),
       "allow_requests": cipo.allow_requests,
-      "allow_checkout": cipo.allow_checkout,
       "checkout_duration": cipo.checkout_duration,
       "policy_library_level": cipo.policy_library_level,
       "is_default": cipo.is_default,

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -60,7 +60,7 @@ def test_item_loans_elements(
         get_default_loan_duration(loan_pending_martigny, None)
 
     assert item_lib_fully.last_location_pid == item_lib_fully.location_pid
-    circ_policy_default_martigny['allow_checkout'] = False
+    del circ_policy_default_martigny['checkout_duration']
     circ_policy_default_martigny.update(
         circ_policy_default_martigny, dbcommit=True, reindex=True)
 

--- a/tests/unit/test_circ_policies_jsonschema.py
+++ b/tests/unit/test_circ_policies_jsonschema.py
@@ -86,17 +86,6 @@ def test_circ_policy_renewal_duration(
         validate(circ_policy_martigny_data_tmp, circ_policy_schema)
 
 
-def test_circ_policy_allow_checkout(
-    circ_policy_schema, circ_policy_martigny_data_tmp
-):
-    """Test allow_checkout for circulation policy jsonschema."""
-    validate(circ_policy_martigny_data_tmp, circ_policy_schema)
-
-    with pytest.raises(ValidationError):
-        circ_policy_martigny_data_tmp['allow_checkout'] = 25
-        validate(circ_policy_martigny_data_tmp, circ_policy_schema)
-
-
 def test_circ_policy_checkout_duration(
     circ_policy_schema, circ_policy_martigny_data_tmp
 ):


### PR DESCRIPTION
Removes the `allow_checkout` field from circulation policy JSON schema.
This data is redundant with the `checkout_duration` data ; if a cipo
resource defines a `checkout_duration` data (even if duration is 0),
then the checkout is allowed, otherwise, when data is missing from
resource, the checkout is disallowed.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
