### PR TITLE
sip2: implements selfcheck user accounts

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -97,6 +97,7 @@ from .modules.patron_types.permissions import PatronTypePermission
 from .modules.patrons.api import Patron
 from .modules.patrons.permissions import PatronPermission
 from .modules.permissions import record_permission_factory
+from .modules.selfcheck.permissions import seflcheck_permission_factory
 from .modules.templates.api import Template
 from .modules.templates.permissions import TemplatePermission
 from .modules.users.api import get_profile_countries, \
@@ -2669,6 +2670,8 @@ SIP2_SUPPORT_ONLINE_STATUS = True
 SIP2_SUPPORT_OFFLINE_STATUS = True
 SIP2_SUPPORT_STATUS_UPDATE = True
 SIP2_DATE_FORMAT = '%Y%m%d    %H%M%S'
+
+SIP2_PERMISSIONS_FACTORY = seflcheck_permission_factory
 
 SIP2_REMOTE_ACTION_HANDLERS = dict(
     rero_ils=dict(

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -94,6 +94,10 @@
       "type": "string",
       "title": "Request pickup location PID"
     },
+    "selfcheck_terminal_id": {
+      "type": "string",
+      "title": "Selfcheck terminal id"
+    },
     "start_date": {
       "type": "string",
       "format": "date-time",

--- a/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
@@ -80,6 +80,9 @@
       "transaction_user_pid": {
         "type": "keyword"
       },
+      "selfcheck_terminal_id": {
+        "type": "keyword"
+      },
       "to_anonymize": {
         "type": "boolean"
       },

--- a/rero_ils/modules/selfcheck/admin.py
+++ b/rero_ils/modules/selfcheck/admin.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Admin views for selfcheck user."""
+
+from flask_admin.contrib.sqla import ModelView
+from flask_admin.form.fields import DateTimeField
+from flask_babelex import gettext as _
+from werkzeug.local import LocalProxy
+from wtforms.fields import SelectField
+from wtforms.validators import DataRequired
+
+from .models import SelfcheckTerminal
+from ..locations.api import search_location_by_pid, search_locations_by_pid
+from ..organisations.api import Organisation
+
+
+class SelfcheckTerminalView(ModelView):
+    """Flask-Admin view to manage selfcheck terminals."""
+
+    can_view_details = True
+    can_create = True
+    can_delete = True
+
+    list_all = (
+        'id', 'name', 'access_token', 'organisation_pid', 'library_pid',
+        'location_pid', 'active', 'last_login_at', 'last_login_ip',
+    )
+
+    column_list = \
+        column_searchable_list = \
+        column_sortable_list = \
+        column_details_list = \
+        list_all
+
+    form_columns = ('name', 'access_token', 'location_pid', 'active')
+
+    form_args = dict(
+        name=dict(label='Name', validators=[DataRequired()]),
+        access_token=dict(label='Access token', validators=[DataRequired()]),
+        location_pid=dict(
+            label='Location',
+            validators=[DataRequired()],
+            choices=LocalProxy(lambda: [
+                (opts.get('location_pid'), opts.get('location_name')) for opts
+                in locations_form_options()
+            ]),
+        ),
+    )
+
+    column_filters = ('id', 'name', 'active', 'organisation_pid',
+                      'library_pid', 'location_pid', 'last_login_at')
+
+    column_default_sort = ('last_login_at', True)
+
+    form_overrides = {
+        'location_pid': SelectField,
+        'last_login_at': DateTimeField
+    }
+
+    def on_model_change(self, form, model, is_created):
+        """Fill organisation_pid when saving.
+
+        :param form:
+            Form used to create/update model
+        :param model:
+            Model that was created/updated
+        :param is_created:
+            True if model was created, False if model was updated
+        """
+        location_pid = form.location_pid.data
+        location = search_location_by_pid(location_pid)
+        model.organisation_pid = location.organisation['pid']
+        model.library_pid = location.library['pid']
+
+
+def locations_form_options():
+    """Get locations form options."""
+    location_opts = []
+    for org in Organisation.get_all():
+        search = search_locations_by_pid(organisation_pid=org.pid,
+                                         sort_by_field='code',
+                                         preserve_order=True)
+        search = search.exclude('term', is_online=True)
+        for location in search.scan():
+            location_opts.append({
+                'location_pid': location.pid,
+                'location_name': '{org} - {loc_code} ({loc_name})'.format(
+                    org=org.get('name'),
+                    loc_code=location.code,
+                    loc_name=location.name
+                )
+            })
+    return location_opts
+
+
+selfcheck_terminal_adminview = {
+    'model': SelfcheckTerminal,
+    'modelview': SelfcheckTerminalView,
+    'category': _('Selfcheck Terminal Management'),
+}
+
+__all__ = (
+    'selfcheck_terminal_adminview',
+    'SelfcheckTerminalView'
+)

--- a/rero_ils/modules/selfcheck/models.py
+++ b/rero_ils/modules/selfcheck/models.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Database models for selfcheck terminal."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_db import db
+from sqlalchemy_utils import IPAddressType
+
+
+class SelfcheckTerminal(db.Model):
+    """Selfcheck terminal model."""
+
+    __tablename__ = 'selfcheck_terminals'
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+
+    name = db.Column(db.String(255), unique=True)
+    access_token = db.Column(db.String(255), nullable=False)
+    organisation_pid = db.Column(db.String(255), nullable=False)
+    library_pid = db.Column(db.String(255), nullable=False)
+    location_pid = db.Column(db.String(255), nullable=False)
+    active = db.Column(db.Boolean(name='active'), default=True)
+    last_login_at = db.Column(db.DateTime)
+    last_login_ip = db.Column(IPAddressType, nullable=True)
+
+    @classmethod
+    def find_terminal(cls, **kwargs):
+        """Find selfcheck terminal within the given arguments."""
+        query = cls.query
+        return query.filter_by(**kwargs).first()

--- a/rero_ils/modules/selfcheck/permissions.py
+++ b/rero_ils/modules/selfcheck/permissions.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -15,26 +16,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-ARG VERSION=latest
-FROM rero/rero-ils-base:${VERSION}
+"""Selfcheck permissions."""
 
-USER 0
+from ..permissions import deny_access
+from ...permissions import monitoring_permission
 
-COPY ./ ${WORKING_DIR}/src
-WORKDIR ${WORKING_DIR}/src
-COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 
-RUN chown -R invenio:invenio ${WORKING_DIR}
+def seflcheck_permission_factory(action):
+    """Default api permission factory."""
+    if action in ['api-monitoring']:
+        return monitoring_permission
 
-USER 1000
-
-ARG GIT_HASH
-ENV INVENIO_RERO_ILS_APP_GIT_HASH ${GIT_HASH:-''}
-ARG GIT_UI_HASH
-ENV INVENIO_RERO_ILS_UI_GIT_HASH ${GIT_UI_HASH:-''}
-ARG UI_TGZ=""
-
-ENV INVENIO_COLLECT_STORAGE='flask_collect.storage.file'
-
-RUN poetry run bootstrap --deploy ${UI_TGZ}
-RUN poetry install --no-root --extras sip2
+    return deny_access

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,10 @@ setup(
         'babel.extractors': [
             'json = rero_ils.modules.babel_extractors:extract_json'
         ],
+        'invenio_admin.views': [
+            'selfcheck_users_accounts = \
+                rero_ils.modules.selfcheck.admin:selfcheck_terminal_adminview',
+        ],
         'invenio_base.apps': [
             # 'flask_debugtoolbar = flask_debugtoolbar:DebugToolbarExtension',
             'rero-ils = rero_ils.modules.ext:REROILSAPP'
@@ -172,6 +176,7 @@ setup(
             'templates = rero_ils.modules.templates.models',
             'vendors = rero_ils.modules.vendors.models',
             'operation_logs = rero_ils.modules.operation_logs.models',
+            'selfcheck = rero_ils.modules.selfcheck.models',
         ],
         'invenio_pidstore.minters': [
             'acq_account_id = rero_ils.modules.acq_accounts.api:acq_account_id_minter',

--- a/tests/api/selfcheck/test_admin.py
+++ b/tests/api/selfcheck/test_admin.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests Selfcheck admin."""
+
+from __future__ import absolute_import, print_function
+
+from flask import url_for
+from flask_admin import Admin
+from invenio_db import db
+
+from rero_ils.modules.selfcheck.admin import selfcheck_terminal_adminview
+
+
+def test_admin_view(app):
+    """Test flask-admin interface."""
+    assert isinstance(selfcheck_terminal_adminview, dict)
+
+    assert 'model' in selfcheck_terminal_adminview
+    assert 'modelview' in selfcheck_terminal_adminview
+
+    admin = Admin(app, name="Test")
+
+    selfcheck_user_adminview_copy = dict(selfcheck_terminal_adminview)
+    selfcheck_user_model = selfcheck_user_adminview_copy.pop('model')
+    selfcheck_user_view = selfcheck_user_adminview_copy.pop('modelview')
+    admin.add_view(selfcheck_user_view(selfcheck_user_model, db.session,
+                                       **selfcheck_user_adminview_copy))
+
+    with app.test_request_context():
+        request_url = url_for('selfcheckterminal.index_view')
+
+    with app.app_context():
+        with app.test_client() as client:
+            res = client.get(
+                request_url,
+                follow_redirects=True
+            )
+            assert res.status_code == 200
+            assert b'Name' in (res.get_data())
+            assert b'Access Token' in (res.get_data())
+            assert b'Organisation Pid' in (res.get_data())
+            assert b'Library Pid' in (res.get_data())
+            assert b'Location Pid' in (res.get_data())
+
+
+def test_admin_createuser(app, client, loc_public_martigny):
+    """Test flask-admin user creation."""
+
+    create_view_url = url_for('selfcheckterminal.create_view')
+
+    # test required values
+    res = client.post(
+        create_view_url,
+        data={},
+        follow_redirects=True
+    )
+    assert b'This field is required.' in res.data
+    assert res.data.count(b'This field is required.') == 3
+
+    # test create selfcheck user
+    res = client.post(
+        create_view_url,
+        data={
+            'name': 'test_user',
+            'access_token': 'TESTACCESSTOKEN',
+            'location_pid': 'loc1',
+        },
+        follow_redirects=True
+    )
+    assert b'Record was successfully created.' in res.data
+
+    # test create selfcheck user whith same username
+    res = client.post(
+        create_view_url,
+        data={
+            'name': 'test_user',
+            'access_token': 'TESTACCESSTOKEN',
+            'location_pid': 'loc1',
+        },
+        follow_redirects=True
+    )
+    assert b'Already exists.' in res.data

--- a/tests/api/selfcheck/test_models.py
+++ b/tests/api/selfcheck/test_models.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests Selfcheck admin."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from invenio_db import db
+from sqlalchemy.exc import IntegrityError
+
+from rero_ils.modules.selfcheck.models import SelfcheckTerminal
+
+
+def test_selfcheckuser(app):
+    """Test SelfcheckUser model."""
+
+    selfcheck_terminal = SelfcheckTerminal(
+        name='selfcheck_test',
+        access_token='UNACCESSTOKENDETEST',
+        organisation_pid='org1',
+        library_pid='lib1',
+        location_pid='loc1',
+    )
+    # 1. test create selfcheck user
+    assert not selfcheck_terminal.active
+    db.session.add(selfcheck_terminal)
+    db.session.commit()
+    selfcheck_terminal_id = selfcheck_terminal.id
+    assert selfcheck_terminal.active
+    selfcheck_terminals = SelfcheckTerminal.query.all()
+    assert len(selfcheck_terminals) == 1
+
+    # 2. test update selfcheck user
+    selfcheck_terminal_patch = SelfcheckTerminal(
+        id=selfcheck_terminal_id,
+        name='selfcheck_test_modified',
+        access_token='UNACCESSTOKENDETEST',
+        organisation_pid='org1',
+        library_pid='lib1',
+        location_pid='loc1',
+    )
+    db.session.merge(selfcheck_terminal_patch)
+    db.session.commit()
+
+    # 3. test unique name for selfcheck terminal
+    selfcheck_terminal = SelfcheckTerminal(
+        name='selfcheck_test_modified',
+        access_token='UNACCESSTOKENDETEST',
+        organisation_pid='org1',
+        library_pid='lib1',
+        location_pid='loc2',
+    )
+    db.session.add(selfcheck_terminal)
+    pytest.raises(IntegrityError, db.session.commit)

--- a/tests/fixtures/sip2.py
+++ b/tests/fixtures/sip2.py
@@ -21,40 +21,55 @@
 from copy import deepcopy
 
 import pytest
-from utils import create_patron
+from utils import create_patron, create_selfcheck_terminal, create_user_token
 
 
 @pytest.fixture(scope="module")
-def sip2_librarian_martigny_data(data):
+def selfcheck_librarian_martigny_data(data):
     """Load Martigny librarian data."""
     return deepcopy(data.get('ptrn2'))
 
 
 @pytest.fixture(scope="module")
-def sip2_librarian_martigny(
-        app,
-        roles,
-        lib_martigny,
-        sip2_librarian_martigny_data):
-    """Create Martigny librarian without sending reset password instruction."""
-    data = sip2_librarian_martigny_data
-    yield create_patron(data)
+def selfcheck_librarian_martigny(app, roles, loc_public_martigny,
+                                 librarian_martigny,
+                                 selfcheck_termial_martigny_data):
+    """Create selfcheck config and token for Martigny librarian."""
+    # create token for selfcheck terminal
+    create_user_token(
+        client_name='selfcheck_token',
+        user=librarian_martigny.user,
+        access_token=selfcheck_termial_martigny_data.get('access_token')
+    )
+
+    # create config for selfcheck terminal
+    data = selfcheck_termial_martigny_data
+    return create_selfcheck_terminal(data)
 
 
 @pytest.fixture(scope="module")
-def sip2_patron_martigny_data(data):
+def selfcheck_termial_martigny_data(data):
+    """Load Martigny librarian SIP2 account data."""
+    return {
+        'name': 'sip2Test',
+        'access_token': 'TESTACCESSTOKEN',
+        'organisation_pid': 'org1',
+        'library_pid': 'lib1',
+        'location_pid': 'loc1',
+    }
+
+
+@pytest.fixture(scope="module")
+def selfcheck_patron_martigny_data(data):
     """Load Martigny librarian data."""
     return deepcopy(data.get('ptrn6'))
 
 
 @pytest.fixture(scope="module")
-def sip2_patron_martigny(
-        app,
-        roles,
-        lib_martigny,
-        patron_type_children_martigny,
-        sip2_patron_martigny_data):
+def selfcheck_patron_martigny(app, roles, lib_martigny,
+                              patron_type_children_martigny,
+                              selfcheck_patron_martigny_data):
     """Create Martigny patron without sending reset password instruction."""
     # create patron account
-    data = sip2_patron_martigny_data
+    data = selfcheck_patron_martigny_data
     yield create_patron(data)


### PR DESCRIPTION
To easiest manage selfcheck user accounts, we separate them from rero-ils users.

* Adds separate table to store selfcheck users.
* Adatps loan json schema to store terminal id on creation.
* Adds command into Dockerfile to install sip2 module.

Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
