### PR TITLE
items: fix holding update when receiving an issue

### DIFF
--- a/rero_ils/modules/items/tasks.py
+++ b/rero_ils/modules/items/tasks.py
@@ -29,7 +29,7 @@ from ..utils import extracted_data_from_ref, set_timestamp
 @shared_task
 def process_late_claimed_issues(
     expected_issues_to_late=True, create_first_claim=True,
-        create_next_claim=True, dbcommit=False, reindex=False):
+        create_next_claim=True, dbcommit=True, reindex=True):
     """Job to manage serials claims.
 
     Receives the next late expected issue for all holdings.


### PR DESCRIPTION
When an issue is created withe item editor (slow received), the holding
was updated but not committed into the DB.

Closes rero/rero-ils#1696

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
