### PR TITLE
translations: fix the extraction process

### DIFF
--- a/rero_ils/modules/contributions/views.py
+++ b/rero_ils/modules/contributions/views.py
@@ -155,7 +155,8 @@ def translat_unified(data, prefix=''):
     """
     translated_data = {}
     for key, value in data.items():
-        translated_data[_(f'{prefix}{key}')] = value
+        translated_data[_('{prefix}{key}'.format(
+            prefix=prefix, key=key))] = value
     return translated_data
 
 
@@ -167,10 +168,12 @@ def translat(data, prefix='', seperator=', '):
         if isinstance(data, list):
             translated = []
             for item in data:
-                translated.append(_(f'{prefix}{item}'))
+                translated.append(_('{prefix}{item}'.format(
+                    prefix=prefix, item=item)))
             translated = seperator.join(translated)
         elif isinstance(data, str):
-            translated = _(f'{prefix}{data}')
+            translated = _('{prefix}{data}'.format(
+                prefix=prefix, data=data))
     return translated
 
 


### PR DESCRIPTION
* Restores the format syntax instead of the f-string, because babel
  does not support it, thus failing in extracting the strings.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- Because the message extraction is broken on the `dev` branch.

## How to test?

- Try to extract the translation strings. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
