### PR TITLE
patron: the user data comes from the profile

### DIFF
--- a/rero_ils/modules/patrons/cli.py
+++ b/rero_ils/modules/patrons/cli.py
@@ -34,6 +34,7 @@ from invenio_userprofiles.models import UserProfile
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.local import LocalProxy
 
+from .api import create_patron_from_data
 from ..patrons.api import Patron, PatronProvider
 from ..providers import append_fixtures_new_identifiers
 from ..utils import read_json_record
@@ -101,17 +102,16 @@ def import_users(infile, append, verbose, password, lazy, dont_stop_on_error,
                     '{count: <8} User already exist: {username}'.format(
                         count=count,
                         username=username
-                    ), fg='yellow')
+                    ), fg='red')
+                continue
             except NoResultFound:
                 pass
         try:
             # patron creation
-            patron = Patron.create(
-                patron_data,
-                # delete_pid=True,
+            patron = create_patron_from_data(
+                data=patron_data,
                 dbcommit=False,
-                reindex=False,
-                email_notification=False
+                reindex=False
             )
             user = patron.user
             user.password = hash_password(password)

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -5,15 +5,7 @@
   "description": "JSON schema for a user.",
   "additionalProperties": false,
   "propertiesOrder": [
-    "first_name",
-    "last_name",
-    "birth_date",
-    "email",
-    "username",
-    "street",
-    "postal_code",
-    "city",
-    "phone",
+    "user_id",
     "roles",
     "patron",
     "libraries",
@@ -22,10 +14,6 @@
   "required": [
     "$schema",
     "pid",
-    "first_name",
-    "last_name",
-    "birth_date",
-    "username",
     "user_id",
     "roles"
   ],

--- a/rero_ils/utils.py
+++ b/rero_ils/utils.py
@@ -19,6 +19,7 @@
 
 
 from flask import current_app
+from flask_security.confirmable import confirm_user
 from invenio_i18n.ext import current_i18n
 
 
@@ -57,3 +58,53 @@ def remove_empties_from_dict(a_dict):
         if v:
             new_dict[k] = v
     return new_dict or None
+
+def create_user_from_data(data):
+    """Create a user and set the profile fields from a data.
+
+    :param data: A dict containing a mix of patron and user data.
+    :returns: The modified dict.
+    """
+    from datetime import datetime
+
+    from invenio_accounts.ext import hash_password
+    from invenio_accounts.models import User
+    from invenio_db import db
+
+    profile_fields = [
+        'first_name', 'last_name', 'street', 'postal_code',
+        'city', 'birth_date', 'username', 'phone', 'keep_history'
+    ]
+    with db.session.begin_nested():
+        # create the user
+        user = User(
+            password=hash_password(data.get('birth_date', '123456')),
+            profile=dict(), active=True)
+        db.session.add(user)
+        # set the user fields
+        if data.get('email') is not None:
+            user.email = data.get('email')
+        profile = user.profile
+        # set the profile
+        for field in profile_fields:
+            value = data.get(field)
+            if field == 'keep_history':
+                value = data.get('patron', {}).get(field)
+            if value is not None:
+                if field == 'birth_date':
+                    value = datetime.strptime(value, '%Y-%m-%d')
+                setattr(profile, field, value)
+        db.session.merge(user)
+    db.session.commit()
+    confirm_user(user)
+    # remove the user fields from the data
+    for field in profile_fields:
+        try:
+            if field == 'keep_history':
+                del data['patron'][field]
+            else:
+                del data[field]
+        except KeyError:
+            pass
+    data['user_id'] = user.id
+    return data

--- a/tests/api/acq_accounts/test_acq_accounts_permissions.py
+++ b/tests/api/acq_accounts/test_acq_accounts_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.acq_accounts.permissions import AcqAccountPermission
 
 
-def test_acq_accounts_permissions_api(client, patron_martigny_no_email,
-                                      system_librarian_martigny_no_email,
-                                      librarian_martigny_no_email,
+def test_acq_accounts_permissions_api(client, patron_martigny,
+                                      system_librarian_martigny,
+                                      librarian_martigny,
                                       budget_2020_sion,
                                       lib_sion,
                                       acq_account_fiction_martigny,
@@ -58,7 +58,7 @@ def test_acq_accounts_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(acq_account_permissions_url)
     assert res.status_code == 403
 
@@ -67,7 +67,7 @@ def test_acq_accounts_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' acq_account for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(acq_account_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -96,7 +96,7 @@ def test_acq_accounts_permissions_api(client, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about acq_account of its own organisation
     #   * sys_lib can't do anything about acq_account of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(acq_account_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -114,9 +114,9 @@ def test_acq_accounts_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_acq_accounts_permissions(patron_martigny_no_email,
-                                  librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email,
+def test_acq_accounts_permissions(patron_martigny,
+                                  librarian_martigny,
+                                  system_librarian_martigny,
                                   org_martigny, org_sion, lib_sion,
                                   acq_account_fiction_martigny,
                                   acq_account_books_saxon,
@@ -136,7 +136,7 @@ def test_acq_accounts_permissions(patron_martigny_no_email,
     acq_account_sion = acq_account_fiction_sion
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not AcqAccountPermission.list(None, acq_account_martigny)
         assert not AcqAccountPermission.read(None, acq_account_martigny)
@@ -147,7 +147,7 @@ def test_acq_accounts_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny
@@ -171,7 +171,7 @@ def test_acq_accounts_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny

--- a/tests/api/acq_accounts/test_acq_accounts_rest.py
+++ b/tests/api/acq_accounts/test_acq_accounts_rest.py
@@ -177,8 +177,8 @@ def test_acq_accounts_can_delete(
 
 
 def test_filtered_acq_accounts_get(
-        client, librarian_martigny_no_email, acq_account_fiction_martigny,
-        librarian_sion_no_email, acq_account_fiction_sion):
+        client, librarian_martigny, acq_account_fiction_martigny,
+        librarian_sion, acq_account_fiction_sion):
     """Test acq accounts filter by organisation."""
     list_url = url_for('invenio_records_rest.acac_list')
 
@@ -186,7 +186,7 @@ def test_filtered_acq_accounts_get(
     assert res.status_code == 401
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.acac_list')
 
     res = client.get(list_url)
@@ -195,7 +195,7 @@ def test_filtered_acq_accounts_get(
     assert data['hits']['total']['value'] == 1
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.acac_list')
 
     res = client.get(list_url)
@@ -206,11 +206,11 @@ def test_filtered_acq_accounts_get(
 
 def test_acq_account_secure_api(client, json_header,
                                 acq_account_fiction_martigny,
-                                librarian_martigny_no_email,
-                                librarian_sion_no_email):
+                                librarian_martigny,
+                                librarian_sion):
     """Test acq account secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.acac_item',
                          pid_value=acq_account_fiction_martigny.pid)
 
@@ -218,7 +218,7 @@ def test_acq_account_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acac_item',
                          pid_value=acq_account_fiction_martigny.pid)
 
@@ -228,13 +228,13 @@ def test_acq_account_secure_api(client, json_header,
 
 def test_acq_account_secure_api_create(client, json_header,
                                        acq_account_fiction_martigny_data,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       librarian_martigny,
+                                       librarian_sion,
                                        acq_account_books_saxon_data,
-                                       system_librarian_martigny_no_email):
+                                       system_librarian_martigny):
     """Test acq account secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.acac_list'
 
     acq_account_books_saxon_data.pop('pid')
@@ -253,7 +253,7 @@ def test_acq_account_secure_api_create(client, json_header,
     )
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -262,7 +262,7 @@ def test_acq_account_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -274,13 +274,13 @@ def test_acq_account_secure_api_create(client, json_header,
 
 def test_acq_account_secure_api_update(client,
                                        acq_account_books_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       librarian_martigny,
+                                       librarian_sion,
                                        acq_account_books_martigny_data,
                                        json_header):
     """Test acq account secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.acac_item',
                          pid_value=acq_account_books_martigny.pid)
 
@@ -294,7 +294,7 @@ def test_acq_account_secure_api_update(client,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -306,13 +306,13 @@ def test_acq_account_secure_api_update(client,
 
 def test_acq_account_secure_api_delete(client,
                                        acq_account_books_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       librarian_martigny,
+                                       librarian_sion,
                                        acq_account_general_fully,
                                        json_header):
     """Test acq account secure api delete."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.acac_item',
                          pid_value=acq_account_books_martigny.pid)
 
@@ -326,7 +326,7 @@ def test_acq_account_secure_api_delete(client,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403

--- a/tests/api/acq_invoices/test_acq_invoices_permissions.py
+++ b/tests/api/acq_invoices/test_acq_invoices_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.acq_invoices.permissions import AcqInvoicePermission
 
 
-def test_invoice_permissions_api(client, org_sion, patron_martigny_no_email,
-                                 system_librarian_martigny_no_email,
-                                 librarian_martigny_no_email,
+def test_invoice_permissions_api(client, org_sion, patron_martigny,
+                                 system_librarian_martigny,
+                                 librarian_martigny,
                                  acq_invoice_fiction_martigny,
                                  acq_invoice_fiction_saxon,
                                  acq_invoice_fiction_sion):
@@ -56,7 +56,7 @@ def test_invoice_permissions_api(client, org_sion, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(invoice_permissions_url)
     assert res.status_code == 403
 
@@ -65,7 +65,7 @@ def test_invoice_permissions_api(client, org_sion, patron_martigny_no_email,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' invoices for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(invoice_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -94,7 +94,7 @@ def test_invoice_permissions_api(client, org_sion, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about invoices of its own organisation
     #   * sys_lib can't do anything about invoices of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(invoice_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -112,9 +112,9 @@ def test_invoice_permissions_api(client, org_sion, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_invoice_permissions(patron_martigny_no_email,
-                             librarian_martigny_no_email,
-                             system_librarian_martigny_no_email,
+def test_invoice_permissions(patron_martigny,
+                             librarian_martigny,
+                             system_librarian_martigny,
                              document, org_martigny,
                              acq_invoice_fiction_sion,
                              acq_invoice_fiction_saxon,
@@ -134,7 +134,7 @@ def test_invoice_permissions(patron_martigny_no_email,
     invoice_sion = acq_invoice_fiction_sion
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not AcqInvoicePermission.list(None, invoice_martigny)
         assert not AcqInvoicePermission.read(None, invoice_martigny)
@@ -145,7 +145,7 @@ def test_invoice_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny
@@ -169,7 +169,7 @@ def test_invoice_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny

--- a/tests/api/acq_invoices/test_acq_invoices_rest.py
+++ b/tests/api/acq_invoices/test_acq_invoices_rest.py
@@ -182,8 +182,8 @@ def test_acquisition_invoices_can_delete(client, acq_invoice_fiction_martigny):
 
 
 def test_filtered_acquisition_invoices_get(
-        client, librarian_martigny_no_email, acq_invoice_fiction_martigny,
-        acq_invoice_fiction_saxon, librarian_sion_no_email,
+        client, librarian_martigny, acq_invoice_fiction_martigny,
+        acq_invoice_fiction_saxon, librarian_sion,
         acq_invoice_fiction_sion):
     """Test acquisition invoices filter by organisation."""
     list_url = url_for('invenio_records_rest.acin_list')
@@ -192,7 +192,7 @@ def test_filtered_acquisition_invoices_get(
     assert res.status_code == 401
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.acin_list')
 
     res = client.get(list_url)
@@ -201,7 +201,7 @@ def test_filtered_acquisition_invoices_get(
     assert data['hits']['total']['value'] == 2
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.acin_list')
 
     res = client.get(list_url)
@@ -212,10 +212,10 @@ def test_filtered_acquisition_invoices_get(
 
 def test_acquisition_invoice_secure_api(
         client, json_header, acq_invoice_fiction_martigny,
-        librarian_martigny_no_email, librarian_sion_no_email):
+        librarian_martigny, librarian_sion):
     """Test acquisition invoice secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.acin_item',
                          pid_value=acq_invoice_fiction_martigny.pid)
 
@@ -223,7 +223,7 @@ def test_acquisition_invoice_secure_api(
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acin_item',
                          pid_value=acq_invoice_fiction_martigny.pid)
 
@@ -233,12 +233,12 @@ def test_acquisition_invoice_secure_api(
 
 def test_acquisition_invoice_secure_api_create(
         client, json_header, org_martigny, vendor_martigny, vendor2_martigny,
-        acq_invoice_fiction_martigny, librarian_martigny_no_email,
-        librarian_sion_no_email, acq_invoice_fiction_saxon,
-        system_librarian_martigny_no_email):
+        acq_invoice_fiction_martigny, librarian_martigny,
+        librarian_sion, acq_invoice_fiction_saxon,
+        system_librarian_martigny):
     """Test acquisition invoice secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.acin_list'
 
     data = acq_invoice_fiction_saxon
@@ -259,7 +259,7 @@ def test_acquisition_invoice_secure_api_create(
     )
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -268,7 +268,7 @@ def test_acquisition_invoice_secure_api_create(
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -280,10 +280,10 @@ def test_acquisition_invoice_secure_api_create(
 
 def test_acquisition_invoice_secure_api_update(
         client, org_sion, vendor_sion, acq_invoice_fiction_sion,
-        librarian_martigny_no_email, librarian_sion_no_email, json_header):
+        librarian_martigny, librarian_sion, json_header):
     """Test acquisition invoice secure api update."""
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acin_item',
                          pid_value=acq_invoice_fiction_sion.pid)
     data = acq_invoice_fiction_sion
@@ -296,7 +296,7 @@ def test_acquisition_invoice_secure_api_update(
     assert res.status_code == 200
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     res = client.put(
         record_url,

--- a/tests/api/acq_order_lines/test_acq_order_lines_permissions.py
+++ b/tests/api/acq_order_lines/test_acq_order_lines_permissions.py
@@ -26,9 +26,9 @@ from rero_ils.modules.acq_order_lines.permissions import AcqOrderLinePermission
 
 def test_order_lines_permissions_api(client, document, org_martigny,
                                      vendor2_martigny, lib_sion,
-                                     patron_martigny_no_email,
-                                     system_librarian_martigny_no_email,
-                                     librarian_martigny_no_email,
+                                     patron_martigny,
+                                     system_librarian_martigny,
+                                     librarian_martigny,
                                      acq_order_line_fiction_martigny,
                                      acq_order_line_fiction_saxon,
                                      acq_order_line_fiction_sion):
@@ -58,7 +58,7 @@ def test_order_lines_permissions_api(client, document, org_martigny,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(acq_oline_permissions_url)
     assert res.status_code == 403
 
@@ -67,7 +67,7 @@ def test_order_lines_permissions_api(client, document, org_martigny,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' order lines for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(acq_oline_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -96,7 +96,7 @@ def test_order_lines_permissions_api(client, document, org_martigny,
     # Logged as system librarian
     #   * sys_lib can do everything about order lines of its own organisation
     #   * sys_lib can't do anything about order lines of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(acq_oline_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -114,9 +114,9 @@ def test_order_lines_permissions_api(client, document, org_martigny,
     assert not data['delete']['can']
 
 
-def test_order_lines_permissions(patron_martigny_no_email,
-                                 librarian_martigny_no_email,
-                                 system_librarian_martigny_no_email,
+def test_order_lines_permissions(patron_martigny,
+                                 librarian_martigny,
+                                 system_librarian_martigny,
                                  document, org_martigny, lib_sion,
                                  vendor2_martigny,
                                  acq_order_line_fiction_sion,
@@ -137,7 +137,7 @@ def test_order_lines_permissions(patron_martigny_no_email,
     acq_oline_sion = acq_order_line_fiction_sion
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not AcqOrderLinePermission.list(None, acq_oline_martigny)
         assert not AcqOrderLinePermission.read(None, acq_oline_martigny)
@@ -148,7 +148,7 @@ def test_order_lines_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny
@@ -172,7 +172,7 @@ def test_order_lines_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny

--- a/tests/api/acq_order_lines/test_acq_order_lines_rest.py
+++ b/tests/api/acq_order_lines/test_acq_order_lines_rest.py
@@ -168,11 +168,11 @@ def test_acq_order_lines_document_can_delete(
 
 def test_acq_order_line_secure_api(client, json_header,
                                    acq_order_line_fiction_martigny,
-                                   librarian_martigny_no_email,
-                                   librarian_sion_no_email):
+                                   librarian_martigny,
+                                   librarian_sion):
     """Test acq order line secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.acol_item',
                          pid_value=acq_order_line_fiction_martigny.pid)
 
@@ -180,7 +180,7 @@ def test_acq_order_line_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acol_item',
                          pid_value=acq_order_line_fiction_martigny.pid)
 
@@ -192,13 +192,13 @@ def test_acq_order_secure_api_create(client, json_header,
                                      org_martigny,
                                      vendor_martigny, vendor2_martigny,
                                      acq_order_line_fiction_martigny,
-                                     librarian_martigny_no_email,
-                                     librarian_sion_no_email,
+                                     librarian_martigny,
+                                     librarian_sion,
                                      acq_order_line_fiction_saxon,
-                                     system_librarian_martigny_no_email):
+                                     system_librarian_martigny):
     """Test acq order line secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.acol_list'
 
     data = acq_order_line_fiction_saxon
@@ -219,7 +219,7 @@ def test_acq_order_secure_api_create(client, json_header,
     )
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -228,7 +228,7 @@ def test_acq_order_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     data = acq_order_line_fiction_saxon
     res, _ = postdata(
@@ -244,12 +244,12 @@ def test_acq_order_line_secure_api_update(client,
                                           vendor_sion,
                                           acq_order_fiction_sion,
                                           acq_order_line_fiction_sion,
-                                          librarian_martigny_no_email,
-                                          librarian_sion_no_email,
+                                          librarian_martigny,
+                                          librarian_sion,
                                           json_header):
     """Test acq order line secure api update."""
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acol_item',
                          pid_value=acq_order_line_fiction_sion.pid)
     data = acq_order_line_fiction_sion
@@ -262,7 +262,7 @@ def test_acq_order_line_secure_api_update(client,
     assert res.status_code == 200
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     res = client.put(
         record_url,

--- a/tests/api/acq_orders/test_acq_orders_permissions.py
+++ b/tests/api/acq_orders/test_acq_orders_permissions.py
@@ -25,9 +25,9 @@ from rero_ils.modules.acq_orders.permissions import AcqOrderPermission
 
 
 def test_orders_permissions_api(client, org_martigny, vendor2_martigny,
-                                patron_martigny_no_email,
-                                system_librarian_martigny_no_email,
-                                librarian_martigny_no_email,
+                                patron_martigny,
+                                system_librarian_martigny,
+                                librarian_martigny,
                                 acq_order_fiction_saxon,
                                 acq_order_fiction_martigny,
                                 acq_order_fiction_sion):
@@ -57,7 +57,7 @@ def test_orders_permissions_api(client, org_martigny, vendor2_martigny,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(acq_order_permissions_url)
     assert res.status_code == 403
 
@@ -66,7 +66,7 @@ def test_orders_permissions_api(client, org_martigny, vendor2_martigny,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' orders for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(acq_order_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -95,7 +95,7 @@ def test_orders_permissions_api(client, org_martigny, vendor2_martigny,
     # Logged as system librarian
     #   * sys_lib can do everything about orders of its own organisation
     #   * sys_lib can't do anything about orders of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(acq_order_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -113,9 +113,9 @@ def test_orders_permissions_api(client, org_martigny, vendor2_martigny,
     assert not data['delete']['can']
 
 
-def test_orders_permissions(patron_martigny_no_email,
-                            librarian_martigny_no_email,
-                            system_librarian_martigny_no_email,
+def test_orders_permissions(patron_martigny,
+                            librarian_martigny,
+                            system_librarian_martigny,
                             org_martigny, vendor2_martigny,
                             acq_order_fiction_sion,
                             acq_order_fiction_saxon,
@@ -135,7 +135,7 @@ def test_orders_permissions(patron_martigny_no_email,
     acq_order_sion = acq_order_fiction_sion
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not AcqOrderPermission.list(None, acq_order_martigny)
         assert not AcqOrderPermission.read(None, acq_order_martigny)
@@ -146,7 +146,7 @@ def test_orders_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny
@@ -170,7 +170,7 @@ def test_orders_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.acq_accounts.permissions.current_organisation',
         org_martigny

--- a/tests/api/acq_orders/test_acq_orders_rest.py
+++ b/tests/api/acq_orders/test_acq_orders_rest.py
@@ -174,8 +174,8 @@ def test_acq_orders_can_delete(
 
 
 def test_filtered_acq_orders_get(
-        client, librarian_martigny_no_email, acq_order_fiction_martigny,
-        librarian_sion_no_email, acq_order_fiction_sion):
+        client, librarian_martigny, acq_order_fiction_martigny,
+        librarian_sion, acq_order_fiction_sion):
     """Test acq accounts filter by organisation."""
     list_url = url_for('invenio_records_rest.acor_list')
 
@@ -183,7 +183,7 @@ def test_filtered_acq_orders_get(
     assert res.status_code == 401
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.acor_list')
 
     res = client.get(list_url)
@@ -192,7 +192,7 @@ def test_filtered_acq_orders_get(
     assert data['hits']['total']['value'] == 2
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.acor_list')
 
     res = client.get(list_url)
@@ -203,11 +203,11 @@ def test_filtered_acq_orders_get(
 
 def test_acq_order_secure_api(client, json_header,
                               acq_order_fiction_martigny,
-                              librarian_martigny_no_email,
-                              librarian_sion_no_email):
+                              librarian_martigny,
+                              librarian_sion):
     """Test acq order secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.acor_item',
                          pid_value=acq_order_fiction_martigny.pid)
 
@@ -215,7 +215,7 @@ def test_acq_order_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acor_item',
                          pid_value=acq_order_fiction_martigny.pid)
 
@@ -227,13 +227,13 @@ def test_acq_order_secure_api_create(client, json_header,
                                      org_martigny,
                                      vendor_martigny, vendor2_martigny,
                                      acq_order_fiction_martigny,
-                                     librarian_martigny_no_email,
-                                     librarian_sion_no_email,
+                                     librarian_martigny,
+                                     librarian_sion,
                                      acq_order_fiction_saxon,
-                                     system_librarian_martigny_no_email):
+                                     system_librarian_martigny):
     """Test acq order secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.acor_list'
 
     data = acq_order_fiction_saxon
@@ -254,7 +254,7 @@ def test_acq_order_secure_api_create(client, json_header,
     )
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -263,7 +263,7 @@ def test_acq_order_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -277,12 +277,12 @@ def test_acq_order_secure_api_update(client,
                                      org_sion,
                                      vendor_sion,
                                      acq_order_fiction_sion,
-                                     librarian_martigny_no_email,
-                                     librarian_sion_no_email,
+                                     librarian_martigny,
+                                     librarian_sion,
                                      json_header):
     """Test acq order secure api update."""
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.acor_item',
                          pid_value=acq_order_fiction_sion.pid)
     data = acq_order_fiction_sion
@@ -295,7 +295,7 @@ def test_acq_order_secure_api_update(client,
     assert res.status_code == 200
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     res = client.put(
         record_url,

--- a/tests/api/budgets/test_budgets_permissions.py
+++ b/tests/api/budgets/test_budgets_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.budgets.permissions import BudgetPermission
 
 
-def test_budget_permissions_api(client, org_sion, patron_martigny_no_email,
-                                system_librarian_martigny_no_email,
-                                librarian_martigny_no_email,
+def test_budget_permissions_api(client, org_sion, patron_martigny,
+                                system_librarian_martigny,
+                                librarian_martigny,
                                 budget_2017_martigny, budget_2020_sion):
     """Test budget permissions api."""
     budget_permissions_url = url_for(
@@ -49,7 +49,7 @@ def test_budget_permissions_api(client, org_sion, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(budget_permissions_url)
     assert res.status_code == 403
 
@@ -57,7 +57,7 @@ def test_budget_permissions_api(client, org_sion, patron_martigny_no_email,
     #   * lib can 'list' and 'read' budget of its own organisation
     #   * lib can't 'create', 'update', delete any budgets
     #   * lib can't 'list' and 'read' budget of others organisation.
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(budget_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -79,7 +79,7 @@ def test_budget_permissions_api(client, org_sion, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about budgets of its own organisation
     #   * sys_lib can't do anything about budgets of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(budget_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -97,9 +97,9 @@ def test_budget_permissions_api(client, org_sion, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_budget_permissions(patron_martigny_no_email,
-                            librarian_martigny_no_email,
-                            system_librarian_martigny_no_email,
+def test_budget_permissions(patron_martigny,
+                            librarian_martigny,
+                            system_librarian_martigny,
                             org_martigny, org_sion,
                             budget_2018_martigny, budget_2020_sion):
     """Test budget permissions class."""
@@ -114,7 +114,7 @@ def test_budget_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.budgets.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not BudgetPermission.list(None, budget_2018_martigny)
         assert not BudgetPermission.read(None, budget_2018_martigny)
@@ -125,7 +125,7 @@ def test_budget_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.budgets.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.budgets.permissions.current_organisation',
         org_martigny
@@ -144,7 +144,7 @@ def test_budget_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.budgets.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.budgets.permissions.current_organisation',
         org_martigny

--- a/tests/api/budgets/test_budgets_rest.py
+++ b/tests/api/budgets/test_budgets_rest.py
@@ -160,8 +160,8 @@ def test_budgets_can_delete(
 
 
 def test_filtered_budgets_get(
-        client, librarian_martigny_no_email, budget_2020_martigny,
-        librarian_sion_no_email, budget_2020_sion):
+        client, librarian_martigny, budget_2020_martigny,
+        librarian_sion, budget_2020_sion):
     """Test acq accounts filter by organisation."""
     list_url = url_for('invenio_records_rest.budg_list')
 
@@ -169,7 +169,7 @@ def test_filtered_budgets_get(
     assert res.status_code == 401
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.budg_list')
 
     res = client.get(list_url)
@@ -178,7 +178,7 @@ def test_filtered_budgets_get(
     assert data['hits']['total']['value'] == 2
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.budg_list')
 
     res = client.get(list_url)
@@ -189,11 +189,11 @@ def test_filtered_budgets_get(
 
 def test_budget_secure_api(client, json_header,
                            budget_2020_martigny,
-                           librarian_martigny_no_email,
-                           librarian_sion_no_email):
+                           librarian_martigny,
+                           librarian_sion):
     """Test acq account secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.budg_item',
                          pid_value=budget_2020_martigny.pid)
 
@@ -201,7 +201,7 @@ def test_budget_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.budg_item',
                          pid_value=budget_2020_martigny.pid)
 
@@ -211,13 +211,13 @@ def test_budget_secure_api(client, json_header,
 
 def test_budget_secure_api_create(client, json_header,
                                   budget_2020_martigny,
-                                  librarian_martigny_no_email,
-                                  librarian_sion_no_email,
+                                  librarian_martigny,
+                                  librarian_sion,
                                   budget_2019_martigny,
-                                  system_librarian_martigny_no_email):
+                                  system_librarian_martigny):
     """Test acq account secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.budg_list'
 
     del budget_2019_martigny['pid']
@@ -236,7 +236,7 @@ def test_budget_secure_api_create(client, json_header,
     )
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -245,7 +245,7 @@ def test_budget_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -257,14 +257,14 @@ def test_budget_secure_api_create(client, json_header,
 
 def test_budget_secure_api_update(client,
                                   budget_2017_martigny,
-                                  librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email,
-                                  system_librarian_sion_no_email,
-                                  librarian_sion_no_email,
+                                  librarian_martigny,
+                                  system_librarian_martigny,
+                                  system_librarian_sion,
+                                  librarian_sion,
                                   json_header):
     """Test acq account secure api update."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.budg_item',
                          pid_value=budget_2017_martigny.pid)
 
@@ -278,7 +278,7 @@ def test_budget_secure_api_update(client,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -290,13 +290,13 @@ def test_budget_secure_api_update(client,
 
 def test_budget_secure_api_delete(client,
                                   budget_2017_martigny,
-                                  librarian_martigny_no_email,
-                                  librarian_sion_no_email,
-                                  system_librarian_martigny_no_email,
+                                  librarian_martigny,
+                                  librarian_sion,
+                                  system_librarian_martigny,
                                   json_header):
     """Test acq account secure api delete."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.budg_item',
                          pid_value=budget_2017_martigny.pid)
 
@@ -304,11 +304,11 @@ def test_budget_secure_api_delete(client,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.delete(record_url)
     assert res.status_code == 204

--- a/tests/api/circ_policies/test_circ_policies_permissions.py
+++ b/tests/api/circ_policies/test_circ_policies_permissions.py
@@ -25,8 +25,8 @@ from rero_ils.modules.circ_policies.permissions import \
     CirculationPolicyPermission
 
 
-def test_circ_policies_permissions_api(client, librarian_martigny_no_email,
-                                       system_librarian_martigny_no_email,
+def test_circ_policies_permissions_api(client, librarian_martigny,
+                                       system_librarian_martigny,
                                        circ_policy_short_martigny,
                                        circ_policy_temp_martigny,
                                        circ_policy_default_sion):
@@ -60,7 +60,7 @@ def test_circ_policies_permissions_api(client, librarian_martigny_no_email,
     #   * lib can 'read' cipo from its own organisation
     #   * lib can't never 'create', 'delete', cipo
     #   * lib can update cipo depending of cipo settings
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(cipo_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -80,7 +80,7 @@ def test_circ_policies_permissions_api(client, librarian_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do anything about patron type for its own organisation
     #   * sys_lib can't doo anything about patron type for other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(cipo_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -96,9 +96,9 @@ def test_circ_policies_permissions_api(client, librarian_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_circ_policies_permissions(patron_martigny_no_email,
-                                   librarian_martigny_no_email,
-                                   system_librarian_martigny_no_email,
+def test_circ_policies_permissions(patron_martigny,
+                                   librarian_martigny,
+                                   system_librarian_martigny,
                                    circ_policy_short_martigny,
                                    circ_policy_temp_martigny, org_martigny):
     """Test circulation policies permission class."""
@@ -115,7 +115,7 @@ def test_circ_policies_permissions(patron_martigny_no_email,
     cipo_tmp = circ_policy_temp_martigny
     with mock.patch(
         'rero_ils.modules.circ_policies.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.circ_policies.permissions.current_organisation',
         org_martigny
@@ -129,7 +129,7 @@ def test_circ_policies_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.circ_policies.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.circ_policies.permissions.current_organisation',
         org_martigny
@@ -144,7 +144,7 @@ def test_circ_policies_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.circ_policies.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.circ_policies.permissions.current_organisation',
         org_martigny

--- a/tests/api/circ_policies/test_circ_policies_rest.py
+++ b/tests/api/circ_policies/test_circ_policies_rest.py
@@ -92,12 +92,12 @@ def test_circ_policies_get(client, circ_policy_default_martigny):
 
 
 def test_filtered_circ_policies_get(
-        client, librarian_martigny_no_email, circ_policy_default_martigny,
+        client, librarian_martigny, circ_policy_default_martigny,
         circ_policy_short_martigny, circ_policy_temp_martigny,
-        librarian_sion_no_email, circ_policy_default_sion):
+        librarian_sion, circ_policy_default_sion):
     """Test circulation policies filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.cipo_list')
 
     res = client.get(list_url)
@@ -106,7 +106,7 @@ def test_filtered_circ_policies_get(
     assert data['hits']['total']['value'] == 3
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.cipo_list')
 
     res = client.get(list_url)
@@ -210,11 +210,11 @@ def test_circ_policies_name_validate(client, circ_policy_default_martigny):
 
 def test_circ_policy_secure_api(client, json_header,
                                 circ_policy_default_martigny,
-                                librarian_martigny_no_email,
-                                librarian_sion_no_email):
+                                librarian_martigny,
+                                librarian_sion):
     """Test circulation policies secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_default_martigny.pid)
 
@@ -222,7 +222,7 @@ def test_circ_policy_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_default_martigny.pid)
 
@@ -232,12 +232,12 @@ def test_circ_policy_secure_api(client, json_header,
 
 def test_circ_policy_secure_api_create(client, json_header,
                                        circ_policy_default_martigny,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email,
+                                       system_librarian_martigny,
+                                       system_librarian_sion,
                                        circ_policy_default_martigny_data):
     """Test circulation policies secure api create."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.cipo_list'
 
     del circ_policy_default_martigny_data['pid']
@@ -249,7 +249,7 @@ def test_circ_policy_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -264,14 +264,14 @@ def test_circ_policy_secure_api_update(client,
                                        circ_policy_short_martigny_data,
                                        circ_policy_temp_martigny,
                                        circ_policy_temp_martigny_data,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email,
-                                       librarian_martigny_no_email,
-                                       librarian_saxon_no_email,
+                                       system_librarian_martigny,
+                                       system_librarian_sion,
+                                       librarian_martigny,
+                                       librarian_saxon,
                                        json_header):
     """Test circulation policies secure api update."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_short_martigny.pid)
 
@@ -285,7 +285,7 @@ def test_circ_policy_secure_api_update(client,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -297,14 +297,14 @@ def test_circ_policy_secure_api_update(client,
     # special case : cipo at library_level
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_temp_martigny.pid)
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.put(
         record_url,
         data=json.dumps(circ_policy_temp_martigny_data),
         headers=json_header
     )
     assert res.status_code == 200
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
     res = client.put(
         record_url,
         data=json.dumps(circ_policy_temp_martigny_data),
@@ -315,8 +315,8 @@ def test_circ_policy_secure_api_update(client,
 
 def test_circ_policy_secure_api_delete(client,
                                        circ_policy_short_martigny,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email,
+                                       system_librarian_martigny,
+                                       system_librarian_sion,
                                        circ_policy_short_martigny_data,
                                        json_header):
     """Test circulation policies secure api delete."""
@@ -324,11 +324,11 @@ def test_circ_policy_secure_api_delete(client,
                          pid_value=circ_policy_short_martigny.pid)
 
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.delete(record_url)
     assert res.status_code == 204
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.delete(record_url)
     assert res.status_code == 410

--- a/tests/api/circulation/scenarios/test_scenario_a.py
+++ b/tests/api/circulation/scenarios/test_scenario_a.py
@@ -25,21 +25,21 @@ from rero_ils.modules.items.models import ItemStatus
 
 
 def test_circ_scenario_a(
-        client, librarian_martigny_no_email, lib_martigny,
-        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
+        client, librarian_martigny, lib_martigny,
+        patron_martigny, loc_public_martigny, item_lib_martigny,
         circulation_policies):
     """Test the first circulation scenario."""
     # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
     # A request is made on on-shelf item, that has no requests, to be picked
     # up at the owning library. Validated by the librarian. Picked up at same
     # owning library. and returned on-time at the owning library
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     # ADD_REQUEST_1.1
     res, data = postdata(

--- a/tests/api/circulation/scenarios/test_scenario_b.py
+++ b/tests/api/circulation/scenarios/test_scenario_b.py
@@ -25,9 +25,9 @@ from rero_ils.modules.items.models import ItemStatus
 
 
 def test_circ_scenario_b(
-        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
-        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
-        circulation_policies, loc_public_saxon, librarian_saxon_no_email):
+        client, librarian_martigny, lib_martigny, lib_saxon,
+        patron_martigny, loc_public_martigny, item_lib_martigny,
+        circulation_policies, loc_public_saxon, librarian_saxon):
     """Test the second circulation scenario."""
     # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
     # A request is made on item of library A, on-shelf without previous
@@ -36,13 +36,13 @@ def test_circ_scenario_b(
     # Picked up at library B. Returned on-time at the library B, goes
     # in transit. Received at library A and goes on shelf.
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.librarian_request', dict(circ_params))
@@ -54,14 +54,14 @@ def test_circ_scenario_b(
         client, 'api_item.validate_request', dict(circ_params))
     assert res.status_code == 200
 
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
 
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))
@@ -76,13 +76,13 @@ def test_circ_scenario_b(
     assert res.status_code == 200
     assert item_lib_martigny.status == ItemStatus.ON_SHELF
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))

--- a/tests/api/circulation/scenarios/test_scenario_c.py
+++ b/tests/api/circulation/scenarios/test_scenario_c.py
@@ -25,11 +25,11 @@ from rero_ils.modules.items.models import ItemStatus
 
 
 def test_circ_scenario_c(
-        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
-        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
-        circulation_policies, loc_public_saxon, librarian_saxon_no_email,
-        patron2_martigny_no_email, lib_fully, loc_public_fully,
-        librarian_fully_no_email):
+        client, librarian_martigny, lib_martigny, lib_saxon,
+        patron_martigny, loc_public_martigny, item_lib_martigny,
+        circulation_policies, loc_public_saxon, librarian_saxon,
+        patron2_martigny, lib_fully, loc_public_fully,
+        librarian_fully):
     """Test the third circulation scenario."""
     # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
     # A request is made on item of library A, on-shelf without previous
@@ -42,13 +42,13 @@ def test_circ_scenario_c(
     # after the end of first renewal. goes in transit to library A. Received at
     #  library A and goes on shelf.
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.librarian_request', dict(circ_params))
@@ -60,14 +60,14 @@ def test_circ_scenario_c(
         client, 'api_item.validate_request', dict(circ_params))
     assert res.status_code == 200
 
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
 
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))
@@ -79,10 +79,10 @@ def test_circ_scenario_c(
 
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_fully.pid,
             'transaction_library_pid': lib_fully.pid,
-            'transaction_user_pid': librarian_fully_no_email.pid
+            'transaction_user_pid': librarian_fully.pid
     }
     res, data = postdata(
         client, 'api_item.librarian_request', dict(circ_params))
@@ -91,23 +91,23 @@ def test_circ_scenario_c(
 
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))
     assert res.status_code == 200
     assert item_lib_martigny.status == ItemStatus.ON_SHELF
 
-    login_user_via_session(client, librarian_fully_no_email.user)
+    login_user_via_session(client, librarian_fully.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_fully.pid,
             'transaction_library_pid': lib_fully.pid,
-            'transaction_user_pid': librarian_fully_no_email.pid
+            'transaction_user_pid': librarian_fully.pid
     }
     res, data = postdata(
         client, 'api_item.checkout', dict(circ_params))
@@ -121,13 +121,13 @@ def test_circ_scenario_c(
         client, 'api_item.checkin', dict(circ_params))
     assert res.status_code == 200
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))

--- a/tests/api/circulation/scenarios/test_scenario_d.py
+++ b/tests/api/circulation/scenarios/test_scenario_d.py
@@ -23,11 +23,11 @@ from utils import get_json, postdata
 
 
 def test_circ_scenario_d(
-        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
-        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
-        circulation_policies, loc_public_saxon, librarian_saxon_no_email,
-        patron2_martigny_no_email, lib_fully, loc_public_fully,
-        librarian_fully_no_email):
+        client, librarian_martigny, lib_martigny, lib_saxon,
+        patron_martigny, loc_public_martigny, item_lib_martigny,
+        circulation_policies, loc_public_saxon, librarian_saxon,
+        patron2_martigny, lib_fully, loc_public_fully,
+        librarian_fully):
     """Test the fourth circulation scenario."""
     # https://github.com/rero/rero-ils/blob/dev/doc/circulation/scenarios.md
     # An inexperienced librarian A (library A) makes a checkin on item A,
@@ -50,19 +50,19 @@ def test_circ_scenario_d(
 
     # An inexperienced librarian A (library A) makes a checkin on item A,
     # which is on shelf at library A and without requests (-> nothing happens).
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))
     assert res.status_code == 400
 
     # Item A is requested by patron A.
-    circ_params['patron_pid'] = patron_martigny_no_email.pid
+    circ_params['patron_pid'] = patron_martigny.pid
     res, data = postdata(
         client, 'api_item.librarian_request', dict(circ_params))
     assert res.status_code == 200
@@ -70,13 +70,13 @@ def test_circ_scenario_d(
 
     # Another librarian B of library B tries
     # to check it out for patron B (-> denied).
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
     res, data = postdata(
         client, 'api_item.checkout', dict(circ_params))
@@ -93,10 +93,10 @@ def test_circ_scenario_d(
     # for patron B (-> denied),
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
     res, data = postdata(
         client, 'api_item.checkout', dict(circ_params))
@@ -104,10 +104,10 @@ def test_circ_scenario_d(
     # then for patron A (-> ok).
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_saxon.pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
 
     res, data = postdata(
@@ -125,13 +125,13 @@ def test_circ_scenario_d(
     assert res.status_code == 200
 
     # Patron A requests it again, with pickup library A.
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.librarian_request', dict(circ_params))
@@ -147,10 +147,10 @@ def test_circ_scenario_d(
     # He then checks it out for patron B.
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.checkout', dict(circ_params))
@@ -158,39 +158,39 @@ def test_circ_scenario_d(
 
     # Patron B returns item A at library C.
     # It goes in transit to library A for patron A.
-    login_user_via_session(client, librarian_fully_no_email.user)
+    login_user_via_session(client, librarian_fully.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'pickup_location_pid': loc_public_fully.pid,
             'transaction_library_pid': lib_fully.pid,
-            'transaction_user_pid': librarian_fully_no_email.pid
+            'transaction_user_pid': librarian_fully.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))
     assert res.status_code == 200
 
     # Before arriving to library A, it transits through library B.
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
     # Patron A
     # cancels his request. Item A transits through library C. It is then
     # received at its owning library A.
     circ_params = {
             'pid': martigny_loan_pid,
             'transaction_library_pid': lib_saxon.pid,
-            'transaction_user_pid': librarian_saxon_no_email.pid
+            'transaction_user_pid': librarian_saxon.pid
     }
     res, data = postdata(
         client, 'api_item.cancel_item_request', dict(circ_params))
     assert res.status_code == 200
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     circ_params = {
             'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid,
+            'patron_pid': patron_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid,
             'transaction_library_pid': lib_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid
+            'transaction_user_pid': librarian_martigny.pid
     }
     res, data = postdata(
         client, 'api_item.checkin', dict(circ_params))

--- a/tests/api/circulation/test_actions_views_add_request.py
+++ b/tests/api/circulation/test_actions_views_add_request.py
@@ -23,11 +23,11 @@ from utils import postdata
 
 
 def test_add_request_failed_actions(
-        client, librarian_martigny_no_email, lib_martigny,
-        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
+        client, librarian_martigny, lib_martigny,
+        patron_martigny, loc_public_martigny, item_lib_martigny,
         circulation_policies):
     """Test item failed actions."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # test fails for a request with a missing parameter pickup_location_pid
     res, data = postdata(
@@ -35,7 +35,7 @@ def test_add_request_failed_actions(
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid
+            patron_pid=patron_martigny.pid
         )
     )
     assert res.status_code == 400
@@ -46,7 +46,7 @@ def test_add_request_failed_actions(
         client,
         'api_item.librarian_request',
         dict(
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid
         )
     )
@@ -69,7 +69,7 @@ def test_add_request_failed_actions(
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid
         )
     )
@@ -77,37 +77,37 @@ def test_add_request_failed_actions(
 
 
 def test_add_request(
-        client, librarian_martigny_no_email, lib_martigny,
-        patron_martigny_no_email, loc_public_martigny, item_lib_martigny,
-        circulation_policies, patron2_martigny_no_email):
+        client, librarian_martigny, lib_martigny,
+        patron_martigny, loc_public_martigny, item_lib_martigny,
+        circulation_policies, patron2_martigny):
     """Test a successful frontend add request action."""
     # test passes when all required parameters are given
     # test passes when the transaction libarary pid is given
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
 
     # test passes when the transaction location pid is given
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/circulation/test_actions_views_cancel_request.py
+++ b/tests/api/circulation/test_actions_views_cancel_request.py
@@ -23,13 +23,13 @@ from utils import postdata
 
 
 def test_cancel_an_item_request(
-        client, librarian_martigny_no_email, lib_martigny,
+        client, librarian_martigny, lib_martigny,
         item_at_desk_martigny_patron_and_loan_at_desk,
         item_on_shelf_martigny_patron_and_loan_pending, loc_public_martigny,
         circulation_policies):
     """Test the frontend cancel an item request action."""
     # test passes when all required parameters are given
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
 
     # test fails when there is a missing required parameter
@@ -60,7 +60,7 @@ def test_cancel_an_item_request(
         'api_item.cancel_item_request',
         dict(
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 404
@@ -72,13 +72,13 @@ def test_cancel_an_item_request(
         dict(
             pid=loan.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
 
     # test passes when the transaction library pid is given
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
     res, data = postdata(
         client,
@@ -86,7 +86,7 @@ def test_cancel_an_item_request(
         dict(
             pid=loan.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/circulation/test_actions_views_change_pickup.py
+++ b/tests/api/circulation/test_actions_views_change_pickup.py
@@ -23,12 +23,12 @@ from utils import postdata
 
 
 def test_change_pickup_location_request(
-        client, librarian_martigny_no_email, lib_martigny,
+        client, librarian_martigny, lib_martigny,
         item_at_desk_martigny_patron_and_loan_at_desk,
         item_on_shelf_martigny_patron_and_loan_pending, loc_public_martigny,
         circulation_policies, loc_public_fully):
     """Test the frontend update pickup location calls."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
 
     # test fails when there is a missing required parameter
@@ -65,14 +65,14 @@ def test_change_pickup_location_request(
 
 
 def test_change_pickup_location_request_for_other_loans(
-        client, librarian_martigny_no_email, lib_martigny,
+        client, librarian_martigny, lib_martigny,
         item_at_desk_martigny_patron_and_loan_at_desk,
         loc_public_martigny, circulation_policies, loc_public_fully,
         item_on_loan_martigny_patron_and_loan_on_loan,
         item_in_transit_martigny_patron_and_loan_for_pickup,
         item_in_transit_martigny_patron_and_loan_to_house):
     """Test the frontend update pickup location calls of other loan states."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     # CHANGE_PICKUP_LOCATION_2_1: update denied on ITEM_ON_LOAN loans.
     item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
     res, data = postdata(

--- a/tests/api/circulation/test_actions_views_checkin.py
+++ b/tests/api/circulation/test_actions_views_checkin.py
@@ -26,13 +26,13 @@ from rero_ils.modules.items.models import ItemStatus
 
 
 def test_checkin_an_item(
-        client, librarian_martigny_no_email, lib_martigny,
+        client, librarian_martigny, lib_martigny,
         item_on_loan_martigny_patron_and_loan_on_loan, loc_public_martigny,
         item2_on_loan_martigny_patron_and_loan_on_loan,
         circulation_policies):
     """Test the frontend return a checked-out item action."""
     # test passes when all required parameters are given
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
 
     # test fails when there is a missing required parameter
@@ -63,7 +63,7 @@ def test_checkin_an_item(
         'api_item.checkin',
         dict(
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 404
@@ -75,7 +75,7 @@ def test_checkin_an_item(
         dict(
             item_pid=item.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -90,7 +90,7 @@ def test_checkin_an_item(
         dict(
             item_pid=item.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -98,19 +98,19 @@ def test_checkin_an_item(
     assert item.status == ItemStatus.ON_SHELF
 
 
-def test_auto_checkin_else(client, librarian_martigny_no_email,
-                           patron_martigny_no_email, loc_public_martigny,
+def test_auto_checkin_else(client, librarian_martigny,
+                           patron_martigny, loc_public_martigny,
                            item_lib_martigny, json_header, lib_martigny,
                            loc_public_saxon):
     """Test item checkin no action."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.checkin',
         dict(
             item_pid=item_lib_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 400

--- a/tests/api/circulation/test_actions_views_checkout.py
+++ b/tests/api/circulation/test_actions_views_checkout.py
@@ -27,10 +27,10 @@ from rero_ils.modules.items.models import ItemStatus
 
 def test_checkout_missing_parameters(
         client,
-        librarian_martigny_no_email,
+        librarian_martigny,
         lib_martigny,
         loc_public_martigny,
-        patron_martigny_no_email,
+        patron_martigny,
         item_lib_martigny,
         circulation_policies):
     """Test checkout with missing parameters.
@@ -41,7 +41,7 @@ def test_checkout_missing_parameters(
         - transaction_location_pid or transaction_library_pid
         - transaction_user_pid
     """
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
 
@@ -59,7 +59,7 @@ def test_checkout_missing_parameters(
         'api_item.checkout',
         dict(
             item_pid=item.pid,
-            patron_pid=patron_martigny_no_email.pid
+            patron_pid=patron_martigny.pid
         )
     )
     assert res.status_code == 400
@@ -68,8 +68,8 @@ def test_checkout_missing_parameters(
         'api_item.checkout',
         dict(
             item_pid=item.pid,
-            patron_pid=patron_martigny_no_email.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            patron_pid=patron_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 400
@@ -77,22 +77,22 @@ def test_checkout_missing_parameters(
 
 def test_checkout(
         client,
-        librarian_martigny_no_email,
+        librarian_martigny,
         lib_martigny,
         loc_public_martigny,
-        patron_martigny_no_email,
+        patron_martigny,
         item_lib_martigny,
         circulation_policies,
         item_on_shelf_martigny_patron_and_loan_pending):
     """Test a successful frontend checkout action."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
 
     params = dict(
         item_pid=item.pid,
-        patron_pid=patron_martigny_no_email.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid
     )
 
@@ -128,7 +128,7 @@ def test_checkout(
         dict(
             item_pid=item.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -140,8 +140,8 @@ def test_checkout(
 
     params = dict(
         item_pid=item.pid,
-        patron_pid=patron_martigny_no_email.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
         end_date=next_saturday.isoformat()
     )

--- a/tests/api/circulation/test_actions_views_extend_loan_request.py
+++ b/tests/api/circulation/test_actions_views_extend_loan_request.py
@@ -27,7 +27,7 @@ from rero_ils.modules.patrons.api import Patron
 
 def test_extend_loan_missing_parameters(
         client,
-        librarian_martigny_no_email,
+        librarian_martigny,
         lib_martigny,
         loc_public_martigny,
         circulation_policies,
@@ -38,7 +38,7 @@ def test_extend_loan_missing_parameters(
         - transaction_location_pid or transaction_library_pid
         - transaction_user_pid
     """
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     assert item.status == ItemStatus.ON_LOAN
 
@@ -65,7 +65,7 @@ def test_extend_loan_missing_parameters(
         'api_item.extend_loan',
         dict(
             item_pid=item.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 400
@@ -73,13 +73,13 @@ def test_extend_loan_missing_parameters(
 
 def test_extend_loan(
         client,
-        librarian_martigny_no_email,
+        librarian_martigny,
         lib_martigny,
         loc_public_martigny,
         circulation_policies,
         item_on_loan_martigny_patron_and_loan_on_loan):
     """Test frontend extend action."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     assert item.status == ItemStatus.ON_LOAN
 
@@ -94,7 +94,7 @@ def test_extend_loan(
         'api_item.extend_loan',
         dict(
             item_pid=item.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -110,7 +110,7 @@ def test_extend_loan(
         'api_item.extend_loan',
         dict(
             item_pid=item.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )

--- a/tests/api/circulation/test_actions_views_validate_request.py
+++ b/tests/api/circulation/test_actions_views_validate_request.py
@@ -23,12 +23,12 @@ from utils import postdata
 
 
 def test_validate_item_request(
-        client, librarian_martigny_no_email, lib_martigny,
+        client, librarian_martigny, lib_martigny,
         item2_on_shelf_martigny_patron_and_loan_pending,
         item_on_shelf_martigny_patron_and_loan_pending, loc_public_martigny,
         circulation_policies):
     """Test the frontend validate an item request action."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
 
     # test fails when there is a missing required parameter
@@ -59,7 +59,7 @@ def test_validate_item_request(
         'api_item.validate_request',
         dict(
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 404
@@ -71,13 +71,13 @@ def test_validate_item_request(
         dict(
             pid=loan.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
 
     # test passes when the transaction library pid is given
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item2_on_shelf_martigny_patron_and_loan_pending
     res, data = postdata(
         client,
@@ -85,7 +85,7 @@ def test_validate_item_request(
         dict(
             pid=loan.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -32,14 +32,14 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 
 def test_checkout_library_limit(
-     client, app, librarian_martigny_no_email, lib_martigny,
+     client, app, librarian_martigny, lib_martigny,
      patron_type_children_martigny, item_lib_martigny, item2_lib_martigny,
      item3_lib_martigny, item_lib_martigny_data, item2_lib_martigny_data,
-     item3_lib_martigny_data, loc_public_martigny, patron_martigny_no_email,
+     item3_lib_martigny_data, loc_public_martigny, patron_martigny,
      circ_policy_short_martigny):
     """Test checkout library limits."""
 
-    patron = patron_martigny_no_email
+    patron = patron_martigny
     item2_original_data = deepcopy(item2_lib_martigny_data)
     item3_original_data = deepcopy(item3_lib_martigny_data)
     item1 = item_lib_martigny
@@ -48,7 +48,7 @@ def test_checkout_library_limit(
     library_ref = get_ref_for_pid('lib', lib_martigny.pid)
     location_ref = get_ref_for_pid('loc', loc_public_martigny.pid)
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # Update fixtures for the tests
     #   * Update the patron_type to set a checkout limits
@@ -76,7 +76,7 @@ def test_checkout_library_limit(
         item_pid=item1.pid,
         patron_pid=patron.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 200
     loan1_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
@@ -87,7 +87,7 @@ def test_checkout_library_limit(
         item_pid=item2.pid,
         patron_pid=patron.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 403
     assert 'Checkout denied' in data['message']
@@ -107,7 +107,7 @@ def test_checkout_library_limit(
         item_pid=item2.pid,
         patron_pid=patron.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 200
     loan2_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
@@ -115,7 +115,7 @@ def test_checkout_library_limit(
         item_pid=item3.pid,
         patron_pid=patron.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 403
     assert 'Checkout denied' in data['message']
@@ -133,7 +133,7 @@ def test_checkout_library_limit(
         item_pid=item3.pid,
         patron_pid=patron.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 403
     assert 'Checkout denied' in data['message']
@@ -155,7 +155,7 @@ def test_checkout_library_limit(
         item_pid=item3.pid,
         patron_pid=patron.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ), url_data={'override_blocking': 'true'})
     assert res.status_code == 200
     loan3_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
@@ -168,20 +168,20 @@ def test_checkout_library_limit(
         item_pid=item3.pid,
         pid=loan3_pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     res, data = postdata(client, 'api_item.checkin', dict(
         item_pid=item2.pid,
         pid=loan2_pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 200
     res, data = postdata(client, 'api_item.checkin', dict(
         item_pid=item1.pid,
         pid=loan1_pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
     ))
     assert res.status_code == 200
     del patron_type['limits']
@@ -191,19 +191,19 @@ def test_checkout_library_limit(
 
 
 def test_overdue_limit(
-     client, app, librarian_martigny_no_email, lib_martigny, item_lib_martigny,
+     client, app, librarian_martigny, lib_martigny, item_lib_martigny,
      item2_lib_martigny, patron_type_children_martigny,
      item3_lib_martigny, item_lib_martigny_data, item2_lib_martigny_data,
-     item3_lib_martigny_data, loc_public_martigny, patron_martigny_no_email,
+     item3_lib_martigny_data, loc_public_martigny, patron_martigny,
      circ_policy_short_martigny):
     """Test overdue limit."""
 
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     # [0] prepare overdue transaction
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     # checkout
     res, data = postdata(
         client,
@@ -212,7 +212,7 @@ def test_overdue_limit(
             item_pid=item_pid,
             patron_pid=patron_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -260,7 +260,7 @@ def test_overdue_limit(
             item_pid=item2_lib_martigny.pid,
             patron_pid=patron_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 403
@@ -275,7 +275,7 @@ def test_overdue_limit(
             patron_pid=patron_pid,
             pickup_location_pid=loc_public_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 403
@@ -287,7 +287,7 @@ def test_overdue_limit(
         'api_item.extend_loan',
         dict(
             item_pid=item_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -318,7 +318,7 @@ def test_overdue_limit(
             item_pid=item2_lib_martigny.pid,
             patron_pid=patron_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 403
@@ -333,7 +333,7 @@ def test_overdue_limit(
             patron_pid=patron_pid,
             pickup_location_pid=loc_public_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 403
@@ -345,7 +345,7 @@ def test_overdue_limit(
         'api_item.extend_loan',
         dict(
             item_pid=item_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -367,7 +367,7 @@ def test_overdue_limit(
             item_pid=item_pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200

--- a/tests/api/circulation/test_locations_restrictions.py
+++ b/tests/api/circulation/test_locations_restrictions.py
@@ -28,9 +28,9 @@ from rero_ils.modules.loans.utils import can_be_requested
 
 
 def test_item_pickup_location(
-        client, librarian_martigny_no_email, item2_lib_martigny):
+        client, librarian_martigny, item2_lib_martigny):
     """Test get item pickup locations."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     # test with dummy data will return 404
     res = client.get(
         url_for(
@@ -53,7 +53,7 @@ def test_item_pickup_location(
 
 def test_location_disallow_request(item_lib_martigny, loc_public_martigny,
                                    loc_public_martigny_data, lib_martigny,
-                                   patron_martigny_no_email):
+                                   patron_martigny):
     """Test a request when location disallow request."""
 
     # update location to disallow request
@@ -65,7 +65,7 @@ def test_location_disallow_request(item_lib_martigny, loc_public_martigny,
     loan = Loan({
         'item_pid': item_pid_to_object(item_lib_martigny.pid),
         'library_pid': lib_martigny.pid,
-        'patron_pid': patron_martigny_no_email.pid
+        'patron_pid': patron_martigny.pid
     })
     assert not can_be_requested(loan)
 

--- a/tests/api/circulation/test_temporary_item_type.py
+++ b/tests/api/circulation/test_temporary_item_type.py
@@ -29,23 +29,23 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 def test_checkout_temporary_item_type(
         client,
-        librarian_martigny_no_email,
+        librarian_martigny,
         lib_martigny,
         loc_public_martigny,
-        patron_martigny_no_email,
+        patron_martigny,
         item_lib_martigny,
         item_type_on_site_martigny,
         circ_policy_short_martigny,
         circ_policy_default_martigny):
     """Test checkout or item with temporary item_types"""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
 
     # test basic behavior
     cipo_used = CircPolicy.provide_circ_policy(
         lib_martigny.pid,
-        patron_martigny_no_email.patron_type_pid,
+        patron_martigny.patron_type_pid,
         item.item_type_circulation_category_pid
     )
     assert cipo_used == circ_policy_short_martigny
@@ -59,7 +59,7 @@ def test_checkout_temporary_item_type(
     item = item.update(data=item, dbcommit=True, reindex=True)
     cipo_tmp_used = CircPolicy.provide_circ_policy(
         lib_martigny.pid,
-        patron_martigny_no_email.patron_type_pid,
+        patron_martigny.patron_type_pid,
         item.item_type_circulation_category_pid
     )
     assert cipo_tmp_used == circ_policy_default_martigny
@@ -73,8 +73,8 @@ def test_checkout_temporary_item_type(
     # corresponding to the temporary item_type
     params = dict(
         item_pid=item.pid,
-        patron_pid=patron_martigny_no_email.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid
     )
     res, data = postdata(client, 'api_item.checkout', params)

--- a/tests/api/collections/test_collections_permissions.py
+++ b/tests/api/collections/test_collections_permissions.py
@@ -30,9 +30,9 @@ def test_collections_permissions_api(client, document,
                                      item_lib_martigny, item2_lib_martigny,
                                      item_lib_sion, item2_lib_sion,
                                      loc_public_martigny, coll_martigny_1,
-                                     coll_sion_1, patron_martigny_no_email,
-                                     system_librarian_martigny_no_email,
-                                     librarian_martigny_no_email):
+                                     coll_sion_1, patron_martigny,
+                                     system_librarian_martigny,
+                                     librarian_martigny):
     """Test collections permissions."""
     coll_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -56,7 +56,7 @@ def test_collections_permissions_api(client, document,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(coll_permissions_url)
     assert res.status_code == 403
     data = get_json(res)
@@ -65,7 +65,7 @@ def test_collections_permissions_api(client, document,
     #   * lib can 'list' and 'read' all the collections
     #   * lib can 'create', 'update', delete only for his library
     #   * lib can't 'create', 'update', 'delete' item for other org
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(coll_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -87,7 +87,7 @@ def test_collections_permissions_api(client, document,
     #   * sys lib can 'list' and 'read' all the collections
     #   * sys lib can 'create', 'update', delete only for his organisation
     #   * sys lib can't 'create', 'update', 'delete' item for other org
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(coll_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -104,9 +104,9 @@ def test_collections_permissions_api(client, document,
     assert not data['delete']['can']
 
 
-def test_collections_permissions(patron_martigny_no_email,
-                                 librarian_martigny_no_email,
-                                 system_librarian_martigny_no_email,
+def test_collections_permissions(patron_martigny,
+                                 librarian_martigny,
+                                 system_librarian_martigny,
                                  coll_martigny_1, coll_sion_1,
                                  coll_saxon_1, lib_martigny, org_martigny):
     """Test collection permissions class."""
@@ -121,7 +121,7 @@ def test_collections_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.collections.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert CollectionPermission.list(None, coll_martigny_1)
         assert CollectionPermission.read(None, coll_martigny_1)
@@ -132,7 +132,7 @@ def test_collections_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.collections.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.collections.permissions.current_organisation',
         org_martigny
@@ -156,7 +156,7 @@ def test_collections_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.collections.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.collections.permissions.current_organisation',
         org_martigny

--- a/tests/api/contributions/test_contributions_permissions.py
+++ b/tests/api/contributions/test_contributions_permissions.py
@@ -23,9 +23,9 @@ from utils import get_json
 from rero_ils.modules.contributions.permissions import ContributionPermission
 
 
-def test_contribution_permissions_api(client, patron_martigny_no_email,
+def test_contribution_permissions_api(client, patron_martigny,
                                       contribution_person,
-                                      librarian_martigny_no_email):
+                                      librarian_martigny):
     """Test organisations permissions api."""
     prs_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -42,12 +42,12 @@ def test_contribution_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(prs_permissions_url)
     assert res.status_code == 403
 
     # Logged as librarian
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(prs_real_permission_url)
     assert res.status_code == 200
     data = get_json(res)

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -25,7 +25,7 @@ from rero_ils.modules.documents.permissions import DocumentPermission
 
 
 def test_documents_permissions_api(client, document, ebook_1,
-                                   system_librarian_martigny_no_email):
+                                   system_librarian_martigny):
     """Test documents permissions api."""
     # Logged as system librarian.
     #   * All operation are allowed for normal document
@@ -35,7 +35,7 @@ def test_documents_permissions_api(client, document, ebook_1,
         route_name='documents',
         record_pid=document.pid
     )
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(doc_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -50,7 +50,7 @@ def test_documents_permissions_api(client, document, ebook_1,
         route_name='documents',
         record_pid=ebook_1.pid
     )
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(doc_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -61,8 +61,8 @@ def test_documents_permissions_api(client, document, ebook_1,
     assert not data['delete']['can']
 
 
-def test_documents_permissions(patron_martigny_no_email,
-                               librarian_martigny_no_email,
+def test_documents_permissions(patron_martigny,
+                               librarian_martigny,
                                document):
     """Test documents permissions class."""
 
@@ -76,7 +76,7 @@ def test_documents_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.documents.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert DocumentPermission.list(None, document)
         assert DocumentPermission.read(None, document)
@@ -87,7 +87,7 @@ def test_documents_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.documents.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ):
         assert DocumentPermission.list(None, document)
         assert DocumentPermission.read(None, document)

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -58,13 +58,13 @@ def test_documents_permissions(client, document, json_header):
 
 
 def test_documents_newacq_filters(app, client,
-                                  system_librarian_martigny_no_email,
+                                  system_librarian_martigny,
                                   rero_json_header, document,
                                   holding_lib_martigny, holding_lib_saxon,
                                   loc_public_saxon,
                                   item_lib_martigny_data,
                                   ):
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
 
     # compute useful date
     today = datetime.today()
@@ -458,22 +458,22 @@ def test_documents_get_resolve_rero_json(
 def test_document_can_request_view(
         client, item_lib_fully,
         loan_pending_martigny, document,
-        patron_martigny_no_email,
-        patron2_martigny_no_email,
+        patron_martigny,
+        patron2_martigny,
         item_type_standard_martigny,
         circulation_policies,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny,
         item_lib_saxon,
         item_lib_sion,
         loc_public_martigny
 ):
     """Test can request on document view."""
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
 
     with mock.patch(
         'rero_ils.modules.documents.views.current_user',
-        patron_martigny_no_email.user
+        patron_martigny.user
     ):
         can, _ = can_request(item_lib_fully)
         assert can
@@ -482,7 +482,7 @@ def test_document_can_request_view(
 
     with mock.patch(
         'rero_ils.modules.documents.views.current_user',
-        patron2_martigny_no_email.user
+        patron2_martigny.user
     ):
         can, _ = can_request(item_lib_fully)
         assert not can

--- a/tests/api/documents/test_marcxml_rest_api.py
+++ b/tests/api/documents/test_marcxml_rest_api.py
@@ -26,7 +26,7 @@ from rero_ils.modules.cli import tokens_create
 
 def test_marcxml_documents_create(
         client, document_marcxml, documents_marcxml, rero_marcxml_header,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Test post of marcxml document for logged users."""
     res, data = postdata(
         client,
@@ -37,7 +37,7 @@ def test_marcxml_documents_create(
     )
     assert res.status_code == 401
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'invenio_records_rest.doc_list',
@@ -61,12 +61,12 @@ def test_marcxml_documents_create(
 
 def test_marcxml_documents_create_with_a_token(
         app, client, document_marcxml, rero_marcxml_header,
-        librarian_martigny_no_email, script_info):
+        librarian_martigny, script_info):
     """Test post of marcxml document with an access token."""
     runner = CliRunner()
     res = runner.invoke(
         tokens_create,
-        ['-n', 'test', '-u', librarian_martigny_no_email.get('email'),
+        ['-n', 'test', '-u', librarian_martigny.get('email'),
          '-t', 'my_token'],
         obj=script_info
     )

--- a/tests/api/holdings/test_holdings_permissions.py
+++ b/tests/api/holdings/test_holdings_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.holdings.permissions import HoldingPermission
 
 
-def test_holdings_permissions_api(client, patron_martigny_no_email,
-                                  system_librarian_martigny_no_email,
-                                  librarian_martigny_no_email,
+def test_holdings_permissions_api(client, patron_martigny,
+                                  system_librarian_martigny,
+                                  librarian_martigny,
                                   holding_lib_martigny, holding_lib_saxon,
                                   holding_lib_sion,
                                   holding_lib_martigny_w_patterns):
@@ -61,7 +61,7 @@ def test_holdings_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(holding_permissions_url)
     assert res.status_code == 403
 
@@ -69,7 +69,7 @@ def test_holdings_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'list' and 'read' holding of its own organisation
     #   * lib can 'create', 'update', 'delete' only for its own organisation
     #   * lib can't 'create', 'update', 'delete' item for other organisation
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(holding_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -107,7 +107,7 @@ def test_holdings_permissions_api(client, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about patron of its own organisation
     #   * sys_lib can't do anything about patron of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(holding_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -134,9 +134,9 @@ def test_holdings_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_holdings_permissions(patron_martigny_no_email, org_martigny,
-                              librarian_martigny_no_email,
-                              system_librarian_martigny_no_email,
+def test_holdings_permissions(patron_martigny, org_martigny,
+                              librarian_martigny,
+                              system_librarian_martigny,
                               holding_lib_sion, holding_lib_saxon,
                               holding_lib_martigny,
                               holding_lib_martigny_w_patterns,
@@ -155,7 +155,7 @@ def test_holdings_permissions(patron_martigny_no_email, org_martigny,
     holding_serial_sion = holding_lib_sion_w_patterns
     with mock.patch(
         'rero_ils.modules.holdings.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert HoldingPermission.list(None, holding_lib_martigny)
         assert HoldingPermission.read(None, holding_lib_martigny)
@@ -166,7 +166,7 @@ def test_holdings_permissions(patron_martigny_no_email, org_martigny,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.holdings.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.holdings.permissions.current_organisation',
         org_martigny
@@ -197,7 +197,7 @@ def test_holdings_permissions(patron_martigny_no_email, org_martigny,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.holdings.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.holdings.permissions.current_organisation',
         org_martigny

--- a/tests/api/holdings/test_holdings_rest.py
+++ b/tests/api/holdings/test_holdings_rest.py
@@ -123,12 +123,12 @@ def test_holding_can_delete_and_utils(client, holding_lib_martigny, document,
 
 
 def test_filtered_holdings_get(
-        client, librarian_martigny_no_email, holding_lib_martigny,
+        client, librarian_martigny, holding_lib_martigny,
         holding_lib_fully, holding_lib_saxon, holding_lib_sion,
-        librarian_sion_no_email):
+        librarian_sion):
     """Test holding filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.hold_list')
 
     res = client.get(list_url)
@@ -137,7 +137,7 @@ def test_filtered_holdings_get(
     assert data['hits']['total']['value'] == 3
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.hold_list')
 
     res = client.get(list_url)
@@ -147,11 +147,11 @@ def test_filtered_holdings_get(
 
 
 def test_holding_secure_api(client, json_header, holding_lib_martigny,
-                            librarian_martigny_no_email,
-                            librarian_sion_no_email):
+                            librarian_martigny,
+                            librarian_sion):
     """Test holding secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.hold_item',
                          pid_value=holding_lib_martigny.pid)
 
@@ -159,7 +159,7 @@ def test_holding_secure_api(client, json_header, holding_lib_martigny,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.hold_item',
                          pid_value=holding_lib_martigny.pid)
 
@@ -168,12 +168,12 @@ def test_holding_secure_api(client, json_header, holding_lib_martigny,
 
 
 def test_holding_secure_api_create(client, json_header, holding_lib_martigny,
-                                   librarian_martigny_no_email,
-                                   librarian_sion_no_email,
+                                   librarian_martigny,
+                                   librarian_sion,
                                    holding_lib_martigny_data):
     """Test holding secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.hold_list'
 
     # we no longer allow manual creation of standard holdings records
@@ -186,7 +186,7 @@ def test_holding_secure_api_create(client, json_header, holding_lib_martigny,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -197,13 +197,13 @@ def test_holding_secure_api_create(client, json_header, holding_lib_martigny,
 
 
 def test_holding_secure_api_update(client, holding_lib_sion,
-                                   librarian_martigny_no_email,
-                                   librarian_sion_no_email,
+                                   librarian_martigny,
+                                   librarian_sion,
                                    holding_lib_sion_data,
                                    json_header):
     """Test holding secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.hold_item',
                          pid_value=holding_lib_sion.pid)
 
@@ -217,7 +217,7 @@ def test_holding_secure_api_update(client, holding_lib_sion,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     # we no longer allow manual the update of standard holdings records
     res = client.put(
@@ -229,10 +229,10 @@ def test_holding_secure_api_update(client, holding_lib_sion,
 
 
 def test_holding_secure_api_delete(client, holding_lib_saxon,
-                                   librarian_martigny_no_email,
-                                   librarian_sion_no_email):
+                                   librarian_martigny,
+                                   librarian_sion):
     """Test holding secure api delete."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.hold_item',
                          pid_value=holding_lib_saxon.pid)
     # Martigny
@@ -241,7 +241,7 @@ def test_holding_secure_api_delete(client, holding_lib_saxon,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -37,9 +37,9 @@ from rero_ils.modules.utils import get_ref_for_pid, get_schema_for_resource
 
 
 def test_pattern_preview_api(
-        client, holding_lib_martigny_w_patterns, librarian_martigny_no_email):
+        client, holding_lib_martigny_w_patterns, librarian_martigny):
     """Test holdings patterns preview api."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     holding = holding_lib_martigny_w_patterns
     # holding = Holding.get_record_by_pid(holding.pid)
     # test preview by default 10 issues returned
@@ -80,9 +80,9 @@ def test_pattern_preview_api(
 
 
 def test_pattern_preview_api(
-        client, holding_lib_martigny_w_patterns, librarian_martigny_no_email):
+        client, holding_lib_martigny_w_patterns, librarian_martigny):
     """Test holdings patterns preview api."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     holding = holding_lib_martigny_w_patterns
     # holding = Holding.get_record_by_pid(holding.pid)
     # test preview by default 10 issues returned
@@ -124,8 +124,8 @@ def test_pattern_preview_api(
 
 def test_receive_regular_issue_api(
         client, holding_lib_martigny_w_patterns,
-        librarian_fully_no_email, librarian_martigny_no_email,
-        system_librarian_sion_no_email):
+        librarian_fully, librarian_martigny,
+        system_librarian_sion):
     """Test holdings receive regular issues API."""
     holding = holding_lib_martigny_w_patterns
     holding = Holding.get_record_by_pid(holding.pid)
@@ -141,7 +141,7 @@ def test_receive_regular_issue_api(
 
     # librarian of another library are not authoritzed to receive issues
     # for another library.
-    login_user_via_session(client, librarian_fully_no_email.user)
+    login_user_via_session(client, librarian_fully.user)
     res, data = postdata(
         client,
         'api_holding.receive_regular_issue',
@@ -149,7 +149,7 @@ def test_receive_regular_issue_api(
     )
     assert res.status_code == 401
     # only users of same organisation may receive issues.
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res, data = postdata(
         client,
         'api_holding.receive_regular_issue',
@@ -157,7 +157,7 @@ def test_receive_regular_issue_api(
     )
     assert res.status_code == 401
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_holding.receive_regular_issue',
@@ -190,12 +190,12 @@ def test_receive_regular_issue_api(
 
 
 def test_create_holdings_with_pattern(
-        client, librarian_martigny_no_email, loc_public_martigny,
+        client, librarian_martigny, loc_public_martigny,
         journal, item_type_standard_martigny, document,
         json_header, holding_lib_martigny_data, pattern_yearly_one_level_data,
         holding_lib_martigny_w_patterns_data):
     """Test create holding type serial with patterns."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.hold_list'
 
     del holding_lib_martigny_data['pid']
@@ -242,9 +242,9 @@ def test_create_holdings_with_pattern(
 
 def test_holding_pattern_preview_api(
         client, pattern_yearly_one_level_data,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Test holdings patterns preview api."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     patterns = pattern_yearly_one_level_data.get('patterns')
     # test preview by default 10 issues returned
     res, data = postdata(
@@ -274,9 +274,9 @@ def test_holding_pattern_preview_api(
 
 def test_automatic_item_creation_no_serials(
         client, json_header, holding_lib_martigny_w_patterns,
-        item_lib_martigny_data, librarian_martigny_no_email):
+        item_lib_martigny_data, librarian_martigny):
     """Test automatically created items are not attached to serials."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_url = 'invenio_records_rest.item_list'
     res, _ = postdata(
         client,
@@ -293,7 +293,7 @@ def test_automatic_item_creation_no_serials(
 
 
 def test_pattern_validate_next_expected_date(
-        client, librarian_martigny_no_email,
+        client, librarian_martigny,
         journal, loc_public_sion, item_type_regular_sion, document,
         pattern_yearly_two_times_data, json_header,
         holding_lib_sion_w_patterns_data):
@@ -301,7 +301,7 @@ def test_pattern_validate_next_expected_date(
 
     the next_expected_date.
     """
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     holding = holding_lib_sion_w_patterns_data
     holding['holdings_type'] = 'serial'
     holding['patterns'] = \
@@ -320,13 +320,13 @@ def test_pattern_validate_next_expected_date(
 
 def test_irregular_issue_creation_update_delete_api(
         client, holding_lib_martigny_w_patterns,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Test create, update and delete of an irregular issue API."""
     holding = holding_lib_martigny_w_patterns
     issue_display, expected_date = holding._get_next_issue_display_text(
                         holding.get('patterns'))
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = {
         'issue': {
             'status': ItemIssueStatus.RECEIVED,

--- a/tests/api/ill_requests/test_ill_requests_permissions.py
+++ b/tests/api/ill_requests/test_ill_requests_permissions.py
@@ -24,7 +24,7 @@ from utils import get_json
 from rero_ils.modules.ill_requests.permissions import ILLRequestPermission
 
 
-def test_ill_requests_permissions_api(client, librarian_martigny_no_email,
+def test_ill_requests_permissions_api(client, librarian_martigny,
                                       ill_request_martigny, ill_request_sion):
     """Test ill_request permissions api."""
     illr_permissions_url = url_for(
@@ -50,7 +50,7 @@ def test_ill_requests_permissions_api(client, librarian_martigny_no_email,
     #   * lib can 'list', 'create' ill_requests
     #   * lib can 'read', 'update', 'delete' ill_request from its own
     #     organisation
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(illr_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -66,9 +66,9 @@ def test_ill_requests_permissions_api(client, librarian_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_ill_requests_permissions(patron_martigny_no_email,
-                                  librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email,
+def test_ill_requests_permissions(patron_martigny,
+                                  librarian_martigny,
+                                  system_librarian_martigny,
                                   ill_request_martigny, ill_request_sion,
                                   org_martigny):
     """Test patron types permissions class."""
@@ -83,7 +83,7 @@ def test_ill_requests_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.ill_requests.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.ill_requests.permissions.current_organisation',
         org_martigny
@@ -103,7 +103,7 @@ def test_ill_requests_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.ill_requests.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.ill_requests.permissions.current_organisation',
         org_martigny
@@ -123,7 +123,7 @@ def test_ill_requests_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.ill_requests.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.ill_requests.permissions.current_organisation',
         org_martigny

--- a/tests/api/ill_requests/test_ill_requests_rest.py
+++ b/tests/api/ill_requests/test_ill_requests_rest.py
@@ -80,7 +80,7 @@ def test_ill_requests_get(client, ill_request_martigny):
 @mock.patch('invenio_records_rest.views.verify_record_permission',
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def test_ill_requests_post_put_delete(client, org_martigny, json_header,
-                                      patron_martigny_no_email,
+                                      patron_martigny,
                                       loc_public_martigny,
                                       ill_request_martigny_data):
     """Test record retrieval."""
@@ -134,12 +134,12 @@ def test_ill_requests_can_delete(client, ill_request_martigny):
 
 
 def test_filtered_ill_requests_get(
-        client, librarian_martigny_no_email, ill_request_martigny,
-        librarian_sion_no_email, ill_request_sion):
+        client, librarian_martigny, ill_request_martigny,
+        librarian_sion, ill_request_sion):
     """Test ill_requests filter by organisation."""
     list_url = url_for('invenio_records_rest.illr_list')
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(list_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -147,7 +147,7 @@ def test_filtered_ill_requests_get(
     assert ill_request_martigny.pid in pids
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     res = client.get(list_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -157,8 +157,8 @@ def test_filtered_ill_requests_get(
 
 def test_ill_request_secure_api(client, json_header, ill_request_martigny,
                                 ill_request_martigny_data, ill_request_sion,
-                                librarian_martigny_no_email,
-                                system_librarian_sion_no_email):
+                                librarian_martigny,
+                                system_librarian_sion):
     """Test ill request secure api access."""
     martigny_url = url_for('invenio_records_rest.illr_item',
                            pid_value=ill_request_martigny.pid)
@@ -167,7 +167,7 @@ def test_ill_request_secure_api(client, json_header, ill_request_martigny,
     # Logged as Martigny librarian
     #   * can read martigny request
     #   * can't read sion request
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(martigny_url)
     assert res.status_code == 200
     res = client.get(sion_url)
@@ -177,15 +177,15 @@ def test_ill_request_secure_api(client, json_header, ill_request_martigny,
 def test_ill_request_secure_api_update(client, json_header,
                                        ill_request_martigny_data,
                                        ill_request_martigny, ill_request_sion,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email):
+                                       system_librarian_martigny,
+                                       system_librarian_sion):
     """Test ill request secure api update."""
     martigny_url = url_for('invenio_records_rest.illr_item',
                            pid_value=ill_request_martigny.pid)
     sion_url = url_for('invenio_records_rest.illr_item',
                        pid_value=ill_request_sion.pid)
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     data = ill_request_martigny_data
     data['document']['title'] = 'Test title'
     res = client.put(
@@ -196,7 +196,7 @@ def test_ill_request_secure_api_update(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.put(
         martigny_url,
         data=json.dumps(data),
@@ -207,9 +207,9 @@ def test_ill_request_secure_api_update(client, json_header,
 
 def test_ill_request_secure_api_delete(client, ill_request_martigny,
                                        ill_request_sion,
-                                       system_librarian_martigny_no_email):
+                                       system_librarian_martigny):
     """Test ill requests secure api delete."""
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for(
         'invenio_records_rest.illr_item',
         pid_value=ill_request_sion.pid

--- a/tests/api/item_types/test_item_types_permissions.py
+++ b/tests/api/item_types/test_item_types_permissions.py
@@ -24,8 +24,8 @@ from utils import get_json
 from rero_ils.modules.item_types.permissions import ItemTypePermission
 
 
-def test_item_types_permissions_api(client, librarian_martigny_no_email,
-                                    system_librarian_martigny_no_email,
+def test_item_types_permissions_api(client, librarian_martigny,
+                                    system_librarian_martigny,
                                     item_type_standard_martigny,
                                     item_type_regular_sion):
     """Test patron types permissions api."""
@@ -52,7 +52,7 @@ def test_item_types_permissions_api(client, librarian_martigny_no_email,
     #   * lib can 'list' item_type
     #   * lib can 'read' item_type from its own organisation
     #   * lib can't never 'create', 'delete', 'update' item_type
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(itty_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -68,7 +68,7 @@ def test_item_types_permissions_api(client, librarian_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do anything about item_type for its own organisation
     #   * sys_lib can't do anything about item_type for other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(itty_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -84,9 +84,9 @@ def test_item_types_permissions_api(client, librarian_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_item_types_permissions(patron_martigny_no_email,
-                                librarian_martigny_no_email,
-                                system_librarian_martigny_no_email,
+def test_item_types_permissions(patron_martigny,
+                                librarian_martigny,
+                                system_librarian_martigny,
                                 item_type_standard_martigny, org_martigny):
     """Test patron types permissions class."""
 
@@ -101,7 +101,7 @@ def test_item_types_permissions(patron_martigny_no_email,
     itty = item_type_standard_martigny
     with mock.patch(
         'rero_ils.modules.item_types.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.item_types.permissions.current_organisation',
         org_martigny
@@ -115,7 +115,7 @@ def test_item_types_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.item_types.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.item_types.permissions.current_organisation',
         org_martigny
@@ -129,7 +129,7 @@ def test_item_types_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.item_types.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.item_types.permissions.current_organisation',
         org_martigny

--- a/tests/api/item_types/test_item_types_rest.py
+++ b/tests/api/item_types/test_item_types_rest.py
@@ -196,13 +196,13 @@ def test_item_types_can_delete(client, item_type_standard_martigny,
 
 
 def test_filtered_item_types_get(
-        client, librarian_martigny_no_email, item_type_standard_martigny,
+        client, librarian_martigny, item_type_standard_martigny,
         item_type_on_site_martigny, item_type_specific_martigny,
-        librarian_sion_no_email, item_type_regular_sion,
+        librarian_sion, item_type_regular_sion,
         item_type_internal_sion, item_type_particular_sion):
     """Test item types filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.itty_list')
 
     res = client.get(list_url)
@@ -211,7 +211,7 @@ def test_filtered_item_types_get(
     assert data['hits']['total']['value'] == 4
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.itty_list')
 
     res = client.get(list_url)
@@ -222,11 +222,11 @@ def test_filtered_item_types_get(
 
 def test_item_type_secure_api(client, json_header,
                               item_type_standard_martigny,
-                              librarian_martigny_no_email,
-                              librarian_sion_no_email):
+                              librarian_martigny,
+                              librarian_sion):
     """Test item type secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.itty_item',
                          pid_value=item_type_standard_martigny.pid)
 
@@ -234,7 +234,7 @@ def test_item_type_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.itty_item',
                          pid_value=item_type_standard_martigny.pid)
 
@@ -244,12 +244,12 @@ def test_item_type_secure_api(client, json_header,
 
 def test_item_type_secure_api_create(client, json_header,
                                      item_type_standard_martigny,
-                                     system_librarian_martigny_no_email,
-                                     system_librarian_sion_no_email,
+                                     system_librarian_martigny,
+                                     system_librarian_sion,
                                      item_type_standard_martigny_data):
     """Test item type secure api create."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.itty_list'
 
     del item_type_standard_martigny_data['pid']
@@ -261,7 +261,7 @@ def test_item_type_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -273,13 +273,13 @@ def test_item_type_secure_api_create(client, json_header,
 
 def test_item_type_secure_api_update(client,
                                      item_type_on_site_martigny,
-                                     system_librarian_martigny_no_email,
-                                     system_librarian_sion_no_email,
+                                     system_librarian_martigny,
+                                     system_librarian_sion,
                                      item_type_on_site_martigny_data,
                                      json_header):
     """Test item type secure api update."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.itty_item',
                          pid_value=item_type_on_site_martigny.pid)
 
@@ -293,7 +293,7 @@ def test_item_type_secure_api_update(client,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -305,13 +305,13 @@ def test_item_type_secure_api_update(client,
 
 def test_item_type_secure_api_delete(client,
                                      item_type_on_site_martigny,
-                                     system_librarian_martigny_no_email,
-                                     system_librarian_sion_no_email,
+                                     system_librarian_martigny,
+                                     system_librarian_sion,
                                      item_type_on_site_martigny_data,
                                      json_header):
     """Test item type secure api delete."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.itty_item',
                          pid_value=item_type_on_site_martigny.pid)
 
@@ -320,7 +320,7 @@ def test_item_type_secure_api_delete(client,
         assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403

--- a/tests/api/items/test_items_in_transit.py
+++ b/tests/api/items/test_items_in_transit.py
@@ -28,21 +28,21 @@ from rero_ils.modules.loans.api import LoanAction
 
 
 def test_items_in_transit_between_libraries(
-        client, librarian_martigny_no_email, librarian_saxon_no_email,
-        patron_martigny_no_email, loc_public_martigny,
+        client, librarian_martigny, librarian_saxon,
+        patron_martigny, loc_public_martigny,
         item_type_standard_martigny, loc_public_saxon, item_lib_martigny,
         json_header, circulation_policies):
     """Test item in-transit scenarios."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     # checkout the item at location A
     res, data = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_location_pid=loc_public_saxon.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -61,7 +61,7 @@ def test_items_in_transit_between_libraries(
             item_pid=item_lib_martigny.pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/items/test_items_issue.py
+++ b/tests/api/items/test_items_issue.py
@@ -29,13 +29,13 @@ from rero_ils.modules.items.api import Item
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def test_issues_permissions(client, json_header,
                             holding_lib_martigny_w_patterns,
-                            librarian_martigny_no_email):
+                            librarian_martigny):
     """Test specific items issues permissions."""
 
     # receive a regular issue
     holding = holding_lib_martigny_w_patterns
     holding = Holding.get_record_by_pid(holding.pid)
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_holding.receive_regular_issue',

--- a/tests/api/items/test_items_permissions.py
+++ b/tests/api/items/test_items_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.items.permissions import ItemPermission
 
 
-def test_items_permissions_api(client, patron_martigny_no_email,
-                               system_librarian_martigny_no_email,
-                               librarian_martigny_no_email,
+def test_items_permissions_api(client, patron_martigny,
+                               system_librarian_martigny,
+                               librarian_martigny,
                                item_lib_martigny, item_lib_saxon,
                                item_lib_sion):
     """Test items permissions api."""
@@ -55,7 +55,7 @@ def test_items_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(item_permissions_url)
     assert res.status_code == 403
 
@@ -64,7 +64,7 @@ def test_items_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' item of others organisation.
     #   * lib can't 'create', 'update', 'delete' item for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(item_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -93,7 +93,7 @@ def test_items_permissions_api(client, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about patron of its own organisation
     #   * sys_lib can't do anything about patron of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(item_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -111,9 +111,9 @@ def test_items_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_items_permissions(patron_martigny_no_email, org_martigny,
-                           librarian_martigny_no_email,
-                           system_librarian_martigny_no_email,
+def test_items_permissions(patron_martigny, org_martigny,
+                           librarian_martigny,
+                           system_librarian_martigny,
                            item_lib_sion, item_lib_saxon, item_lib_martigny):
     """Test item permissions class."""
 
@@ -127,7 +127,7 @@ def test_items_permissions(patron_martigny_no_email, org_martigny,
     # As Patron
     with mock.patch(
         'rero_ils.modules.items.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert ItemPermission.list(None, item_lib_martigny)
         assert ItemPermission.read(None, item_lib_martigny)
@@ -138,7 +138,7 @@ def test_items_permissions(patron_martigny_no_email, org_martigny,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.items.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.items.permissions.current_organisation',
         org_martigny
@@ -162,7 +162,7 @@ def test_items_permissions(patron_martigny_no_email, org_martigny,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.items.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.items.permissions.current_organisation',
         org_martigny

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -37,7 +37,7 @@ from rero_ils.modules.loans.utils import get_extension_params
 
 
 def test_items_permissions(client, item_lib_martigny,
-                           patron_martigny_no_email,
+                           patron_martigny,
                            json_header):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.item_item', pid_value='item1')
@@ -79,7 +79,7 @@ def test_items_permissions(client, item_lib_martigny,
         data={}
     )
     assert res.status_code == 401
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     for view in views:
         res, _ = postdata(client, view, {})
         assert res.status_code == 403
@@ -189,17 +189,17 @@ def test_items_post_put_delete(client, document, loc_public_martigny,
 
 
 def test_checkout_default_policy(client, lib_martigny,
-                                 librarian_martigny_no_email,
-                                 patron_martigny_no_email,
+                                 librarian_martigny,
+                                 patron_martigny,
                                  loc_public_martigny,
                                  item_type_standard_martigny,
                                  item_lib_martigny, json_header,
                                  circulation_policies):
     """Test circ policy parameters"""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     from rero_ils.modules.circ_policies.api import CircPolicy
     circ_policy = CircPolicy.provide_circ_policy(
@@ -215,7 +215,7 @@ def test_checkout_default_policy(client, lib_martigny,
         dict(
             item_pid=item_pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -237,7 +237,7 @@ def test_checkout_default_policy(client, lib_martigny,
         dict(
             item_pid=item_pid,
             pid=loan.get('pid'),
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -245,17 +245,17 @@ def test_checkout_default_policy(client, lib_martigny,
 
 
 def test_checkout_library_level_policy(client, lib_martigny,
-                                       librarian_martigny_no_email,
-                                       patron_martigny_no_email,
+                                       librarian_martigny,
+                                       patron_martigny,
                                        loc_public_martigny,
                                        item_type_standard_martigny,
                                        item_lib_martigny, json_header,
                                        circ_policy_short_martigny):
     """Test circ policy parameters"""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     # checkout
     res, data = postdata(
@@ -264,7 +264,7 @@ def test_checkout_library_level_policy(client, lib_martigny,
         dict(
             item_pid=item_pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -286,7 +286,7 @@ def test_checkout_library_level_policy(client, lib_martigny,
         dict(
             item_pid=item_pid,
             pid=loan.get('pid'),
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -294,17 +294,17 @@ def test_checkout_library_level_policy(client, lib_martigny,
 
 
 def test_checkout_organisation_policy(client, lib_martigny,
-                                      librarian_martigny_no_email,
-                                      patron_martigny_no_email,
+                                      librarian_martigny,
+                                      patron_martigny,
                                       loc_public_martigny,
                                       item_type_standard_martigny,
                                       item_lib_martigny, json_header,
                                       circ_policy_short_martigny):
     """Test circ policy parameters"""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     # checkout
     res, data = postdata(
@@ -313,7 +313,7 @@ def test_checkout_organisation_policy(client, lib_martigny,
         dict(
             item_pid=item_pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -335,25 +335,25 @@ def test_checkout_organisation_policy(client, lib_martigny,
         dict(
             item_pid=item_pid,
             pid=loan.get('pid'),
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
     assert res.status_code == 200
 
 
-def test_items_receive(client, librarian_martigny_no_email,
-                       patron_martigny_no_email, loc_public_martigny,
+def test_items_receive(client, librarian_martigny,
+                       patron_martigny, loc_public_martigny,
                        item_type_standard_martigny,
                        item_lib_martigny, json_header,
                        circulation_policies):
     """Test item receive."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
     assert not item.patron_has_an_active_loan_on_item(
-        patron_martigny_no_email.get('patron', {}).get('barcode'))
+        patron_martigny.get('patron', {}).get('barcode'))
     location = loc_public_martigny
     # checkout
     res, data = postdata(
@@ -362,7 +362,7 @@ def test_items_receive(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -372,7 +372,7 @@ def test_items_receive(client, librarian_martigny_no_email,
     assert item_data.get('status') == ItemStatus.ON_LOAN
     assert actions.get(LoanAction.CHECKOUT)
     assert item.patron_has_an_active_loan_on_item(
-        patron_martigny_no_email.get('patron', {}).get('barcode'))
+        patron_martigny.get('patron', {}).get('barcode'))
     loan_pid = actions[LoanAction.CHECKOUT].get('pid')
 
     # checkin
@@ -383,7 +383,7 @@ def test_items_receive(client, librarian_martigny_no_email,
             item_pid=item_pid,
             pid=loan_pid,
             transaction_location_pid='fake',
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -399,7 +399,7 @@ def test_items_receive(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             pid=loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -410,16 +410,16 @@ def test_items_receive(client, librarian_martigny_no_email,
     assert actions.get(LoanAction.RECEIVE)
 
 
-def test_items_no_extend(client, librarian_martigny_no_email,
-                         patron_martigny_no_email, loc_public_martigny,
+def test_items_no_extend(client, librarian_martigny,
+                         patron_martigny, loc_public_martigny,
                          item_type_standard_martigny,
                          item_lib_martigny, json_header,
                          circ_policy_short_martigny):
     """Test items when no renewals is possible."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
     location = loc_public_martigny
 
     # checkout
@@ -429,7 +429,7 @@ def test_items_no_extend(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -453,7 +453,7 @@ def test_items_no_extend(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             pid=loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -475,15 +475,15 @@ def test_items_no_extend(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             pid=loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
     assert res.status_code == 200
 
 
-def test_items_deny_requests(client, librarian_martigny_no_email,
-                             patron_martigny_no_email, loc_public_martigny,
+def test_items_deny_requests(client, librarian_martigny,
+                             patron_martigny, loc_public_martigny,
                              item_type_standard_martigny, lib_martigny,
                              item_lib_martigny, json_header,
                              circ_policy_short_martigny):
@@ -495,10 +495,10 @@ def test_items_deny_requests(client, librarian_martigny_no_email,
         dbcommit=True,
         reindex=True)
     flush_index(CircPoliciesSearch.Meta.index)
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron = patron_martigny_no_email
+    patron = patron_martigny
     patron_pid = patron.pid
 
     # request
@@ -509,7 +509,7 @@ def test_items_deny_requests(client, librarian_martigny_no_email,
             item_pid=item_pid,
             pickup_location_pid=location.pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -539,20 +539,20 @@ def test_items_deny_requests(client, librarian_martigny_no_email,
 
 def test_extend_possible_actions(client, item_lib_martigny,
                                  loc_public_martigny,
-                                 librarian_martigny_no_email,
-                                 patron_martigny_no_email,
+                                 librarian_martigny,
+                                 patron_martigny,
                                  circ_policy_short_martigny):
     """Extend action changes according to params of cipo."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
     res, _ = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item.pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -601,7 +601,7 @@ def test_extend_possible_actions(client, item_lib_martigny,
         dict(
             item_pid=item.pid,
             pid=loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -615,17 +615,17 @@ def test_extend_possible_actions(client, item_lib_martigny,
     assert circ_policy['number_renewals'] == 1
 
 
-def test_items_extend_end_date(client, librarian_martigny_no_email,
-                               patron_martigny_no_email,
+def test_items_extend_end_date(client, librarian_martigny,
+                               patron_martigny,
                                loc_public_martigny,
                                item_type_standard_martigny,
                                item_lib_martigny, json_header,
                                circ_policy_short_martigny):
     """Test correct renewal due date for items."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     # checkout
     res, data = postdata(
@@ -634,7 +634,7 @@ def test_items_extend_end_date(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             patron_pid=patron_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -657,7 +657,7 @@ def test_items_extend_end_date(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             pid=loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -686,7 +686,7 @@ def test_items_extend_end_date(client, librarian_martigny_no_email,
         dict(
             item_pid=item_pid,
             pid=loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -694,19 +694,19 @@ def test_items_extend_end_date(client, librarian_martigny_no_email,
 
 
 def test_multiple_loans_on_item_error(client,
-                                      patron_martigny_no_email,
-                                      patron2_martigny_no_email,
+                                      patron_martigny,
+                                      patron2_martigny,
                                       loc_public_martigny,
                                       item_type_standard_martigny,
                                       item_lib_martigny, json_header,
                                       circulation_policies,
                                       loc_public_fully,
-                                      librarian_martigny_no_email):
+                                      librarian_martigny):
     """Test MultipleLoansOnItemError."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
-    checked_patron = patron2_martigny_no_email.pid
-    requested_patron = patron_martigny_no_email.pid
+    checked_patron = patron2_martigny.pid
+    requested_patron = patron_martigny.pid
     location = loc_public_martigny
     # checkout to checked_patron
     res, data = postdata(
@@ -716,7 +716,7 @@ def test_multiple_loans_on_item_error(client,
             item_pid=item.pid,
             patron_pid=checked_patron,
             transaction_location_pid=location.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -736,7 +736,7 @@ def test_multiple_loans_on_item_error(client,
             item_pid=item.pid,
             pickup_location_pid=loc_public_fully.pid,
             patron_pid=requested_patron,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -756,7 +756,7 @@ def test_multiple_loans_on_item_error(client,
             item_pid=item.pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_fully.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -780,7 +780,7 @@ def test_multiple_loans_on_item_error(client,
         dict(
             item_pid=item.pid,
             pid=req_loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -788,12 +788,12 @@ def test_multiple_loans_on_item_error(client,
 
 
 def test_filtered_items_get(
-        client, librarian_martigny_no_email, item_lib_martigny,
+        client, librarian_martigny, item_lib_martigny,
         item_lib_saxon, item_lib_fully,
-        librarian_sion_no_email, item_lib_sion):
+        librarian_sion, item_lib_sion):
     """Test items filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.item_list')
 
     res = client.get(list_url)
@@ -802,7 +802,7 @@ def test_filtered_items_get(
     assert data['hits']['total']['value'] == 4
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.item_list')
 
     res = client.get(list_url)
@@ -811,12 +811,12 @@ def test_filtered_items_get(
     assert data['hits']['total']['value'] == 1
 
 
-def test_items_notes(client, librarian_martigny_no_email, item_lib_martigny,
+def test_items_notes(client, librarian_martigny, item_lib_martigny,
                      json_header):
     """Test items notes."""
 
     item = item_lib_martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # at start the items have one note
     assert len(item.notes) == 1
@@ -855,15 +855,15 @@ def test_items_notes(client, librarian_martigny_no_email, item_lib_martigny,
     assert item.get_note('dummy') is None
 
 
-def test_pending_loans_order(client, librarian_martigny_no_email,
-                             patron_martigny_no_email, loc_public_martigny,
+def test_pending_loans_order(client, librarian_martigny,
+                             patron_martigny, loc_public_martigny,
                              item_type_standard_martigny,
                              item2_lib_martigny, json_header,
-                             patron2_martigny_no_email, patron_sion_no_email,
+                             patron2_martigny, patron_sion,
                              circulation_policies):
     """Test sort of pending loans."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    library_pid = librarian_martigny_no_email\
+    login_user_via_session(client, librarian_martigny.user)
+    library_pid = librarian_martigny\
         .replace_refs()['libraries'][0]['pid']
 
     res, _ = postdata(
@@ -871,9 +871,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron_sion_no_email.pid,
+            patron_pid=patron_sion.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -883,9 +883,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -896,9 +896,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -942,9 +942,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
     assert res.status_code == 200
     data = get_json(res)
     loans = data['hits']['hits'][0]['item']['pending_loans']
-    assert loans[0]['patron_pid'] == patron_sion_no_email.pid
-    assert loans[1]['patron_pid'] == patron_martigny_no_email.pid
-    assert loans[2]['patron_pid'] == patron2_martigny_no_email.pid
+    assert loans[0]['patron_pid'] == patron_sion.pid
+    assert loans[1]['patron_pid'] == patron_martigny.pid
+    assert loans[2]['patron_pid'] == patron2_martigny.pid
 
     # sort by invalid field
     res = client.get(
@@ -957,13 +957,13 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
 
 
 def test_item_possible_actions(client, item_lib_martigny,
-                               librarian_martigny_no_email,
-                               patron_martigny_no_email,
+                               librarian_martigny,
+                               patron_martigny,
                                circulation_policies):
     """Possible action changes according to params of cipo."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
     res = client.get(
         url_for(
             'api_item.item',

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -26,14 +26,14 @@ from rero_ils.modules.items.api import Item
 
 
 def test_item_dumps(client, item_lib_martigny, org_martigny,
-                    librarian_martigny_no_email):
+                    librarian_martigny):
     """Test item dumps and elastic search version."""
     item_dumps = Item(item_lib_martigny.dumps()).replace_refs()
 
     assert item_dumps.get('available')
     assert item_dumps.get('organisation').get('pid') == org_martigny.pid
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.item_item',
                          pid_value=item_lib_martigny.pid)
 
@@ -46,18 +46,18 @@ def test_item_dumps(client, item_lib_martigny, org_martigny,
 
 
 def test_item_secure_api(client, json_header, item_lib_martigny,
-                         librarian_martigny_no_email, librarian_sion_no_email,
+                         librarian_martigny, librarian_sion,
                          loc_public_saxon):
     """Test item secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.item_item',
                          pid_value=item_lib_martigny.pid)
     res = client.get(record_url)
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.item_item',
                          pid_value=item_lib_martigny.pid)
 
@@ -66,14 +66,14 @@ def test_item_secure_api(client, json_header, item_lib_martigny,
 
 
 def test_item_secure_api_create(client, json_header, item_lib_martigny,
-                                librarian_martigny_no_email,
-                                librarian_sion_no_email,
+                                librarian_martigny,
+                                librarian_sion,
                                 item_lib_martigny_data,
                                 item_lib_saxon_data,
-                                system_librarian_martigny_no_email):
+                                system_librarian_martigny):
     """Test item secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_url = 'invenio_records_rest.item_list'
 
     del item_lib_martigny_data['pid']
@@ -94,7 +94,7 @@ def test_item_secure_api_create(client, json_header, item_lib_martigny,
     # librarian can not create items for another library
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_url,
@@ -104,7 +104,7 @@ def test_item_secure_api_create(client, json_header, item_lib_martigny,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -116,14 +116,14 @@ def test_item_secure_api_create(client, json_header, item_lib_martigny,
 
 
 def test_item_secure_api_update(client, json_header, item_lib_saxon,
-                                librarian_martigny_no_email,
-                                librarian_sion_no_email,
+                                librarian_martigny,
+                                librarian_sion,
                                 item_lib_martigny,
-                                system_librarian_martigny_no_email
+                                system_librarian_martigny
                                 ):
     """Test item secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.item_item',
                          pid_value=item_lib_martigny.pid)
 
@@ -148,7 +148,7 @@ def test_item_secure_api_update(client, json_header, item_lib_saxon,
     # librarian can not update items of other libraries
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.put(
         record_url,
         data=json.dumps(item_lib_saxon),
@@ -158,7 +158,7 @@ def test_item_secure_api_update(client, json_header, item_lib_saxon,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -170,14 +170,14 @@ def test_item_secure_api_update(client, json_header, item_lib_saxon,
 
 
 def test_item_secure_api_delete(client, item_lib_saxon,
-                                librarian_martigny_no_email,
-                                librarian_sion_no_email,
+                                librarian_martigny,
+                                librarian_sion,
                                 item_lib_martigny,
                                 json_header,
-                                system_librarian_martigny_no_email):
+                                system_librarian_martigny):
     """Test item secure api delete."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.item_item',
                          pid_value=item_lib_martigny.pid)
 
@@ -193,27 +193,27 @@ def test_item_secure_api_delete(client, item_lib_saxon,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.delete(record_url)
     # librarian can not delete items of other organisations
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.delete(record_url)
     # sys_librarian can delete items in other libraries in same org.
     assert res.status_code == 204
 
 
-def test_pending_loans_order(client, librarian_martigny_no_email,
-                             patron_martigny_no_email, loc_public_martigny,
+def test_pending_loans_order(client, librarian_martigny,
+                             patron_martigny, loc_public_martigny,
                              item_type_standard_martigny,
                              item2_lib_martigny, json_header,
-                             patron2_martigny_no_email, patron_sion_no_email,
+                             patron2_martigny, patron_sion,
                              circulation_policies):
     """Test sort of pending loans."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    library_pid = librarian_martigny_no_email\
+    login_user_via_session(client, librarian_martigny.user)
+    library_pid = librarian_martigny\
         .replace_refs()['libraries'][0]['pid']
 
     res, _ = postdata(
@@ -221,9 +221,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron_sion_no_email.pid,
+            patron_pid=patron_sion.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -233,9 +233,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -246,9 +246,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -292,9 +292,9 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
     assert res.status_code == 200
     data = get_json(res)
     loans = data['hits']['hits'][0]['item']['pending_loans']
-    assert loans[0]['patron_pid'] == patron_sion_no_email.pid
-    assert loans[1]['patron_pid'] == patron_martigny_no_email.pid
-    assert loans[2]['patron_pid'] == patron2_martigny_no_email.pid
+    assert loans[0]['patron_pid'] == patron_sion.pid
+    assert loans[1]['patron_pid'] == patron_martigny.pid
+    assert loans[2]['patron_pid'] == patron2_martigny.pid
 
     # sort by invalid field
     res = client.get(
@@ -306,21 +306,21 @@ def test_pending_loans_order(client, librarian_martigny_no_email,
     assert 'RequestError(400' in data['status']
 
 
-def test_patron_checkouts_order(client, librarian_martigny_no_email,
-                                patron_martigny_no_email, loc_public_martigny,
+def test_patron_checkouts_order(client, librarian_martigny,
+                                patron_martigny, loc_public_martigny,
                                 item_type_standard_martigny,
                                 item3_lib_martigny, json_header,
                                 item4_lib_martigny,
                                 circulation_policies):
     """Test sort of checkout loans."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, _ = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item3_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         ),
     )
@@ -331,8 +331,8 @@ def test_patron_checkouts_order(client, librarian_martigny_no_email,
         'api_item.checkout',
         dict(
             item_pid=item4_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         ),
     )
@@ -341,7 +341,7 @@ def test_patron_checkouts_order(client, librarian_martigny_no_email,
     # sort by transaction_date asc
     res = client.get(
         url_for(
-            'api_item.loans', patron_pid=patron_martigny_no_email.pid,
+            'api_item.loans', patron_pid=patron_martigny.pid,
             sort='_created'))
     assert res.status_code == 200
     data = get_json(res)
@@ -353,7 +353,7 @@ def test_patron_checkouts_order(client, librarian_martigny_no_email,
     # sort by transaction_date desc
     res = client.get(
         url_for(
-            'api_item.loans', patron_pid=patron_martigny_no_email.pid,
+            'api_item.loans', patron_pid=patron_martigny.pid,
             sort='-transaction_date'))
     assert res.status_code == 200
     data = get_json(res)
@@ -365,7 +365,7 @@ def test_patron_checkouts_order(client, librarian_martigny_no_email,
     # sort by invalid field
     res = client.get(
         url_for(
-            'api_item.loans', patron_pid=patron_martigny_no_email.pid,
+            'api_item.loans', patron_pid=patron_martigny.pid,
             sort='does not exist'))
     assert res.status_code == 500
     data = get_json(res)

--- a/tests/api/libraries/test_libraries_permissions.py
+++ b/tests/api/libraries/test_libraries_permissions.py
@@ -24,10 +24,10 @@ from utils import get_json
 from rero_ils.modules.libraries.permissions import LibraryPermission
 
 
-def test_library_permissions_api(client, patron_martigny_no_email,
+def test_library_permissions_api(client, patron_martigny,
                                  lib_martigny, lib_sion, lib_saxon,
-                                 librarian_martigny_no_email,
-                                 system_librarian_martigny_no_email):
+                                 librarian_martigny,
+                                 system_librarian_martigny):
     """Test libraries permissions api."""
     lib_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -54,7 +54,7 @@ def test_library_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(lib_permissions_url)
     assert res.status_code == 403
 
@@ -63,7 +63,7 @@ def test_library_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' acq_account for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(lib_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -93,7 +93,7 @@ def test_library_permissions_api(client, patron_martigny_no_email,
     #   * sys_lib can 'list' organisations
     #   * sys_lib can never 'create' and 'delete' any organisation
     #   * sys_lib can 'read' and 'update' only their own organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(lib_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -110,9 +110,9 @@ def test_library_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_library_permissions(patron_martigny_no_email,
-                             librarian_martigny_no_email,
-                             system_librarian_martigny_no_email,
+def test_library_permissions(patron_martigny,
+                             librarian_martigny,
+                             system_librarian_martigny,
                              org_martigny, lib_martigny, lib_saxon, lib_sion):
     """Test library permissions class."""
 
@@ -126,7 +126,7 @@ def test_library_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.libraries.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not LibraryPermission.list(None, lib_martigny)
         assert not LibraryPermission.read(None, lib_martigny)
@@ -137,7 +137,7 @@ def test_library_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.libraries.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.libraries.permissions.current_organisation',
         org_martigny
@@ -157,7 +157,7 @@ def test_library_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.libraries.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.libraries.permissions.current_organisation',
         org_martigny

--- a/tests/api/libraries/test_libraries_rest.py
+++ b/tests/api/libraries/test_libraries_rest.py
@@ -201,7 +201,7 @@ def test_library_exceptions(lib_martigny):
     )
 
 
-def test_library_can_delete(lib_martigny, librarian_martigny_no_email,
+def test_library_can_delete(lib_martigny, librarian_martigny,
                             loc_public_martigny):
     """Test can delete a library."""
     links = lib_martigny.get_links_to_me()
@@ -215,10 +215,10 @@ def test_library_can_delete(lib_martigny, librarian_martigny_no_email,
 
 
 def test_filtered_libraries_get(
-        client, librarian_martigny_no_email, lib_martigny, lib_saxon,
-        lib_fully, librarian_sion_no_email, lib_sion):
+        client, librarian_martigny, lib_martigny, lib_saxon,
+        lib_fully, librarian_sion, lib_sion):
     """Test libraries filter by organisation."""    # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.lib_list')
 
     res = client.get(list_url)
@@ -227,7 +227,7 @@ def test_filtered_libraries_get(
     assert data['hits']['total']['value'] == 3
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.lib_list')
 
     res = client.get(list_url)
@@ -237,13 +237,13 @@ def test_filtered_libraries_get(
 
 
 def test_library_secure_api(client, lib_martigny, lib_fully,
-                            librarian_martigny_no_email,
-                            librarian_sion_no_email,
-                            system_librarian_martigny_no_email,
-                            system_librarian_sion_no_email):
+                            librarian_martigny,
+                            librarian_sion,
+                            system_librarian_martigny,
+                            system_librarian_sion):
     """Test library secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_martigny.pid)
 
@@ -257,7 +257,7 @@ def test_library_secure_api(client, lib_martigny, lib_fully,
     # a librarian is authorized to access other library records of its org
     assert res.status_code == 200
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_martigny.pid)
     res = client.get(record_url)
@@ -271,7 +271,7 @@ def test_library_secure_api(client, lib_martigny, lib_fully,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_martigny.pid)
 
@@ -279,21 +279,21 @@ def test_library_secure_api(client, lib_martigny, lib_fully,
     # a librarian is not authorized to access library record of another  org
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.get(record_url)
     # a sys_lib is not authorized to access its library record of its org
     assert res.status_code == 403
 
 
 def test_library_secure_api_create(client, lib_martigny,
-                                   lib_fully_data, librarian_martigny_no_email,
-                                   librarian_sion_no_email,
+                                   lib_fully_data, librarian_martigny,
+                                   librarian_sion,
                                    lib_martigny_data,
-                                   system_librarian_martigny_no_email,
-                                   system_librarian_sion_no_email):
+                                   system_librarian_martigny,
+                                   system_librarian_sion):
     """Test library secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.lib_list'
 
     del lib_martigny_data['pid']
@@ -315,7 +315,7 @@ def test_library_secure_api_create(client, lib_martigny,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -325,7 +325,7 @@ def test_library_secure_api_create(client, lib_martigny,
     # a librarian is not authorized to create library record of other org
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -342,7 +342,7 @@ def test_library_secure_api_create(client, lib_martigny,
     # a sys_librarian is authorized to create new library record in its org
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -353,14 +353,14 @@ def test_library_secure_api_create(client, lib_martigny,
 
 
 def test_library_secure_api_update(client, lib_fully, lib_martigny,
-                                   librarian_martigny_no_email,
-                                   librarian_sion_no_email,
+                                   librarian_martigny,
+                                   librarian_sion,
                                    json_header,
-                                   system_librarian_martigny_no_email,
-                                   system_librarian_sion_no_email):
+                                   system_librarian_martigny,
+                                   system_librarian_sion):
     """Test library secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_martigny.pid)
 
@@ -385,7 +385,7 @@ def test_library_secure_api_update(client, lib_fully, lib_martigny,
     # a librarian is not authorized to update an external library of its org
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.put(
         record_url,
         data=json.dumps(lib_fully),
@@ -406,7 +406,7 @@ def test_library_secure_api_update(client, lib_fully, lib_martigny,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_fully.pid)
@@ -420,7 +420,7 @@ def test_library_secure_api_update(client, lib_fully, lib_martigny,
     # librarian is not authorized to update an external library of another org
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.put(
         record_url,
         data=json.dumps(lib_fully),
@@ -431,13 +431,13 @@ def test_library_secure_api_update(client, lib_fully, lib_martigny,
 
 
 def test_library_secure_api_delete(client, lib_fully, lib_martigny,
-                                   librarian_martigny_no_email,
-                                   librarian_sion_no_email,
-                                   system_librarian_martigny_no_email,
-                                   system_librarian_sion_no_email):
+                                   librarian_martigny,
+                                   librarian_sion,
+                                   system_librarian_martigny,
+                                   system_librarian_sion):
     """Test library secure api delete."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_martigny.pid)
 
@@ -453,19 +453,19 @@ def test_library_secure_api_delete(client, lib_fully, lib_martigny,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.delete(record_url)
     # librarian is not authorized to delete an external library of another org
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
 
     res = client.delete(record_url)
     # sys_librarian is authorized to delete any library of its org
     assert res.status_code == 204
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     record_url = url_for('invenio_records_rest.lib_item',
                          pid_value=lib_martigny.pid)
 

--- a/tests/api/loans/test_loans_api_rest.py
+++ b/tests/api/loans/test_loans_api_rest.py
@@ -27,23 +27,23 @@ from rero_ils.modules.loans.api import Loan, LoanAction, patron_profile
 
 
 def test_patron_profile_loans(
-        client, librarian_martigny_no_email,
-        patron_martigny_no_email, loc_public_martigny,
+        client, librarian_martigny,
+        patron_martigny, loc_public_martigny,
         item_lib_martigny, json_header, circulation_policies):
     """Test patron profile loans sent to patron account."""
 
     # No patron history
-    assert not patron_profile(patron_martigny_no_email)[3]
+    assert not patron_profile(patron_martigny)[3]
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -57,15 +57,15 @@ def test_patron_profile_loans(
             item_pid=item_lib_martigny.pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
 
     # Some history are created
-    assert patron_profile(patron_martigny_no_email)[3][0]['pid'] == loan_pid
+    assert patron_profile(patron_martigny)[3][0]['pid'] == loan_pid
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for(
         'invenio_records_rest.loanid_item', pid_value=loan_pid)
     res = client.get(record_url)
@@ -82,7 +82,7 @@ def test_patron_profile_loans(
     loan = Loan.get_record_by_pid(loan_pid)
     loan['to_anonymize'] = True
     loan.update(loan, dbcommit=True, reindex=True)
-    assert not patron_profile(patron_martigny_no_email)[3]
+    assert not patron_profile(patron_martigny)[3]
 
     # anonymised loans are not readable.
     record_url = url_for(
@@ -101,4 +101,4 @@ def test_patron_profile_loans(
     loan.update(loan, dbcommit=True, reindex=True)
 
     item_lib_martigny.delete(dbcommit=True, delindex=True)
-    assert not patron_profile(patron_martigny_no_email)[3]
+    assert not patron_profile(patron_martigny)[3]

--- a/tests/api/loans/test_loans_permissions.py
+++ b/tests/api/loans/test_loans_permissions.py
@@ -24,10 +24,10 @@ from utils import get_json
 from rero_ils.modules.loans.permissions import LoanPermission
 
 
-def test_loans_permissions_api(client, patron_martigny_no_email,
+def test_loans_permissions_api(client, patron_martigny,
                                loan_overdue_martigny, loan_overdue_sion,
                                loan_overdue_saxon,
-                               system_librarian_martigny_no_email):
+                               system_librarian_martigny):
     """Test loans permissions api."""
     loan_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -54,14 +54,14 @@ def test_loans_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(loan_permissions_url)
     assert res.status_code == 403
 
     # Logged as system librarian
     #   * sys_lib can 'list' and 'read' all loans
     #   * sys_lib can't 'read' 'update', 'delete' loans
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(loan_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -90,9 +90,9 @@ def test_loans_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_loan_permissions(patron_martigny_no_email,
-                          librarian_martigny_no_email,
-                          system_librarian_martigny_no_email,
+def test_loan_permissions(patron_martigny,
+                          librarian_martigny,
+                          system_librarian_martigny,
                           loan_overdue_saxon, loan_overdue_martigny,
                           loan_overdue_sion, org_martigny):
     """Test library permissions class."""
@@ -110,7 +110,7 @@ def test_loan_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.loans.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.loans.permissions.current_organisation',
         org_martigny
@@ -124,7 +124,7 @@ def test_loan_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.loans.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.loans.permissions.current_organisation',
         org_martigny

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -64,10 +64,10 @@ def test_loans_permissions(client, loan_pending_martigny, json_header):
 
 
 def test_loans_logged_permissions(client, loan_pending_martigny,
-                                  librarian_martigny_no_email,
+                                  librarian_martigny,
                                   json_header):
     """Test record retrieval."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item_url = url_for('invenio_records_rest.loanid_item', pid_value='1')
 
     res = client.get(item_url)
@@ -90,28 +90,28 @@ def test_loans_logged_permissions(client, loan_pending_martigny,
     assert res.status_code == 403
 
 
-def test_due_soon_loans(client, librarian_martigny_no_email,
-                        patron_martigny_no_email, loc_public_martigny,
+def test_due_soon_loans(client, librarian_martigny,
+                        patron_martigny, loc_public_martigny,
                         item_type_standard_martigny,
                         item_lib_martigny,
                         circ_policy_short_martigny):
     """Test overdue loans."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     assert not get_last_transaction_loc_for_item(item_pid)
 
     assert not item.patron_has_an_active_loan_on_item(
-        patron_martigny_no_email.get('patron', {}).get('barcode'))
+        patron_martigny.get('patron', {}).get('barcode'))
     assert item.can_delete
     assert item.available
 
     from rero_ils.modules.circ_policies.api import CircPolicy
     circ_policy = CircPolicy.provide_circ_policy(
         item.library_pid,
-        patron_martigny_no_email.patron_type_pid,
+        patron_martigny.patron_type_pid,
         item.item_type_pid
     )
     circ_policy['number_of_days_before_due_date'] = 7
@@ -130,7 +130,7 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
             item_pid=item_pid,
             patron_pid=patron_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -158,24 +158,24 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
             item_pid=item_pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
 
 
-def test_overdue_loans(client, librarian_martigny_no_email,
-                       patron_martigny_no_email, loc_public_martigny,
+def test_overdue_loans(client, librarian_martigny,
+                       patron_martigny, loc_public_martigny,
                        item_type_standard_martigny,
                        item_lib_martigny, item2_lib_martigny,
                        patron_type_children_martigny,
                        circ_policy_short_martigny,
-                       patron3_martigny_blocked_no_email):
+                       patron3_martigny_blocked):
     """Test overdue loans."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
 
     # checkout
     res, data = postdata(
@@ -185,7 +185,7 @@ def test_overdue_loans(client, librarian_martigny_no_email,
             item_pid=item_pid,
             patron_pid=patron_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200, "It probably failed while \
@@ -216,9 +216,9 @@ def test_overdue_loans(client, librarian_martigny_no_email,
         'api_item.checkout',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron3_martigny_blocked_no_email.pid,
+            patron_pid=patron3_martigny_blocked.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 403
@@ -232,16 +232,16 @@ def test_overdue_loans(client, librarian_martigny_no_email,
             item_pid=item_pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
 
 
 def test_checkout_item_transit(client, item2_lib_martigny,
-                               librarian_martigny_no_email,
-                               librarian_saxon_no_email,
-                               patron_martigny_no_email,
+                               librarian_martigny,
+                               librarian_saxon,
+                               patron_martigny,
                                loc_public_saxon, lib_martigny,
                                loc_public_martigny,
                                circulation_policies):
@@ -249,7 +249,7 @@ def test_checkout_item_transit(client, item2_lib_martigny,
     assert item2_lib_martigny.available
 
     # request
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     loc_public_martigny['notification_email'] = 'dummy_email@fake.domain'
     loc_public_martigny['send_notification'] = True
     loc_public_martigny.update(
@@ -264,9 +264,9 @@ def test_checkout_item_transit(client, item2_lib_martigny,
         dict(
             item_pid=item2_lib_martigny.pid,
             pickup_location_pid=loc_public_saxon.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -294,7 +294,7 @@ def test_checkout_item_transit(client, item2_lib_martigny,
             item_pid=item2_lib_martigny.pid,
             pid=loan_pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -305,7 +305,7 @@ def test_checkout_item_transit(client, item2_lib_martigny,
     loan = Loan.get_record_by_pid(loan_pid)
     assert loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
 
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
     # receive
     res, _ = postdata(
         client,
@@ -314,7 +314,7 @@ def test_checkout_item_transit(client, item2_lib_martigny,
             item_pid=item2_lib_martigny.pid,
             pid=loan_pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -330,9 +330,9 @@ def test_checkout_item_transit(client, item2_lib_martigny,
         'api_item.checkout',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -342,11 +342,11 @@ def test_checkout_item_transit(client, item2_lib_martigny,
     assert loan_before_checkout.get('pid') == loan_after_checkout.get('pid')
 
 
-def test_loan_access_permissions(client, librarian_martigny_no_email,
+def test_loan_access_permissions(client, librarian_martigny,
                                  loc_public_saxon,
-                                 patron_martigny_no_email,
-                                 item_lib_sion, patron_sion_no_email,
-                                 librarian_sion_no_email,
+                                 patron_martigny,
+                                 item_lib_sion, patron_sion,
+                                 librarian_sion,
                                  circulation_policies
                                  ):
     """Test loans read permissions."""
@@ -356,15 +356,15 @@ def test_loan_access_permissions(client, librarian_martigny_no_email,
     assert res.status_code == 401
 
     # ensure we have loans from the two configured organisation.
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     res, _ = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item_lib_sion.pid,
-            patron_pid=patron_sion_no_email.pid,
+            patron_pid=patron_sion.pid,
             transaction_location_pid=loc_public_saxon.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -379,17 +379,17 @@ def test_loan_access_permissions(client, librarian_martigny_no_email,
     assert loans_martigny
     assert loans_sion
     # Test loan list API access.
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     loan_list = url_for('invenio_records_rest.loanid_list', q='pid:1')
     res = client.get(loan_list)
     assert res.status_code == 200
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     loan_list = url_for('invenio_records_rest.loanid_list', q='pid:1')
     res = client.get(loan_list)
     assert res.status_code == 200
 
     # librarian or system librarian have access all loans of its org
-    user = librarian_martigny_no_email
+    user = librarian_martigny
     login_user_via_session(client, user.user)
     for loan in loans:
         record_url = url_for(
@@ -401,7 +401,7 @@ def test_loan_access_permissions(client, librarian_martigny_no_email,
             assert res.status_code == 403
 
     # patron can access only its loans
-    user = patron_martigny_no_email
+    user = patron_martigny
     login_user_via_session(client, user.user)
     for loan in loans:
         record_url = url_for(
@@ -416,15 +416,15 @@ def test_loan_access_permissions(client, librarian_martigny_no_email,
             assert res.status_code == 403
 
 
-def test_timezone_due_date(client, librarian_martigny_no_email,
-                           patron_martigny_no_email, loc_public_martigny,
+def test_timezone_due_date(client, librarian_martigny,
+                           patron_martigny, loc_public_martigny,
                            item_type_standard_martigny,
                            item3_lib_martigny,
                            circ_policy_short_martigny,
                            lib_martigny):
     """Test that timezone affects due date regarding library location."""
     # Login to perform action
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # Close the library all days. Except Monday.
     del lib_martigny['opening_hours']
@@ -477,11 +477,11 @@ def test_timezone_due_date(client, librarian_martigny_no_email,
     checkout_duration = 3
     item = item3_lib_martigny
     item_pid = item.pid
-    patron_pid = patron_martigny_no_email.pid
+    patron_pid = patron_martigny.pid
     from rero_ils.modules.circ_policies.api import CircPolicy
     circ_policy = CircPolicy.provide_circ_policy(
         item.library_pid,
-        patron_martigny_no_email.patron_type_pid,
+        patron_martigny.patron_type_pid,
         item.item_type_pid
     )
     circ_policy['number_of_days_before_due_date'] = 7
@@ -500,7 +500,7 @@ def test_timezone_due_date(client, librarian_martigny_no_email,
             item_pid=item_pid,
             patron_pid=patron_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -531,23 +531,23 @@ It should be the same date, even if timezone changed."
 
 def test_librarian_request_on_blocked_user(
         client, item_lib_martigny, lib_martigny,
-        librarian_martigny_no_email, loc_public_martigny,
-        patron3_martigny_blocked_no_email,
+        librarian_martigny, loc_public_martigny,
+        patron3_martigny_blocked,
         circulation_policies):
     """Librarian request on blocked user returns a specific 403 message."""
     assert item_lib_martigny.available
 
     # request
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron3_martigny_blocked_no_email.pid,
+            patron_pid=patron3_martigny_blocked.pid,
             pickup_location_pid=loc_public_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 403

--- a/tests/api/loans/test_loans_utils.py
+++ b/tests/api/loans/test_loans_utils.py
@@ -23,7 +23,7 @@ from rero_ils.modules.loans.utils import loan_build_document_ref, \
 from rero_ils.modules.utils import get_ref_for_pid
 
 
-def test_loans_build_refs(item_lib_martigny, patron_martigny_no_email,
+def test_loans_build_refs(item_lib_martigny, patron_martigny,
                           document):
     """Test functions buildings refs."""
 
@@ -31,7 +31,7 @@ def test_loans_build_refs(item_lib_martigny, patron_martigny_no_email,
     loan = Loan({
         'item_pid': item_pid_to_object(item_lib_martigny.pid),
         'document_pid': document.pid,
-        'patron_pid': patron_martigny_no_email.pid
+        'patron_pid': patron_martigny.pid
     })
 
     assert loan_build_item_ref(None, loan) == \
@@ -39,4 +39,4 @@ def test_loans_build_refs(item_lib_martigny, patron_martigny_no_email,
     assert loan_build_document_ref(None, loan) == \
         get_ref_for_pid('doc', document.pid)
     assert loan_build_patron_ref(None, loan) == \
-        get_ref_for_pid('patrons', patron_martigny_no_email.pid)
+        get_ref_for_pid('patrons', patron_martigny.pid)

--- a/tests/api/local_fields/test_local_fields_permissions.py
+++ b/tests/api/local_fields/test_local_fields_permissions.py
@@ -22,7 +22,7 @@ from utils import get_json
 
 def test_local_fields_permissions_api(
         client, org_martigny, document, local_field_martigny,
-        patron_sion_no_email, librarian_martigny_no_email):
+        patron_sion, librarian_martigny):
     """Test local fields permissions api."""
     local_field_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -39,12 +39,12 @@ def test_local_fields_permissions_api(
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_sion_no_email.user)
+    login_user_via_session(client, patron_sion.user)
     res = client.get(local_field_permissions_url)
     assert res.status_code == 403
 
     # Logged as
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(local_field_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)

--- a/tests/api/locations/test_locations_permissions.py
+++ b/tests/api/locations/test_locations_permissions.py
@@ -24,10 +24,10 @@ from utils import get_json
 from rero_ils.modules.locations.permissions import LocationPermission
 
 
-def test_location_permissions_api(client, patron_martigny_no_email,
+def test_location_permissions_api(client, patron_martigny,
                                   loc_public_martigny, loc_public_saxon,
-                                  loc_public_sion, librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email):
+                                  loc_public_sion, librarian_martigny,
+                                  system_librarian_martigny):
     """Test locations permissions api."""
     loc_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -54,7 +54,7 @@ def test_location_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(loc_permissions_url)
     assert res.status_code == 403
 
@@ -63,7 +63,7 @@ def test_location_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', delete only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' acq_account for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(loc_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -93,7 +93,7 @@ def test_location_permissions_api(client, patron_martigny_no_email,
     #   * sys_lib can 'list' organisations
     #   * sys_lib can never 'create' and 'delete' any organisation
     #   * sys_lib can 'read' and 'update' only their own organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(loc_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -110,9 +110,9 @@ def test_location_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_location_permissions(patron_martigny_no_email,
-                              librarian_martigny_no_email,
-                              system_librarian_martigny_no_email,
+def test_location_permissions(patron_martigny,
+                              librarian_martigny,
+                              system_librarian_martigny,
                               org_martigny, loc_public_martigny,
                               loc_public_saxon, loc_public_sion):
     """Test location permissions class."""
@@ -127,7 +127,7 @@ def test_location_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.locations.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not LocationPermission.list(None, loc_public_martigny)
         assert not LocationPermission.read(None, loc_public_martigny)
@@ -138,7 +138,7 @@ def test_location_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.locations.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.locations.permissions.current_organisation',
         org_martigny
@@ -158,7 +158,7 @@ def test_location_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.locations.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.locations.permissions.current_organisation',
         org_martigny

--- a/tests/api/locations/test_locations_rest.py
+++ b/tests/api/locations/test_locations_rest.py
@@ -32,8 +32,8 @@ from rero_ils.modules.errors import RecordValidationError
 from rero_ils.modules.locations.api import Location, LocationsSearch
 
 
-def test_location_pickup_locations(locations, patron_martigny_no_email,
-                                   patron_sion_no_email, loc_public_martigny,
+def test_location_pickup_locations(locations, patron_martigny,
+                                   patron_sion, loc_public_martigny,
                                    item2_lib_martigny):
     """Test for pickup locations."""
 
@@ -44,10 +44,10 @@ def test_location_pickup_locations(locations, patron_martigny_no_email,
 
     # check pickup restrictions by patron_pid
     pickup_locations = Location.get_pickup_location_pids(
-        patron_pid=patron_martigny_no_email.pid)
+        patron_pid=patron_martigny.pid)
     assert set(pickup_locations) == set(['loc1', 'loc3', 'loc5'])
     pickup_locations = Location.get_pickup_location_pids(
-        patron_pid=patron_sion_no_email.pid)
+        patron_pid=patron_sion.pid)
     assert set(pickup_locations) == set(['loc7'])
 
     # check pickup restrictions by item_barcode
@@ -68,7 +68,7 @@ def test_location_pickup_locations(locations, patron_martigny_no_email,
     assert set(pickup_locations) == set(['loc3'])
 
     pickup_locations = Location.get_pickup_location_pids(
-        patron_pid=patron_sion_no_email.pid,
+        patron_pid=patron_sion.pid,
         item_pid=item2_lib_martigny.pid)
     assert set(pickup_locations) == set([])
 
@@ -233,11 +233,11 @@ def test_location_can_delete(client, item_lib_martigny, loc_public_martigny):
     assert 'links' in reasons
 
 
-def test_filtered_locations_get(client, librarian_martigny_no_email,
-                                librarian_sion_no_email, locations):
+def test_filtered_locations_get(client, librarian_martigny,
+                                librarian_sion, locations):
     """Test location filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.loc_list')
 
     res = client.get(list_url)
@@ -246,7 +246,7 @@ def test_filtered_locations_get(client, librarian_martigny_no_email,
     assert data['hits']['total']['value'] == 9
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.loc_list')
 
     res = client.get(list_url)
@@ -256,13 +256,13 @@ def test_filtered_locations_get(client, librarian_martigny_no_email,
 
 
 def test_location_secure_api(client, json_header, loc_public_martigny,
-                             loc_public_fully, librarian_martigny_no_email,
-                             librarian_sion_no_email,
-                             system_librarian_martigny_no_email,
-                             system_librarian_sion_no_email):
+                             loc_public_fully, librarian_martigny,
+                             librarian_sion,
+                             system_librarian_martigny,
+                             system_librarian_sion):
     """Test location secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.loc_item',
                          pid_value=loc_public_martigny.pid)
 
@@ -277,13 +277,13 @@ def test_location_secure_api(client, json_header, loc_public_martigny,
     # a librarian is authorized to access any location of its organisation
     assert res.status_code == 200
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(record_url)
     # a sys_librarian is authorized to access any location of its organisation
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.loc_item',
                          pid_value=loc_public_martigny.pid)
 
@@ -291,23 +291,23 @@ def test_location_secure_api(client, json_header, loc_public_martigny,
     # librarian is not authorized to access any location of other organisation
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.get(record_url)
     # a sys_librarian is not authorized to access any location of other org
     assert res.status_code == 403
 
 
 def test_location_secure_api_create(client, lib_fully, lib_martigny,
-                                    librarian_martigny_no_email,
-                                    librarian_sion_no_email,
+                                    librarian_martigny,
+                                    librarian_sion,
                                     loc_public_martigny_data,
                                     loc_public_fully_data,
-                                    system_librarian_martigny_no_email,
-                                    system_librarian_sion_no_email):
+                                    system_librarian_martigny,
+                                    system_librarian_sion):
     """Test location secure api create."""
     # try to create a pickup location without pickup location name. This should
     # be failed due to `extended_validation` rules
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.loc_list'
     fake_location_data = deepcopy(loc_public_martigny_data)
     del fake_location_data['pid']
@@ -340,7 +340,7 @@ def test_location_secure_api_create(client, lib_fully, lib_martigny,
     # librarian is not authorized to create a location in other libraries.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -350,7 +350,7 @@ def test_location_secure_api_create(client, lib_fully, lib_martigny,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -360,7 +360,7 @@ def test_location_secure_api_create(client, lib_fully, lib_martigny,
     # librarian is not authorized to create a location at other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -372,14 +372,14 @@ def test_location_secure_api_create(client, lib_fully, lib_martigny,
 
 def test_location_secure_api_update(client, loc_restricted_saxon,
                                     loc_public_fully, loc_public_martigny,
-                                    librarian_martigny_no_email,
-                                    librarian_sion_no_email,
+                                    librarian_martigny,
+                                    librarian_sion,
                                     json_header,
-                                    system_librarian_martigny_no_email,
-                                    system_librarian_sion_no_email):
+                                    system_librarian_martigny,
+                                    system_librarian_sion):
     """Test location secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.loc_item',
                          pid_value=loc_public_martigny.pid)
 
@@ -404,7 +404,7 @@ def test_location_secure_api_update(client, loc_restricted_saxon,
     # librarian is not authorized to update a location of another library.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.put(
         record_url,
         data=json.dumps(loc_restricted_saxon),
@@ -414,7 +414,7 @@ def test_location_secure_api_update(client, loc_restricted_saxon,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -424,7 +424,7 @@ def test_location_secure_api_update(client, loc_restricted_saxon,
     # librarian is not authorized to update any location of another org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.put(
         record_url,
         data=json.dumps(loc_restricted_saxon),
@@ -436,13 +436,13 @@ def test_location_secure_api_update(client, loc_restricted_saxon,
 def test_location_secure_api_delete(client, loc_restricted_saxon,
                                     loc_restricted_martigny,
                                     loc_public_martigny,
-                                    librarian_martigny_no_email,
-                                    librarian_sion_no_email,
-                                    system_librarian_martigny_no_email,
-                                    system_librarian_sion_no_email):
+                                    librarian_martigny,
+                                    librarian_sion,
+                                    system_librarian_martigny,
+                                    system_librarian_sion):
     """Test location secure api delete."""
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.loc_item',
                          pid_value=loc_restricted_martigny.pid)
 
@@ -457,13 +457,13 @@ def test_location_secure_api_delete(client, loc_restricted_saxon,
     # librarian is not authorized to delete any location of other libraries.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.delete(record_url)
     # librarian is authorized to delete any location of its org.
     assert res.status_code == 204
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     record_url = url_for('invenio_records_rest.loc_item',
                          pid_value=loc_public_martigny.pid)
@@ -471,7 +471,7 @@ def test_location_secure_api_delete(client, loc_restricted_saxon,
     # librarian is not authorized to delete any location of other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.delete(record_url)
     # sys_ibrarian is not authorized to delete any location of other org.
     assert res.status_code == 403

--- a/tests/api/notifications/test_notifications_permissions.py
+++ b/tests/api/notifications/test_notifications_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.notifications.permissions import NotificationPermission
 
 
-def test_notifications_permissions_api(client, patron_martigny_no_email,
-                                       system_librarian_martigny_no_email,
-                                       librarian_martigny_no_email,
+def test_notifications_permissions_api(client, patron_martigny,
+                                       system_librarian_martigny,
+                                       librarian_martigny,
                                        notification_overdue_martigny,
                                        notification_overdue_saxon,
                                        notification_overdue_sion):
@@ -56,7 +56,7 @@ def test_notifications_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(notif_permissions_url)
     assert res.status_code == 403
 
@@ -65,7 +65,7 @@ def test_notifications_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', 'delete' only for its library
     #   * lib can't 'read' notification of others organisation.
     #   * lib can't 'create', 'update', 'delete' notification for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(notif_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -94,7 +94,7 @@ def test_notifications_permissions_api(client, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about notification of its own organisation
     #   * sys_lib can't do anything about notification of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(notif_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -112,9 +112,9 @@ def test_notifications_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_notifcations_permissions(patron_martigny_no_email,
-                                  librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email,
+def test_notifcations_permissions(patron_martigny,
+                                  librarian_martigny,
+                                  system_librarian_martigny,
                                   org_martigny,
                                   notification_overdue_sion,
                                   notification_overdue_martigny,
@@ -134,7 +134,7 @@ def test_notifcations_permissions(patron_martigny_no_email,
     notif_sion = notification_overdue_sion
     with mock.patch(
         'rero_ils.modules.notifications.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not NotificationPermission.list(None, notif_martigny)
         assert not NotificationPermission.read(None, notif_martigny)
@@ -145,7 +145,7 @@ def test_notifcations_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.notifications.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.notifications.permissions.current_organisation',
         org_martigny
@@ -169,7 +169,7 @@ def test_notifcations_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.notifications.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.notifications.permissions.current_organisation',
         org_martigny

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -63,11 +63,11 @@ def test_notifications_permissions(
 
 def test_filtered_notifications_get(
         client, notification_availability_martigny,
-        librarian_martigny_no_email,
-        librarian_sion_no_email):
+        librarian_martigny,
+        librarian_sion):
     """Test notification filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.notif_list')
 
     res = client.get(list_url)
@@ -76,7 +76,7 @@ def test_filtered_notifications_get(
     assert data['hits']['total']['value'] == 1
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.notif_list')
 
     res = client.get(list_url)
@@ -86,13 +86,13 @@ def test_filtered_notifications_get(
 
 
 def test_notification_secure_api(client, json_header,
-                                 librarian_martigny_no_email,
-                                 librarian_sion_no_email,
+                                 librarian_martigny,
+                                 librarian_sion,
                                  dummy_notification,
                                  loan_validated_martigny):
     """Test notification secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.notif_list'
     item_url = url_for('invenio_records_rest.notif_item', pid_value='notif1')
 
@@ -128,7 +128,7 @@ def test_notification_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     # test get notification
     res = client.get(item_url)
@@ -155,7 +155,7 @@ def test_notification_secure_api(client, json_header,
     res = client.delete(item_url)
     assert res.status_code == 403
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     # test notification delete at Martigny
     res = client.delete(item_url)
     assert res.status_code == 204
@@ -306,24 +306,24 @@ def test_notifications_post_put_delete(
     notif.delete(dbcommit=True, delindex=True)
 
 
-def test_recall_notification(client, patron_martigny_no_email, lib_martigny,
-                             json_header, patron2_martigny_no_email,
-                             item_lib_martigny, librarian_martigny_no_email,
+def test_recall_notification(client, patron_martigny, lib_martigny,
+                             json_header, patron2_martigny,
+                             item_lib_martigny, librarian_martigny,
                              circulation_policies, loc_public_martigny,
                              mailbox):
     """Test recall notification."""
     # process all notifications still in the queue
     Notification.process_notifications()
     mailbox.clear()
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -338,9 +338,9 @@ def test_recall_notification(client, patron_martigny_no_email, lib_martigny,
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -371,7 +371,7 @@ def test_recall_notification(client, patron_martigny_no_email, lib_martigny,
         dict(
             item_pid=item_lib_martigny.pid,
             pid=request_loan_pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -384,9 +384,9 @@ def test_recall_notification(client, patron_martigny_no_email, lib_martigny,
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -407,24 +407,24 @@ def test_recall_notification(client, patron_martigny_no_email, lib_martigny,
 
 
 def test_recall_notification_without_email(
-                              client, patron_sion_without_email, lib_martigny,
-                              json_header, patron2_martigny_no_email,
-                              item3_lib_martigny, librarian_martigny_no_email,
-                              circulation_policies, loc_public_martigny,
-                              mailbox):
+        client, patron_sion_without_email1, lib_martigny,
+        json_header, patron2_martigny,
+        item3_lib_martigny, librarian_martigny,
+        circulation_policies, loc_public_martigny,
+        mailbox):
     """Test recall notification."""
     # process all notifications still in the queue
     Notification.process_notifications()
     mailbox.clear()
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, data = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item3_lib_martigny.pid,
-            patron_pid=patron_sion_without_email.pid,
+            patron_pid=patron_sion_without_email1.pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid,
+            transaction_user_pid=librarian_martigny.pid,
         )
     )
     assert res.status_code == 200
@@ -439,9 +439,9 @@ def test_recall_notification_without_email(
         dict(
             item_pid=item3_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -468,14 +468,14 @@ def test_recall_notification_without_email(
 
 def test_availability_notification(
         loan_validated_martigny, item2_lib_martigny,
-        patron_martigny_no_email):
+        patron_martigny):
     """Test availability notification created from a loan."""
     loan = loan_validated_martigny
     assert loan.is_notified(notification_type='availability')
     notification = get_availability_notification(loan_validated_martigny)
     assert notification.loan_pid == loan_validated_martigny.get('pid')
     assert notification.item_pid == item2_lib_martigny.pid
-    assert notification.patron_pid == patron_martigny_no_email.pid
+    assert notification.patron_pid == patron_martigny.pid
 
     assert not loan_validated_martigny.is_notified(notification_type='recall')
     assert not get_recall_notification(loan_validated_martigny)

--- a/tests/api/operation_logs/test_operation_logs_permissions.py
+++ b/tests/api/operation_logs/test_operation_logs_permissions.py
@@ -28,11 +28,11 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 
 def test_operation_logs_permissions_api(
-        client, document, patron_sion_no_email,
-        librarian_martigny_no_email):
+        client, document, patron_sion,
+        librarian_martigny):
     """Test operation log permissions api."""
     oplg = OperationLog.get_record_by_pid('1')
-        
+
     operation_log_permissions_url = url_for(
         'api_blueprint.permissions',
         route_name='operation_logs'
@@ -48,12 +48,12 @@ def test_operation_logs_permissions_api(
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_sion_no_email.user)
+    login_user_via_session(client, patron_sion.user)
     res = client.get(operation_log_permissions_url)
     assert res.status_code == 403
 
     # Logged as
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(operation_log_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -64,10 +64,10 @@ def test_operation_logs_permissions_api(
     assert not data['update']['can']
 
 
-def test_operation_logs_permissions(patron_martigny_no_email, org_martigny,
-                           librarian_martigny_no_email, org_sion,
-                           item_lib_martigny, 
-                           system_librarian_martigny_no_email):
+def test_operation_logs_permissions(patron_martigny, org_martigny,
+                           librarian_martigny, org_sion,
+                           item_lib_martigny,
+                           system_librarian_martigny):
     """Test operation log permissions class."""
 
     oplg = OperationLog.get_record_by_pid('1')
@@ -82,7 +82,7 @@ def test_operation_logs_permissions(patron_martigny_no_email, org_martigny,
     # As Patron
     with mock.patch(
         'rero_ils.modules.operation_logs.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not OperationLogPermission.list(None, oplg)
         assert not OperationLogPermission.read(None, oplg)
@@ -98,7 +98,7 @@ def test_operation_logs_permissions(patron_martigny_no_email, org_martigny,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.operation_logs.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ):
         assert OperationLogPermission.list(None, oplg)
         assert OperationLogPermission.read(None, oplg)
@@ -119,7 +119,7 @@ def test_operation_logs_permissions(patron_martigny_no_email, org_martigny,
     # # As System-librarian
     # with mock.patch(
     #     'rero_ils.modules.operation_logs.permissions.current_patron',
-    #     system_librarian_martigny_no_email
+    #     system_librarian_martigny
     # ):
     #     assert not OperationLogPermission.list(None, oplg)
     #     assert not OperationLogPermission.read(None, oplg)

--- a/tests/api/operation_logs/test_operation_logs_rest.py
+++ b/tests/api/operation_logs/test_operation_logs_rest.py
@@ -25,21 +25,21 @@ from rero_ils.modules.operation_logs.models import OperationLogOperation
 
 
 def test_operation_log_entries(
-    client, librarian_martigny_no_email, document):
+    client, librarian_martigny, document):
     """Test operation log entries after record update."""
     with mock.patch(
         'rero_ils.modules.operation_logs.listener.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ):
-        login_user_via_session(client, librarian_martigny_no_email.user)
+        login_user_via_session(client, librarian_martigny.user)
         print('_start_here')
         document.update(
             document, dbcommit=True, reindex=True)
     search = OperationLogsSearch()
-    results = search.filter('term', 
+    results = search.filter('term',
         operation=OperationLogOperation.UPDATE).filter(
         'term', record__pid=document.pid).filter(
-        'term', user_name=librarian_martigny_no_email.formatted_name
+        'term', user_name=librarian_martigny.formatted_name
     ).source().count()
 
     assert results == 1

--- a/tests/api/organisations/test_organisations_permissions.py
+++ b/tests/api/organisations/test_organisations_permissions.py
@@ -24,9 +24,9 @@ from utils import get_json
 from rero_ils.modules.organisations.permissions import OrganisationPermission
 
 
-def test_organisation_permissions_api(client, patron_martigny_no_email,
+def test_organisation_permissions_api(client, patron_martigny,
                                       org_martigny, org_sion,
-                                      system_librarian_martigny_no_email):
+                                      system_librarian_martigny):
     """Test organisations permissions api."""
     org_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -48,7 +48,7 @@ def test_organisation_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(org_permissions_url)
     assert res.status_code == 403
 
@@ -56,7 +56,7 @@ def test_organisation_permissions_api(client, patron_martigny_no_email,
     #   * sys_lib can 'list' organisations
     #   * sys_lib can never 'create' and 'delete' any organisation
     #   * sys_lib can 'read' and 'update' only their own organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(org_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -73,9 +73,9 @@ def test_organisation_permissions_api(client, patron_martigny_no_email,
     assert not data['update']['can']
 
 
-def test_organisation_permissions(patron_martigny_no_email,
-                                  librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email,
+def test_organisation_permissions(patron_martigny,
+                                  librarian_martigny,
+                                  system_librarian_martigny,
                                   org_martigny_data, org_martigny):
     """Test organisation permissions class."""
 
@@ -89,7 +89,7 @@ def test_organisation_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.organisations.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not OrganisationPermission.list(None, org_martigny_data)
         assert not OrganisationPermission.read(None, org_martigny_data)
@@ -100,7 +100,7 @@ def test_organisation_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.organisations.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.organisations.permissions.current_organisation',
         org_martigny
@@ -114,7 +114,7 @@ def test_organisation_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.organisations.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.organisations.permissions.current_organisation',
         org_martigny

--- a/tests/api/organisations/test_organisations_rest_api.py
+++ b/tests/api/organisations/test_organisations_rest_api.py
@@ -44,12 +44,12 @@ def test_get_record_by_online_harvested_source(org_martigny):
 
 
 def test_organisation_secure_api_update(client, json_header, org_martigny,
-                                        librarian_martigny_no_email,
-                                        system_librarian_martigny_no_email,
-                                        librarian_sion_no_email,
+                                        librarian_martigny,
+                                        system_librarian_martigny,
+                                        librarian_sion,
                                         org_martigny_data):
     """Test organisation secure api create."""
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.org_item',
                          pid_value=org_martigny.pid)
 
@@ -66,7 +66,7 @@ def test_organisation_secure_api_update(client, json_header, org_martigny,
     client.get(list_url)
     assert res.status_code == 200
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     data['name'] = 'New Name 2'
     res = client.put(
         record_url,
@@ -76,7 +76,7 @@ def test_organisation_secure_api_update(client, json_header, org_martigny,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -98,11 +98,11 @@ def test_location_can_delete(client, org_martigny, lib_martigny):
 
 
 def test_organisation_secure_api(client, json_header, org_martigny,
-                                 librarian_martigny_no_email,
-                                 librarian_sion_no_email):
+                                 librarian_martigny,
+                                 librarian_sion):
     """Test organisation secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.org_item',
                          pid_value=org_martigny.pid)
 
@@ -110,18 +110,18 @@ def test_organisation_secure_api(client, json_header, org_martigny,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.org_item',
                          pid_value=org_martigny.pid)
 
 
 def test_organisation_secure_api_create(client, json_header, org_martigny,
-                                        librarian_martigny_no_email,
-                                        librarian_sion_no_email,
+                                        librarian_martigny,
+                                        librarian_sion,
                                         org_martigny_data):
     """Test organisation secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.org_list'
 
     del org_martigny_data['pid']
@@ -133,7 +133,7 @@ def test_organisation_secure_api_create(client, json_header, org_martigny,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -144,11 +144,11 @@ def test_organisation_secure_api_create(client, json_header, org_martigny,
 
 
 def test_organisation_secure_api_delete(client, json_header, org_martigny,
-                                        librarian_martigny_no_email,
-                                        librarian_sion_no_email,
+                                        librarian_martigny,
+                                        librarian_sion,
                                         org_martigny_data):
     """Test organisation secure api delete."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.org_item',
                          pid_value=org_martigny.pid)
 
@@ -156,7 +156,7 @@ def test_organisation_secure_api_delete(client, json_header, org_martigny,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403

--- a/tests/api/patron_transaction_events/test_patron_transaction_events_permissions.py
+++ b/tests/api/patron_transaction_events/test_patron_transaction_events_permissions.py
@@ -25,9 +25,9 @@ from rero_ils.modules.patron_transaction_events.permissions import \
     PatronTransactionEventPermission
 
 
-def test_ptre_permissions_api(client, patron_martigny_no_email,
-                              system_librarian_martigny_no_email,
-                              librarian_martigny_no_email,
+def test_ptre_permissions_api(client, patron_martigny,
+                              system_librarian_martigny,
+                              librarian_martigny,
                               patron_transaction_overdue_event_martigny,
                               patron_transaction_overdue_event_saxon,
                               patron_transaction_overdue_event_sion):
@@ -57,7 +57,7 @@ def test_ptre_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(ptre_permissions_url)
     assert res.status_code == 403
 
@@ -66,7 +66,7 @@ def test_ptre_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', 'delete' only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' acq_account for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(ptre_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -97,7 +97,7 @@ def test_ptre_permissions_api(client, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about pttr of its own organisation
     #   * sys_lib can't do anything about pttr of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(ptre_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -116,9 +116,9 @@ def test_ptre_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_ptre_permissions(patron_martigny_no_email,
-                          librarian_martigny_no_email,
-                          system_librarian_martigny_no_email,
+def test_ptre_permissions(patron_martigny,
+                          librarian_martigny,
+                          system_librarian_martigny,
                           org_martigny, patron_transaction_overdue_event_saxon,
                           patron_transaction_overdue_event_sion,
                           patron_transaction_overdue_event_martigny):
@@ -137,10 +137,10 @@ def test_ptre_permissions(patron_martigny_no_email,
     ptre_si = patron_transaction_overdue_event_sion
     with mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_user',
-        patron_martigny_no_email.user
+        patron_martigny.user
     ):
         assert PatronTransactionEventPermission.list(None, ptre_m)
         assert PatronTransactionEventPermission.read(None, ptre_m)
@@ -151,10 +151,10 @@ def test_ptre_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_user',
-        librarian_martigny_no_email.user
+        librarian_martigny.user
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.'
         'current_organisation',
@@ -179,10 +179,10 @@ def test_ptre_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_user',
-        system_librarian_martigny_no_email.user
+        system_librarian_martigny.user
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.'
         'current_organisation',

--- a/tests/api/patron_transaction_events/test_patron_transaction_events_rest.py
+++ b/tests/api/patron_transaction_events/test_patron_transaction_events_rest.py
@@ -184,19 +184,19 @@ def test_patron_transaction_event_utils_shortcuts(
 
 
 def test_filtered_patron_transaction_events_get(
-        client, librarian_martigny_no_email,
+        client, librarian_martigny,
         patron_transaction_overdue_event_martigny,
-        librarian_sion_no_email, patron_martigny_no_email
+        librarian_sion, patron_martigny
 ):
     """Test patron transaction event filter by organisation."""
     list_url = url_for('invenio_records_rest.ptre_list')
 
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(list_url)
     assert res.status_code == 200
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     res = client.get(list_url)
     assert res.status_code == 200
@@ -204,7 +204,7 @@ def test_filtered_patron_transaction_events_get(
     assert data['hits']['total']['value'] == 1
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.ptre_list')
 
     res = client.get(list_url)
@@ -215,9 +215,9 @@ def test_filtered_patron_transaction_events_get(
 
 def test_patron_transaction_event_secure_api(
         client, json_header, patron_transaction_overdue_event_martigny,
-        librarian_martigny_no_email, librarian_sion_no_email,
-        system_librarian_martigny_no_email, system_librarian_sion_no_email,
-        patron_transaction_overdue_event_saxon, patron_martigny_no_email):
+        librarian_martigny, librarian_sion,
+        system_librarian_martigny, system_librarian_sion,
+        patron_transaction_overdue_event_saxon, patron_martigny):
     """Test patron transaction event secure api access."""
     # test if a 'creation_date' attribute is created if not present into data
     trans_data = deepcopy(patron_transaction_overdue_event_martigny)
@@ -229,13 +229,13 @@ def test_patron_transaction_event_secure_api(
         'invenio_records_rest.ptre_item',
         pid_value=patron_transaction_overdue_event_martigny.pid)
 
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(record_url)
     # a patron is authorized to access his events
     assert res.status_code == 200
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     res = client.get(record_url)
     # a librarian is authorized to access any patron event of its library
@@ -248,13 +248,13 @@ def test_patron_transaction_event_secure_api(
     # a librarian can access any patron event of its organisation
     assert res.status_code == 200
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(record_url)
     # a sys_librarian can access any patron event of its organisation
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for(
         'invenio_records_rest.ptre_item',
         pid_value=patron_transaction_overdue_event_martigny.pid)
@@ -263,20 +263,20 @@ def test_patron_transaction_event_secure_api(
     # librarian can not access any patron event of other organisation
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.get(record_url)
     # a sys_librarian can not access any patron event of other org
     assert res.status_code == 403
 
 
 def test_patron_transaction_event_secure_api_create(
-        client, librarian_martigny_no_email,
-        librarian_sion_no_email, patron_transaction_overdue_event_martigny,
-        system_librarian_martigny_no_email,
-        system_librarian_sion_no_email):
+        client, librarian_martigny,
+        librarian_sion, patron_transaction_overdue_event_martigny,
+        system_librarian_martigny,
+        system_librarian_sion):
     """Test patron transction event secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.ptre_list'
     patron_event = deepcopy(patron_transaction_overdue_event_martigny)
     del patron_event['pid']
@@ -299,7 +299,7 @@ def test_patron_transaction_event_secure_api_create(
     # librarian is can create a patron event in other libraries.
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -309,7 +309,7 @@ def test_patron_transaction_event_secure_api_create(
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     patron_event_3 = deepcopy(patron_transaction_overdue_event_martigny)
     del patron_event_3['pid']
@@ -322,7 +322,7 @@ def test_patron_transaction_event_secure_api_create(
     # librarian is not authorized to create a patron event at other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -334,12 +334,12 @@ def test_patron_transaction_event_secure_api_create(
 
 def test_patron_transaction_event_secure_api_update(
         client, patron_transaction_overdue_event_saxon,
-        patron_transaction_overdue_event_martigny, librarian_martigny_no_email,
-        librarian_sion_no_email, json_header,
-        system_librarian_martigny_no_email, system_librarian_sion_no_email):
+        patron_transaction_overdue_event_martigny, librarian_martigny,
+        librarian_sion, json_header,
+        system_librarian_martigny, system_librarian_sion):
     """Test patron transaction event secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for(
         'invenio_records_rest.ptre_item',
         pid_value=patron_transaction_overdue_event_martigny.pid)
@@ -365,7 +365,7 @@ def test_patron_transaction_event_secure_api_update(
     # librarian is can update a patron event of another library.
     assert res.status_code == 200
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.put(
         record_url,
         data=json.dumps(patron_transaction_overdue_event_saxon),
@@ -375,7 +375,7 @@ def test_patron_transaction_event_secure_api_update(
     assert res.status_code == 200
 
 #     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -385,7 +385,7 @@ def test_patron_transaction_event_secure_api_update(
     # librarian can not update any patron event of another org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.put(
         record_url,
         data=json.dumps(patron_transaction_overdue_event_saxon),
@@ -396,12 +396,12 @@ def test_patron_transaction_event_secure_api_update(
 
 def test_patron_transaction_event_secure_api_delete(
         client, patron_transaction_overdue_event_saxon,
-        patron_transaction_overdue_event_martigny, librarian_martigny_no_email,
-        librarian_sion_no_email, system_librarian_martigny_no_email,
-        system_librarian_sion_no_email):
+        patron_transaction_overdue_event_martigny, librarian_martigny,
+        librarian_sion, system_librarian_martigny,
+        system_librarian_sion):
     """Test patron transaction event secure api delete."""
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     record_url = url_for(
         'invenio_records_rest.ptre_item',
@@ -410,12 +410,12 @@ def test_patron_transaction_event_secure_api_delete(
     # librarian can not delete any patron event of other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.delete(record_url)
     # sys_ibrarian can not delete any patron event of other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.ptre_item',
                          pid_value=patron_transaction_overdue_event_saxon.pid)
 

--- a/tests/api/patron_transactions/test_patron_transactions_permissions.py
+++ b/tests/api/patron_transactions/test_patron_transactions_permissions.py
@@ -25,9 +25,9 @@ from rero_ils.modules.patron_transactions.permissions import \
     PatronTransactionPermission
 
 
-def test_pttr_permissions_api(client, patron_martigny_no_email,
-                              system_librarian_martigny_no_email,
-                              librarian_martigny_no_email,
+def test_pttr_permissions_api(client, patron_martigny,
+                              system_librarian_martigny,
+                              librarian_martigny,
                               patron_transaction_overdue_martigny,
                               patron_transaction_overdue_saxon,
                               patron_transaction_overdue_sion):
@@ -57,7 +57,7 @@ def test_pttr_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(pttr_permissions_url)
     assert res.status_code == 403
 
@@ -66,7 +66,7 @@ def test_pttr_permissions_api(client, patron_martigny_no_email,
     #   * lib can 'create', 'update', 'delete' only for its library
     #   * lib can't 'read' acq_account of others organisation.
     #   * lib can't 'create', 'update', 'delete' acq_account for other org/lib
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(pttr_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -97,7 +97,7 @@ def test_pttr_permissions_api(client, patron_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do everything about pttr of its own organisation
     #   * sys_lib can't do anything about pttr of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(pttr_saxon_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -116,9 +116,9 @@ def test_pttr_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_pttr_permissions(patron_martigny_no_email,
-                          librarian_martigny_no_email,
-                          system_librarian_martigny_no_email,
+def test_pttr_permissions(patron_martigny,
+                          librarian_martigny,
+                          system_librarian_martigny,
                           org_martigny, patron_transaction_overdue_saxon,
                           patron_transaction_overdue_sion,
                           patron_transaction_overdue_martigny):
@@ -137,10 +137,10 @@ def test_pttr_permissions(patron_martigny_no_email,
     pttr_si = patron_transaction_overdue_sion
     with mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_user',
-        patron_martigny_no_email.user
+        patron_martigny.user
     ):
         assert PatronTransactionPermission.list(None, pttr_m)
         assert PatronTransactionPermission.read(None, pttr_m)
@@ -151,10 +151,10 @@ def test_pttr_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_user',
-        librarian_martigny_no_email.user
+        librarian_martigny.user
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.'
         'current_organisation',
@@ -179,10 +179,10 @@ def test_pttr_permissions(patron_martigny_no_email,
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.current_user',
-        system_librarian_martigny_no_email.user
+        system_librarian_martigny.user
     ), mock.patch(
         'rero_ils.modules.patron_transactions.permissions.'
         'current_organisation',

--- a/tests/api/patron_transactions/test_patron_transactions_rest.py
+++ b/tests/api/patron_transactions/test_patron_transactions_rest.py
@@ -192,9 +192,9 @@ def test_patron_transaction_shortcuts_utils(
 
 
 def test_filtered_patron_transactions_get(
-        client, librarian_martigny_no_email,
+        client, librarian_martigny,
         patron_transaction_overdue_martigny,
-        librarian_sion_no_email, patron_martigny_no_email
+        librarian_sion, patron_martigny
 ):
     """Test patron transaction filter by organisation."""
     list_url = url_for('invenio_records_rest.pttr_list')
@@ -202,7 +202,7 @@ def test_filtered_patron_transactions_get(
     res = client.get(list_url)
     assert res.status_code == 401
 
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
 
     res = client.get(list_url)
     assert res.status_code == 200
@@ -210,7 +210,7 @@ def test_filtered_patron_transactions_get(
     assert data['hits']['total']['value'] == 1
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     res = client.get(list_url)
     assert res.status_code == 200
@@ -218,7 +218,7 @@ def test_filtered_patron_transactions_get(
     assert data['hits']['total']['value'] == 1
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.pttr_list')
 
     res = client.get(list_url)
@@ -229,11 +229,11 @@ def test_filtered_patron_transactions_get(
 
 def test_patron_transaction_secure_api(
         client, json_header, patron_transaction_overdue_martigny,
-        librarian_martigny_no_email, librarian_sion_no_email,
-        system_librarian_martigny_no_email, system_librarian_sion_no_email,
-        patron_transaction_overdue_saxon, patron_martigny_no_email):
+        librarian_martigny, librarian_sion,
+        system_librarian_martigny, system_librarian_sion,
+        patron_transaction_overdue_saxon, patron_martigny):
     """Test patron transaction secure api access."""
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     record_url = url_for('invenio_records_rest.pttr_item',
                          pid_value=patron_transaction_overdue_martigny.pid)
 
@@ -242,7 +242,7 @@ def test_patron_transaction_secure_api(
     assert res.status_code == 200
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.pttr_item',
                          pid_value=patron_transaction_overdue_martigny.pid)
 
@@ -257,13 +257,13 @@ def test_patron_transaction_secure_api(
     # a librarian can access any patron transaction of its organisation
     assert res.status_code == 200
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(record_url)
     # a sys_librarian can access any patron transaction of its organisation
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.pttr_item',
                          pid_value=patron_transaction_overdue_martigny.pid)
 
@@ -271,20 +271,20 @@ def test_patron_transaction_secure_api(
     # librarian can not access any patron transaction of other organisation
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.get(record_url)
     # a sys_librarian can not access any patron transaction of other org
     assert res.status_code == 403
 
 
 def test_patron_transaction_secure_api_create(
-        client, librarian_martigny_no_email,
-        librarian_sion_no_email, patron_transaction_overdue_martigny,
-        system_librarian_martigny_no_email,
-        system_librarian_sion_no_email):
+        client, librarian_martigny,
+        librarian_sion, patron_transaction_overdue_martigny,
+        system_librarian_martigny,
+        system_librarian_sion):
     """Test patron transction secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.pttr_list'
     patron_transaction = deepcopy(patron_transaction_overdue_martigny)
     del patron_transaction['pid']
@@ -307,7 +307,7 @@ def test_patron_transaction_secure_api_create(
     # librarian is can create a patron transaction in other libraries.
     assert res.status_code == 201
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -317,7 +317,7 @@ def test_patron_transaction_secure_api_create(
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     patron_transaction_3 = deepcopy(patron_transaction_overdue_martigny)
     del patron_transaction_3['pid']
@@ -330,7 +330,7 @@ def test_patron_transaction_secure_api_create(
     # librarian is not authorized to create a patron transaction at other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res, _ = postdata(
         client,
         post_entrypoint,
@@ -342,12 +342,12 @@ def test_patron_transaction_secure_api_create(
 
 def test_patron_transaction_secure_api_update(
         client, patron_transaction_overdue_saxon,
-        patron_transaction_overdue_martigny, librarian_martigny_no_email,
-        librarian_sion_no_email, json_header,
-        system_librarian_martigny_no_email, system_librarian_sion_no_email):
+        patron_transaction_overdue_martigny, librarian_martigny,
+        librarian_sion, json_header,
+        system_librarian_martigny, system_librarian_sion):
     """Test patron transaction secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.pttr_item',
                          pid_value=patron_transaction_overdue_martigny.pid)
 
@@ -372,7 +372,7 @@ def test_patron_transaction_secure_api_update(
     # librarian is can update a patron transaction of another library.
     assert res.status_code == 200
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.put(
         record_url,
         data=json.dumps(patron_transaction_overdue_saxon),
@@ -382,7 +382,7 @@ def test_patron_transaction_secure_api_update(
     assert res.status_code == 200
 
 #     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -392,7 +392,7 @@ def test_patron_transaction_secure_api_update(
     # librarian can not update any patron transaction of another org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.put(
         record_url,
         data=json.dumps(patron_transaction_overdue_saxon),
@@ -403,12 +403,12 @@ def test_patron_transaction_secure_api_update(
 
 def test_patron_transaction_secure_api_delete(
         client, patron_transaction_overdue_saxon,
-        patron_transaction_overdue_martigny, librarian_martigny_no_email,
-        librarian_sion_no_email, system_librarian_martigny_no_email,
-        system_librarian_sion_no_email):
+        patron_transaction_overdue_martigny, librarian_martigny,
+        librarian_sion, system_librarian_martigny,
+        system_librarian_sion):
     """Test patron transaction secure api delete."""
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
 
     record_url = url_for('invenio_records_rest.pttr_item',
                          pid_value=patron_transaction_overdue_martigny.pid)
@@ -416,12 +416,12 @@ def test_patron_transaction_secure_api_delete(
     # librarian can not delete any patron transaction of other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.delete(record_url)
     # sys_ibrarian can not delete any patron transaction of other org.
     assert res.status_code == 403
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.pttr_item',
                          pid_value=patron_transaction_overdue_saxon.pid)
 
@@ -446,7 +446,7 @@ def test_patron_transaction_secure_api_delete(
 
 
 def test_patron_subscription_transaction(
-        patron_type_youngsters_sion, patron_sion_no_email):
+        patron_type_youngsters_sion, patron_sion):
     """Test the creation of a subscription transaction for a patron."""
     subscription_start_date = datetime.now()
     subscription_end_date = add_years(subscription_start_date, 1)
@@ -455,7 +455,7 @@ def test_patron_subscription_transaction(
     assert subscription_end_date.day == subscription_start_date.day
 
     subscription = PatronTransaction.create_subscription_for_patron(
-        patron_sion_no_email,
+        patron_sion,
         patron_type_youngsters_sion,
         subscription_start_date,
         subscription_end_date,
@@ -470,14 +470,14 @@ def test_patron_subscription_transaction(
     assert event.get('amount') == subscription.get('total_amount')
 
 
-def test_get_transactions_pids_for_patron(patron_sion_no_email):
+def test_get_transactions_pids_for_patron(patron_sion):
     """Test function get_transactions_pids_for_patron."""
     assert PatronTransaction.get_transactions_count_for_patron(
-        patron_sion_no_email.pid
+        patron_sion.pid
     ) == 2
     assert len(list(PatronTransaction.get_transactions_pids_for_patron(
-        patron_sion_no_email.pid, status='open'
+        patron_sion.pid, status='open'
     ))) == 2
     assert len(list(PatronTransaction.get_transactions_pids_for_patron(
-        patron_sion_no_email.pid, status='closed'
+        patron_sion.pid, status='closed'
     ))) == 0

--- a/tests/api/patron_types/test_patron_types_permissions.py
+++ b/tests/api/patron_types/test_patron_types_permissions.py
@@ -24,8 +24,8 @@ from utils import get_json
 from rero_ils.modules.patron_types.permissions import PatronTypePermission
 
 
-def test_patron_types_permissions_api(client, librarian_martigny_no_email,
-                                      system_librarian_martigny_no_email,
+def test_patron_types_permissions_api(client, librarian_martigny,
+                                      system_librarian_martigny,
                                       patron_type_adults_martigny,
                                       patron_type_youngsters_sion):
     """Test patron types permissions api."""
@@ -52,7 +52,7 @@ def test_patron_types_permissions_api(client, librarian_martigny_no_email,
     #   * lib can 'list' patron_type
     #   * lib can 'read' patron_type from its own organisation
     #   * lib can't never 'create', 'delete', 'update' patron_type
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(ptty_adult_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -68,7 +68,7 @@ def test_patron_types_permissions_api(client, librarian_martigny_no_email,
     # Logged as system librarian
     #   * sys_lib can do anything about patron_type for its own organisation
     #   * sys_lib can't do anything about patron_type for other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(ptty_adult_martigny_permissions_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -84,9 +84,9 @@ def test_patron_types_permissions_api(client, librarian_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_patron_types_permissions(patron_martigny_no_email,
-                                  librarian_martigny_no_email,
-                                  system_librarian_martigny_no_email,
+def test_patron_types_permissions(patron_martigny,
+                                  librarian_martigny,
+                                  system_librarian_martigny,
                                   patron_type_adults_martigny, org_martigny):
     """Test patron types permissions class."""
 
@@ -101,7 +101,7 @@ def test_patron_types_permissions(patron_martigny_no_email,
     ptty = patron_type_adults_martigny
     with mock.patch(
         'rero_ils.modules.patron_types.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ), mock.patch(
         'rero_ils.modules.patron_types.permissions.current_organisation',
         org_martigny
@@ -115,7 +115,7 @@ def test_patron_types_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.patron_types.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patron_types.permissions.current_organisation',
         org_martigny
@@ -129,7 +129,7 @@ def test_patron_types_permissions(patron_martigny_no_email,
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.patron_types.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patron_types.permissions.current_organisation',
         org_martigny

--- a/tests/api/patron_types/test_patron_types_rest.py
+++ b/tests/api/patron_types/test_patron_types_rest.py
@@ -184,7 +184,7 @@ def test_patron_types_name_validate(client, patron_type_children_martigny):
 
 
 def test_patron_types_can_delete(client, patron_type_children_martigny,
-                                 patron_martigny_no_email,
+                                 patron_martigny,
                                  circulation_policies):
     """Test can delete a patron type."""
     patron_type = patron_type_children_martigny
@@ -199,12 +199,12 @@ def test_patron_types_can_delete(client, patron_type_children_martigny,
 
 
 def test_filtered_patron_types_get(
-        client, librarian_martigny_no_email, patron_type_children_martigny,
-        patron_type_adults_martigny, librarian_sion_no_email,
+        client, librarian_martigny, patron_type_children_martigny,
+        patron_type_adults_martigny, librarian_sion,
         patron_type_youngsters_sion, patron_type_grown_sion):
     """Test patron types filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.ptty_list')
 
     res = client.get(list_url)
@@ -213,7 +213,7 @@ def test_filtered_patron_types_get(
     assert data['hits']['total']['value'] == 2
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.ptty_list')
 
     res = client.get(list_url)
@@ -224,11 +224,11 @@ def test_filtered_patron_types_get(
 
 def test_patron_type_secure_api(client, json_header,
                                 patron_type_children_martigny,
-                                librarian_martigny_no_email,
-                                librarian_sion_no_email):
+                                librarian_martigny,
+                                librarian_sion):
     """Test patron type secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.ptty_item',
                          pid_value=patron_type_children_martigny.pid)
 
@@ -236,7 +236,7 @@ def test_patron_type_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.ptty_item',
                          pid_value=patron_type_children_martigny.pid)
 
@@ -246,12 +246,12 @@ def test_patron_type_secure_api(client, json_header,
 
 def test_patron_type_secure_api_create(client, json_header,
                                        patron_type_children_martigny,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email,
+                                       system_librarian_martigny,
+                                       system_librarian_sion,
                                        patron_type_children_martigny_data):
     """Test patron type secure api create."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.ptty_list'
 
     del patron_type_children_martigny_data['pid']
@@ -263,7 +263,7 @@ def test_patron_type_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -275,11 +275,11 @@ def test_patron_type_secure_api_create(client, json_header,
 
 def test_patron_type_secure_api_update(client, json_header,
                                        patron_type_adults_martigny,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email,
+                                       system_librarian_martigny,
+                                       system_librarian_sion,
                                        patron_type_adults_martigny_data):
     """Test patron type secure api create."""
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.ptty_item',
                          pid_value=patron_type_adults_martigny.pid)
 
@@ -293,7 +293,7 @@ def test_patron_type_secure_api_update(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res = client.put(
         record_url,
@@ -305,11 +305,11 @@ def test_patron_type_secure_api_update(client, json_header,
 
 def test_patron_type_secure_api_delete(client, json_header,
                                        patron_type_adults_martigny,
-                                       system_librarian_martigny_no_email,
-                                       system_librarian_sion_no_email,
+                                       system_librarian_martigny,
+                                       system_librarian_sion,
                                        patron_type_adults_martigny_data):
     """Test patron type secure api delete."""
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.ptty_item',
                          pid_value=patron_type_adults_martigny.pid)
 
@@ -318,7 +318,7 @@ def test_patron_type_secure_api_delete(client, json_header,
         assert res.status_code == 204
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403
@@ -326,7 +326,7 @@ def test_patron_type_secure_api_delete(client, json_header,
 
 def test_patron_types_subscription(
         patron_type_youngsters_sion, patron_type_adults_martigny,
-        patron_type_grown_sion, patron_sion_no_email):
+        patron_type_grown_sion, patron_sion):
     """Test subscription behavior for patron_types."""
     assert patron_type_youngsters_sion.is_subscription_required
 
@@ -344,13 +344,13 @@ def test_patron_types_subscription(
     # Test 'get_linked_patrons' functions.
     assert len(list(patron_type_grown_sion.get_linked_patron())) == 1
     assert len(list(patron_type_youngsters_sion.get_linked_patron())) == 0
-    patron_sion_no_email['patron']['type']['$ref'] = get_ref_for_pid(
+    patron_sion['patron']['type']['$ref'] = get_ref_for_pid(
         'ptty', patron_type_youngsters_sion.pid)
-    patron_sion_no_email.update(patron_sion_no_email, dbcommit=True)
-    patron_sion_no_email.reindex()
+    patron_sion.update(patron_sion, dbcommit=True)
+    patron_sion.reindex()
     assert len(list(patron_type_grown_sion.get_linked_patron())) == 0
     assert len(list(patron_type_youngsters_sion.get_linked_patron())) == 1
-    patron_sion_no_email['patron']['type']['$ref'] = get_ref_for_pid(
+    patron_sion['patron']['type']['$ref'] = get_ref_for_pid(
         'ptty', patron_type_grown_sion.pid)
-    patron_sion_no_email.update(patron_sion_no_email, dbcommit=True)
-    patron_sion_no_email.reindex()
+    patron_sion.update(patron_sion, dbcommit=True)
+    patron_sion.reindex()

--- a/tests/api/patrons/test_patrons_blocked.py
+++ b/tests/api/patrons/test_patrons_blocked.py
@@ -27,17 +27,17 @@ from rero_ils.modules.loans.utils import can_be_requested
 
 def test_blocked_field_exists(
         client,
-        librarian_martigny_no_email,
-        patron_martigny_no_email,
-        patron3_martigny_blocked_no_email):
+        librarian_martigny,
+        patron_martigny,
+        patron3_martigny_blocked):
     """Test ptrn6 have blocked field present and set to False."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    patron3 = patron3_martigny_blocked_no_email
+    login_user_via_session(client, librarian_martigny.user)
+    patron3 = patron3_martigny_blocked
 
     # non blocked patron
     non_blocked_patron_url = url_for(
         'invenio_records_rest.ptrn_item',
-        pid_value=patron_martigny_no_email.pid)
+        pid_value=patron_martigny.pid)
     res = client.get(non_blocked_patron_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -47,7 +47,7 @@ def test_blocked_field_exists(
     # blocked patron
     blocked_patron_url = url_for(
         'invenio_records_rest.ptrn_item',
-        pid_value=patron3_martigny_blocked_no_email.pid)
+        pid_value=patron3_martigny_blocked.pid)
     res = client.get(blocked_patron_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -61,13 +61,13 @@ def test_blocked_field_exists(
 
 def test_blocked_field_not_present(
         client,
-        librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        librarian_martigny,
+        patron2_martigny):
     """Test ptrn7 do not have any blocked field."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item_url = url_for(
         'invenio_records_rest.ptrn_item',
-        pid_value=patron2_martigny_no_email.pid)
+        pid_value=patron2_martigny.pid)
     res = client.get(item_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -75,19 +75,19 @@ def test_blocked_field_not_present(
 
 
 def test_blocked_patron_cannot_request(client,
-                                       librarian_martigny_no_email,
+                                       librarian_martigny,
                                        item_lib_martigny,
                                        lib_martigny,
-                                       patron_martigny_no_email,
-                                       patron3_martigny_blocked_no_email,
+                                       patron_martigny,
+                                       patron3_martigny_blocked,
                                        circulation_policies):
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(
         url_for(
             'api_item.can_request',
             item_pid=item_lib_martigny.pid,
             library_pid=lib_martigny.pid,
-            patron_barcode=patron3_martigny_blocked_no_email.get(
+            patron_barcode=patron3_martigny_blocked.get(
                 'patron', {}).get('barcode')
         )
     )
@@ -101,7 +101,7 @@ def test_blocked_patron_cannot_request(client,
             'api_item.can_request',
             item_pid=item_lib_martigny.pid,
             library_pid=lib_martigny.pid,
-            patron_barcode=patron_martigny_no_email.get(
+            patron_barcode=patron_martigny.get(
                 'patron', {}).get('barcode')
         )
     )
@@ -113,6 +113,6 @@ def test_blocked_patron_cannot_request(client,
     loan = Loan({
         'item_pid': item_pid_to_object(item_lib_martigny.pid),
         'library_pid': lib_martigny.pid,
-        'patron_pid': patron3_martigny_blocked_no_email.pid
+        'patron_pid': patron3_martigny_blocked.pid
     })
     assert not can_be_requested(loan)

--- a/tests/api/patrons/test_patrons_permissions.py
+++ b/tests/api/patrons/test_patrons_permissions.py
@@ -21,11 +21,11 @@ import mock
 from rero_ils.modules.patrons.permissions import PatronPermission
 
 
-def test_patrons_permissions(patron_martigny_no_email,
-                             librarian_martigny_no_email,
-                             system_librarian_martigny_no_email,
-                             org_martigny, librarian_saxon_no_email,
-                             patron_sion_no_email):
+def test_patrons_permissions(patron_martigny,
+                             librarian_martigny,
+                             system_librarian_martigny,
+                             org_martigny, librarian_saxon,
+                             patron_sion):
     """Test patrons permissions class."""
 
     # Anonymous user
@@ -36,64 +36,64 @@ def test_patrons_permissions(patron_martigny_no_email,
     assert not PatronPermission.delete(None, {})
 
     # As Patron
-    sys_lib = system_librarian_martigny_no_email
+    sys_lib = system_librarian_martigny
     with mock.patch(
         'rero_ils.modules.patrons.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
-        assert not PatronPermission.list(None, patron_martigny_no_email)
-        assert not PatronPermission.read(None, patron_martigny_no_email)
-        assert not PatronPermission.create(None, patron_martigny_no_email)
-        assert not PatronPermission.update(None, patron_martigny_no_email)
-        assert not PatronPermission.delete(None, patron_martigny_no_email)
+        assert not PatronPermission.list(None, patron_martigny)
+        assert not PatronPermission.read(None, patron_martigny)
+        assert not PatronPermission.create(None, patron_martigny)
+        assert not PatronPermission.update(None, patron_martigny)
+        assert not PatronPermission.delete(None, patron_martigny)
 
     # As Librarian
     with mock.patch(
         'rero_ils.modules.patrons.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patrons.permissions.current_organisation',
         org_martigny
     ):
-        assert PatronPermission.list(None, patron_martigny_no_email)
-        assert PatronPermission.read(None, patron_martigny_no_email)
-        assert PatronPermission.create(None, patron_martigny_no_email)
-        assert PatronPermission.update(None, patron_martigny_no_email)
-        assert PatronPermission.delete(None, patron_martigny_no_email)
+        assert PatronPermission.list(None, patron_martigny)
+        assert PatronPermission.read(None, patron_martigny)
+        assert PatronPermission.create(None, patron_martigny)
+        assert PatronPermission.update(None, patron_martigny)
+        assert PatronPermission.delete(None, patron_martigny)
 
-        assert PatronPermission.read(None, librarian_saxon_no_email)
-        assert not PatronPermission.create(None, librarian_saxon_no_email)
-        assert not PatronPermission.update(None, librarian_saxon_no_email)
-        assert not PatronPermission.delete(None, librarian_saxon_no_email)
+        assert PatronPermission.read(None, librarian_saxon)
+        assert not PatronPermission.create(None, librarian_saxon)
+        assert not PatronPermission.update(None, librarian_saxon)
+        assert not PatronPermission.delete(None, librarian_saxon)
 
-        assert not PatronPermission.read(None, patron_sion_no_email)
-        assert not PatronPermission.create(None, patron_sion_no_email)
-        assert not PatronPermission.update(None, patron_sion_no_email)
-        assert not PatronPermission.delete(None, patron_sion_no_email)
+        assert not PatronPermission.read(None, patron_sion)
+        assert not PatronPermission.create(None, patron_sion)
+        assert not PatronPermission.update(None, patron_sion)
+        assert not PatronPermission.delete(None, patron_sion)
 
         assert not PatronPermission.create(None, sys_lib)
         assert not PatronPermission.update(None, sys_lib)
         assert not PatronPermission.delete(None, sys_lib)
 
-        assert not PatronPermission.delete(None, librarian_martigny_no_email)
+        assert not PatronPermission.delete(None, librarian_martigny)
 
     # As System-librarian
     with mock.patch(
         'rero_ils.modules.patrons.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.patrons.permissions.current_organisation',
         org_martigny
     ):
-        assert PatronPermission.list(None, librarian_saxon_no_email)
-        assert PatronPermission.read(None, librarian_saxon_no_email)
-        assert PatronPermission.create(None, librarian_saxon_no_email)
-        assert PatronPermission.update(None, librarian_saxon_no_email)
-        assert PatronPermission.delete(None, librarian_saxon_no_email)
+        assert PatronPermission.list(None, librarian_saxon)
+        assert PatronPermission.read(None, librarian_saxon)
+        assert PatronPermission.create(None, librarian_saxon)
+        assert PatronPermission.update(None, librarian_saxon)
+        assert PatronPermission.delete(None, librarian_saxon)
 
-        assert not PatronPermission.read(None, patron_sion_no_email)
-        assert not PatronPermission.create(None, patron_sion_no_email)
-        assert not PatronPermission.update(None, patron_sion_no_email)
-        assert not PatronPermission.delete(None, patron_sion_no_email)
+        assert not PatronPermission.read(None, patron_sion)
+        assert not PatronPermission.create(None, patron_sion)
+        assert not PatronPermission.update(None, patron_sion)
+        assert not PatronPermission.delete(None, patron_sion)
 
         assert not PatronPermission.delete(None, sys_lib)

--- a/tests/api/patrons/test_patrons_views.py
+++ b/tests/api/patrons/test_patrons_views.py
@@ -26,17 +26,17 @@ from rero_ils.modules.items.models import ItemStatus
 from rero_ils.modules.loans.api import LoanAction
 
 
-def test_patron_can_delete(client, librarian_martigny_no_email,
-                           patron_martigny_no_email, loc_public_martigny,
+def test_patron_can_delete(client, librarian_martigny,
+                           patron_martigny, loc_public_martigny,
                            item_lib_martigny, json_header, lib_martigny,
                            circulation_policies):
     """Test patron can delete."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
-    patron = patron_martigny_no_email
+    patron = patron_martigny
     location = loc_public_martigny
 
-    data = deepcopy(patron_martigny_no_email)
+    data = deepcopy(patron_martigny)
     del data['patron']['type']
     assert not data.get_organisation()
 
@@ -49,18 +49,18 @@ def test_patron_can_delete(client, librarian_martigny_no_email,
             pickup_location_pid=location.pid,
             patron_pid=patron.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
     loan_pid = data.get('action_applied')[LoanAction.REQUEST].get('pid')
 
-    links = patron_martigny_no_email.get_links_to_me()
+    links = patron_martigny.get_links_to_me()
     assert 'loans' in links
 
-    assert not patron_martigny_no_email.can_delete
+    assert not patron_martigny.can_delete
 
-    reasons = patron_martigny_no_email.reasons_not_to_delete()
+    reasons = patron_martigny.reasons_not_to_delete()
     assert 'links' in reasons
 
     res, data = postdata(
@@ -69,21 +69,21 @@ def test_patron_can_delete(client, librarian_martigny_no_email,
         dict(
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
     assert item.status == ItemStatus.ON_SHELF
 
 
-def test_patron_utils(client, librarian_martigny_no_email,
-                      patron_martigny_no_email, loc_public_martigny,
+def test_patron_utils(client, librarian_martigny,
+                      patron_martigny, loc_public_martigny,
                       item_lib_martigny, json_header,
-                      circulation_policies, librarian_martigny):
+                      circulation_policies):
     """Test patron utils."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
-    patron = patron_martigny_no_email
+    patron = patron_martigny
     location = loc_public_martigny
 
     from rero_ils.modules.patrons.views import get_location_name_from_pid

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -46,7 +46,7 @@ def test_invenio_sip2():
     assert check_sip2_module()
 
 
-def test_selfcheck_login(sip2_librarian_martigny_no_email):
+def test_selfcheck_login(sip2_librarian_martigny):
     """Test selfcheck client login."""
 
     # test failed login
@@ -56,17 +56,17 @@ def test_selfcheck_login(sip2_librarian_martigny_no_email):
 
     # test success login
     response = selfcheck_login(
-        sip2_librarian_martigny_no_email.get('email'),
-        sip2_librarian_martigny_no_email.get('birth_date'))
+        sip2_librarian_martigny.get('email'),
+        sip2_librarian_martigny.get('birth_date'))
     assert response
     assert response.get('authenticated')
 
 
-def test_authorize_patron(sip2_patron_martigny_no_email):
+def test_authorize_patron(sip2_patron_martigny):
     """Test authorize patron."""
 
     # try to authorize with wrong password
-    response = authorize_patron(sip2_patron_martigny_no_email.get(
+    response = authorize_patron(sip2_patron_martigny.get(
         'patron', {}).get('barcode'), 'invalid_password')
     assert not response
 
@@ -76,52 +76,52 @@ def test_authorize_patron(sip2_patron_martigny_no_email):
 
     # authorize success
     response = authorize_patron(
-        sip2_patron_martigny_no_email.get('patron', {}).get('barcode'),
-        sip2_patron_martigny_no_email.get('birth_date'))
+        sip2_patron_martigny.get('patron', {}).get('barcode'),
+        sip2_patron_martigny.get('birth_date'))
     assert response
 
 
-def test_validate_patron(patron_martigny):
+def test_validate_patron(sip2_patron_martigny):
     """Test validate patron."""
     # test valid patron barcode
     assert validate_patron_account(
-        patron_martigny.get('patron', {}).get('barcode'))
+        sip2_patron_martigny.get('patron', {}).get('barcode'))
 
     # test invalid patron barcode
     assert not validate_patron_account('invalid_barcode')
 
 
-def test_system_status(sip2_librarian_martigny_no_email):
+def test_system_status(sip2_librarian_martigny):
     """Test automated circulation system status."""
-    response = system_status(sip2_librarian_martigny_no_email.get('pid'))
+    response = system_status(sip2_librarian_martigny.get('pid'))
     assert response.get('institution_id') == \
-        sip2_librarian_martigny_no_email.library_pid
+        sip2_librarian_martigny.library_pid
 
 
-def test_enable_patron(sip2_patron_martigny_no_email):
+def test_enable_patron(sip2_patron_martigny):
     """Test enable patron."""
     response = enable_patron(
-        sip2_patron_martigny_no_email.get('patron', {}).get('barcode'))
-    assert response['institution_id'] == sip2_patron_martigny_no_email\
+        sip2_patron_martigny.get('patron', {}).get('barcode'))
+    assert response['institution_id'] == sip2_patron_martigny\
         .library_pid
     assert response['patron_id']
     assert response['patron_name']
 
 
-def test_patron_information(client, sip2_librarian_martigny_no_email,
-                            sip2_patron_martigny_no_email, loc_public_martigny,
+def test_patron_information(client, sip2_librarian_martigny,
+                            sip2_patron_martigny, loc_public_martigny,
                             item_lib_martigny, item2_lib_martigny,
                             circulation_policies, lib_martigny):
     """Test patron information."""
-    login_user_via_session(client, sip2_librarian_martigny_no_email.user)
+    login_user_via_session(client, sip2_librarian_martigny.user)
     # checkout
     res, data = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=sip2_patron_martigny_no_email.pid,
-            transaction_user_pid=sip2_librarian_martigny_no_email.pid,
+            patron_pid=sip2_patron_martigny.pid,
+            transaction_user_pid=sip2_librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -150,15 +150,15 @@ def test_patron_information(client, sip2_librarian_martigny_no_email,
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=sip2_patron_martigny_no_email.pid,
+            patron_pid=sip2_patron_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=sip2_librarian_martigny_no_email.pid
+            transaction_user_pid=sip2_librarian_martigny.pid
         )
     )
     assert res.status_code == 200
     # get patron information
-    response = patron_information(sip2_patron_martigny_no_email.get(
+    response = patron_information(sip2_patron_martigny.get(
         'patron', {}).get('barcode'))
     assert response
 
@@ -169,27 +169,27 @@ def test_patron_information(client, sip2_librarian_martigny_no_email,
         dict(
             item_pid=item_lib_martigny.pid,
             pid=loan_pid,
-            transaction_user_pid=sip2_librarian_martigny_no_email.pid,
+            transaction_user_pid=sip2_librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
     assert res.status_code == 200
 
 
-def test_item_information(client, sip2_librarian_martigny_no_email,
-                          sip2_patron_martigny_no_email, loc_public_martigny,
+def test_item_information(client, sip2_librarian_martigny,
+                          sip2_patron_martigny, loc_public_martigny,
                           item_lib_martigny,
                           circulation_policies):
     """Test item information."""
-    login_user_via_session(client, sip2_librarian_martigny_no_email.user)
+    login_user_via_session(client, sip2_librarian_martigny.user)
     # checkout
     res, data = postdata(
         client,
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=sip2_patron_martigny_no_email.pid,
-            transaction_user_pid=sip2_librarian_martigny_no_email.pid,
+            patron_pid=sip2_patron_martigny.pid,
+            transaction_user_pid=sip2_librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
@@ -215,7 +215,7 @@ def test_item_information(client, sip2_librarian_martigny_no_email,
     flush_index(LoansSearch.Meta.index)
     assert number_of_reminders_sent(loan) == 1
 
-    patron_barcode = sip2_patron_martigny_no_email\
+    patron_barcode = sip2_patron_martigny\
         .get('patron', {}).get('barcode')
     item_pid = item_lib_martigny.pid
 
@@ -243,26 +243,26 @@ def test_item_information(client, sip2_librarian_martigny_no_email,
         dict(
             item_pid=item_lib_martigny.pid,
             pid=loan_pid,
-            transaction_user_pid=sip2_librarian_martigny_no_email.pid,
+            transaction_user_pid=sip2_librarian_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
     assert res.status_code == 200
 
 
-def test_selfcheck_checkout(client, sip2_librarian_martigny_no_email,
-                            sip2_patron_martigny_no_email, loc_public_martigny,
-                            item_lib_martigny, librarian2_martigny_no_email,
+def test_selfcheck_checkout(client, sip2_librarian_martigny,
+                            sip2_patron_martigny, loc_public_martigny,
+                            item_lib_martigny, librarian2_martigny,
                             circulation_policies):
     """Test selfcheck checkout."""
-    patron_barcode = sip2_patron_martigny_no_email \
+    patron_barcode = sip2_patron_martigny \
         .get('patron', {}).get('barcode')
     item_barcode = item_lib_martigny.get('barcode')
 
     # selfcheck checkout
     checkout = selfcheck_checkout(
-        user_pid=sip2_librarian_martigny_no_email.pid,
-        institution_id=sip2_librarian_martigny_no_email.library_pid,
+        user_pid=sip2_librarian_martigny.pid,
+        institution_id=sip2_librarian_martigny.library_pid,
         patron_barcode=patron_barcode,
         item_barcode=item_barcode,
     )
@@ -271,42 +271,42 @@ def test_selfcheck_checkout(client, sip2_librarian_martigny_no_email,
     assert checkout.due_date
 
     # librarian checkin
-    login_user_via_session(client, librarian2_martigny_no_email.user)
+    login_user_via_session(client, librarian2_martigny.user)
     res, _ = postdata(
         client,
         'api_item.checkin',
         dict(
             item_pid=item_lib_martigny.pid,
-            transaction_user_pid=librarian2_martigny_no_email.pid,
+            transaction_user_pid=librarian2_martigny.pid,
             transaction_location_pid=loc_public_martigny.pid
         )
     )
     assert res.status_code == 200
 
 
-def test_selfcheck_checkin(client, sip2_librarian_martigny_no_email,
-                           librarian2_martigny_no_email, loc_public_martigny,
-                           sip2_patron_martigny_no_email, item_lib_martigny,
+def test_selfcheck_checkin(client, sip2_librarian_martigny,
+                           librarian2_martigny, loc_public_martigny,
+                           sip2_patron_martigny, item_lib_martigny,
                            document, circulation_policies):
     """Test selfcheck checkin."""
-    patron_barcode = sip2_patron_martigny_no_email \
+    patron_barcode = sip2_patron_martigny \
         .get('patron', {}).get('barcode')
     item_barcode = item_lib_martigny.get('barcode')
 
     # librarian checkout
-    login_user_via_session(client, librarian2_martigny_no_email.user)
+    login_user_via_session(client, librarian2_martigny.user)
     res, data = postdata(client, 'api_item.checkout', dict(
         item_pid=item_lib_martigny.pid,
-        patron_pid=sip2_patron_martigny_no_email.pid,
+        patron_pid=sip2_patron_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian2_martigny_no_email.pid,
+        transaction_user_pid=librarian2_martigny.pid,
     ))
     assert res.status_code == 200
 
     # test selfcheck checkin with invalid item barcode
     checkin = selfcheck_checkin(
-        user_pid=sip2_librarian_martigny_no_email.pid,
-        institution_id=sip2_librarian_martigny_no_email.library_pid,
+        user_pid=sip2_librarian_martigny.pid,
+        institution_id=sip2_librarian_martigny.library_pid,
         patron_barcode=patron_barcode,
         item_barcode='wrong_item_barcode',
     )
@@ -315,8 +315,8 @@ def test_selfcheck_checkin(client, sip2_librarian_martigny_no_email,
 
     # selfcheck checkin
     checkin = selfcheck_checkin(
-        user_pid=sip2_librarian_martigny_no_email.pid,
-        institution_id=sip2_librarian_martigny_no_email.library_pid,
+        user_pid=sip2_librarian_martigny.pid,
+        institution_id=sip2_librarian_martigny.library_pid,
         patron_barcode=patron_barcode,
         item_barcode=item_barcode,
     )

--- a/tests/api/templates/test_templates_permissions.py
+++ b/tests/api/templates/test_templates_permissions.py
@@ -24,12 +24,12 @@ from utils import get_json
 from rero_ils.modules.templates.permissions import TemplatePermission
 
 
-def test_templates_permissions_api(client, patron_martigny_no_email,
+def test_templates_permissions_api(client, patron_martigny,
                                    templ_doc_private_martigny,
                                    templ_doc_public_martigny,
-                                   librarian_martigny_no_email,
+                                   librarian_martigny,
                                    templ_doc_public_sion,
-                                   system_librarian_martigny_no_email):
+                                   system_librarian_martigny):
     """Test templates permissions api."""
     template_permissions_url = url_for(
         'api_blueprint.permissions',
@@ -56,12 +56,12 @@ def test_templates_permissions_api(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(template_permissions_url)
     assert res.status_code == 403
 
     # Logged as librarian
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(templ_doc_pub_martigny_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -88,7 +88,7 @@ def test_templates_permissions_api(client, patron_martigny_no_email,
     assert not data['delete']['can']
 
     # Logged as system librarian
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(templ_doc_private_martigny_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -106,8 +106,8 @@ def test_templates_permissions_api(client, patron_martigny_no_email,
 
 
 def test_template_permissions(
-        patron_martigny_no_email, librarian_martigny_no_email,
-        system_librarian_martigny_no_email, org_martigny,
+        patron_martigny, librarian_martigny,
+        system_librarian_martigny, org_martigny,
         templ_doc_public_martigny, templ_doc_private_martigny,
         templ_doc_public_sion):
     """Test template permissions class."""
@@ -122,7 +122,7 @@ def test_template_permissions(
     # As Patron
     with mock.patch(
         'rero_ils.modules.templates.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not TemplatePermission.list(None, {})
         assert not TemplatePermission.read(None, {})
@@ -133,7 +133,7 @@ def test_template_permissions(
     # As Librarian
     with mock.patch(
         'rero_ils.modules.templates.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.templates.permissions.current_organisation',
         org_martigny
@@ -153,7 +153,7 @@ def test_template_permissions(
     # As SystemLibrarian
     with mock.patch(
         'rero_ils.modules.templates.permissions.current_patron',
-        system_librarian_martigny_no_email
+        system_librarian_martigny
     ), mock.patch(
         'rero_ils.modules.templates.permissions.current_organisation',
         org_martigny

--- a/tests/api/templates/test_templates_rest.py
+++ b/tests/api/templates/test_templates_rest.py
@@ -58,14 +58,14 @@ def test_templates_get(client, templ_doc_public_martigny):
 
 
 def test_filtered_templates_get(
-        client, librarian_martigny_no_email, templ_doc_public_martigny,
-        templ_doc_private_martigny, librarian_sion_no_email,
-        system_librarian_martigny_no_email, librarian_fully_no_email,
-        system_librarian_sion_no_email):
+        client, librarian_martigny, templ_doc_public_martigny,
+        templ_doc_private_martigny, librarian_sion,
+        system_librarian_martigny, librarian_fully,
+        system_librarian_sion):
     """Test templates filter by organisation."""
     # Martigny
     # system librarian can have access to all templates
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     list_url = url_for('invenio_records_rest.tmpl_list')
 
     res = client.get(list_url)
@@ -74,7 +74,7 @@ def test_filtered_templates_get(
     assert data['hits']['total']['value'] == 2
 
     # librarian martigny can have access to all public and his templates
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.tmpl_list')
 
     res = client.get(list_url)
@@ -83,7 +83,7 @@ def test_filtered_templates_get(
     assert data['hits']['total']['value'] == 2
 
     # librarian fully can have access to all public templates only
-    login_user_via_session(client, librarian_fully_no_email.user)
+    login_user_via_session(client, librarian_fully.user)
     list_url = url_for('invenio_records_rest.tmpl_list')
 
     res = client.get(list_url)
@@ -93,7 +93,7 @@ def test_filtered_templates_get(
 
     # Sion
     # librarian sion can have access to no templates
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.tmpl_list')
 
     res = client.get(list_url)
@@ -102,7 +102,7 @@ def test_filtered_templates_get(
     assert data['hits']['total']['value'] == 0
 
     # system librarian sion can have access to no templates
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     list_url = url_for('invenio_records_rest.tmpl_list')
 
     res = client.get(list_url)
@@ -114,7 +114,7 @@ def test_filtered_templates_get(
 @mock.patch('invenio_records_rest.views.verify_record_permission',
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def test_templates_post_put_delete(client, org_martigny,
-                                   system_librarian_martigny_no_email,
+                                   system_librarian_martigny,
                                    templ_doc_public_martigny_data,
                                    json_header):
     """Test template post."""
@@ -174,11 +174,11 @@ def test_templates_post_put_delete(client, org_martigny,
 
 def test_template_secure_api(client, json_header,
                              templ_doc_public_martigny,
-                             librarian_martigny_no_email,
-                             librarian_sion_no_email):
+                             librarian_martigny,
+                             librarian_sion):
     """Test templates secure api access."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     record_url = url_for('invenio_records_rest.tmpl_item',
                          pid_value=templ_doc_public_martigny.pid)
 
@@ -186,7 +186,7 @@ def test_template_secure_api(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     record_url = url_for('invenio_records_rest.tmpl_item',
                          pid_value=templ_doc_public_martigny.pid)
 
@@ -195,12 +195,12 @@ def test_template_secure_api(client, json_header,
 
 
 def test_template_secure_api_create(client, json_header,
-                                    system_librarian_martigny_no_email,
-                                    system_librarian_sion_no_email,
+                                    system_librarian_martigny,
+                                    system_librarian_sion,
                                     templ_doc_public_martigny_data):
     """Test templates secure api create."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.tmpl_list'
 
     del templ_doc_public_martigny_data['pid']
@@ -212,7 +212,7 @@ def test_template_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
 
     res, _ = postdata(
         client,
@@ -225,14 +225,14 @@ def test_template_secure_api_create(client, json_header,
 def test_template_secure_api_update(client,
                                     templ_doc_private_martigny,
                                     templ_doc_private_martigny_data,
-                                    system_librarian_martigny_no_email,
-                                    system_librarian_sion_no_email,
-                                    librarian_martigny_no_email,
-                                    librarian_saxon_no_email,
+                                    system_librarian_martigny,
+                                    system_librarian_sion,
+                                    librarian_martigny,
+                                    librarian_saxon,
                                     json_header):
     """Test templates secure api update."""
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     record_url = url_for('invenio_records_rest.tmpl_item',
                          pid_value=templ_doc_private_martigny.pid)
 
@@ -245,7 +245,7 @@ def test_template_secure_api_update(client,
     )
     assert res.status_code == 403
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     data = templ_doc_private_martigny_data
     data['name'] = 'Test Name'
     res = client.put(
@@ -264,7 +264,7 @@ def test_template_secure_api_update(client,
     )
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     data = templ_doc_private_martigny_data
     data['visibility'] = 'public'
     res = client.put(
@@ -274,7 +274,7 @@ def test_template_secure_api_update(client,
     )
     assert res.status_code == 403
 
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
     data = templ_doc_private_martigny_data
     data['name'] = 'Test Name'
     res = client.put(
@@ -285,7 +285,7 @@ def test_template_secure_api_update(client,
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.put(
         record_url,
         data=json.dumps(data),
@@ -296,28 +296,28 @@ def test_template_secure_api_update(client,
 
 def test_template_secure_api_delete(client,
                                     templ_doc_private_martigny,
-                                    system_librarian_martigny_no_email,
-                                    system_librarian_sion_no_email,
+                                    system_librarian_martigny,
+                                    system_librarian_sion,
                                     templ_doc_public_martigny,
-                                    librarian_saxon_no_email,
-                                    librarian_martigny_no_email,
+                                    librarian_saxon,
+                                    librarian_martigny,
                                     json_header):
     """Test templates secure api delete."""
     record_url = url_for('invenio_records_rest.tmpl_item',
                          pid_value=templ_doc_private_martigny.pid)
 
     # Saxon
-    login_user_via_session(client, librarian_saxon_no_email.user)
+    login_user_via_session(client, librarian_saxon.user)
     res = client.delete(record_url)
     assert res.status_code == 403
 
     # Sion
-    login_user_via_session(client, system_librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion.user)
     res = client.delete(record_url)
     assert res.status_code == 403
 
     # Martigny
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.delete(record_url)
     assert res.status_code == 403
 
@@ -325,10 +325,10 @@ def test_template_secure_api_delete(client,
                          pid_value=templ_doc_public_martigny.pid)
 
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.delete(record_url)
     assert res.status_code == 403
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.delete(record_url)
     assert res.status_code == 204

--- a/tests/api/test_circ_bug.py
+++ b/tests/api/test_circ_bug.py
@@ -25,12 +25,12 @@ from rero_ils.modules.loans.api import LoanAction
 
 
 def test_document_with_one_item_attached_bug(
-        client, librarian_martigny_no_email, patron_martigny_no_email,
-        patron2_martigny_no_email, loc_public_martigny,
+        client, librarian_martigny, patron_martigny,
+        patron2_martigny, loc_public_martigny,
         item_type_standard_martigny, item_lib_martigny, json_header,
         circulation_policies, lib_martigny):
     """Test document with one item."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # checkout first item1 to patron
     res, data = postdata(
@@ -38,9 +38,9 @@ def test_document_with_one_item_attached_bug(
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -55,9 +55,9 @@ def test_document_with_one_item_attached_bug(
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -72,7 +72,7 @@ def test_document_with_one_item_attached_bug(
             item_pid=item_lib_martigny.pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -84,23 +84,23 @@ def test_document_with_one_item_attached_bug(
         dict(
             pid=loan2_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
     assert item_lib_martigny.number_of_requests() == 0
 
 
-def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
-                                          patron_martigny_no_email,
-                                          patron2_martigny_no_email,
+def test_document_with_items_attached_bug(client, librarian_martigny,
+                                          patron_martigny,
+                                          patron2_martigny,
                                           item2_lib_martigny,
                                           loc_public_martigny,
                                           item_type_standard_martigny,
                                           item_lib_martigny, json_header,
                                           circulation_policies, lib_martigny):
     """Test document with multiple items."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # checkout first item1 to patron
     res, data = postdata(
@@ -108,9 +108,9 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
         'api_item.checkout',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -124,9 +124,9 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
         'api_item.checkout',
         dict(
             item_pid=item2_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid,
+            patron_pid=patron_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -140,9 +140,9 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -154,9 +154,9 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
         dict(
             item_pid=item2_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid,
+            patron_pid=patron2_martigny.pid,
             transaction_library_pid=lib_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -171,7 +171,7 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
             item_pid=item_lib_martigny.pid,
             pid=loan_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200
@@ -187,7 +187,7 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
             item_pid=item2_lib_martigny.pid,
             pid=loan2_pid,
             transaction_location_pid=loc_public_martigny.pid,
-            transaction_user_pid=librarian_martigny_no_email.pid
+            transaction_user_pid=librarian_martigny.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/test_monitoring_rest.py
+++ b/tests/api/test_monitoring_rest.py
@@ -70,7 +70,7 @@ def test_monitoring_es_db_counts(client):
 
 
 def test_monitoring_check_es_db_counts(app, client, contribution_person_data,
-                                       system_librarian_martigny_no_email):
+                                       system_librarian_martigny):
     """Test monitoring check_es_db_counts."""
     res = client.get(url_for('api_monitoring.check_es_db_counts'))
     assert res.status_code == 200
@@ -102,7 +102,7 @@ def test_monitoring_check_es_db_counts(app, client, contribution_person_data,
     res = client.get(url_for('api_monitoring.missing_pids', doc_type='cont'))
     assert res.status_code == 401
 
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(
         url_for('api_monitoring.missing_pids', doc_type='cont')
     )
@@ -112,7 +112,7 @@ def test_monitoring_check_es_db_counts(app, client, contribution_person_data,
     db.session.add(
         ActionUsers.allow(
             superuser_access,
-            user=system_librarian_martigny_no_email.user
+            user=system_librarian_martigny.user
         )
     )
     db.session.commit()

--- a/tests/api/test_patron_payments_rest.py
+++ b/tests/api/test_patron_payments_rest.py
@@ -27,8 +27,8 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 
 def test_patron_payment(
-        client, librarian_martigny_no_email,
-        librarian_sion_no_email, patron_transaction_overdue_event_martigny):
+        client, librarian_martigny,
+        librarian_sion, patron_transaction_overdue_event_martigny):
     """Test patron payment."""
     transaction = \
         patron_transaction_overdue_event_martigny.patron_transaction()
@@ -38,7 +38,7 @@ def test_patron_payment(
     transaction = PatronTransaction.get_record_by_pid(transaction.pid)
     assert calculated_amount == transaction.total_amount == 2.00
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.ptre_list'
     payment = deepcopy(patron_transaction_overdue_event_martigny)
 
@@ -48,7 +48,7 @@ def test_patron_payment(
     payment['subtype'] = 'cash'
     payment['amount'] = 0.54
     payment['operator'] = {'$ref': get_ref_for_pid(
-        'patrons', librarian_martigny_no_email.pid)}
+        'patrons', librarian_martigny.pid)}
     res, _ = postdata(
         client,
         post_entrypoint,

--- a/tests/api/test_permissions_patron.py
+++ b/tests/api/test_permissions_patron.py
@@ -19,7 +19,6 @@
 
 from copy import deepcopy
 
-import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import postdata
@@ -33,12 +32,12 @@ def test_anonymous_user():
 
 
 def test_patron_permissions(
-        client, json_header, system_librarian_martigny_no_email,
-        patron_martigny_no_email,
-        librarian_fully_no_email):
+        client, json_header, system_librarian_martigny,
+        patron_martigny,
+        librarian_fully):
     """Test patron permissions."""
     # Login as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
 
     record = {
         "$schema": "https://ils.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -82,11 +81,9 @@ def test_patron_permissions(
         data['roles'] = [record['role']]
         data['patron']['barcode'] = 'barcode' + str(counter)
         data['email'] = str(counter) + '@domain.com'
-        with mock.patch('rero_ils.modules.patrons.api.'
-                        'send_reset_password_instructions'):
-            res, _ = postdata(
-                client,
-                'invenio_records_rest.ptrn_list',
-                data
-            )
-            assert res.status_code == 403
+        res, _ = postdata(
+            client,
+            'invenio_records_rest.ptrn_list',
+            data
+        )
+        assert res.status_code == 403

--- a/tests/api/test_pid_rest.py
+++ b/tests/api/test_pid_rest.py
@@ -24,13 +24,13 @@ from rero_ils.modules.locations.api import Location
 
 
 def test_ilsrecord_pid_after_validationerror(
-        client, loc_online_martigny_data, librarian_martigny_no_email):
+        client, loc_online_martigny_data, librarian_martigny):
     """Check PID before and after a ValidationError: it should be the same"""
     loc = Location.create(loc_online_martigny_data, delete_pid=True)
     next_pid = str(int(loc.pid) + 1)
 
     # post invalid data and post them
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, _ = postdata(
         client,
         'invenio_records_rest.loc_list',

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -289,11 +289,11 @@ def test_document_search(
 
 def test_patrons_search(
         client,
-        librarian_martigny_no_email
+        librarian_martigny
 ):
     """Test document boosting."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    birthdate = librarian_martigny_no_email.get('birth_date')
+    login_user_via_session(client, librarian_martigny.user)
+    birthdate = librarian_martigny.get('birth_date')
     # complete birthdate
     list_url = url_for(
         'invenio_records_rest.ptrn_list',

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -25,11 +25,11 @@ from utils import get_csv, get_json, login_user
 def test_patrons_serializers(
     client,
     json_header,
-    librarian_martigny_no_email,
-    librarian2_martigny_no_email
+    librarian_martigny,
+    librarian2_martigny
 ):
     """Test serializers for patrons."""
-    login_user(client, librarian_martigny_no_email)
+    login_user(client, librarian_martigny)
 
     list_url = url_for('invenio_records_rest.ptrn_list')
     response = client.get(list_url, headers=json_header)
@@ -50,13 +50,13 @@ def test_items_serializers(
     csv_header,
     json_header,
     rero_json_header,
-    patron_martigny_no_email,
-    librarian_martigny_no_email,
-    librarian_sion_no_email,
+    patron_martigny,
+    librarian_martigny,
+    librarian_sion,
     loan_pending_martigny
 ):
     """Test record retrieval."""
-    login_user(client, librarian_martigny_no_email)
+    login_user(client, librarian_martigny)
 
     item_url = url_for(
         'invenio_records_rest.item_item', pid_value=item_lib_fully.pid)

--- a/tests/api/test_user_authentication.py
+++ b/tests/api/test_user_authentication.py
@@ -24,7 +24,7 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
 
-def test_login(client, patron_sion_no_email):
+def test_login(client, patron_sion):
     """Test login with several scenarios."""
 
     # user does not exists
@@ -46,7 +46,7 @@ def test_login(client, patron_sion_no_email):
         client,
         'invenio_accounts_rest_auth.login',
         {
-            'email': patron_sion_no_email.get('email'),
+            'email': patron_sion.get('email'),
             'password': 'bad'
         }
     )
@@ -60,12 +60,12 @@ def test_login(client, patron_sion_no_email):
         client,
         'invenio_accounts_rest_auth.login',
         {
-            'email': patron_sion_no_email.get('email'),
-            'password': patron_sion_no_email.get('birth_date')
+            'email': patron_sion.get('email'),
+            'password': patron_sion.get('birth_date')
         }
     )
-    assert res.status_code == 200
     data = get_json(res)
+    assert res.status_code == 200
     assert data.get('id')
     # logout for the next test
     client.post(url_for('invenio_accounts_rest_auth.logout'))
@@ -75,26 +75,26 @@ def test_login(client, patron_sion_no_email):
         client,
         'invenio_accounts_rest_auth.login',
         {
-            'email': patron_sion_no_email.get('username'),
-            'password': patron_sion_no_email.get('birth_date')
+            'email': patron_sion.get('username'),
+            'password': patron_sion.get('birth_date')
         }
     )
-    assert res.status_code == 200
     data = get_json(res)
+    assert res.status_code == 200
     assert data.get('id')
     # logout for the next test
     client.post(url_for('invenio_accounts_rest_auth.logout'))
 
 
-def test_login_without_email(client, patron_sion_without_email):
+def test_login_without_email(client, patron_sion_without_email1):
     """Test login with several scenarios."""
     # login by username without email
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.login',
         {
-            'email': patron_sion_without_email.get('username'),
-            'password': patron_sion_without_email.get('birth_date')
+            'email': patron_sion_without_email1.get('username'),
+            'password': patron_sion_without_email1.get('birth_date')
         }
     )
     assert res.status_code == 200
@@ -104,9 +104,9 @@ def test_login_without_email(client, patron_sion_without_email):
     client.post(url_for('invenio_accounts_rest_auth.logout'))
 
 
-def test_change_password(client, patron_martigny_no_email,
-                         librarian_sion_no_email,
-                         librarian_martigny_no_email):
+def test_change_password(client, patron_martigny,
+                         librarian_sion,
+                         librarian_martigny):
     """Test login with several scenarios."""
 
     # try to change password with an anonymous user
@@ -114,7 +114,7 @@ def test_change_password(client, patron_martigny_no_email,
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'password': patron_martigny_no_email.get('birth_date'),
+            'password': patron_martigny.get('birth_date'),
             'new_password': 'new'
         }
     )
@@ -122,12 +122,12 @@ def test_change_password(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # with a logged but the password is too short
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'password': patron_martigny_no_email.get('birth_date'),
+            'password': patron_martigny.get('birth_date'),
             'new_password': 'new'
         }
     )
@@ -140,7 +140,7 @@ def test_change_password(client, patron_martigny_no_email,
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'password': patron_martigny_no_email.get('birth_date'),
+            'password': patron_martigny.get('birth_date'),
             'new_password': 'new_passwd'
         }
     )
@@ -149,12 +149,12 @@ def test_change_password(client, patron_martigny_no_email,
     assert data.get('message') == 'You successfully changed your password.'
 
     # with a librarian of a different organisation
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'username': patron_martigny_no_email.get('username'),
+            'username': patron_martigny.get('username'),
             'new_password': 'new_passwd2'
         }
     )
@@ -162,12 +162,12 @@ def test_change_password(client, patron_martigny_no_email,
     assert res.status_code == 401
 
     # with a librarian of the same organisation
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'username': patron_martigny_no_email.get('username'),
+            'username': patron_martigny.get('username'),
             'new_password': 'new_passwd2'
         }
     )
@@ -179,9 +179,9 @@ def test_change_password(client, patron_martigny_no_email,
     client.post(url_for('invenio_accounts_rest_auth.logout'))
 
 
-def test_patron_reset_notice(patron_martigny_no_email, mailbox):
+def test_patron_reset_notice(patron_martigny, mailbox):
     """Test password reset notice template."""
-    send_password_reset_notice(patron_martigny_no_email.user)
+    send_password_reset_notice(patron_martigny.user)
     assert len(mailbox) == 1
     assert re.search(
         r'Your password has been successfully reset.', mailbox[0].body

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -22,8 +22,8 @@ from utils import get_json
 
 
 def test_user_info(
-        client, document, user_with_profile, patron_martigny_no_email,
-        system_librarian_martigny_no_email):
+        client, document, user_with_profile, patron_martigny,
+        system_librarian_martigny):
     """Test users API."""
     # failed: no logged user
     res = client.get(
@@ -35,7 +35,7 @@ def test_user_info(
     assert res.status_code == 401
 
     # patron should not have the permission
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(
         url_for(
             'api_blueprint.user_info',
@@ -45,7 +45,7 @@ def test_user_info(
     assert res.status_code == 403
 
     # librarian
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
 
     # user does not exists
     res = client.get(

--- a/tests/api/vendors/test_vendors.py
+++ b/tests/api/vendors/test_vendors.py
@@ -24,10 +24,10 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
 
-def test_vendors_get(client, librarian_martigny_no_email, vendor_martigny):
+def test_vendors_get(client, librarian_martigny, vendor_martigny):
     """Test vendor record retrieval."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item_url = url_for(
         'invenio_records_rest.vndr_item',
         pid_value=vendor_martigny.pid)
@@ -48,12 +48,12 @@ def test_vendors_get(client, librarian_martigny_no_email, vendor_martigny):
         assert k in data
 
 
-def test_filtered_vendors_get(client, librarian_martigny_no_email,
-                              librarian_sion_no_email, vendor_martigny,
+def test_filtered_vendors_get(client, librarian_martigny,
+                              librarian_sion, vendor_martigny,
                               vendor2_martigny, vendor_sion, vendor2_sion):
     """Test vendors filter by organisation."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     list_url = url_for('invenio_records_rest.vndr_list')
 
     res = client.get(list_url)
@@ -62,7 +62,7 @@ def test_filtered_vendors_get(client, librarian_martigny_no_email,
     assert data['hits']['total']['value'] == 2
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, librarian_sion.user)
     list_url = url_for('invenio_records_rest.vndr_list')
 
     res = client.get(list_url)
@@ -82,10 +82,10 @@ def test_vendors_can_delete(
     assert reasons['links']['acq_invoices']
 
 
-def test_vendor_post_update_delete(client, librarian_martigny_no_email,
+def test_vendor_post_update_delete(client, librarian_martigny,
                                    vendor3_martigny_data, json_header):
     """Test CRUD on vendor."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     item_url = url_for('invenio_records_rest.vndr_item', pid_value='vndr3')
 
     # create

--- a/tests/api/vendors/test_vendors_permissions.py
+++ b/tests/api/vendors/test_vendors_permissions.py
@@ -24,8 +24,8 @@ from utils import get_json
 from rero_ils.modules.vendors.permissions import VendorPermission
 
 
-def test_vendor_permissions_api(client, org_sion, patron_martigny_no_email,
-                                system_librarian_martigny_no_email,
+def test_vendor_permissions_api(client, org_sion, patron_martigny,
+                                system_librarian_martigny,
                                 vendor_martigny, vendor_sion):
     """Test organisations permissions api."""
     vendor_permissions_url = url_for(
@@ -48,14 +48,14 @@ def test_vendor_permissions_api(client, org_sion, patron_martigny_no_email,
     assert res.status_code == 401
 
     # Logged as patron
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(vendor_permissions_url)
     assert res.status_code == 403
 
     # Logged as system librarian
     #   * sys_lib can do everything about vendors of its own organisation
     #   * sys_lib can't do anything about vendors of other organisation
-    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny.user)
     res = client.get(vendor_martigny_permission_url)
     assert res.status_code == 200
     data = get_json(res)
@@ -73,8 +73,8 @@ def test_vendor_permissions_api(client, org_sion, patron_martigny_no_email,
     assert not data['delete']['can']
 
 
-def test_vendor_permissions(patron_martigny_no_email,
-                            librarian_martigny_no_email,
+def test_vendor_permissions(patron_martigny,
+                            librarian_martigny,
                             org_martigny, org_sion,
                             vendor_martigny, vendor_sion):
     """Test organisation permissions class."""
@@ -89,7 +89,7 @@ def test_vendor_permissions(patron_martigny_no_email,
     # As Patron
     with mock.patch(
         'rero_ils.modules.vendors.permissions.current_patron',
-        patron_martigny_no_email
+        patron_martigny
     ):
         assert not VendorPermission.list(None, vendor_martigny)
         assert not VendorPermission.read(None, vendor_martigny)
@@ -100,7 +100,7 @@ def test_vendor_permissions(patron_martigny_no_email,
     # As Librarian
     with mock.patch(
         'rero_ils.modules.vendors.permissions.current_patron',
-        librarian_martigny_no_email
+        librarian_martigny
     ), mock.patch(
         'rero_ils.modules.vendors.permissions.current_organisation',
         org_martigny

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -20,10 +20,10 @@
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
-import mock
 import pytest
 from invenio_circulation.search.api import LoansSearch
-from utils import flush_index, item_record_to_a_specific_loan_state
+from utils import create_patron, flush_index, \
+    item_record_to_a_specific_loan_state
 
 from rero_ils.modules.ill_requests.api import ILLRequest, ILLRequestsSearch
 from rero_ils.modules.items.api import ItemsSearch
@@ -31,7 +31,6 @@ from rero_ils.modules.loans.api import Loan, LoanState
 from rero_ils.modules.notifications.api import NotificationsSearch, \
     get_availability_notification
 from rero_ils.modules.patron_transactions.api import PatronTransactionsSearch
-from rero_ils.modules.patrons.api import Patron, PatronsSearch
 
 
 @pytest.fixture(scope="module")
@@ -65,31 +64,8 @@ def system_librarian_martigny(
         patron_type_children_martigny,
         system_librarian_martigny_data):
     """Create Martigny system librarian record."""
-    ptrn = Patron.create(
-        data=system_librarian_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def system_librarian_martigny_no_email(
-        app,
-        roles,
-        lib_martigny,
-        patron_type_children_martigny,
-        system_librarian_martigny_data):
-    """Create Martigny system librarian without sending reset password."""
-    ptrn = Patron.create(
-        data=system_librarian_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = system_librarian_martigny_data
+    yield create_patron(data)
 
 
 @pytest.fixture(scope="module")
@@ -111,30 +87,8 @@ def system_librarian2_martigny(
         lib_martigny,
         system_librarian2_martigny_data):
     """Create Martigny system librarian record."""
-    ptrn = Patron.create(
-        data=system_librarian2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def system_librarian2_martigny_no_email(
-        app,
-        roles,
-        lib_martigny,
-        system_librarian2_martigny_data):
-    """Create Martigny system librarian without sending reset password."""
-    ptrn = Patron.create(
-        data=system_librarian2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = system_librarian2_martigny_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny, Lib: Martigny, Librarian 1 ----------
@@ -157,39 +111,8 @@ def librarian_martigny(
         lib_martigny,
         librarian_martigny_data):
     """Create Martigny librarian record."""
-    ptrn = Patron.get_record_by_pid(librarian_martigny_data['pid'])
-    if ptrn:
-        ptrn = ptrn.update(
-            data=librarian_martigny_data,
-            dbcommit=True,
-            reindex=True
-        )
-    else:
-        ptrn = Patron.create(
-            data=librarian_martigny_data,
-            delete_pid=False,
-            dbcommit=True,
-            reindex=True
-        )
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def librarian_martigny_no_email(
-        app,
-        roles,
-        lib_martigny,
-        librarian_martigny_data):
-    """Create Martigny librarian without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=librarian_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = librarian_martigny_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny, Lib: Martigny, Librarian 2 ----------
@@ -212,31 +135,8 @@ def librarian2_martigny(
         lib_martigny,
         librarian2_martigny_data):
     """Create Martigny librarian record."""
-    ptrn = Patron.create(
-        data=librarian2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-# ------------ Org: Martigny, Lib: Saxon, Librarian 1 ----------
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def librarian2_martigny_no_email(
-        app,
-        roles,
-        lib_martigny,
-        librarian2_martigny_data):
-    """Create Martigny librarian without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=librarian2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = librarian2_martigny_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny, Lib: Saxon, Librarian 1 ----------
@@ -259,30 +159,8 @@ def librarian_saxon(
         lib_saxon,
         librarian_saxon_data):
     """Create Saxon librarian record."""
-    ptrn = Patron.create(
-        data=librarian_saxon_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def librarian_saxon_no_email(
-        app,
-        roles,
-        lib_saxon,
-        librarian_saxon_data):
-    """Create Saxon librarian without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=librarian_saxon_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = librarian_saxon_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny, Lib: Fully, Librarian 1 ----------
@@ -305,30 +183,8 @@ def librarian_fully(
         lib_fully,
         librarian_fully_data):
     """Create Fully librarian record."""
-    ptrn = Patron.create(
-        data=librarian_fully_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def librarian_fully_no_email(
-        app,
-        roles,
-        lib_fully,
-        librarian_fully_data):
-    """Create Fully librarian without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=librarian_fully_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = librarian_fully_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny Patron 1 ----------
@@ -352,39 +208,8 @@ def patron_martigny(
         patron_type_children_martigny,
         patron_martigny_data):
     """Create Martigny patron record."""
-    ptrn = Patron.get_record_by_pid(patron_martigny_data.get('pid'))
-    if ptrn:
-        ptrn = ptrn.update(
-            data=patron_martigny_data,
-            dbcommit=True,
-            reindex=True
-        )
-    else:
-        ptrn = Patron.create(
-            data=patron_martigny_data,
-            delete_pid=False,
-            dbcommit=True,
-            reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron_martigny_no_email(
-        app,
-        roles,
-        lib_martigny,
-        patron_type_children_martigny,
-        patron_martigny_data):
-    """Create Martigny patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = patron_martigny_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny Patron 2 ----------
@@ -402,30 +227,8 @@ def patron2_martigny(
         patron_type_adults_martigny,
         patron2_martigny_data):
     """Create Martigny patron record."""
-    ptrn = Patron.create(
-        data=patron2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron2_martigny_no_email(
-        app,
-        roles,
-        patron_type_adults_martigny,
-        patron2_martigny_data):
-    """Create Martigny patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = patron2_martigny_data
+    yield create_patron(data)
 
 
 # ------------ Org: Martigny Patron 3 (blocked) ----------
@@ -444,32 +247,8 @@ def patron3_martigny_blocked(
         patron_type_adults_martigny,
         patron3_martigny_blocked_data):
     """Create Martigny patron record."""
-    ptrn = Patron.create(
-        data=patron3_martigny_blocked_data,
-        delete_pid=True,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron3_martigny_blocked_no_email(
-        app,
-        roles,
-        lib_martigny,
-        lib_saxon,
-        patron_type_adults_martigny,
-        patron3_martigny_blocked_data):
-    """Create Martigny patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron3_martigny_blocked_data,
-        delete_pid=True,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = patron3_martigny_blocked_data
+    yield create_patron(data)
 
 
 @pytest.fixture(scope="module")
@@ -486,30 +265,8 @@ def patron4_martigny(
         patron_type_adults_martigny,
         patron4_martigny_data):
     """Create Martigny patron record."""
-    ptrn = Patron.create(
-        data=patron4_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron4_martigny_no_email(
-        app,
-        roles,
-        patron_type_adults_martigny,
-        patron4_martigny_data):
-    """Create Martigny patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron4_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = patron4_martigny_data
+    yield create_patron(data)
 
 
 # ------------ Org: Sion, Lib: Sion, System Librarian ----------
@@ -532,30 +289,8 @@ def system_librarian_sion(
         lib_sion,
         system_librarian_sion_data):
     """Create Sion system librarian record."""
-    ptrn = Patron.create(
-        data=system_librarian_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def system_librarian_sion_no_email(
-        app,
-        roles,
-        lib_sion,
-        system_librarian_sion_data):
-    """Create Sion system librarian without sending reset password."""
-    ptrn = Patron.create(
-        data=system_librarian_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = system_librarian_sion_data
+    yield create_patron(data)
 
 
 # ------------ Org: Sion, Lib: Sion, Librarian ----------
@@ -572,30 +307,8 @@ def librarian_sion(
         lib_sion,
         librarian_sion_data):
     """Create sion librarian record."""
-    ptrn = Patron.create(
-        data=librarian_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def librarian_sion_no_email(
-        app,
-        roles,
-        lib_sion,
-        librarian_sion_data):
-    """Create sion librarian without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=librarian_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = librarian_sion_data
+    yield create_patron(data)
 
 
 # ------------ Org: Sion Patron 1 ----------
@@ -619,53 +332,24 @@ def patron_sion(
         patron_type_grown_sion,
         patron_sion_data):
     """Create Sion patron record."""
-    ptrn = Patron.create(
-        data=patron_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = patron_sion_data
+    yield create_patron(data)
 
 
 @pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron_sion_no_email(
+def patron_sion_without_email1(
         app,
         roles,
         lib_sion,
         patron_type_grown_sion,
         patron_sion_data):
     """Create Sion patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron_sion_without_email(
-        app,
-        roles,
-        lib_sion,
-        patron_type_grown_sion,
-        patron_sion_data):
-    """Create Sion patron without sending reset password instruction."""
-    del patron_sion_data['email']
-    patron_sion_data['pid'] = 'ptrn10wthoutemail'
-    patron_sion_data['username'] = 'withoutemail'
-    patron_sion_data['patron']['communication_channel'] = 'mail'
-    ptrn = Patron.create(
-        data=patron_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
+    data = deepcopy(patron_sion_data)
+    del data['email']
+    data['pid'] = 'ptrn10wthoutemail'
+    data['username'] = 'withoutemail'
+    data['patron']['communication_channel'] = 'mail'
+    yield create_patron(data)
 
 
 # ------------ Loans: pending loan ----------
@@ -674,8 +358,8 @@ def loan_pending_martigny(
         app,
         item_lib_fully,
         loc_public_martigny,
-        librarian_martigny_no_email,
-        patron2_martigny_no_email,
+        librarian_martigny,
+        patron2_martigny,
         circulation_policies):
     """Create loan record with state pending.
 
@@ -683,9 +367,9 @@ def loan_pending_martigny(
     """
     transaction_date = datetime.now(timezone.utc).isoformat()
     item_lib_fully.request(
-        patron_pid=patron2_martigny_no_email.pid,
+        patron_pid=patron2_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_date=transaction_date,
         pickup_location_pid=loc_public_martigny.pid,
         document_pid=item_lib_fully.replace_refs()['document']['pid']
@@ -717,8 +401,8 @@ def loan_validated_martigny(
         item2_lib_martigny,
         loc_public_martigny,
         item_type_standard_martigny,
-        librarian_martigny_no_email,
-        patron_martigny_no_email,
+        librarian_martigny,
+        patron_martigny,
         circulation_policies):
     """Request and validate item to a patron.
 
@@ -727,9 +411,9 @@ def loan_validated_martigny(
     transaction_date = datetime.now(timezone.utc).isoformat()
 
     item2_lib_martigny.request(
-        patron_pid=patron_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_date=transaction_date,
         pickup_location_pid=loc_public_martigny.pid,
         document_pid=item2_lib_martigny.replace_refs()['document']['pid']
@@ -742,9 +426,9 @@ def loan_validated_martigny(
         item_pid=item2_lib_martigny.pid))[0]
     item2_lib_martigny.validate_request(
         pid=loan.pid,
-        patron_pid=patron_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_date=transaction_date,
         pickup_location_pid=loc_public_martigny.pid,
         document_pid=item2_lib_martigny.replace_refs()['document']['pid']
@@ -781,8 +465,8 @@ def loan_overdue_martigny(
         item4_lib_martigny,
         loc_public_martigny,
         item_type_standard_martigny,
-        librarian_martigny_no_email,
-        patron_martigny_no_email,
+        librarian_martigny,
+        patron_martigny,
         circulation_policies):
     """Checkout an item to a patron.
 
@@ -791,9 +475,9 @@ def loan_overdue_martigny(
     transaction_date = datetime.now(timezone.utc).isoformat()
 
     item4_lib_martigny.checkout(
-        patron_pid=patron_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_date=transaction_date,
         document_pid=item4_lib_martigny.replace_refs()['document']['pid']
     )
@@ -857,8 +541,8 @@ def loan_overdue_saxon(
         item2_lib_saxon,
         loc_public_martigny,
         item_type_standard_martigny,
-        librarian_martigny_no_email,
-        patron_martigny_no_email,
+        librarian_martigny,
+        patron_martigny,
         circulation_policies):
     """Checkout an item to a patron.
 
@@ -867,9 +551,9 @@ def loan_overdue_saxon(
     transaction_date = datetime.now(timezone.utc).isoformat()
 
     item2_lib_saxon.checkout(
-        patron_pid=patron_martigny_no_email.pid,
+        patron_pid=patron_martigny.pid,
         transaction_location_pid=loc_public_martigny.pid,
-        transaction_user_pid=librarian_martigny_no_email.pid,
+        transaction_user_pid=librarian_martigny.pid,
         transaction_date=transaction_date,
         document_pid=item2_lib_saxon.replace_refs()['document']['pid']
     )
@@ -936,8 +620,8 @@ def loan_overdue_sion(
         item_lib_sion,
         loc_public_sion,
         item_type_regular_sion,
-        librarian_sion_no_email,
-        patron_sion_no_email,
+        librarian_sion,
+        patron_sion,
         circulation_policies):
     """Checkout an item to a patron.
 
@@ -946,9 +630,9 @@ def loan_overdue_sion(
     transaction_date = datetime.now(timezone.utc).isoformat()
 
     item_lib_sion.checkout(
-        patron_pid=patron_sion_no_email.pid,
+        patron_pid=patron_sion.pid,
         transaction_location_pid=loc_public_sion.pid,
-        transaction_user_pid=librarian_sion_no_email.pid,
+        transaction_user_pid=librarian_sion.pid,
         transaction_date=transaction_date,
         document_pid=item_lib_sion.replace_refs()['document']['pid']
     )
@@ -1012,9 +696,9 @@ def patron_transaction_overdue_event_sion_data(data):
 @pytest.fixture(scope="module")
 def item_on_shelf_martigny_patron_and_loan_pending(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies,):
+        patron_martigny, circulation_policies,):
     """Creates an item on_shelf requested by a patron.
 
     :return item: the created or copied item.
@@ -1022,24 +706,24 @@ def item_on_shelf_martigny_patron_and_loan_pending(
     :return loan: the pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.PENDING,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item2_on_shelf_martigny_patron_and_loan_pending(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies,):
+        patron_martigny, circulation_policies,):
     """Creates an item on_shelf requested by a patron.
 
     :return item: the created or copied item.
@@ -1047,24 +731,24 @@ def item2_on_shelf_martigny_patron_and_loan_pending(
     :return loan: the pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.PENDING,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item_at_desk_martigny_patron_and_loan_at_desk(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item with a validated pending request.
 
     :return item: the created or copied item.
@@ -1072,24 +756,24 @@ def item_at_desk_martigny_patron_and_loan_at_desk(
     :return loan: the validated pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_AT_DESK,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item2_at_desk_martigny_patron_and_loan_at_desk(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item with a validated pending request.
 
     :return item: the created or copied item.
@@ -1097,24 +781,24 @@ def item2_at_desk_martigny_patron_and_loan_at_desk(
     :return loan: the validated pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_AT_DESK,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item3_at_desk_martigny_patron_and_loan_at_desk(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item with a validated pending request.
 
     :return item: the created or copied item.
@@ -1122,24 +806,24 @@ def item3_at_desk_martigny_patron_and_loan_at_desk(
     :return loan: the validated pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_AT_DESK,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item4_at_desk_martigny_patron_and_loan_at_desk(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item with a validated pending request.
 
     :return item: the created or copied item.
@@ -1147,24 +831,24 @@ def item4_at_desk_martigny_patron_and_loan_at_desk(
     :return loan: the validated pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_AT_DESK,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item5_at_desk_martigny_patron_and_loan_at_desk(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item with a validated pending request.
 
     :return item: the created or copied item.
@@ -1172,24 +856,24 @@ def item5_at_desk_martigny_patron_and_loan_at_desk(
     :return loan: the validated pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_AT_DESK,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item_on_shelf_fully_patron_and_loan_pending(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_fully, loc_public_fully,
-        patron_martigny_no_email, circulation_policies,):
+        patron_martigny, circulation_policies,):
     """Creates an item on_shelf requested by a patron.
 
     :return item: the created or copied item.
@@ -1197,24 +881,24 @@ def item_on_shelf_fully_patron_and_loan_pending(
     :return loan: the pending loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_fully,
         loan_state=LoanState.PENDING,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item_on_loan_martigny_patron_and_loan_on_loan(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item on_loan.
 
     :return item: the created or copied item.
@@ -1222,24 +906,24 @@ def item_on_loan_martigny_patron_and_loan_on_loan(
     :return loan: the ITEM_ON_LOAN loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_ON_LOAN,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item2_on_loan_martigny_patron_and_loan_on_loan(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item on_loan.
 
     :return item: the created or copied item.
@@ -1247,24 +931,24 @@ def item2_on_loan_martigny_patron_and_loan_on_loan(
     :return loan: the ITEM_ON_LOAN loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_ON_LOAN,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item3_on_loan_martigny_patron_and_loan_on_loan(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item on_loan.
 
     :return item: the created or copied item.
@@ -1272,24 +956,24 @@ def item3_on_loan_martigny_patron_and_loan_on_loan(
     :return loan: the ITEM_ON_LOAN loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_ON_LOAN,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item4_on_loan_martigny_patron_and_loan_on_loan(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item on_loan.
 
     :return item: the created or copied item.
@@ -1297,24 +981,24 @@ def item4_on_loan_martigny_patron_and_loan_on_loan(
     :return loan: the ITEM_ON_LOAN loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_ON_LOAN,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item5_on_loan_martigny_patron_and_loan_on_loan(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item on_loan.
 
     :return item: the created or copied item.
@@ -1322,24 +1006,24 @@ def item5_on_loan_martigny_patron_and_loan_on_loan(
     :return loan: the ITEM_ON_LOAN loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_ON_LOAN,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item_on_loan_fully_patron_and_loan_on_loan(
         app,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_lib_fully, loc_public_fully,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item on_loan.
 
     :return item: the created or copied item.
@@ -1347,24 +1031,24 @@ def item_on_loan_fully_patron_and_loan_on_loan(
     :return loan: the ITEM_ON_LOAN loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_fully,
         loan_state=LoanState.ITEM_ON_LOAN,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item_in_transit_martigny_patron_and_loan_for_pickup(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit for pickup.
 
     :return item: the created or copied item.
@@ -1372,24 +1056,24 @@ def item_in_transit_martigny_patron_and_loan_for_pickup(
     :return loan: the ITEM_IN_TRANSIT_FOR_PICKUP loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item2_in_transit_martigny_patron_and_loan_for_pickup(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit for pickup.
 
     :return item: the created or copied item.
@@ -1397,24 +1081,24 @@ def item2_in_transit_martigny_patron_and_loan_for_pickup(
     :return loan: the ITEM_IN_TRANSIT_FOR_PICKUP loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item3_in_transit_martigny_patron_and_loan_for_pickup(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit for pickup.
 
     :return item: the created or copied item.
@@ -1422,24 +1106,24 @@ def item3_in_transit_martigny_patron_and_loan_for_pickup(
     :return loan: the ITEM_IN_TRANSIT_FOR_PICKUP loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, loan = item_record_to_a_specific_loan_state(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item_in_transit_martigny_patron_and_loan_to_house(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit to house.
 
     :return item: the created or copied item.
@@ -1447,9 +1131,9 @@ def item_in_transit_martigny_patron_and_loan_to_house(
     :return loan: the ITEM_IN_TRANSIT_TO_HOUSE loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -1457,15 +1141,15 @@ def item_in_transit_martigny_patron_and_loan_to_house(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item2_in_transit_martigny_patron_and_loan_to_house(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit to house.
 
     :return item: the created or copied item.
@@ -1473,9 +1157,9 @@ def item2_in_transit_martigny_patron_and_loan_to_house(
     :return loan: the ITEM_IN_TRANSIT_TO_HOUSE loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -1483,15 +1167,15 @@ def item2_in_transit_martigny_patron_and_loan_to_house(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item3_in_transit_martigny_patron_and_loan_to_house(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit to house.
 
     :return item: the created or copied item.
@@ -1499,9 +1183,9 @@ def item3_in_transit_martigny_patron_and_loan_to_house(
     :return loan: the ITEM_IN_TRANSIT_TO_HOUSE loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -1509,15 +1193,15 @@ def item3_in_transit_martigny_patron_and_loan_to_house(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item4_in_transit_martigny_patron_and_loan_to_house(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit to house.
 
     :return item: the created or copied item.
@@ -1525,9 +1209,9 @@ def item4_in_transit_martigny_patron_and_loan_to_house(
     :return loan: the ITEM_IN_TRANSIT_TO_HOUSE loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -1535,15 +1219,15 @@ def item4_in_transit_martigny_patron_and_loan_to_house(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item5_in_transit_martigny_patron_and_loan_to_house(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit to house.
 
     :return item: the created or copied item.
@@ -1551,9 +1235,9 @@ def item5_in_transit_martigny_patron_and_loan_to_house(
     :return loan: the ITEM_IN_TRANSIT_TO_HOUSE loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -1561,15 +1245,15 @@ def item5_in_transit_martigny_patron_and_loan_to_house(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 @pytest.fixture(scope="module")
 def item6_in_transit_martigny_patron_and_loan_to_house(
         app,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         item_lib_martigny, loc_public_martigny,
-        patron_martigny_no_email, circulation_policies):
+        patron_martigny, circulation_policies):
     """Creates an item in_transit to house.
 
     :return item: the created or copied item.
@@ -1577,9 +1261,9 @@ def item6_in_transit_martigny_patron_and_loan_to_house(
     :return loan: the ITEM_IN_TRANSIT_TO_HOUSE loan.
     """
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -1587,7 +1271,7 @@ def item6_in_transit_martigny_patron_and_loan_to_house(
         item=item_lib_martigny,
         loan_state=LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
         params=params, copy_item=True)
-    return item, patron_martigny_no_email, loan
+    return item, patron_martigny, loan
 
 
 # -------------- ILL requests ----------------------
@@ -1604,7 +1288,7 @@ def ill_request_martigny_data_tmp(data):
 
 
 @pytest.fixture(scope="module")
-def ill_request_martigny(app, loc_public_martigny, patron_martigny_no_email,
+def ill_request_martigny(app, loc_public_martigny, patron_martigny,
                          ill_request_martigny_data):
     """Create ill request for Martigny location."""
     illr = ILLRequest.create(
@@ -1623,7 +1307,7 @@ def ill_request_sion_data(data):
 
 
 @pytest.fixture(scope="module")
-def ill_request_sion(app, loc_public_sion, patron_sion_no_email,
+def ill_request_sion(app, loc_public_sion, patron_sion,
                      ill_request_sion_data):
     """Create ill request for Sion location."""
     illr = ILLRequest.create(

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -870,7 +870,7 @@ def templ_doc_public_martigny_data(data):
 @pytest.fixture(scope="module")
 def templ_doc_public_martigny(
         app, org_martigny, templ_doc_public_martigny_data,
-        system_librarian_martigny_no_email):
+        system_librarian_martigny):
     """Create template for a public document martigny."""
     template = Template.create(
         data=templ_doc_public_martigny_data,
@@ -890,7 +890,7 @@ def templ_doc_private_martigny_data(data):
 @pytest.fixture(scope="module")
 def templ_doc_private_martigny(
         app, org_martigny, templ_doc_private_martigny_data,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Create template for a private document martigny."""
     template = Template.create(
         data=templ_doc_private_martigny_data,
@@ -910,7 +910,7 @@ def templ_doc_public_sion_data(data):
 @pytest.fixture(scope="module")
 def templ_doc_public_sion(
         app, org_sion, templ_doc_public_sion_data,
-        system_librarian_sion_no_email):
+        system_librarian_sion):
     """Create template for a public document sion."""
     template = Template.create(
         data=templ_doc_public_sion_data,
@@ -930,7 +930,7 @@ def templ_holdings_public_martigny_data(data):
 @pytest.fixture(scope="module")
 def templ_holdings_public_martigny(
         app, org_martigny, templ_holdings_public_martigny_data,
-        system_librarian_martigny_no_email):
+        system_librarian_martigny):
     """Load template for a public holdings martigny."""
     template = Template.create(
         data=templ_holdings_public_martigny_data,
@@ -950,7 +950,7 @@ def templ_item_public_martigny_data(data):
 @pytest.fixture(scope="module")
 def templ_item_public_martigny(
         app, org_martigny, templ_item_public_martigny_data,
-        system_librarian_martigny_no_email):
+        system_librarian_martigny):
     """Load template for a public item martigny."""
     template = Template.create(
         data=templ_item_public_martigny_data,
@@ -970,7 +970,7 @@ def templ_patron_public_martigny_data(data):
 @pytest.fixture(scope="module")
 def templ_patron_public_martigny(
         app, org_martigny, templ_patron_public_martigny_data,
-        system_librarian_martigny_no_email):
+        system_librarian_martigny):
     """Load template for a public item martigny."""
     template = Template.create(
         data=templ_patron_public_martigny_data,

--- a/tests/fixtures/sip2.py
+++ b/tests/fixtures/sip2.py
@@ -20,11 +20,8 @@
 
 from copy import deepcopy
 
-import mock
 import pytest
-from utils import flush_index
-
-from rero_ils.modules.patrons.api import Patron, PatronsSearch
+from utils import create_patron
 
 
 @pytest.fixture(scope="module")
@@ -34,23 +31,14 @@ def sip2_librarian_martigny_data(data):
 
 
 @pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def sip2_librarian_martigny_no_email(
+def sip2_librarian_martigny(
         app,
         roles,
         lib_martigny,
         sip2_librarian_martigny_data):
     """Create Martigny librarian without sending reset password instruction."""
-    # create patron account
-    patron = Patron.create(
-        data=sip2_librarian_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-
-    flush_index(PatronsSearch.Meta.index)
-    return patron
-
+    data = sip2_librarian_martigny_data
+    yield create_patron(data)
 
 @pytest.fixture(scope="module")
 def sip2_patron_martigny_data(data):
@@ -59,19 +47,12 @@ def sip2_patron_martigny_data(data):
 
 
 @pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def sip2_patron_martigny_no_email(
+def sip2_patron_martigny(
         app,
         roles,
         patron_type_children_martigny,
         sip2_patron_martigny_data):
     """Create Martigny patron without sending reset password instruction."""
     # create patron account
-    patron = Patron.create(
-        data=sip2_patron_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-
-    flush_index(PatronsSearch.Meta.index)
-    return patron
+    data = sip2_patron_martigny_data
+    yield create_patron(data)

--- a/tests/ui/circulation/test_actions_add_request.py
+++ b/tests/ui/circulation/test_actions_add_request.py
@@ -27,8 +27,8 @@ from rero_ils.modules.loans.api import LoanState
 
 def test_add_request_on_item_on_shelf(
         item_on_shelf_martigny_patron_and_loan_pending,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test requests on an on_shelf item."""
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
 
@@ -42,7 +42,7 @@ def test_add_request_on_item_on_shelf(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     with pytest.raises(RecordCannotBeRequestedError):
@@ -53,7 +53,7 @@ def test_add_request_on_item_on_shelf(
     # the following tests the circulation action ADD_REQUEST_1_2_2
     # for an item on_shelf with a pending loan, a patron that does not own the
     # pending loan can add a new pending loan on same item.
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     item, requested_loan = item_record_to_a_specific_loan_state(
         item=item, loan_state=LoanState.PENDING,
         params=params, copy_item=False)
@@ -62,8 +62,8 @@ def test_add_request_on_item_on_shelf(
 
 def test_add_request_on_item_at_desk(
         client, item_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test requests on an at_desk item."""
     item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
 
@@ -72,7 +72,7 @@ def test_add_request_on_item_at_desk(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     with pytest.raises(RecordCannotBeRequestedError):
@@ -83,7 +83,7 @@ def test_add_request_on_item_at_desk(
     # the following tests the circulation action ADD_REQUEST_2_2
     # a patron who doesnt own the ITEM_AT_DESK loan can add a new pending loan.
 
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     item, requested_loan = item_record_to_a_specific_loan_state(
         item=item, loan_state=LoanState.PENDING, params=params,
         copy_item=False)
@@ -93,8 +93,8 @@ def test_add_request_on_item_at_desk(
 
 def test_add_request_on_item_on_loan(
         item_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, patron4_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, patron4_martigny):
     """Test requests on an on_loan item."""
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
 
@@ -103,7 +103,7 @@ def test_add_request_on_item_on_loan(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     with pytest.raises(RecordCannotBeRequestedError):
@@ -114,7 +114,7 @@ def test_add_request_on_item_on_loan(
     # the following tests the circulation action ADD_REQUEST_3_2_1
     # any patron who does not own the ITEM_ON_LOAN loan can add a new pending
     # loan.
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     item, requested_loan = item_record_to_a_specific_loan_state(
         item=item, loan_state=LoanState.PENDING, params=params,
         copy_item=False)
@@ -124,7 +124,7 @@ def test_add_request_on_item_on_loan(
     # the following tests the circulation action ADD_REQUEST_3_2_2_1
     # when an item on_loan has pending requests, the patron who owns the
     # pending loan may not add a new pending loan
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     with pytest.raises(RecordCannotBeRequestedError):
         item, requested_loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params,
@@ -132,7 +132,7 @@ def test_add_request_on_item_on_loan(
     # the following tests the circulation action ADD_REQUEST_3_2_2_2
     # when an item on_loan has pending requests, any patron who does not own
     # the pending loan may add a new pending loan
-    params['patron_pid'] = patron4_martigny_no_email.pid
+    params['patron_pid'] = patron4_martigny.pid
     item, second_requested_loan = item_record_to_a_specific_loan_state(
         item=item, loan_state=LoanState.PENDING, params=params,
         copy_item=False)
@@ -143,8 +143,8 @@ def test_add_request_on_item_on_loan(
 
 def test_add_request_on_item_in_transit_for_pickup(
         item_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_fully):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_fully):
     """Test requests on an in_transit item for pickup."""
     item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
 
@@ -153,7 +153,7 @@ def test_add_request_on_item_in_transit_for_pickup(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     with pytest.raises(RecordCannotBeRequestedError):
@@ -164,7 +164,7 @@ def test_add_request_on_item_in_transit_for_pickup(
     # the following tests the circulation action ADD_REQUEST_4_2
     # a patron who does not own the IN_TRANSIT_FOR_PICKUP loan can add
     # a new pending loan.
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     item, requested_loan = item_record_to_a_specific_loan_state(
         item=item, loan_state=LoanState.PENDING, params=params,
         copy_item=False)
@@ -174,9 +174,9 @@ def test_add_request_on_item_in_transit_for_pickup(
 
 def test_add_request_on_item_in_transit_to_house(
         item_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_fully,
-        patron4_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_fully,
+        patron4_martigny):
     """Test requests on an in_transit item to house."""
     item, patron, loan = item_in_transit_martigny_patron_and_loan_to_house
 
@@ -184,9 +184,9 @@ def test_add_request_on_item_in_transit_to_house(
     # any patron can add a new pending loan on an item with a loan equal to
     # ITEM_IN_TRANSIT_TO_HOUSE
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid,
     }
@@ -207,7 +207,7 @@ def test_add_request_on_item_in_transit_to_house(
     # the following tests the circulation action ADD_REQUEST_5_2_2
     # when a pending loan exist on an item with loan ITEM_IN_TRANSIT_TO_HOUSE,
     # any patron who does now own the pending loan can add a new pending loan.
-    params['patron_pid'] = patron4_martigny_no_email.pid
+    params['patron_pid'] = patron4_martigny.pid
     item, second_requested_loan = item_record_to_a_specific_loan_state(
         item=item, loan_state=LoanState.PENDING, params=params,
         copy_item=False)

--- a/tests/ui/circulation/test_actions_cancel_request.py
+++ b/tests/ui/circulation/test_actions_cancel_request.py
@@ -29,8 +29,8 @@ from rero_ils.modules.loans.api import Loan, LoanState
 
 def test_cancel_request_on_item_on_shelf(
         item_lib_martigny, item_on_shelf_martigny_patron_and_loan_pending,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel request on an on_shelf item."""
     # the following tests the circulation action CANCEL_REQUEST_1_1
     # on_shelf item with no pending requests, not possible to cancel a request.
@@ -45,9 +45,9 @@ def test_cancel_request_on_item_on_shelf(
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
     # add request for another patron
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -57,7 +57,7 @@ def test_cancel_request_on_item_on_shelf(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -68,7 +68,7 @@ def test_cancel_request_on_item_on_shelf(
 
 def test_cancel_request_on_item_at_desk_no_requests_externally(
         client, item_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         loc_public_fully):
     """Test cancel requests on an at_desk item externally."""
     item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
@@ -79,7 +79,7 @@ def test_cancel_request_on_item_at_desk_no_requests_externally(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -90,7 +90,7 @@ def test_cancel_request_on_item_at_desk_no_requests_externally(
 
 def test_cancel_request_on_item_at_desk_no_requests_at_home(
         client, item2_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email):
+        loc_public_martigny, librarian_martigny):
     """Test cancel requests on an at_desk item at home."""
     item, patron, loan = item2_at_desk_martigny_patron_and_loan_at_desk
     # the following tests the circulation action CANCEL_REQUEST_2_1_1_2
@@ -100,7 +100,7 @@ def test_cancel_request_on_item_at_desk_no_requests_at_home(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -111,8 +111,8 @@ def test_cancel_request_on_item_at_desk_no_requests_at_home(
 
 def test_cancel_request_on_item_at_desk_with_requests_externally(
         client, item3_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_fully):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_fully):
     """Test cancel requests on an at_desk item with requests at externally."""
     item, patron, loan = item3_at_desk_martigny_patron_and_loan_at_desk
     # the following tests the circulation action CANCEL_REQUEST_2_1_2_1
@@ -122,9 +122,9 @@ def test_cancel_request_on_item_at_desk_with_requests_externally(
     # firt pending loan
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -135,7 +135,7 @@ def test_cancel_request_on_item_at_desk_with_requests_externally(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -148,8 +148,8 @@ def test_cancel_request_on_item_at_desk_with_requests_externally(
 
 def test_cancel_request_on_item_at_desk_with_requests_at_home(
         client, item4_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel requests on an at_desk item with requests at home."""
     item, patron, loan = item4_at_desk_martigny_patron_and_loan_at_desk
     # the following tests the circulation action CANCEL_REQUEST_2_1_2_2
@@ -159,9 +159,9 @@ def test_cancel_request_on_item_at_desk_with_requests_at_home(
     # firt pending loan
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -172,7 +172,7 @@ def test_cancel_request_on_item_at_desk_with_requests_at_home(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -185,17 +185,17 @@ def test_cancel_request_on_item_at_desk_with_requests_at_home(
 
 def test_cancel_pending_request_on_item_at_desk(
         client, item5_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel requests on an at_desk item with requests at home."""
     item, patron, loan = item5_at_desk_martigny_patron_and_loan_at_desk
     # the following tests the circulation action CANCEL_REQUEST_2_2
     # an item at_desk with other pending loans. when a librarian wants to
     # cancel one of the pending loans. the item remains at_desk
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -206,7 +206,7 @@ def test_cancel_pending_request_on_item_at_desk(
     params = {
         'pid': requested_loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -219,8 +219,8 @@ def test_cancel_pending_request_on_item_at_desk(
 
 def test_cancel_item_request_on_item_on_loan(
         client, item_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel requests on an on_loan item."""
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     # the following tests the circulation action CANCEL_REQUEST_3_1
@@ -229,7 +229,7 @@ def test_cancel_item_request_on_item_on_loan(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item.cancel_item_request(**params)
@@ -242,9 +242,9 @@ def test_cancel_item_request_on_item_on_loan(
     # an item on_loan with other pending loans. when a librarian wants to
     # cancel the pending loan. action is permitted and item remains on_loan.
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -255,7 +255,7 @@ def test_cancel_item_request_on_item_on_loan(
     params = {
         'pid': requested_loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -268,8 +268,8 @@ def test_cancel_item_request_on_item_on_loan(
 
 def test_cancel_item_request_on_item_in_transit_for_pickup(
         client, item_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel requests on an in_transit for pickup item."""
     item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
     # the following tests the circulation action CANCEL_REQUEST_4_1_1
@@ -279,7 +279,7 @@ def test_cancel_item_request_on_item_in_transit_for_pickup(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -290,8 +290,8 @@ def test_cancel_item_request_on_item_in_transit_for_pickup(
 
 def test_cancel_item_request_on_item_in_transit_for_pickup_with_requests(
         client, item2_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel requests on an in_transit for pickup item with requests."""
     item, patron, loan = item2_in_transit_martigny_patron_and_loan_for_pickup
     # the following tests the circulation action CANCEL_REQUEST_4_1_2
@@ -300,9 +300,9 @@ def test_cancel_item_request_on_item_in_transit_for_pickup_with_requests(
     # cancel loan, next pending loan is validated.
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -313,7 +313,7 @@ def test_cancel_item_request_on_item_in_transit_for_pickup_with_requests(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -326,8 +326,8 @@ def test_cancel_item_request_on_item_in_transit_for_pickup_with_requests(
 
 def test_cancel_pending_loan_on_item_in_transit_for_pickup_with_requests(
         client, item3_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel pending loan on an in_transit for pickup item."""
     item, patron, loan = item3_in_transit_martigny_patron_and_loan_for_pickup
     # the following tests the circulation action CANCEL_REQUEST_4_2
@@ -336,9 +336,9 @@ def test_cancel_pending_loan_on_item_in_transit_for_pickup_with_requests(
     # item remains in_transit
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -349,7 +349,7 @@ def test_cancel_pending_loan_on_item_in_transit_for_pickup_with_requests(
     params = {
         'pid': requested_loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -362,7 +362,7 @@ def test_cancel_pending_loan_on_item_in_transit_for_pickup_with_requests(
 
 def test_cancel_request_on_item_in_transit_to_house(
         client, item_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email):
+        loc_public_martigny, librarian_martigny):
     """Test cancel request loan on an in_transit to_house item."""
     item, patron, loan = item_in_transit_martigny_patron_and_loan_to_house
     # the following tests the circulation action CANCEL_REQUEST_5_1_1
@@ -372,7 +372,7 @@ def test_cancel_request_on_item_in_transit_to_house(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -383,8 +383,8 @@ def test_cancel_request_on_item_in_transit_to_house(
 
 def test_cancel_request_on_item_in_transit_to_house_with_requests(
         client, item2_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel request on an in_transit to_house item with requests."""
     item, patron, loan = item2_in_transit_martigny_patron_and_loan_to_house
     # the following tests the circulation action CANCEL_REQUEST_5_1_2
@@ -392,9 +392,9 @@ def test_cancel_request_on_item_in_transit_to_house_with_requests(
     # librarian wants to cancel the in_transit loan. action is permitted.
     # the loan will be cancelled. and first pending loan will be validated.
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -405,7 +405,7 @@ def test_cancel_request_on_item_in_transit_to_house_with_requests(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -418,8 +418,8 @@ def test_cancel_request_on_item_in_transit_to_house_with_requests(
 
 def test_cancel_pending_on_item_in_transit_to_house(
         client, item3_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test cancel pending loan on an in_transit to_house item."""
     item, patron, loan = item3_in_transit_martigny_patron_and_loan_to_house
     # the following tests the circulation action CANCEL_REQUEST_5_2
@@ -427,9 +427,9 @@ def test_cancel_pending_on_item_in_transit_to_house(
     # librarian wants to cancel the pending loan. action is permitted.
     # the loan will be cancelled. and in_transit loan remains in transit.
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -440,7 +440,7 @@ def test_cancel_pending_on_item_in_transit_to_house(
     params = {
         'pid': requested_loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item.cancel_item_request(**params)
     item = Item.get_record_by_pid(item.pid)

--- a/tests/ui/circulation/test_actions_checkin.py
+++ b/tests/ui/circulation/test_actions_checkin.py
@@ -28,9 +28,9 @@ from rero_ils.modules.loans.api import Loan, LoanState
 
 
 def test_checkin_on_item_on_shelf_no_requests(
-        item_lib_martigny, patron_martigny_no_email, lib_martigny,
-        loc_public_martigny, librarian_martigny_no_email, lib_fully,
-        patron2_martigny_no_email, loc_public_fully, circulation_policies):
+        item_lib_martigny, patron_martigny, lib_martigny,
+        loc_public_martigny, librarian_martigny, lib_fully,
+        patron2_martigny, loc_public_fully, circulation_policies):
     """Test checkin on an on_shelf item with no requests."""
     # the following tests the circulation action CHECKIN_1_1_1
     # an on_shelf item with no pending requests. when the item library equal
@@ -38,7 +38,7 @@ def test_checkin_on_item_on_shelf_no_requests(
     # no circulation action will be performed.
     params = {
         'transaction_library_pid': lib_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item_lib_martigny.checkin(**params)
@@ -62,8 +62,8 @@ def test_checkin_on_item_on_shelf_no_requests(
 
 def test_checkin_on_item_on_shelf_with_requests(
         item_on_shelf_martigny_patron_and_loan_pending,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_fully, lib_martigny):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_fully, lib_martigny):
     """Test checkin on an on_shelf item with requests."""
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
     # the following tests the circulation action CHECKIN_1_2_1
@@ -74,9 +74,9 @@ def test_checkin_on_item_on_shelf_with_requests(
 
     # create a second pending loan on same item
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -86,7 +86,7 @@ def test_checkin_on_item_on_shelf_with_requests(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     assert item.status == ItemStatus.AT_DESK
@@ -97,8 +97,8 @@ def test_checkin_on_item_on_shelf_with_requests(
 
 def test_checkin_on_item_on_shelf_with_requests_external(
         item_on_shelf_fully_patron_and_loan_pending,
-        loc_public_fully, librarian_martigny_no_email,
-        patron2_martigny_no_email, lib_martigny, loc_public_martigny):
+        loc_public_fully, librarian_martigny,
+        patron2_martigny, lib_martigny, loc_public_martigny):
     """Test checkin on an on_shelf item with requests."""
     item, patron, loan = item_on_shelf_fully_patron_and_loan_pending
     # the following tests the circulation action CHECKIN_1_2_2
@@ -109,9 +109,9 @@ def test_checkin_on_item_on_shelf_with_requests_external(
 
     # create a second pending loan on same item
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -121,7 +121,7 @@ def test_checkin_on_item_on_shelf_with_requests_external(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -134,7 +134,7 @@ def test_checkin_on_item_on_shelf_with_requests_external(
 
 def test_checkin_on_item_at_desk(
         item_at_desk_martigny_patron_and_loan_at_desk,
-        librarian_martigny_no_email, loc_public_fully,
+        librarian_martigny, loc_public_fully,
         lib_martigny, loc_public_martigny):
     """Test checkin on an at_desk item."""
     item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
@@ -144,7 +144,7 @@ def test_checkin_on_item_at_desk(
     # no action is done, item remains at_desk
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.checkin(**params)
@@ -158,7 +158,7 @@ def test_checkin_on_item_at_desk(
 
     params = {
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.checkin(**params)
@@ -170,7 +170,7 @@ def test_checkin_on_item_on_loan(
         item_on_loan_martigny_patron_and_loan_on_loan,
         item2_on_loan_martigny_patron_and_loan_on_loan,
         item_on_loan_fully_patron_and_loan_on_loan, loc_public_fully,
-        loc_public_martigny, librarian_martigny_no_email):
+        loc_public_martigny, librarian_martigny):
     """Test checkin on an on_loan item."""
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     # the following tests the circulation action CHECKIN_3_1_1
@@ -179,7 +179,7 @@ def test_checkin_on_item_on_loan(
     # case when the loan pid is given as a parameter
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     item, actions = item.checkin(**params)
@@ -192,7 +192,7 @@ def test_checkin_on_item_on_loan(
     item, patron, loan = item_on_loan_fully_patron_and_loan_on_loan
     params = {
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -206,7 +206,7 @@ def test_checkin_on_item_on_loan(
     item, patron, loan = item2_on_loan_martigny_patron_and_loan_on_loan
     params = {
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     item, actions = item.checkin(**params)
@@ -218,8 +218,8 @@ def test_checkin_on_item_on_loan(
 
 def test_checkin_on_item_on_loan_with_requests(
         item3_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test checkin on an on_loan item with requests at local library."""
     item, patron, loan = item3_on_loan_martigny_patron_and_loan_on_loan
     # the following tests the circulation action CHECKIN_3_2_1
@@ -228,9 +228,9 @@ def test_checkin_on_item_on_loan_with_requests(
     # checkin the item and item becomes at_desk.
     # the on_loan is returned and validating the first pending loan request.
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
 
@@ -250,8 +250,8 @@ def test_checkin_on_item_on_loan_with_requests(
 def test_checkin_on_item_on_loan_with_requests_externally(
         item4_on_loan_martigny_patron_and_loan_on_loan,
         item5_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_fully, loc_public_saxon):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_fully, loc_public_saxon):
     """Test checkin on an on_loan item with requests at an external library."""
     item, patron, loan = item4_on_loan_martigny_patron_and_loan_on_loan
     # the following tests the circulation action CHECKIN_3_2_2_1
@@ -262,9 +262,9 @@ def test_checkin_on_item_on_loan_with_requests_externally(
     # the pending loan becomes ITEM_IN_TRANSIT_FOR_PICKUP
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
 
@@ -289,9 +289,9 @@ def test_checkin_on_item_on_loan_with_requests_externally(
     # library, the pending loan becomes ITEM_IN_TRANSIT_FOR_PICKUP
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_fully.pid
     }
 
@@ -310,7 +310,7 @@ def test_checkin_on_item_on_loan_with_requests_externally(
 
 def test_checkin_on_item_in_transit_for_pickup(
         item_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         loc_public_fully):
     """Test checkin on an in_transit item for pickup."""
     item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
@@ -323,7 +323,7 @@ def test_checkin_on_item_in_transit_for_pickup(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -334,7 +334,7 @@ def test_checkin_on_item_in_transit_for_pickup(
 
 def test_checkin_on_item_in_transit_for_pickup_externally(
         item2_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         loc_public_fully, loc_public_saxon):
     """Test checkin on an in_transit item for pickup."""
     item, patron, loan = item2_in_transit_martigny_patron_and_loan_for_pickup
@@ -346,7 +346,7 @@ def test_checkin_on_item_in_transit_for_pickup_externally(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.checkin(**params)
@@ -358,7 +358,7 @@ def test_checkin_on_item_in_transit_for_pickup_externally(
 
 def test_checkin_on_item_in_transit_to_house(
         item_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email):
+        loc_public_martigny, librarian_martigny):
     """Test checkin on an in_transit item to house."""
     item, patron, loan = item_in_transit_martigny_patron_and_loan_to_house
 
@@ -369,7 +369,7 @@ def test_checkin_on_item_in_transit_to_house(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     item = Item.get_record_by_pid(item.pid)
@@ -380,7 +380,7 @@ def test_checkin_on_item_in_transit_to_house(
 
 def test_checkin_on_item_in_transit_to_house_externally(
         item2_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email, loc_public_saxon):
+        loc_public_martigny, librarian_martigny, loc_public_saxon):
     """Test checkin on an in_transit item to house."""
     item, patron, loan = item2_in_transit_martigny_patron_and_loan_to_house
 
@@ -391,7 +391,7 @@ def test_checkin_on_item_in_transit_to_house_externally(
     params = {
         'patron_pid': patron.pid,
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.checkin(**params)
@@ -403,8 +403,8 @@ def test_checkin_on_item_in_transit_to_house_externally(
 
 def test_checkin_on_item_in_transit_to_house_with_requests(
         item3_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny):
     """Test checkin on an in_transit item to house."""
     item, patron, loan = item3_in_transit_martigny_patron_and_loan_to_house
 
@@ -416,9 +416,9 @@ def test_checkin_on_item_in_transit_to_house_with_requests(
     # the item becomes at_desk and the loan is terminated.
     # and will validate the first pending loan
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -427,7 +427,7 @@ def test_checkin_on_item_in_transit_to_house_with_requests(
     assert requested_loan['state'] == LoanState.PENDING
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
 
@@ -442,8 +442,8 @@ def test_checkin_on_item_in_transit_to_house_with_requests(
 
 def test_checkin_on_item_in_transit_to_house_with_requests_externally(
         item4_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_saxon):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_saxon):
     """Test checkin on an in_transit item to house."""
     item, patron, loan = item4_in_transit_martigny_patron_and_loan_to_house
 
@@ -455,9 +455,9 @@ def test_checkin_on_item_in_transit_to_house_with_requests_externally(
     # the item becomes at_desk and will validate the first pending loan
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_saxon.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -466,7 +466,7 @@ def test_checkin_on_item_in_transit_to_house_with_requests_externally(
     assert requested_loan['state'] == LoanState.PENDING
     params = {
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
 
     item, actions = item.checkin(**params)
@@ -480,8 +480,8 @@ def test_checkin_on_item_in_transit_to_house_with_requests_externally(
 
 def test_checkin_on_item_in_transit_to_house_with_external_loans(
         item5_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_saxon):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_saxon):
     """Test checkin on an in_transit item to house."""
     item, patron, loan = item5_in_transit_martigny_patron_and_loan_to_house
 
@@ -492,9 +492,9 @@ def test_checkin_on_item_in_transit_to_house_with_external_loans(
     # the to the item library, no action performed.
     # the item remains at_desk
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -503,7 +503,7 @@ def test_checkin_on_item_in_transit_to_house_with_external_loans(
     assert requested_loan['state'] == LoanState.PENDING
     params = {
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
 
     with pytest.raises(NoCirculationAction):
@@ -518,8 +518,8 @@ def test_checkin_on_item_in_transit_to_house_with_external_loans(
 
 def test_checkin_on_item_in_transit_to_house_with_external_loans_transit(
         item6_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        patron2_martigny_no_email, loc_public_saxon, loc_public_saillon):
+        loc_public_martigny, librarian_martigny,
+        patron2_martigny, loc_public_saxon, loc_public_saillon):
     """Test checkin on an in_transit item to house."""
     item, patron, loan = item6_in_transit_martigny_patron_and_loan_to_house
 
@@ -531,9 +531,9 @@ def test_checkin_on_item_in_transit_to_house_with_external_loans_transit(
     # the first pending request. item becomes in_transit and becomes
     # ITEM_IN_TRANSIT_FOR_PICKUP
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_saxon.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -542,7 +542,7 @@ def test_checkin_on_item_in_transit_to_house_with_external_loans_transit(
     assert requested_loan['state'] == LoanState.PENDING
     params = {
         'transaction_location_pid': loc_public_saillon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
 

--- a/tests/ui/circulation/test_actions_checkout.py
+++ b/tests/ui/circulation/test_actions_checkout.py
@@ -32,11 +32,11 @@ from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
 
 def test_checkout_on_item_on_shelf(
         circulation_policies,
-        patron_martigny_no_email,
-        patron2_martigny_no_email,
+        patron_martigny,
+        patron2_martigny,
         item_lib_martigny,
         loc_public_martigny,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_on_shelf_martigny_patron_and_loan_pending):
     """Test checkout on an ON_SHELF item."""
     # Create a new item in ON_SHELF (without Loan)
@@ -50,16 +50,16 @@ def test_checkout_on_item_on_shelf(
     assert created_item.number_of_requests() == 0
     assert created_item.status == ItemStatus.ON_SHELF
     assert not created_item.is_requested_by_patron(
-        patron_martigny_no_email.get('patron', {}).get('barcode'))
+        patron_martigny.get('patron', {}).get('barcode'))
 
     # the following tests the circulation action CHECKOUT_1_1
     # an ON_SHELF item
     # WITHOUT pending loan
     # CAN be CHECKOUT
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     onloan_item, actions = created_item.checkout(**params)
@@ -77,7 +77,7 @@ def test_checkout_on_item_on_shelf(
     # WITH pending loan
     # checkout patron != patron of first PENDING loan
     # can NOT be CHECKOUT
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     # CHECKOUT patron is DIFFERENT from 1st PENDING LOAN patron
     assert params['patron_pid'] != patron['pid']
     with pytest.raises(ItemNotAvailableError):
@@ -98,7 +98,7 @@ def test_checkout_on_item_on_shelf(
         patron.patron.get('barcode'))
     # Checkout it! CHECKOUT patron == 1st PENDING LOAN patron
     assert patron.get('pid') == loan.get('patron_pid')
-    params['patron_pid'] = patron_martigny_no_email.pid
+    params['patron_pid'] = patron_martigny.pid
     onloan_item, actions = pending_item.checkout(**params, pid=loan.pid)
     loan = Loan.get_record_by_pid(actions[LoanAction.CHECKOUT].get('pid'))
     # Check loan is ITEM_ON_LOAN and item is ON_LOAN
@@ -109,9 +109,9 @@ def test_checkout_on_item_on_shelf(
 
 def test_checkout_on_item_at_desk(
         item_at_desk_martigny_patron_and_loan_at_desk,
-        patron2_martigny_no_email,
+        patron2_martigny,
         loc_public_martigny,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Test CHECKOUT on an AT_DESK item."""
     # Prepare a new item with ITEM_AT_DESK loan
     atdesk_item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
@@ -122,9 +122,9 @@ def test_checkout_on_item_at_desk(
     # checkout patron != patron of first PENDING loan
     # can NOT be CHECKOUT (raise ItemNotAvailableError)
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     assert params['patron_pid'] != loan['patron_pid']
@@ -156,10 +156,10 @@ def test_checkout_on_item_at_desk(
 
 def test_checkout_on_item_on_loan(
         item_on_loan_martigny_patron_and_loan_on_loan,
-        patron_martigny_no_email,
-        patron2_martigny_no_email,
+        patron_martigny,
+        patron2_martigny,
         loc_public_martigny,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Test CHECKOUT on an ON_LOAN item."""
     # Prepare a new item with an ITEM_ON_LOAN loan
     onloan_item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
@@ -170,9 +170,9 @@ def test_checkout_on_item_on_loan(
     # checkout patron = patron of current loan
     # can NOT be CHECKOUT
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     # Checkout it! CHECKOUT patron == current LOAN patron
@@ -190,7 +190,7 @@ def test_checkout_on_item_on_loan(
     # an ON_LOAN item
     # checkout patron != patron of current loan
     # can NOT be CHECKOUT
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     assert params['patron_pid'] != patron['pid']
     with pytest.raises(ItemNotAvailableError):
         asked_item, actions = onloan_item.checkout(**params)
@@ -203,10 +203,10 @@ def test_checkout_on_item_on_loan(
 
 def test_checkout_on_item_in_transit_for_pickup(
         item_in_transit_martigny_patron_and_loan_for_pickup,
-        patron_martigny_no_email,
-        patron2_martigny_no_email,
+        patron_martigny,
+        patron2_martigny,
         loc_public_martigny,
-        librarian_martigny_no_email, loc_public_saxon):
+        librarian_martigny, loc_public_saxon):
     """Test CHECKOUT on an IN_TRANSIT (for pickup) item."""
     # Prepare a new item with an IN_TRANSIT loan
     intransit_item, patron, loan = \
@@ -218,9 +218,9 @@ def test_checkout_on_item_in_transit_for_pickup(
     # checkout patron != patron of current loan
     # can NOT be CHECKOUT
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_saxon.pid
     }
     assert params['patron_pid'] != patron['pid']
@@ -236,7 +236,7 @@ def test_checkout_on_item_in_transit_for_pickup(
     # an IN_TRANSIT (for pickup) item
     # checkout patron = patron of current loan
     # CAN be CHECKOUT
-    params['patron_pid'] = patron_martigny_no_email.pid
+    params['patron_pid'] = patron_martigny.pid
     # Checkout it! CHECKOUT patron == current LOAN patron
     assert params['patron_pid'] == patron['pid']
     asked_item, actions = intransit_item.checkout(**params, pid=loan.pid)
@@ -249,8 +249,8 @@ def test_checkout_on_item_in_transit_for_pickup(
 
 def test_checkout_on_item_in_transit_to_house(
         item_in_transit_martigny_patron_and_loan_to_house,
-        patron_martigny_no_email,
-        librarian_martigny_no_email,
+        patron_martigny,
+        librarian_martigny,
         loc_public_martigny,
         loc_public_saxon):
     """Test CHECKOUT on an IN_TRANSIT (to house) item."""
@@ -264,9 +264,9 @@ def test_checkout_on_item_in_transit_to_house(
     # WITHOUT pending loan
     # CAN be CHECKOUT
     params = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
     }
     # Checkout it!
@@ -281,8 +281,8 @@ def test_checkout_on_item_in_transit_to_house(
 
 def test_checkout_on_item_in_transit_to_house_for_another_patron(
         item2_in_transit_martigny_patron_and_loan_to_house,
-        patron2_martigny_no_email,
-        librarian_martigny_no_email,
+        patron2_martigny,
+        librarian_martigny,
         loc_public_martigny,
         loc_public_saxon):
     """Test CHECKOUT on an IN_TRANSIT (to house) item."""
@@ -296,9 +296,9 @@ def test_checkout_on_item_in_transit_to_house_for_another_patron(
     # WITHOUT pending loan
     # CAN be CHECKOUT
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_saxon.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
     }
     # Checkout it!
@@ -314,9 +314,9 @@ def test_checkout_on_item_in_transit_to_house_for_another_patron(
 def test_checkout_on_item_in_transit_to_house_with_pending_loan(
         item_in_transit_martigny_patron_and_loan_to_house,
         item_lib_martigny,
-        patron2_martigny_no_email,
+        patron2_martigny,
         loc_public_martigny,
-        librarian_martigny_no_email,
+        librarian_martigny,
         loc_public_fully):
     """Test item IN_TRANSIT (to house), WITHOUT pending loan, same patron."""
     # Create a new item in IN_TRANSIT_TO_HOUSE
@@ -327,7 +327,7 @@ def test_checkout_on_item_in_transit_to_house_with_pending_loan(
     params = {
         'patron_pid': patron['pid'],
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'checkin_transaction_location_pid': loc_public_fully.pid
     }
@@ -340,7 +340,7 @@ def test_checkout_on_item_in_transit_to_house_with_pending_loan(
             params=params)
 
     # Create a pending loan
-    params['patron_pid'] = patron2_martigny_no_email.pid
+    params['patron_pid'] = patron2_martigny.pid
     checked_item, requested_loan = item_record_to_a_specific_loan_state(
         item=intransit_item,
         loan_state=LoanState.PENDING,

--- a/tests/ui/circulation/test_actions_extend.py
+++ b/tests/ui/circulation/test_actions_extend.py
@@ -28,8 +28,8 @@ from rero_ils.modules.loans.api import LoanState
 
 
 def test_extend_on_item_on_shelf(
-        item_lib_martigny, patron_martigny_no_email,
-        loc_public_martigny, librarian_martigny_no_email,
+        item_lib_martigny, patron_martigny,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test extend an on_shelf item."""
     # the following tests the circulation action EXTEND_1
@@ -37,7 +37,7 @@ def test_extend_on_item_on_shelf(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item_lib_martigny.extend_loan(**params)
@@ -46,7 +46,7 @@ def test_extend_on_item_on_shelf(
 
 def test_extend_on_item_at_desk(
         item_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test extend an at_desk item."""
     # the following tests the circulation action EXTEND_2
@@ -55,7 +55,7 @@ def test_extend_on_item_at_desk(
     # test fails if no loan pid is given
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
@@ -64,7 +64,7 @@ def test_extend_on_item_at_desk(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
         item, actions = item.extend_loan(**params)
@@ -73,7 +73,7 @@ def test_extend_on_item_at_desk(
 
 def test_extend_on_item_on_loan_with_no_requests(
         item_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test extend an on_loan item."""
     # the following tests the circulation action EXTEND_3_1
@@ -82,7 +82,7 @@ def test_extend_on_item_on_loan_with_no_requests(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.extend_loan(**params)
     assert item.status == ItemStatus.ON_LOAN
@@ -90,17 +90,17 @@ def test_extend_on_item_on_loan_with_no_requests(
 
 def test_extend_on_item_on_loan_with_requests(
         item_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
-        circulation_policies, patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        circulation_policies, patron2_martigny):
     """Test extend an on_loan item with requests."""
     # the following tests the circulation action EXTEND_3_2
     # for an on_loan item with requests, the extend action is not possible.
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
 
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -109,7 +109,7 @@ def test_extend_on_item_on_loan_with_requests(
     # test fails if no loan pid is given
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
@@ -118,7 +118,7 @@ def test_extend_on_item_on_loan_with_requests(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
@@ -127,7 +127,7 @@ def test_extend_on_item_on_loan_with_requests(
 
 def test_extend_on_item_in_transit_for_pickup(
         item_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test extend an in_transit for pickup item."""
     # the following tests the circulation action EXTEND_4
@@ -136,7 +136,7 @@ def test_extend_on_item_in_transit_for_pickup(
     # test fails if no loan pid is given
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
@@ -145,7 +145,7 @@ def test_extend_on_item_in_transit_for_pickup(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
         item, actions = item.extend_loan(**params)
@@ -154,7 +154,7 @@ def test_extend_on_item_in_transit_for_pickup(
 
 def test_extend_on_item_in_transit_to_house(
         item_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test extend an in_transit to_house item."""
     # the following tests the circulation action EXTEND_4
@@ -163,7 +163,7 @@ def test_extend_on_item_in_transit_to_house(
     # test fails if no loan pid is given
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
@@ -172,7 +172,7 @@ def test_extend_on_item_in_transit_to_house(
     params = {
         'pid': loan.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
         item, actions = item.extend_loan(**params)

--- a/tests/ui/circulation/test_actions_validate_request.py
+++ b/tests/ui/circulation/test_actions_validate_request.py
@@ -28,8 +28,8 @@ from rero_ils.modules.loans.api import Loan, LoanState
 
 
 def test_validate_on_item_on_shelf_no_requests(
-        item_lib_martigny, patron_martigny_no_email,
-        loc_public_martigny, librarian_martigny_no_email,
+        item_lib_martigny, patron_martigny,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test validate a request on an on_shelf item with no requests."""
     # the following tests the circulation action VALIDATE_1_1
@@ -38,7 +38,7 @@ def test_validate_on_item_on_shelf_no_requests(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item_lib_martigny.validate_request(**params)
@@ -47,7 +47,7 @@ def test_validate_on_item_on_shelf_no_requests(
 
 def test_validate_on_item_on_shelf_with_requests_at_home(
         item_on_shelf_martigny_patron_and_loan_pending,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test validate a request on an on_shelf item with requests at home."""
     # the following tests the circulation action VALIDATE_1_2_1
@@ -57,7 +57,7 @@ def test_validate_on_item_on_shelf_with_requests_at_home(
     item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     item, actions = item.validate_request(**params)
@@ -68,7 +68,7 @@ def test_validate_on_item_on_shelf_with_requests_at_home(
 
 def test_validate_on_item_on_shelf_with_requests_externally(
         item2_on_shelf_martigny_patron_and_loan_pending, loc_public_fully,
-        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_martigny, librarian_martigny,
         circulation_policies):
     """Test validate a request on an on_shelf item with requests externally."""
     # the following tests the circulation action VALIDATE_1_2_2
@@ -78,7 +78,7 @@ def test_validate_on_item_on_shelf_with_requests_externally(
     item, patron, loan = item2_on_shelf_martigny_patron_and_loan_pending
     params = {
         'transaction_location_pid': loc_public_fully.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     item, actions = item.validate_request(**params)
@@ -89,15 +89,15 @@ def test_validate_on_item_on_shelf_with_requests_externally(
 
 def test_validate_on_item_at_desk(
         item_at_desk_martigny_patron_and_loan_at_desk,
-        loc_public_martigny, librarian_martigny_no_email,
-        circulation_policies, patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        circulation_policies, patron2_martigny):
     """Test validate a request on an item at_desk."""
     # the following tests the circulation action VALIDATE_2
     # on at_desk item, the validation is not possible
     item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
@@ -107,9 +107,9 @@ def test_validate_on_item_at_desk(
     assert loan['state'] == LoanState.ITEM_AT_DESK
     # will not be able to validate any requestes for this item
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -126,15 +126,15 @@ def test_validate_on_item_at_desk(
 
 def test_validate_on_item_on_loan(
         item_on_loan_martigny_patron_and_loan_on_loan,
-        loc_public_martigny, librarian_martigny_no_email,
-        circulation_policies, patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        circulation_policies, patron2_martigny):
     """Test validate a request on an item on_loan."""
     # the following tests the circulation action VALIDATE_3
     # on on_loan item, the validation is not possible
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
@@ -145,9 +145,9 @@ def test_validate_on_item_on_loan(
 
     # will not be able to validate any requestes for this item
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -164,15 +164,15 @@ def test_validate_on_item_on_loan(
 
 def test_validate_on_item_in_transit_for_pickup(
         item_in_transit_martigny_patron_and_loan_for_pickup,
-        loc_public_martigny, librarian_martigny_no_email,
-        circulation_policies, patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        circulation_policies, patron2_martigny):
     """Test validate a request on an item in_transit for pickup."""
     # the following tests the circulation action VALIDATE_4
     # on on_loan item, the validation is not possible
     item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
@@ -183,9 +183,9 @@ def test_validate_on_item_in_transit_for_pickup(
 
     # will not be able to validate any requestes for this item
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(
@@ -202,15 +202,15 @@ def test_validate_on_item_in_transit_for_pickup(
 
 def test_validate_on_item_in_transit_to_house(
         item_in_transit_martigny_patron_and_loan_to_house,
-        loc_public_martigny, librarian_martigny_no_email,
-        circulation_policies, patron2_martigny_no_email):
+        loc_public_martigny, librarian_martigny,
+        circulation_policies, patron2_martigny):
     """Test validate a request on an item in_transit to house."""
     # the following tests the circulation action VALIDATE_5
     # on on_loan item, the validation is not possible
     item, patron, loan = item_in_transit_martigny_patron_and_loan_to_house
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pid': loan.pid
     }
     with pytest.raises(NoValidTransitionAvailableError):
@@ -220,9 +220,9 @@ def test_validate_on_item_in_transit_to_house(
     assert loan['state'] == LoanState.ITEM_IN_TRANSIT_TO_HOUSE
     # will not be able to validate any requestes for this item
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, requested_loan = item_record_to_a_specific_loan_state(

--- a/tests/ui/circulation/test_inhouse_cipo.py
+++ b/tests/ui/circulation/test_inhouse_cipo.py
@@ -30,11 +30,11 @@ from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
 
 def test_less_than_one_day_checkout(
         circ_policy_less_than_one_day_martigny,
-        patron_martigny_no_email,
-        patron2_martigny_no_email,
+        patron_martigny,
+        patron2_martigny,
         item_lib_martigny,
         loc_public_martigny,
-        librarian_martigny_no_email,
+        librarian_martigny,
         item_on_shelf_martigny_patron_and_loan_pending):
     """Test checkout on an ON_SHELF item with 'less than one day' cipo."""
     # Create a new item in ON_SHELF (without Loan)
@@ -48,7 +48,7 @@ def test_less_than_one_day_checkout(
     assert created_item.number_of_requests() == 0
     assert created_item.status == ItemStatus.ON_SHELF
     assert not created_item.is_requested_by_patron(
-        patron2_martigny_no_email.get('patron', {}).get('barcode'))
+        patron2_martigny.get('patron', {}).get('barcode'))
 
     # Ensure than the transaction date used will be an open_day.
     owner_lib = Library.get_record_by_pid(created_item.library_pid)
@@ -60,9 +60,9 @@ def test_less_than_one_day_checkout(
         # WITHOUT pending loan
         # CAN be CHECKOUT for less than one day
         params = {
-            'patron_pid': patron2_martigny_no_email.pid,
+            'patron_pid': patron2_martigny.pid,
             'transaction_location_pid': loc_public_martigny.pid,
-            'transaction_user_pid': librarian_martigny_no_email.pid,
+            'transaction_user_pid': librarian_martigny.pid,
             'pickup_location_pid': loc_public_martigny.pid
         }
         onloan_item, actions = created_item.checkout(**params)

--- a/tests/ui/circulation/test_loan_utils.py
+++ b/tests/ui/circulation/test_loan_utils.py
@@ -31,15 +31,15 @@ from rero_ils.modules.loans.utils import can_be_requested
 from rero_ils.modules.locations.api import LocationsSearch
 
 
-def test_loan_utils(client, patron_martigny_no_email,
-                    patron2_martigny_no_email, circulation_policies,
-                    item_lib_martigny, librarian_martigny_no_email,
+def test_loan_utils(client, patron_martigny,
+                    patron2_martigny, circulation_policies,
+                    item_lib_martigny, librarian_martigny,
                     loc_public_martigny):
     """Test loan utils methods."""
     loan_metadata = dict(item_lib_martigny)
     loan_metadata['item_pid'] = item_pid_to_object(item_lib_martigny.pid)
     if 'patron_pid' not in loan_metadata:
-        loan_metadata['patron_pid'] = patron_martigny_no_email.pid
+        loan_metadata['patron_pid'] = patron_martigny.pid
     # Create "virtual" Loan (not registered)
     loan = Loan(loan_metadata)
     # test that loan can successfully move to the pending state
@@ -53,23 +53,23 @@ def test_loan_utils(client, patron_martigny_no_email,
     # test a pending loan will be attached at the right organisation and
     # will not be considered as an active loan
     params = {
-        'patron_pid': patron2_martigny_no_email.pid,
+        'patron_pid': patron2_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     item, loan_pending_martigny = item_record_to_a_specific_loan_state(
         item=item_lib_martigny, loan_state=LoanState.PENDING,
         params=params, copy_item=True)
 
-    assert loan_pending_martigny.patron_pid == patron2_martigny_no_email.pid
+    assert loan_pending_martigny.patron_pid == patron2_martigny.pid
     assert not loan_pending_martigny.is_active
     assert loan_pending_martigny.organisation_pid
 
     # test required parameters for get_loans_by_patron_pid
     with pytest.raises(TypeError):
         assert get_loans_by_patron_pid()
-    assert get_loans_by_patron_pid(patron2_martigny_no_email.pid)
+    assert get_loans_by_patron_pid(patron2_martigny.pid)
 
     # test required parameters for get_last_transaction_loc_for_item
     with pytest.raises(TypeError):
@@ -92,9 +92,9 @@ def test_loan_utils(client, patron_martigny_no_email,
     )
     flush_index(LocationsSearch.Meta.index)
     new_loan = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'transaction_user_pid': librarian_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid
     }
     with pytest.raises(CirculationException):

--- a/tests/ui/documents/test_documents_filter.py
+++ b/tests/ui/documents/test_documents_filter.py
@@ -42,8 +42,8 @@ def test_note_filters(item_lib_martigny):
 
 
 def test_item_and_patron_in_same_organisation(
-        app, item_lib_martigny, patron_martigny_no_email,
-        patron_sion_no_email):
+        app, item_lib_martigny, patron_martigny,
+        patron_sion):
     """Test item and patron are in the same organisation."""
 
     # NOTE : Why with use app_context and login_user
@@ -55,9 +55,9 @@ def test_item_and_patron_in_same_organisation(
     #   called directly the function requiring context) the current_user/patron
     #   will always be unknown from the current context.
     with app.app_context():
-        login_user(patron_martigny_no_email.user)
+        login_user(patron_martigny.user)
         assert item_and_patron_in_same_organisation(item_lib_martigny)
-        login_user(patron_sion_no_email.user)
+        login_user(patron_sion.user)
         assert not item_and_patron_in_same_organisation(item_lib_martigny)
 
 

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -321,7 +321,7 @@ def test_bimonthly_every_two_months_two_levels(
 
 
 def test_holding_validate_next_expected_date(
-        client, librarian_martigny_no_email,
+        client, librarian_martigny,
         journal, loc_public_sion, item_type_internal_sion, document,
         pattern_yearly_two_times_data, json_header,
         holding_lib_sion_w_patterns_data):
@@ -329,7 +329,7 @@ def test_holding_validate_next_expected_date(
 
     the next_expected_date.
     """
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     holding = holding_lib_sion_w_patterns_data
     holding['holdings_type'] = 'serial'
     holding['patterns'] = \
@@ -576,12 +576,12 @@ def test_regular_issue_creation_update_delete_api(
     assert not Item.get_record_by_pid(pid)
 
 
-def test_holding_notes(client, librarian_martigny_no_email,
+def test_holding_notes(client, librarian_martigny,
                        holding_lib_martigny_w_patterns, json_header):
     """Test holdings notes."""
 
     holding = holding_lib_martigny_w_patterns
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
 
     # holdings has only on general note
     assert len(holding.notes) == 1

--- a/tests/ui/ill_requests/test_ill_requests_api.py
+++ b/tests/ui/ill_requests/test_ill_requests_api.py
@@ -53,11 +53,11 @@ def test_ill_request_properties(ill_request_martigny, ill_request_sion,
 
 
 def test_ill_request_get_request(ill_request_martigny, ill_request_sion,
-                                 patron_martigny_no_email):
+                                 patron_martigny):
     """Test ill request get_request functions."""
     assert len(list(ILLRequest.get_requests_by_patron_pid(
-        patron_martigny_no_email.pid, status='pending'
+        patron_martigny.pid, status='pending'
     ))) == 1
     assert len(list(ILLRequest.get_requests_by_patron_pid(
-        patron_martigny_no_email.pid, status='denied'
+        patron_martigny.pid, status='denied'
     ))) == 0

--- a/tests/ui/ill_requests/test_ill_requests_ui.py
+++ b/tests/ui/ill_requests/test_ill_requests_ui.py
@@ -27,7 +27,7 @@ from utils import login_user_for_view
 def test_ill_request_create_request_form(client, app,
                                          ill_request_martigny_data_tmp,
                                          loc_public_martigny,
-                                         patron_martigny_no_email):
+                                         patron_martigny):
     """ test ill request create form."""
     request_form_url = url_for('ill_requests.ill_request_form')
 
@@ -37,7 +37,7 @@ def test_ill_request_create_request_form(client, app,
     assert res.status_code == 302
 
     # logged as user
-    login_user_for_view(client, patron_martigny_no_email)
+    login_user_for_view(client, patron_martigny)
     res = client.get(request_form_url)
     assert res.status_code == 200
 

--- a/tests/ui/ill_requests/test_ill_requests_utils.py
+++ b/tests/ui/ill_requests/test_ill_requests_utils.py
@@ -25,12 +25,12 @@ import mock
 from rero_ils.modules.ill_requests.utils import get_pickup_location_options
 
 
-def test_get_pickup_location_options(patron_martigny_no_email,
+def test_get_pickup_location_options(patron_martigny,
                                      loc_public_martigny,
                                      loc_restricted_martigny):
     """Test pickup location options from utils."""
     with mock.patch('rero_ils.modules.ill_requests.utils.current_patron',
-                    patron_martigny_no_email):
+                    patron_martigny):
         assert loc_public_martigny.get('is_pickup', False)
         assert not loc_restricted_martigny.get('is_pickup', False)
 

--- a/tests/ui/items/test_items_ui.py
+++ b/tests/ui/items/test_items_ui.py
@@ -27,7 +27,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 def test_items_ui_permissions(client, item_lib_martigny,
                               loc_public_martigny,
-                              patron_martigny_no_email, json_header,
+                              patron_martigny, json_header,
                               circulation_policies):
     """Test patron request ui permissions."""
     item_pid = item_lib_martigny.pid
@@ -41,7 +41,7 @@ def test_items_ui_permissions(client, item_lib_martigny,
     res = client.get(request_url)
     assert res.status_code == 401
 
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     request_url = url_for(
         'item.patron_request',
         viewcode='global',

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, print_function
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from invenio_circulation.proxies import current_circulation
 from invenio_circulation.search.api import LoansSearch
 from utils import flush_index, get_mapping
@@ -68,10 +69,11 @@ def test_item_loans_elements(
     assert get_default_loan_duration(new_loan, None) == timedelta(0)
 
 
+@pytest.mark.skip(reason="In progress")
 def test_loan_keep_and_to_anonymize(
         item_on_loan_martigny_patron_and_loan_on_loan,
         item2_on_loan_martigny_patron_and_loan_on_loan,
-        librarian_martigny_no_email, loc_public_martigny):
+        librarian_martigny, loc_public_martigny):
     """Test anonymize and keep loan based on open transactions."""
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     assert not loan.concluded(loan)
@@ -79,7 +81,7 @@ def test_loan_keep_and_to_anonymize(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)
@@ -111,7 +113,7 @@ def test_loan_keep_and_to_anonymize(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
 
@@ -121,9 +123,10 @@ def test_loan_keep_and_to_anonymize(
     assert not loan.can_anonymize(loan_data=loan)
 
 
+@pytest.mark.skip(reason="In progress")
 def test_anonymizer_job(
         item_on_loan_martigny_patron_and_loan_on_loan,
-        librarian_martigny_no_email, loc_public_martigny):
+        librarian_martigny, loc_public_martigny):
     """Test loan anonymizer job."""
     msg = loan_anonymizer(dbcommit=True, reindex=True)
 
@@ -145,7 +148,7 @@ def test_anonymizer_job(
 
     params = {
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     item, actions = item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)

--- a/tests/ui/locations/test_locations_other.py
+++ b/tests/ui/locations/test_locations_other.py
@@ -25,10 +25,10 @@ from rero_ils.modules.locations.api import Location
 
 
 def test_location_get_all_pickup_locations(
-        patron_martigny_no_email, loc_public_martigny, loc_public_sion):
+        patron_martigny, loc_public_martigny, loc_public_sion):
     """Test pickup locations retrieval."""
     locations = Location.get_pickup_location_pids()
     assert set(locations) == {loc_public_martigny.pid, loc_public_sion.pid}
 
-    locations = Location.get_pickup_location_pids(patron_martigny_no_email.pid)
+    locations = Location.get_pickup_location_pids(patron_martigny.pid)
     assert set(locations) == {loc_public_martigny.pid}

--- a/tests/ui/patrons/conftest.py
+++ b/tests/ui/patrons/conftest.py
@@ -22,9 +22,9 @@ import pytest
 
 @pytest.yield_fixture(scope='module')
 def patrons_records(
-    patron_martigny_no_email,
-    patron2_martigny_no_email,
-    librarian_sion_no_email,
-    librarian_saxon_no_email
+    patron_martigny,
+    patron2_martigny,
+    librarian_sion,
+    librarian_saxon
 ):
     """Patrons for test mapping."""

--- a/tests/ui/patrons/test_patrons_jsonresolver.py
+++ b/tests/ui/patrons/test_patrons_jsonresolver.py
@@ -22,7 +22,7 @@ from invenio_records.api import Record
 from jsonref import JsonRefError
 
 
-def test_patrons_jsonresolver(system_librarian_martigny_no_email):
+def test_patrons_jsonresolver(system_librarian_martigny):
     """Test patron json resolver."""
     rec = Record.create({
         'patron': {'$ref': 'https://ils.rero.ch/api/patrons/ptrn1'}
@@ -32,7 +32,7 @@ def test_patrons_jsonresolver(system_librarian_martigny_no_email):
     }
 
     # deleted record
-    system_librarian_martigny_no_email.delete()
+    system_librarian_martigny.delete()
     with pytest.raises(JsonRefError):
         rec.replace_refs().dumps()
 

--- a/tests/ui/patrons/test_patrons_mapping.py
+++ b/tests/ui/patrons/test_patrons_mapping.py
@@ -31,7 +31,7 @@ def test_patron_es_mapping(
     assert mapping == get_mapping(search.Meta.index)
 
 
-def test_patron_search_mapping(app, patrons_records, librarian_saxon_no_email):
+def test_patron_search_mapping(app, patrons_records, librarian_saxon):
     """Test patron search mapping."""
     search = PatronsSearch()
 
@@ -52,4 +52,4 @@ def test_patron_search_mapping(app, patrons_records, librarian_saxon_no_email):
 
     pids = [r.pid for r in search.query(
          'match', first_name='Eléna').source(['pid']).scan()]
-    assert librarian_saxon_no_email.pid in pids
+    assert librarian_saxon.pid in pids

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -30,8 +30,8 @@ from rero_ils.modules.patrons.views import format_currency_filter
 
 
 def test_patrons_profile(
-        client, librarian_martigny_no_email, loan_pending_martigny,
-        patron_martigny_no_email, loc_public_martigny,
+        client, librarian_martigny, loan_pending_martigny,
+        patron_martigny, loc_public_martigny,
         item_type_standard_martigny, item_lib_martigny, json_header,
         circ_policy_short_martigny, ill_request_martigny):
     """Test patron profile."""
@@ -42,17 +42,17 @@ def test_patrons_profile(
         'security.login', next='/global/patrons/profile'))
 
     # check with logged user
-    login_user_via_session(client, patron_martigny_no_email.user)
+    login_user_via_session(client, patron_martigny.user)
     res = client.get(url_for('patrons.profile'))
     assert res.status_code == 200
 
     # create patron transactions
     data = {
-        'patron_pid': patron_martigny_no_email.pid,
+        'patron_pid': patron_martigny.pid,
         'item_pid': item_lib_martigny.pid,
         'pickup_location_pid': loc_public_martigny.pid,
         'transaction_location_pid': loc_public_martigny.pid,
-        'transaction_user_pid': librarian_martigny_no_email.pid
+        'transaction_user_pid': librarian_martigny.pid
     }
     loan = item_lib_martigny.request(**data)
     loan_pid = loan[1].get('request').get('pid')
@@ -95,7 +95,7 @@ def test_patrons_profile(
     loan = item_lib_martigny.checkin(**data)
 
 
-def test_patrons_logged_user(client, librarian_martigny_no_email):
+def test_patrons_logged_user(client, librarian_martigny):
     """Test logged user info API."""
     res = client.get(url_for('patrons.logged_user'))
     assert res.status_code == 200
@@ -103,7 +103,7 @@ def test_patrons_logged_user(client, librarian_martigny_no_email):
     assert not data.get('metadata')
     assert data.get('settings').get('language')
 
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(url_for('patrons.logged_user', resolve=1))
     assert res.status_code == 200
     data = get_json(res)
@@ -116,19 +116,19 @@ def test_patrons_logged_user(client, librarian_martigny_no_email):
         'rero_ils.modules.patrons.views.current_i18n',
         current_i18n
     ):
-        login_user_via_session(client, librarian_martigny_no_email.user)
+        login_user_via_session(client, librarian_martigny.user)
         res = client.get(url_for('patrons.logged_user'))
         assert res.status_code == 200
         data = get_json(res)
-        assert data.get('metadata') == librarian_martigny_no_email
+        assert data.get('metadata') == librarian_martigny
         assert data.get('settings').get('language') == 'fr'
 
 
 def test_patrons_logged_user_resolve(
         client,
-        librarian_martigny_no_email):
+        librarian_martigny):
     """Test that patron library is resolved in JSON data."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, librarian_martigny.user)
     res = client.get(url_for('patrons.logged_user', resolve=1))
     assert res.status_code == 200
     data = get_json(res)
@@ -138,10 +138,10 @@ def test_patrons_logged_user_resolve(
 def test_patrons_blocked_user_profile(
         client,
         lib_martigny,
-        patron3_martigny_blocked_no_email):
+        patron3_martigny_blocked):
     """Test blocked patron profile."""
     # The patron logged in
-    login_user_via_session(client, patron3_martigny_blocked_no_email.user)
+    login_user_via_session(client, patron3_martigny_blocked.user)
     res = client.get(url_for('patrons.profile'))
     assert res.status_code == 200
     # The profile displays the patron a blocked account message.

--- a/tests/ui/templates/test_template_mapping.py
+++ b/tests/ui/templates/test_template_mapping.py
@@ -24,8 +24,8 @@ from rero_ils.modules.templates.api import Template, TemplatesSearch
 
 def test_template_es_mapping(es_clear, db, templ_doc_public_martigny_data,
                              templ_doc_private_martigny_data,
-                             org_martigny, system_librarian_martigny_no_email,
-                             librarian_martigny_no_email):
+                             org_martigny, system_librarian_martigny,
+                             librarian_martigny):
     """Test template elasticsearch mapping."""
     search = TemplatesSearch()
     mapping = get_mapping(search.Meta.index)

--- a/tests/ui/templates/test_templates_api.py
+++ b/tests/ui/templates/test_templates_api.py
@@ -29,7 +29,7 @@ from rero_ils.modules.templates.api import template_id_fetcher as fetcher
 
 def test_template_es_mapping(es_clear, db,
                              templ_doc_public_martigny_data,
-                             org_martigny, system_librarian_martigny_no_email):
+                             org_martigny, system_librarian_martigny):
     """Test template elasticsearch mapping."""
     search = TemplatesSearch()
     mapping = get_mapping(search.Meta.index)
@@ -44,7 +44,7 @@ def test_template_es_mapping(es_clear, db,
 
 
 def test_template_create(db, es_clear, templ_doc_public_martigny_data,
-                         org_martigny, system_librarian_martigny_no_email):
+                         org_martigny, system_librarian_martigny):
     """Test template creation."""
     templ_doc_public_martigny_data['toto'] = 'toto'
     with pytest.raises(ValidationError):

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -30,8 +30,8 @@ def test_has_superuser_access(app):
 
 
 def test_librarian_update_permission_factory(client, document, ebook_1,
-                                             librarian_martigny_no_email):
+                                             librarian_martigny):
     """Test librarian_update_permission_factory function."""
     assert not librarian_update_permission_factory(ebook_1).can()
-    login_user_for_view(client, librarian_martigny_no_email)
+    login_user_for_view(client, librarian_martigny)
     assert librarian_update_permission_factory(document).can()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -41,12 +41,12 @@ def test_cli_validate(app, script_info):
     ]
 
 
-def test_cli_access_token(app, script_info, patron_martigny_no_email):
+def test_cli_access_token(app, script_info, patron_martigny):
     """Test access token cli."""
     runner = CliRunner()
     res = runner.invoke(
         tokens_create,
-        ['-n', 'test', '-u', patron_martigny_no_email.get('email'),
+        ['-n', 'test', '-u', patron_martigny.get('email'),
          '-t', 'my_token'],
         obj=script_info
     )

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -87,14 +87,6 @@ def test_city(patron_schema, patron_martigny_data_tmp_with_id):
         validate(patron_martigny_data_tmp_with_id, patron_schema)
 
 
-def test_username(patron_schema, patron_martigny_data_tmp_with_id):
-    """Test username for patron jsonschemas."""
-    validate(patron_martigny_data_tmp_with_id, patron_schema)
-    del(patron_martigny_data_tmp_with_id['username'])
-    with pytest.raises(ValidationError):
-        validate(patron_martigny_data_tmp_with_id, patron_schema)
-
-
 def test_barcode(patron_schema, patron_martigny_data_tmp_with_id):
     """Test barcode for patron jsonschemas."""
     validate(patron_martigny_data_tmp_with_id, patron_schema)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,8 @@ from rero_ils.modules.loans.api import Loan, LoanAction, LoansSearch, LoanState
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patron_types.api import PatronType
-from rero_ils.modules.patrons.api import Patron
+from rero_ils.modules.patrons.api import Patron, PatronsSearch, \
+    create_patron_from_data
 
 
 class VerifyRecordPermissionPatch(object):
@@ -350,3 +351,17 @@ def item_record_to_a_specific_loan_state(
 
     assert loan['state'] == loan_state
     return item, loan
+
+def create_patron(data):
+    """Create a patron with his related user for text fixtures.
+
+    :param data: - A dict containing a mix of user and patron data.
+    :returns: - A freshly created Patron instance.
+    """
+    ptrn = create_patron_from_data(
+        data=data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn


### PR DESCRIPTION
The user profiles was duplicates on the the patron and the profile data.
The synchronization was done in the both size, ether when the user
change his profile and when a professional change the user informations
in the patron editor.

Here the data are modified only on the profile database and synchronized
ony in one direction: from profile to patron.

* New utilities function are proposed to support the current fixtures
users data format.
* All the patron without email fixtures are removed.
* Loans anonymization is removed from the patron update/creation.

__Notes:__

- this PR contains 2 commits to make the review easier
- a new REST API will be create in a next PR to allow a librarian to change the user profile data
- the loan anonymization will be restore in a new PR
- the tests do not need anymore two version for patron fixture with and without email
- the coverage will be increased in the next PRs
- we need to decide will still in the patron JSON or not (if yes: it need a lot of modifications)
 
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>


## Why are you opening this PR?

- To implement: https://tree.taiga.io/project/rero21-reroils/us/1889?milestone=282105 and https://tree.taiga.io/project/rero21-reroils/us/1905?milestone=282105

## How to test?

- Open an existing patron, change the rero_id and see the user profile data changed in the patron detailed view

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
