### PR TITLE
menu: display "my account" only for a patron

### DIFF
--- a/rero_ils/modules/decorators.py
+++ b/rero_ils/modules/decorators.py
@@ -19,7 +19,7 @@
 
 from functools import wraps
 
-from rero_ils.permissions import login_and_librarian
+from rero_ils.permissions import login_and_librarian, login_and_patron
 
 
 def check_logged_as_librarian(fn):
@@ -31,5 +31,18 @@ def check_logged_as_librarian(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         login_and_librarian()
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+def check_logged_as_patron(fn):
+    """Decorator to check if the current logged user is logged as patron.
+
+    If no user is connected: return 401 (unauthorized)
+    If current logged user isn't `patron`: return 403 (forbidden)
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        login_and_patron()
         return fn(*args, **kwargs)
     return wrapper

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -34,7 +34,7 @@ from invenio_i18n.ext import current_i18n
 from .api import Patron, current_patron
 from .permissions import get_allowed_roles_management
 from .utils import user_has_patron
-from ..decorators import check_logged_as_librarian
+from ..decorators import check_logged_as_librarian, check_logged_as_patron
 from ..items.utils import item_pid_to_object
 from ..loans.api import get_loans_stats_by_patron_pid, get_overdue_loans
 from ..loans.utils import sum_for_fees
@@ -147,7 +147,7 @@ def logged_user():
 @blueprint.route('/global/patrons/profile', defaults={'viewcode': 'global'},
                  methods=['GET', 'POST'])
 @blueprint.route('/<string:viewcode>/patrons/profile')
-@login_required
+@check_logged_as_patron
 @register_menu(
     blueprint,
     'settings.patron_profile',

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -25,7 +25,7 @@ from flask_principal import RoleNeed
 from flask_security import login_required, roles_required
 from invenio_access.permissions import Permission
 
-from .modules.patrons.api import Patron
+from .modules.patrons.api import Patron, current_patron
 
 request_item_permission = Permission(RoleNeed('patron'))
 librarian_permission = Permission(
@@ -76,6 +76,14 @@ def login_and_librarian():
     if not current_user.is_authenticated:
         abort(401)
     if not librarian_permission.can():
+        abort(403)
+
+
+def login_and_patron():
+    """Patron is logged in."""
+    if current_user and not current_user.is_authenticated:
+        abort(401)
+    if not current_patron or not current_patron.is_patron:
         abort(403)
 
 

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -278,7 +278,7 @@ def init_menu_profile():
         rero_register(
             item,
             endpoint=profile_endpoint,
-            visible_when=lambda: current_user.is_authenticated,
+            visible_when=lambda: not current_patron.is_librarian,
             text='{icon} {profile}'.format(
                 icon='<i class="fa fa-book"></i>',
                 profile=_('My Account')


### PR DESCRIPTION
* Displays the entry "my account" in the public view main menu only for a logged patron.
* Restricts the patron profile view "my account" only to a logged patron.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
