### PR TITLE
holdings: allow optional fields for electronic holdings

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/_document_online.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_document_online.html
@@ -17,11 +17,15 @@
 
 #}
 {% set holdings = record.pid|online_holdings(viewcode) %}
+{% for library,accesses in holdings.items() %}
 <div class="card mb-2">
   <!-- Card header -->
   <div id="online_access" class="card-header p-2">
     <div class="row">
-      <div class="col-12">
+      <div class="col-6">
+            {{ library }}
+      </div>
+      <div class="col-6">
             {{ _('Online') }}
       </div>
     </div>
@@ -29,32 +33,35 @@
   <!-- Card body -->
   <div id="collapse-access" class="collapse show" role="tabpanel">
     <div class="card-body p-2">
-      <ul class="list-unstyled my-1">
-        {% for access in holdings %}
-          <li class="{%if loop.index is divisibleby 2 %} bg-light{% endif %}">
-            <div class="row">
-              <div class="col-6">
-                <ul class="list-unstyled">
-                {% for elocation in access.electronic_location %}
-                  <li>
-                    <a class="rero-ils-external-link" href={{ elocation.uri }}>
-                      {{ access.library.name }}
-                    </a>
-                  </li>
-                {% endfor %}
-                </ul>
-              </div>
-              <div class="col-6">
-                <ul class="list-unstyled">
-                {% for note in access.notes %}
-                  <li>{{ note }}</li>
-                {% endfor %}
-                </ul>
+      <ul class="list-unstyled my-1 ">
+        {% for access in accesses %}
+          <li class="{%if loop.index is divisibleby 2 %} bg-light{% endif %} pt-2 pb-2">
+            {% for elocation in access.electronic_location %}
+            <div class="row mb-2">
+              <div class="col-10">
+                <a class="rero-ils-external-link" href={{ elocation.uri }}>
+                    {{ elocation.source }}
+                  </a>
               </div>
             </div>
+            {% endfor %}
+            {% if access.enumerationAndChronology %}
+            <div class="row">
+              <div class="col-sm-4 col-md-3 font-weight-bold label-title pl-5">{{ _('Unit') }}</div>
+              <div class="col-sm-8 col-md-9">{{ access.enumerationAndChronology }}</div>
+            </div>
+            {% endif %}
+
+            {% for note in access.notes %}
+            <div class="row">
+              <div class="col-sm-4 col-md-3 font-weight-bold label-title pl-5">{{ _(note.type) }}</div>
+              <div class="col-sm-8 col-md-9">{{ note.content}}</div>
+            </div>
+            {% endfor %}
           </li>
         {% endfor %}
       </ul>
     </div>
   </div>
 </div>
+{% endfor %}

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -153,13 +153,13 @@ class Holding(IlsRecord):
                 return _(
                     'Must have next expected date for regular frequencies.')
         is_electronic = self.holdings_type == 'electronic'
-        if (document.harvested ^ is_electronic):
+        if document.harvested ^ is_electronic:
             msg = _('Electronic Holding is not attached to the correct \
                     document type. document: {pid}')
             return _(msg.format(pid=document_pid))
         # the enumeration and chronology optional fields are only allowed for
-        # serial holdings
-        if not is_serial:
+        # serial or electronic holdings
+        if not is_serial ^ is_electronic:
             fields = [
                 'enumerationAndChronology', 'notes', 'index', 'missing_issues',
                 'supplementaryContent', 'acquisition_status',

--- a/rero_ils/theme/assets/scss/rero_ils/thumbnail.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/thumbnail.scss
@@ -19,8 +19,6 @@
 
 
 figure#thumbnail .thumb {
-  max-width: 244px;
-  max-height: 244px;
   figcaption {
     overflow-wrap: anywhere;
   }
@@ -33,8 +31,6 @@ figure#thumbnail .figure-caption {
 @media (max-width: map_get($grid-breakpoints, md)) {
 
   figure#thumbnail .thumb {
-    max-width: 70px;
-    max-height: 70px;
     figcaption {
       overflow-wrap: anywhere;
     }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2662,6 +2662,104 @@
       }
     ]
   },
+  "ebook5": {
+    "pid": "ebook5",
+    "identifiedBy": [
+      {
+        "type": "bf:Local",
+        "source": "cantook",
+        "value": "ebook5"
+      }
+    ],
+    "type": [
+      {
+        "main_type": "docmaintype_book",
+        "subtype": "docsubtype_e-book"
+      }
+    ],
+    "issuance": {
+      "main_type": "rdami:1001",
+      "subtype": "materialUnit"
+    },
+    "harvested": true,
+    "electronicLocator": [
+      {
+        "source": "ebibliomedia",
+        "url": "https://www.site1.org/ebook",
+        "type": "resource"
+      }
+    ],
+    "title": [
+      {
+        "type": "bf:Title",
+        "mainTitle": [
+          {
+            "value": "un autre titre"
+          }
+        ]
+      }
+    ],
+    "language": [
+      {
+        "type": "bf:Language",
+        "value": "fre"
+      }
+    ],
+    "contribution": [
+      {
+        "agent": {
+          "preferred_name": "Peter James",
+          "type": "bf:Person"
+        },
+        "role": [
+          "aut"
+        ]
+      }
+    ],
+    "provisionActivity": [
+      {
+        "type": "bf:Publication",
+        "statement": [
+          {
+            "country": "fr",
+            "label": [
+              {
+                "value": "Paris"
+              }
+            ],
+            "type": "bf:Place"
+          },
+          {
+            "label": [
+              {
+                "value": "12-21"
+              }
+            ],
+            "type": "bf:Agent"
+          },
+          {
+            "label": [
+              {
+                "value": "2019"
+              }
+            ],
+            "type": "Date"
+          }
+        ],
+        "startDate": 2019
+      }
+    ],
+    "subjects": [
+      "thriller",
+      "suspense"
+    ],
+    "note": [
+      {
+        "noteType": "general",
+        "label": "La maison des oubli\u00e9s"
+      }
+    ]
+  },
   "item1": {
     "$schema": "https://ils.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item1",

--- a/tests/data/holdings.json
+++ b/tests/data/holdings.json
@@ -346,6 +346,27 @@
       ]
     }
   },
+  "holding7": {
+    "$schema": "https://ils.rero.ch/schemas/holdings/holding-v0.0.1.json",
+    "pid": "holding7",
+    "_masked": false,
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/ebook5"
+    },
+    "circulation_category": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty7"
+    },
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc1"
+    },
+    "holdings_type": "electronic",
+    "electronic_location": [
+      {
+        "source": "ebibliomedia",
+        "uri": "https://bm.ebibliomedia.ch/resources/5f780fc22357943b9a83ca3d"
+      }
+    ]
+  },
   "pattern1": {
     "template_name": "quarterly_one_level",
     "patterns": {

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -111,6 +111,25 @@ def ebook_4(app, ebook_4_data):
 
 
 @pytest.fixture(scope="module")
+def ebook_5_data(data):
+    """Load ebook 5 data."""
+    return deepcopy(data.get('ebook5'))
+
+
+@pytest.fixture(scope="module")
+def ebook_5(app, ebook_5_data):
+    """Load ebook 5 record."""
+    del ebook_5_data['electronicLocator']
+    doc = Document.create(
+        data=ebook_5_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(DocumentsSearch.Meta.index)
+    return doc
+
+
+@pytest.fixture(scope="module")
 def document_data(data):
     """Load document data."""
     return deepcopy(data.get('doc1'))
@@ -737,6 +756,26 @@ def holding_lib_sion_w_patterns(
     """Create holding of sion library with patterns."""
     holding = Holding.create(
         data=holding_lib_sion_w_patterns_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    return holding
+
+
+@pytest.fixture(scope="module")
+def holding_lib_martiny_electronic_data(holdings):
+    """Load electronic holding of Martigny library."""
+    return deepcopy(holdings.get('holding7'))
+
+
+@pytest.fixture(scope="module")
+def holding_lib_martiny_electronic(
+    app, ebook_5, holding_lib_martiny_electronic_data,
+        loc_public_martigny, item_type_online_martigny):
+    """Create electronic holding of Martigny library."""
+    holding = Holding.create(
+        data=holding_lib_martiny_electronic_data,
         delete_pid=False,
         dbcommit=True,
         reindex=True)

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -21,8 +21,10 @@
 
 from __future__ import absolute_import, print_function
 
+import pytest
 from utils import flush_index, get_mapping
 
+from rero_ils.modules.errors import RecordValidationError
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.holdings.api import holding_id_fetcher as fetcher
 from rero_ils.modules.items.views import format_record_call_number
@@ -66,6 +68,54 @@ def test_holding_create(db, es_clear, document, org_martigny,
     assert holding_record.organisation_pid == org_martigny.get('pid')
     # holdings does not exist
     assert not Holding.get_holdings_type_by_holding_pid('toto')
+
+
+def test_holding_extended_validation(client,
+                                     journal, ebook_5,
+                                     item_type_standard_martigny,
+                                     item_type_online_martigny,
+                                     holding_lib_martigny_w_patterns_data,
+                                     holding_lib_martiny_electronic_data):
+    """Test holding extended validation."""
+    # instantiate serial holding
+    holding_tmp = Holding(holding_lib_martigny_w_patterns_data)
+    # 1. holding type serial
+
+    # 1.1. test correct holding
+    holding_tmp.validate()  # validation with extented_validation rules
+
+    # 1.1. test next expected date for regular frequencies
+    expected_date = holding_tmp['patterns']['next_expected_date']
+    del(holding_tmp['patterns']['next_expected_date'])
+    with pytest.raises(RecordValidationError):
+        holding_tmp.validate()
+
+    # reset data with original value
+    holding_tmp['patterns']['next_expected_date'] = expected_date
+
+    # 1.2. test multiple note with same type
+    holding_tmp.get('notes').append({
+        'type': 'general_note',
+        'content': 'other general_note...'
+    })
+    with pytest.raises(RecordValidationError):
+        holding_tmp.validate()
+
+    # 2. holding type electronic
+
+    # 2.1. test holding type electronic attached to wrong document type
+    holding_tmp['holdings_type'] = 'electronic'
+    with pytest.raises(RecordValidationError):
+        holding_tmp.validate()
+
+    # 2.2 test electronic holding
+    # instantiate electronic holding
+    holding_tmp = Holding(holding_lib_martiny_electronic_data)
+    holding_tmp.validate()
+
+    # 2.2 test electronic holding with enumeration and chronology
+    holding_tmp['enumerationAndChronology'] = 'enumerationAndChronology'
+    holding_tmp.validate()
 
 
 def test_holdings_call_number_filter(app):


### PR DESCRIPTION
The enumeration and chronology optional fields are only allowed for serial holdings type.
For electronic holdings type, we need these fields too.

* Adapts extended validation for holdings resource.
* Updates jinja filter.
* Adapts template for online documents.
* Writes some tests.
* Fixes thumbnail overflow on document detail view.

Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
