### PR TITLE
users: add user info API

### DIFF
--- a/rero_ils/accounts_views.py
+++ b/rero_ils/accounts_views.py
@@ -57,7 +57,8 @@ class LoginView(CoreLoginView):
         'password': fields.String(required=True)
     }
 
-    def get_user(self, email=None, **kwargs):
+    @classmethod
+    def get_user(cls, email=None, **kwargs):
         """Retrieve a user by the provided arguments."""
         try:
             profile = UserProfile.get_by_username(email)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -19,11 +19,34 @@
 
 from __future__ import absolute_import, print_function
 
+from datetime import datetime
+
 import pytest
+from invenio_accounts.ext import hash_password
+from invenio_accounts.models import User
 from utils import flush_index
 
 from rero_ils.modules.documents.api import Document, DocumentsSearch
 
+
+@pytest.fixture(scope='function')
+def user_with_profile(db):
+    """Create a simple invenio user with a profile."""
+    with db.session.begin_nested():
+        user = User(
+            email='user_with_profile@test.com',
+            password=hash_password('123456'),
+            profile=dict(), active=True)
+        db.session.add(user)
+        profile = user.profile
+        profile.birth_date = datetime(1990, 1, 1)
+        profile.first_name = 'User'
+        profile.last_name = 'With Profile'
+        profile.city = 'Nowhere'
+        profile.username = 'user_with_profile'
+        db.session.merge(user)
+    db.session.commit()
+    return user
 
 @pytest.fixture(scope='module')
 def create_app():

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test user_info API."""
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json
+
+
+def test_user_info(
+        client, document, user_with_profile, patron_martigny_no_email,
+        system_librarian_martigny_no_email):
+    """Test users API."""
+    # failed: no logged user
+    res = client.get(
+        url_for(
+            'api_blueprint.user_info',
+            email_or_username='lroduit@gmail.com'
+        )
+    )
+    assert res.status_code == 401
+
+    # patron should not have the permission
+    login_user_via_session(client, patron_martigny_no_email.user)
+    res = client.get(
+        url_for(
+            'api_blueprint.user_info',
+            email_or_username='lroduit@gmail.com'
+        )
+    )
+    assert res.status_code == 403
+
+    # librarian
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+
+    # user does not exists
+    res = client.get(
+        url_for(
+            'api_blueprint.user_info',
+            email_or_username='does not exists'
+        )
+    )
+    data = get_json(res)
+    assert data == {}
+    assert res.status_code == 200
+
+    # user already linked to a patron account
+    res = client.get(
+        url_for(
+            'api_blueprint.user_info',
+            email_or_username='lroduit@gmail.com'
+        )
+    )
+    data = get_json(res)
+    assert data == {}
+    assert res.status_code == 200
+
+    # by email
+    res = client.get(
+        url_for(
+            'api_blueprint.user_info',
+            email_or_username=user_with_profile.email
+        )
+    )
+    data = get_json(res)
+    assert data == {
+        'email': user_with_profile.email,
+        'city': user_with_profile.profile.city,
+        'first_name': user_with_profile.profile.first_name,
+        'id': user_with_profile.id,
+        'last_name': user_with_profile.profile.last_name,
+        'username': user_with_profile.profile.username
+    }
+    assert res.status_code == 200
+
+    # by user
+    res = client.get(
+        url_for(
+            'api_blueprint.user_info',
+            email_or_username=user_with_profile.profile.username
+        )
+    )
+    data = get_json(res)
+    assert data == {
+        'email': user_with_profile.email,
+        'city': user_with_profile.profile.city,
+        'first_name': user_with_profile.profile.first_name,
+        'id': user_with_profile.id,
+        'last_name': user_with_profile.profile.last_name,
+        'username': user_with_profile.profile.username
+    }
+    assert res.status_code == 200


### PR DESCRIPTION
* Adds a new API `/api/user_info/<username_or_email>` to get the
  information of a potential future patron or professional.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- To implement: https://tree.taiga.io/project/rero21-reroils/us/1889?milestone=282105

## How to test?

- Register a new user from the web interface and fill all the profile fields: firstname, lastname, ...
- Connect using a librarian and try: https://localhost:5000/api/user_info/<username_or_email>

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [ ] Cypress tests successful?
