### PR TITLE
search: fix circulation search factory

### DIFF
--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -316,7 +316,7 @@ def circulation_search_factory(self, search, query_parser=None):
             search = search.filter(
                 'term', organisation__pid=current_organisation.pid
             )
-        if current_patron.is_patron:
+        elif current_patron.is_patron:
             search = search.filter('term', patron_pid=current_patron.pid)
     # exclude to_anonymize records
     search = search.filter('bool', must_not=[Q('term', to_anonymize=True)])


### PR DESCRIPTION
A user with librarian and patron roles can't see the requests information in the item detail view.
This commit adapts search circulation factory to allow that.

* Closes #1839.

Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- https://github.com/rero/rero-ils/issues/1839

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
