### PR TITLE
sip2: implements selfcheck user accounts

### DIFF
--- a/rero_ils/modules/selfcheck/admin.py
+++ b/rero_ils/modules/selfcheck/admin.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Admin views for selfcheck user."""
+
+from flask_admin.contrib.sqla import ModelView
+from flask_admin.form.fields import DateTimeField
+from flask_babelex import gettext as _
+from werkzeug.local import LocalProxy
+from wtforms.fields import SelectField
+from wtforms.validators import DataRequired
+
+from .models import SelfcheckUser
+from ..locations.api import get_organisation_pid_by_location_pid, \
+    search_locations_by_pid
+from ..organisations.api import Organisation
+
+
+class SelfcheckUserView(ModelView):
+    """Flask-Admin view to manage selfcheck user accounts."""
+
+    can_view_details = True
+    can_create = True
+    can_delete = True
+
+    list_all = (
+        'id', 'username', 'access_token', 'organisation_pid', 'location_pid',
+        'active', 'last_login_at',
+    )
+
+    column_list = \
+        column_searchable_list = \
+        column_sortable_list = \
+        column_details_list = \
+        list_all
+
+    form_columns = ('username', 'access_token', 'location_pid', 'active',
+                    'roles')
+
+    form_args = dict(
+        username=dict(label='Username', validators=[DataRequired()]),
+        access_token=dict(label='Access token', validators=[DataRequired()]),
+        location_pid=dict(
+            label='Location',
+            validators=[DataRequired()],
+            choices=LocalProxy(lambda: [
+                (opts.get('location_pid'), opts.get('location_name')) for opts
+                in locations_form_options()
+            ]),
+        ),
+    )
+
+    column_filters = ('id', 'username', 'active', 'organisation_pid',
+                      'location_pid', 'last_login_at')
+
+    column_default_sort = ('last_login_at', True)
+
+    form_overrides = {
+        'location_pid': SelectField,
+        'last_login_at': DateTimeField
+    }
+
+    def on_model_change(self, form, model, is_created):
+        """Fill organisation_pid when saving."""
+        location_pid = form.location_pid.data
+        org_pid = get_organisation_pid_by_location_pid(location_pid)
+        model.organisation_pid = org_pid
+
+
+def locations_form_options():
+    """Get locations form options."""
+    location_opts = []
+    for org in Organisation.get_all():
+        search = search_locations_by_pid(organisation_pid=org.pid)
+        for location in search.scan():
+            location_opts.append({
+                'organisation_pid': org.pid,
+                'organisation_name': org.get('name'),
+                'location_pid': location.pid,
+                'location_name': '{organisation} : {location}'.format(
+                    organisation=org.get('name'),
+                    location=location.name
+                )
+            })
+    return location_opts
+
+
+selfcheck_user_adminview = {
+    'model': SelfcheckUser,
+    'modelview': SelfcheckUserView,
+    'category': _('Selfcheck User Management'),
+}
+
+__all__ = (
+    'selfcheck_user_adminview',
+    'SelfcheckUserView'
+)

--- a/rero_ils/modules/selfcheck/models.py
+++ b/rero_ils/modules/selfcheck/models.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Database models for selfcheck user."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_db import db
+
+selfcheck_userrole = db.Table(
+    'selfcheck_userrole',
+    db.Column('user_id', db.Integer(), db.ForeignKey(
+        'selfcheck_accounts.id', name='fk_selfcheck_userrole_user_id')),
+    db.Column('role_id', db.Integer(), db.ForeignKey(
+        'accounts_role.id', name='fk_selfcheck_userrole_role_id')),
+)
+"""Relationship between users and roles."""
+
+
+class SelfcheckUser(db.Model):
+    """Selfcheck user model."""
+
+    __tablename__ = 'selfcheck_accounts'
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+
+    username = db.Column(db.String(255), unique=True)
+    access_token = db.Column(db.String(255), nullable=False)
+    organisation_pid = db.Column(db.String(255), nullable=False)
+    location_pid = db.Column(db.String(255), nullable=False)
+    active = db.Column(db.Boolean(name='active'))
+    last_login_at = db.Column(db.DateTime)
+
+    roles = db.relationship('Role', secondary=selfcheck_userrole,
+                            backref=db.backref('selfcheck_users',
+                                               lazy='dynamic'))

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,10 @@ setup(
         'babel.extractors': [
             'json = rero_ils.modules.babel_extractors:extract_json'
         ],
+        'invenio_admin.views': [
+            'selfcheck_users_accounts = \
+                rero_ils.modules.selfcheck.admin:selfcheck_user_adminview',
+        ],
         'invenio_base.apps': [
             # 'flask_debugtoolbar = flask_debugtoolbar:DebugToolbarExtension',
             'rero-ils = rero_ils.modules.ext:REROILSAPP'
@@ -171,6 +175,7 @@ setup(
             'templates = rero_ils.modules.templates.models',
             'vendors = rero_ils.modules.vendors.models',
             'operation_logs = rero_ils.modules.operation_logs.models',
+            'selfcheck = rero_ils.modules.selfcheck.models',
         ],
         'invenio_pidstore.minters': [
             'acq_account_id = rero_ils.modules.acq_accounts.api:acq_account_id_minter',


### PR DESCRIPTION
To easiest manage selfcheck user accounts, we separate them from rero-ils users.

* Adds separate table to store selfcheck users.

Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
