### PR TITLE
documents: fix bug when generating the big and small items

### DIFF
--- a/rero_ils/modules/items/cli.py
+++ b/rero_ils/modules/items/cli.py
@@ -109,12 +109,10 @@ def create_items(count, itemscount, missing, items_f, holdings_f):
             for document_pid in bar:
                 holdings = [{}]
                 # we will not create holdings for ebook and journal documents
-                doc_type = Document.get_record_by_pid(document_pid).get('type')
-                is_book = doc_type[0]['main_type'] == 'docmaintype_book'
-                is_ebook = doc_type[0]['subtype'] == 'docsubtype_e-book'
-                if is_book and is_ebook:
-                    continue
-                if doc_type[0]['main_type'] == 'docmaintype_serial':
+                doc_type = Document.get_record_by_pid(
+                    document_pid).get('type')[0]
+                if doc_type.get('subtype') == 'docsubtype_e-book' \
+                    or doc_type.get('main_type') == 'docmaintype_serial':
                     continue
 
                 if Document.get_record_by_pid(


### PR DESCRIPTION
* Fixes the error `KeyError: 'subtype'` generated at the creation
       of small and big item files.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

error when running `setup --create_items_holdings_small --continue`

```
    return callback(*args, **kwargs)
  File "/Users/baa/devel/rero/rero-ils/rero_ils/modules/items/cli.py", line 173, in create_items
    for item, holding in generate(count, itemscount, missing):
  File "/Users/baa/devel/rero/rero-ils/rero_ils/modules/items/cli.py", line 114, in generate
    is_ebook = doc_type[0]['subtype'] == 'docsubtype_e-book'
KeyError: 'subtype'

```


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
