### PR TITLE
patron transactions: allow to link to a loan

### DIFF
--- a/rero_ils/modules/patron_transaction_events/mappings/v7/patron_transaction_events/patron_transaction_event-v0.0.1.json
+++ b/rero_ils/modules/patron_transaction_events/mappings/v7/patron_transaction_events/patron_transaction_event-v0.0.1.json
@@ -13,6 +13,9 @@
         "properties": {
           "pid": {
             "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
           }
         }
       },
@@ -35,12 +38,18 @@
         "properties": {
           "pid": {
             "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
           }
         }
       },
       "patron": {
         "properties": {
           "pid": {
+            "type": "keyword"
+          },
+          "type": {
             "type": "keyword"
           }
         }
@@ -49,12 +58,18 @@
         "properties": {
           "pid": {
             "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
           }
         }
       },
       "organisation": {
         "properties": {
           "pid": {
+            "type": "keyword"
+          },
+          "type": {
             "type": "keyword"
           }
         }

--- a/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
@@ -116,6 +116,17 @@
         }
       }
     },
+    "loan": {
+      "title": "Loan",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Loan URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/loans/.*?$"
+        }
+      }
+    },
     "organisation": {
       "title": "Organisation",
       "type": "object",

--- a/rero_ils/modules/patron_transactions/listener.py
+++ b/rero_ils/modules/patron_transactions/listener.py
@@ -33,6 +33,8 @@ def enrich_patron_transaction_data(sender, json=None, record=None, index=None,
     if index.split('-')[0] == PatronTransactionsSearch.Meta.index:
         if not isinstance(record, PatronTransaction):
             record = PatronTransaction.get_record_by_pid(record.get('pid'))
-        if record.notification_pid:
-            json['document'] = {'pid': record.document_pid}
-            json['loan'] = {'pid': record.loan_pid}
+        if record.loan:
+            json['document'] = {
+                'pid': record.document_pid,
+                'type': 'documents'
+            }

--- a/tests/api/patron_transactions/test_patron_transactions_rest.py
+++ b/tests/api/patron_transactions/test_patron_transactions_rest.py
@@ -53,12 +53,11 @@ def test_patron_transactions_permissions(
     )
     assert res.status_code == 401
 
-    res = client.put(
+    client.put(
         item_url,
         data={},
         headers=json_header
     )
-
     res = client.delete(item_url)
     assert res.status_code == 401
 
@@ -108,7 +107,6 @@ def test_patron_transactions_get(client, patron_transaction_overdue_martigny):
     data = get_json(res)
     result = data['hits']['hits'][0]['metadata']
     del(result['document'])
-    del(result['loan'])
     assert result == transaction.replace_refs()
 
 


### PR DESCRIPTION
At this time, all PatronTransaction are either linked to a Notification,
either linked to a Patron (for subscription). But the future incremental
fees will not be linked to a Notification but need to be linked to a
Loan. Updates the JSON schema to allow a PatronTransaction to be
directly linked to a Loan resource.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
