### PR TITLE
editor: prevent the enter key to submit the form

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
@@ -153,7 +153,8 @@
           "minLength": 1,
           "form": {
             "templateOptions": {
-              "itemCssClass": "col-lg-6"
+              "itemCssClass": "col-lg-6",
+              "doNotSubmitOnEnter": true
             }
           }
         },

--- a/rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json
+++ b/rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json
@@ -200,7 +200,12 @@
         },
         "identifier": {
           "type": "string",
-          "title": "Identifier"
+          "title": "Identifier",
+          "form": {
+            "templateOptions": {
+              "doNotSubmitOnEnter": true
+            }
+          }
         },
         "source": {
           "type": "object",

--- a/rero_ils/modules/ill_requests/templates/rero_ils/ill_request_form.html
+++ b/rero_ils/modules/ill_requests/templates/rero_ils/ill_request_form.html
@@ -27,7 +27,7 @@
     <p class="mb-0">{{ _('A well detailed request is more likely to be satisfied') }}</p>
   </div>
 
-  <form action="{{ url_for('ill_requests.ill_request_form') }}" method="POST" class="form" role="form" novalidate>
+  <form id="ill-public-form" action="{{ url_for('ill_requests.ill_request_form') }}" method="POST" class="form" role="form" novalidate>
     {{ form.hidden_tag() }}
     {%- if form.csrf_token and form.csrf_token.errors %}
       <div class="alert alert-danger" role="alert">
@@ -62,8 +62,28 @@
     </section>
     <div class="row pt-3">
       <div class="col text-right">
-        <input type="submit" id="submit" class="btn btn-primary" value="{{ _('Create request') }}"/>
+        <input type="submit" id="submit" class="btn btn-primary" value="{{ _('Submit') }}"/>
       </div>
     </div>
   </form>
+
+  <div id="ill-modal-confirmation" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ _('Confirmation') }}</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p>{{ _('Costs may apply. By confirming, you agree to the interlibrary loan conditions of the pick-up library.') }}</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-danger" data-dismiss="modal">{{ _('Cancel') }}</button>
+          <button id="ill-modal-confirmation-btn" type="button" class="btn btn-primary">{{ _('Confirm') }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
 {%- endblock body %}

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -47,7 +47,8 @@
       "form": {
         "focus": true,
         "templateOptions": {
-          "labelClasses": "col-2 text-right"
+          "labelClasses": "col-2 text-right",
+          "doNotSubmitOnEnter": true
         },
         "navigation": {
           "essential": true

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -174,6 +174,9 @@
             "type": "string",
             "minLength": 6,
             "form": {
+              "templateOptions": {
+                "doNotSubmitOnEnter": true
+              },
               "validation": {
                 "validators": {
                   "valueAlreadyExists": {
@@ -377,6 +380,9 @@
       },
       "form": {
         "hideExpression": "!field.parent.model.roles.some(v => v === 'patron')",
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        },
         "templateOptions": {
           "wrappers": [
             "card"

--- a/rero_ils/theme/assets/js/reroils/ills_request.js
+++ b/rero_ils/theme/assets/js/reroils/ills_request.js
@@ -16,9 +16,21 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
-import 'bootstrap';
-import './tooltip';
-import './toast';
-import './login';
-import './toggle';
-import './ills_request';
+
+import $ from 'jquery';
+
+// show a confirmation modal dialog on form submission
+$("#submit").on("click", function(event){
+  if($(this).data('confirmed') !== true) {
+    $("#ill-modal-confirmation").modal('show');
+    event.preventDefault();
+  }
+});
+
+// close the dialog, confirmed is true and trigger the submit click button
+$("#ill-modal-confirmation-btn").on("click", function(event){
+  $( "#submit" ).data('confirmed', true);
+  $("#ill-modal-confirmation").modal('hide');
+  // form submit does not works
+  $("#submit").trigger('click');
+});


### PR DESCRIPTION
* Prevents the enter key to submit the form in some fields that may be
  filled though a scanning device.
* Closes #1421.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero-ils-ui@dev

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
