### PR TITLE
circulation: block operations for expired patron

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,10 @@ live_server_scope = module
 addopts = --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=rero_ils --cov-report=term-missing --ignore=setup.py --ignore=docs/conf.py -m "not external"
 testpaths = docs tests rero_ils
 
+# custom markers
+markers =
+    external: mark a test as dealing with external services.
+
 # not displaying all the PendingDeprecationWarnings from invenio
 filterwarnings =
     ignore::PendingDeprecationWarning

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -380,11 +380,16 @@ class Patron(IlsRecord):
             # 'patron' argument are present into kwargs. This check can't
             # be relevant --> return True by default
             return True, []
-        # a blocked patron can't request any item
-        if patron.is_blocked:
-            return False, [patron.get_blocked_message()]
 
-        return True, []
+        messages = []
+        # 1) a blocked patron can't request any item
+        # 2) a patron with obsolete expiration_date can't request any item
+        if patron.is_blocked:
+            messages.append(patron.get_blocked_message())
+        if patron.is_expired:
+            messages.append(_('Patron rights expired.'))
+
+        return len(messages) == 0, messages
 
     @classmethod
     def can_checkout(cls, item, **kwargs):
@@ -434,8 +439,21 @@ class Patron(IlsRecord):
 
     @property
     def patron(self):
-        """Patron property shorcut."""
+        """Patron property shortcut."""
         return self.get('patron', {})
+
+    @property
+    def expiration_date(self):
+        """Shortcut to find the patron expiration date."""
+        date_string = self.patron.get('expiration_date')
+        if date_string:
+            return datetime.strptime(date_string, '%Y-%m-%d')
+
+    @property
+    def is_expired(self):
+        """Check if patron expiration date is obsolete."""
+        expiration_date = self.expiration_date
+        return expiration_date and datetime.now() > expiration_date
 
     @property
     def formatted_name(self):
@@ -676,6 +694,13 @@ class Patron(IlsRecord):
             }]
 
         messages = []
+        # if patron expiration_date has reached - error type message
+        if self.is_expired:
+            messages.append({
+                'type': 'error',
+                'content': _('Patron rights expired.')
+            })
+
         # other messages must be only rendered for the professional interface
         if not public:
             # check the patron type define limit

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -595,9 +595,9 @@ def test_get_remote_cover(mock_get_cover, app):
 
     mock_get_cover.return_value = mock_response(
         content='thumb({'
-            '"success": true,'
-            '"image": "https:\/\/i.test.com\/images\/P\/XXXXXXXXXX_.jpg"'
-            '})'
+                '    "success": true,'
+                '    "image": "https://i.test.com/images/P/XXXXXXXXXX_.jpg"'
+                '})'
     )
     cover = get_remote_cover('XXXXXXXXXX')
     assert cover == {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,8 @@ pytest_plugins = (
     'fixtures.metadata',
     'fixtures.organisations',
     'fixtures.acquisition',
-    'fixtures.sip2'
+    'fixtures.sip2',
+    'fixtures.basics'
 )
 
 

--- a/tests/fixtures/basics.py
+++ b/tests/fixtures/basics.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2020 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -15,15 +16,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Common pytest patron_types."""
+"""Common pytest fixtures for rero-ils."""
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 
-@pytest.fixture(scope='module')
-def patron_types_records(
-    patron_type_adults_martigny,
-    patron_type_youngsters_sion,
-    patron_type_grown_sion
-):
-    """Patron types for test mapping."""
+@pytest.fixture(scope="module")
+def yesterday():
+    """Get yesterday timestamp."""
+    return datetime.now(timezone.utc) - timedelta(days=1)
+
+
+@pytest.fixture(scope="module")
+def tomorrow():
+    """Get tomorrow timestamp."""
+    return datetime.now(timezone.utc) + timedelta(days=1)

--- a/tests/ui/documents/conftest.py
+++ b/tests/ui/documents/conftest.py
@@ -20,7 +20,7 @@
 import pytest
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def document_records(
     document,
     document_ref,

--- a/tests/ui/holdings/test_serial_claims.py
+++ b/tests/ui/holdings/test_serial_claims.py
@@ -28,7 +28,8 @@ from rero_ils.modules.items.tasks import process_late_claimed_issues
 
 
 def test_late_expected_and_claimed_issues(
-         holding_lib_martigny_w_patterns, holding_lib_sion_w_patterns):
+         holding_lib_martigny_w_patterns, holding_lib_sion_w_patterns,
+         yesterday, tomorrow):
     """Test automatic change of late expected issues status to late
     and automatic change to claimed when issue is due"""
     martigny = holding_lib_martigny_w_patterns
@@ -56,14 +57,10 @@ def test_late_expected_and_claimed_issues(
     assert count_issues(sion) == [1, 0]
 
     # create a second late issue for martigny and no more for sion
-    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)
-                 ).strftime('%Y-%m-%d')
-    tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)
-                ).strftime('%Y-%m-%d')
-    sion['patterns']['next_expected_date'] = tomorrow
+    sion['patterns']['next_expected_date'] = tomorrow.strftime('%Y-%m-%d')
     sion.update(sion, dbcommit=True, reindex=True)
 
-    martigny['patterns']['next_expected_date'] = yesterday
+    martigny['patterns']['next_expected_date'] = yesterday.strftime('%Y-%m-%d')
     martigny.update(martigny, dbcommit=True, reindex=True)
 
     msg = process_late_claimed_issues(dbcommit=True, reindex=True)

--- a/tests/ui/item_types/conftest.py
+++ b/tests/ui/item_types/conftest.py
@@ -20,7 +20,7 @@
 import pytest
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def item_types_records(
     item_type_standard_martigny,
     item_type_on_site_martigny,

--- a/tests/ui/libraries/conftest.py
+++ b/tests/ui/libraries/conftest.py
@@ -20,7 +20,7 @@
 import pytest
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def libraries_records(
     lib_martigny,
     lib_saxon,

--- a/tests/ui/local_fields/conftest.py
+++ b/tests/ui/local_fields/conftest.py
@@ -20,7 +20,7 @@
 import pytest
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def local_fields_records(
     local_field_martigny,
     local_field_sion,

--- a/tests/ui/locations/conftest.py
+++ b/tests/ui/locations/conftest.py
@@ -20,7 +20,7 @@
 import pytest
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def locations_records(
     loc_public_martigny,
     loc_restricted_martigny,

--- a/tests/ui/patrons/conftest.py
+++ b/tests/ui/patrons/conftest.py
@@ -20,7 +20,7 @@
 import pytest
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def patrons_records(
     patron_martigny,
     patron2_martigny,


### PR DESCRIPTION
* Checkout, request and renew circulation operations are blocked if the
  patron expiration date is reached.
* Introduces new utils fixtures and adapts unit tests.
* Closes rero/rero-ils#1495.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
