### PR TITLE
permissions: correct caching problems

### DIFF
--- a/rero_ils/modules/views.py
+++ b/rero_ils/modules/views.py
@@ -54,7 +54,7 @@ def check_authentication(func):
 
 @api_blueprint.route('/permissions/<route_name>', methods=['GET'])
 @api_blueprint.route('/permissions/<route_name>/<record_pid>', methods=['GET'])
-@cached(timeout=10, query_string=False)
+@cached(timeout=10, query_string=True)
 @check_authentication
 def permissions(route_name, record_pid=None):
     """HTTP GET request for record permissions.


### PR DESCRIPTION
The caching for permission API must taking care of query_string. Without
this parameter, `permissions/holdings` and `permissions/holdings/1234`
HTTPS calls use the same cache and the second call return the same
result than the first one.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
