### PR TITLE
tests: fix `test_documents_import_bnf_ean` for pycodestyle

### DIFF
--- a/tests/api/test_external_services.py
+++ b/tests/api/test_external_services.py
@@ -86,8 +86,10 @@ def test_documents_get(client, document):
 @mock.patch('rero_ils.permissions.login_and_librarian',
             mock.MagicMock())
 def test_documents_import_bnf_ean(mock_get, client, bnf_ean_any_123,
-            bnf_ean_any_9782070541270, bnf_ean_any_9782072862014,
-            bnf_anywhere_all_peter, bnf_recordid_all_FRBNF370903960000006):
+                                  bnf_ean_any_9782070541270,
+                                  bnf_ean_any_9782072862014,
+                                  bnf_anywhere_all_peter,
+                                  bnf_recordid_all_FRBNF370903960000006):
     """Test document import from bnf."""
 
     mock_get.return_value = mock_response(


### PR DESCRIPTION
Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
