### PR TITLE
ILL request: fix permissions

### DIFF
--- a/rero_ils/modules/ill_requests/permissions.py
+++ b/rero_ils/modules/ill_requests/permissions.py
@@ -46,14 +46,14 @@ class ILLRequestPermission(RecordPermission):
         :return: True is action can be done.
         """
         if current_patron:
-            # patron an only read their own requests
-            if current_patron.is_patron:
-                return record.patron_pid == current_patron.pid
             # staff member (lib, sys_lib) can always read request from their
             # own organisation
             if current_patron.is_librarian:
                 return current_organisation.pid \
                        == ILLRequest(record).organisation_pid
+            # patron can only read their own requests
+            if current_patron.is_patron:
+                return record.patron_pid == current_patron.pid
         return False
 
     @classmethod


### PR DESCRIPTION
If the current user had role librarian AND role patron, it couln't
view/edit an ILL requests into the admin interface.

Closes rero/rero-ils#1709.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
