### PR TITLE
items: improve response time for csv export

### DIFF
--- a/rero_ils/modules/holdings/api_views.py
+++ b/rero_ils/modules/holdings/api_views.py
@@ -27,9 +27,10 @@ from flask import request as flask_request
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from werkzeug.exceptions import NotFound
 
+from rero_ils.modules.views import check_authentication
+
 from .api import Holding
 from ..errors import RegularReceiveNotAllowed
-from ..items.api_views import check_authentication
 from ...permissions import can_receive_regular_issue
 
 api_blueprint = Blueprint(

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -21,14 +21,11 @@ from datetime import datetime
 from functools import partial
 
 from elasticsearch.exceptions import NotFoundError
-from flask import current_app
-from invenio_circulation.search.api import search_by_pid
 from invenio_search import current_search
 
 from .circulation import ItemCirculation
 from .issue import ItemIssue
 from ..models import ItemIdentifier, ItemMetadata
-from ..utils import item_pid_to_object
 from ...api import IlsRecordError, IlsRecordsIndexer, IlsRecordsSearch
 from ...documents.api import Document, DocumentsSearch
 from ...fetchers import id_fetcher
@@ -48,24 +45,6 @@ ItemProvider = type(
 item_id_minter = partial(id_minter, provider=ItemProvider)
 # fetcher
 item_id_fetcher = partial(id_fetcher, provider=ItemProvider)
-
-
-def search_active_loans_for_item(item_pid):
-    """Return count and all active loans for an item."""
-    item_pid_object = item_pid_to_object(item_pid)
-    states = ['PENDING'] + \
-        current_app.config['CIRCULATION_STATES_LOAN_ACTIVE']
-    search = search_by_pid(
-        item_pid=item_pid_object,
-        filter_states=states,
-        sort_by_field='_created',
-        sort_order='desc'
-    )
-    loans_count = search.count()
-    try:
-        return loans_count, search.scan()
-    except StopIteration:
-        return loans_count
 
 
 class ItemsSearch(IlsRecordsSearch):

--- a/rero_ils/modules/items/listener.py
+++ b/rero_ils/modules/items/listener.py
@@ -49,7 +49,11 @@ def enrich_item_data(sender, json=None, record=None, index=None,
             json['vendor'] = {
                 'pid': item.vendor_pid
             }
-
+        # inherited_first_call_number to issue
+        inherited_first_call_number = item.issue_inherited_first_call_number
+        if inherited_first_call_number:
+            json['issue']['inherited_first_call_number'] = \
+                inherited_first_call_number
         # Local fields in JSON
         local_fields = LocalField.get_local_fields_by_resource(
             'item', item.pid)

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -132,6 +132,9 @@
           "status": {
             "type": "keyword"
           },
+          "inherited_first_call_number": {
+            "type": "keyword"
+          },
           "status_date": {
             "type": "date"
           },

--- a/rero_ils/modules/items/models.py
+++ b/rero_ils/modules/items/models.py
@@ -92,3 +92,10 @@ class ItemNoteTypes:
         CONDITION,
         PATRIMONIAL
     ]
+
+    INVENTORY_LIST_CATEGORY = [
+        GENERAL,
+        STAFF,
+        CHECKIN,
+        CHECKOUT
+    ]

--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -34,15 +34,28 @@ csv_item = ItemCSVSerializer(
         'document_creator',
         'document_main_type',
         'document_sub_type',
+        'library_name',
         'location_name',
         'barcode',
         'call_number',
         'second_call_number',
         'enumerationAndChronology',
+        'item_type',
+        'temporary_item_type',
+        'temporary_item_type_end_date',
+        'general_note',
+        'staff_note',
+        'checkin_note',
+        'checkout_note',
         'loans_count',
         'last_transaction_date',
         'status',
-        'created'
+        'created',
+        'issue_status',
+        'issue_status_date',
+        'issue_claims_count',
+        'issue_expected_date',
+        'issue_regular'
     ]
 )
 csv_item_response = record_responsify(csv_item, "text/csv")

--- a/rero_ils/modules/items/serializers/csv.py
+++ b/rero_ils/modules/items/serializers/csv.py
@@ -20,16 +20,20 @@
 
 import csv
 
-from flask import current_app, request
+import ciso8601
+from elasticsearch_dsl import A
+from flask import current_app, request, stream_with_context
 from invenio_i18n.ext import current_i18n
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 
-from rero_ils.filter import format_date_filter
-from rero_ils.modules.documents.api import search_document_by_pid
-from rero_ils.modules.documents.utils import title_format_text_head
-from rero_ils.modules.items.api import Item, search_active_loans_for_item
+from rero_ils.modules.documents.api import DocumentsSearch
+from rero_ils.modules.item_types.api import ItemTypesSearch
+from rero_ils.modules.libraries.api import LibrariesSearch
+from rero_ils.modules.loans.api import LoansSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.utils import get_i18n_supported_languages
+
+from ..models import ItemNoteTypes
 
 role_filter = [
     'rsp',
@@ -56,96 +60,7 @@ role_filter = [
 
 
 class ItemCSVSerializer(CSVSerializer):
-    """Serialize and filter item circulation status."""
-
-    def transform_search_hit(
-        self, pid, record_hit, links_factory=None, **kwargs
-    ):
-        """Transform search result hit into an intermediate representation.
-
-        :param pid: Persistent identifier instance.
-        :param pid: Persistent identifier instance.
-        :param record_hit: Record metadata retrieved via search.
-        :param links_factory: Factory function for record links.
-        """
-        hit = self.preprocess_search_hit(
-            pid, record_hit, links_factory=links_factory, **kwargs
-        )
-        return hit
-
-    def preprocess_search_hit(self, pid, record_hit, links_factory=None,
-                              **kwargs):
-        """Prepare a record hit from Elasticsearch for serialization.
-
-        :param pid: Persistent identifier instance.
-        :param record_hit: Record metadata retrieved via search.
-        :param links_factory: Factory function for record links.
-        """
-        language = kwargs.get('language')
-
-        record = record_hit['_source']
-        # inherit holdings call number when possible
-        item = Item(record)
-        issue_call_number = item.issue_inherited_first_call_number
-        if issue_call_number:
-            record['call_number'] = issue_call_number
-        item_pid = pid.pid_value
-
-        # process location
-        locations_map = kwargs.get('locations_map')
-        record['location_name'] = locations_map[
-            record.get('location').get('pid')]
-
-        # retrieve and process document
-        document = search_document_by_pid(record['document']['pid'])
-        record['document_title'] = title_format_text_head(document.title,
-                                                          with_subtitle=True)
-
-        # process contributions
-        creator = []
-        if 'contribution' in document:
-            for contribution in document.contribution:
-                if any(role in contribution.role for role in role_filter):
-                    authorized_access_point = \
-                        f'authorized_access_point_{language}'
-                    if authorized_access_point in contribution['agent']:
-                        creator.append(
-                            contribution['agent'][authorized_access_point]
-                        )
-        if creator:
-            record['document_creator'] = ' ; '.join(creator)
-        document_main_type = []
-        document_sub_type = []
-        for document_type in document.type:
-            data = document_type.to_dict()
-            document_main_type.append(data.get('main_type'))
-            document_sub_type.append(data.get('subtype',  ''))
-        record['document_main_type'] = ', '.join(document_main_type)
-        record['document_sub_type'] = ', '.join(document_sub_type)
-
-        # get loans information
-        loans_count, loans = search_active_loans_for_item(item_pid)
-        record['loans_count'] = loans_count
-        if loans_count:
-            # get first loan
-            loan = next(loans)
-            record['last_transaction_date'] = format_date_filter(
-                loan.transaction_date,
-                date_format='short',
-                locale=language,
-            )
-
-        record['created'] = format_date_filter(
-            record['_created'],
-            date_format='short',
-            locale=language,
-        )
-
-        # prevent csv key error
-        # TODO: find other way to prevent csv key error
-        del(record['type'])
-
-        return record
+    """Serialize item search for csv."""
 
     def serialize_search(self, pid_fetcher, search_result, links=None,
                          item_links_factory=None):
@@ -156,42 +71,216 @@ class ItemCSVSerializer(CSVSerializer):
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """
+        # define chunk size
+        chunk_size = 1000
+
         # language
         language = request.args.get("lang", current_i18n.language)
         if not language or language not in get_i18n_supported_languages():
             language = current_app.config.get('BABEL_DEFAULT_LANGUAGE', 'en')
 
-        records = []
+        # prepare mapping dictionnaries
+        item_types_map = {}
+        for item_type in ItemTypesSearch().scan():
+            item_types_map[item_type.pid] = item_type.name
         locations_map = {}
-        for location in LocationsSearch().filter().scan():
+        for location in LocationsSearch().scan():
             locations_map[location.pid] = location.name
-        for hit in search_result['hits']['hits']:
-            processed_hit = self.transform_search_hit(
-                pid_fetcher(hit['_id'], hit['_source']),
-                hit,
-                links_factory=item_links_factory,
-                locations_map=locations_map,
-                language=language
-            )
-            records.append(self.process_dict(processed_hit))
+        libraries_map = {}
+        for library in LibrariesSearch().scan():
+            libraries_map[library.pid] = library.name
 
-        return self._format_csv(records)
+        def generate_csv():
+            def batch(results):
+                """Chunk search results.
 
-    def _format_csv(self, records):
-        """Return the list of records as a CSV string.
+                :param results: search results.
+                :return list of chuncked item pids and search records
+                """
+                records = []
+                pids = []
+                for result in results:
+                    pids.append(result.pid)
+                    records.append(result)
+                    if len(records) % chunk_size == 0:
+                        yield pids, records
+                        pids = []
+                        records = []
+                yield pids, records
 
-        :param records: Records metadata to format.
-        """
-        # build a unique list of all keys in included fields as CSV headers
-        headers = dict.fromkeys(self.csv_included_fields)
-        # write the CSV output in memory
-        line = Line()
-        writer = csv.DictWriter(line,
-                                quoting=csv.QUOTE_ALL,
-                                fieldnames=headers)
-        writer.writeheader()
-        yield line.read()
+            def get_documents_by_item_pids(item_pids):
+                """Get documents for the given item pid list."""
 
-        for record in records:
-            writer.writerow(record)
+                def _build_doc(data):
+                    document_data = {
+                        'document_title': next(
+                            filter(lambda x: x.get('type') == 'bf:Title',
+                                   data.get('title'))
+                        ).get('_text')
+                    }
+                    # process contributions
+                    creator = []
+                    if 'contribution' in data:
+                        for contribution in data.get('contribution'):
+                            if any(role in contribution.get('role')
+                                   for role in role_filter):
+                                authorized_access_point = \
+                                    f'authorized_access_point_{language}'
+                                if authorized_access_point in contribution\
+                                        .get('agent'):
+                                    creator.append(
+                                        contribution['agent'][
+                                            authorized_access_point]
+                                    )
+                    document_data['document_creator'] = ' ; '.join(creator)
+                    document_main_type = []
+                    document_sub_type = []
+                    for document_type in data.get('type'):
+                        # data = document_type.to_dict()
+                        document_main_type.append(
+                            document_type.get('main_type'))
+                        document_sub_type.append(
+                            document_type.get('subtype', ''))
+                    document_data['document_main_type'] = ', '.join(
+                        document_main_type)
+                    document_data['document_sub_type'] = ', '.join(
+                        document_sub_type)
+                    # TODO : build provision activity
+                    return document_data
+
+                doc_search = DocumentsSearch() \
+                    .filter('terms', holdings__items__pid=list(item_pids)) \
+                    .source(
+                    ['pid', 'title', 'contribution', 'provisionActivity',
+                     'type'])
+                docs = {}
+                for doc in doc_search.scan():
+                    docs[doc.pid] = _build_doc(doc.to_dict())
+                return docs
+
+            def get_loans_by_item_pids(item_pids):
+                """Get loans for the given item pid list."""
+                states = ['PENDING'] + \
+                    current_app.config['CIRCULATION_STATES_LOAN_ACTIVE']
+                loan_search = LoansSearch() \
+                    .filter('terms', state=states) \
+                    .filter('terms', item_pid__value=item_pids) \
+                    .source(['pid', 'item_pid.value', '_created'])
+                agg = A('terms', field='item_pid.value', size=chunk_size)
+                loan_search.aggs.bucket('loans_count', agg)
+
+                loan_search = loan_search.extra(
+                    collapse={
+                        'field': 'item_pid.value',
+                        "inner_hits": {
+                            "name": "most_recent",
+                            "size": 1,
+                            "sort": [{"_created": "desc"}],
+                        }
+                    }
+                )
+
+                results = loan_search.execute()
+                agg_buckets = {}
+                for result in results.aggregations.loans_count.buckets:
+                    agg_buckets[result.key] = result.doc_count
+                loans = {}
+                for loan_hit in results:
+                    # get most recent loans
+                    loan_data = loan_hit.meta.inner_hits.most_recent[0]\
+                        .to_dict()
+                    item_pid = loan_data['item_pid']['value']
+                    loans[item_pid] = {
+                        'loans_count': agg_buckets.get(item_pid, 0),
+                        'last_transaction_date': ciso8601.parse_datetime(
+                            loan_data['_created']).date()
+                    }
+                return loans
+
+            headers = dict.fromkeys(self.csv_included_fields)
+
+            # write the CSV output in memory
+            line = Line()
+            writer = csv.DictWriter(line,
+                                    quoting=csv.QUOTE_ALL,
+                                    fieldnames=headers)
+            writer.writeheader()
             yield line.read()
+
+            for pids, batch_results in batch(search_result):
+                # get documents
+                documents = get_documents_by_item_pids(pids)
+
+                # get loans
+                loans = get_loans_by_item_pids(pids)
+
+                for hit in batch_results:
+                    csv_data = hit.to_dict()
+                    csv_data['library_name'] = libraries_map[
+                        hit['library']['pid']]
+                    csv_data['location_name'] = locations_map[
+                        hit['location']['pid']]
+
+                    try:
+                        # update csv data with document
+                        csv_data.update(documents.get(hit['document']['pid']))
+                    except Exception as err:
+                        current_app.logger.error(
+                            'ERROR in csv serializer: '
+                            '{message} on document: {pid}'.format(
+                                message=err,
+                                pid=hit['document']['pid'])
+                        )
+
+                    # update csv data with loan
+                    csv_data.update(loans.get(hit['pid'], {'loans_count': 0}))
+
+                    # process item type and temporary item type
+                    csv_data['item_type'] = item_types_map[
+                        hit['item_type']['pid']]
+                    temporary_item_type = csv_data.get('temporary_item_type')
+                    if temporary_item_type:
+                        csv_data['temporary_item_type'] = item_types_map[
+                            temporary_item_type['pid']]
+                        csv_data['temporary_item_type_end_date'] = \
+                            temporary_item_type.get('end_date')
+
+                    # process note
+                    for note in csv_data.get('notes', []):
+                        if any(note_type in note.get('type')
+                               for note_type in
+                               ItemNoteTypes.INVENTORY_LIST_CATEGORY):
+                            csv_data[note.get('type')] = note.get(
+                                'content')
+
+                    csv_data['created'] = ciso8601.parse_datetime(
+                            hit['_created']).date()
+
+                    # process item issue
+                    if hit['type'] == 'issue':
+                        issue = csv_data['issue']
+                        if issue.get('inherited_first_call_number') \
+                                and not csv_data.get('call_number'):
+                            csv_data['call_number'] = \
+                                issue.get('inherited_first_call_number')
+                        csv_data['issue_status'] = issue.get('status')
+                        if issue.get('status_date'):
+                            csv_data['issue_status_date'] = \
+                                ciso8601.parse_datetime(
+                                    issue.get('status_date')).date()
+                        csv_data['issue_claims_count'] = \
+                            issue.get('claims_count', 0)
+                        csv_data['issue_expected_date'] = \
+                            issue.get('expected_date')
+                        csv_data['issue_regular'] = issue.get('regular')
+
+                    # prevent key error
+                    del (csv_data['type'])
+
+                    # write csv data
+                    data = self.process_dict(csv_data)
+                    writer.writerow(data)
+                    yield line.read()
+
+        # return streamed content
+        return stream_with_context(generate_csv())

--- a/rero_ils/modules/items/views/__init__.py
+++ b/rero_ils/modules/items/views/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -15,15 +16,23 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item data module."""
+"""Blueprints for item."""
 
-from .api import Item, ItemsIndexer, ItemsSearch, item_id_fetcher, \
-    item_id_minter
-from .circulation import ItemCirculation
-from .issue import ItemIssue
-from .record import ItemRecord
+from __future__ import absolute_import
 
-__all__ = (
-    'Item', 'ItemRecord', 'ItemCirculation', 'ItemIssue', 'ItemsSearch',
-    'ItemsIndexer', 'item_id_fetcher', 'item_id_minter'
+from .api_views import api_blueprint
+from .rest import InventoryListResource
+
+inventory_list = InventoryListResource.as_view(
+    'inventory_search'
 )
+api_blueprint.add_url_rule(
+    '/inventory',
+    view_func=inventory_list
+)
+
+blueprints = [
+    api_blueprint,
+]
+
+__all__ = 'api_blueprint'

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -30,16 +30,18 @@ from invenio_circulation.errors import CirculationException, \
     MissingRequiredParameterError
 from werkzeug.exceptions import NotFound
 
-from .api import Item
-from .models import ItemCirculationAction
-from .utils import item_pid_to_object
-from ..circ_policies.api import CircPolicy
-from ..documents.views import item_library_pickup_locations
-from ..errors import NoCirculationActionIsPermitted
-from ..libraries.api import Library
-from ..loans.api import Loan
-from ..patrons.api import Patron, current_librarian, current_patrons
-from ...permissions import librarian_permission, request_item_permission
+from rero_ils.modules.circ_policies.api import CircPolicy
+from rero_ils.modules.documents.views import item_library_pickup_locations
+from rero_ils.modules.errors import NoCirculationActionIsPermitted
+from rero_ils.modules.items.api import Item
+from rero_ils.modules.items.models import ItemCirculationAction
+from rero_ils.modules.items.utils import item_pid_to_object
+from rero_ils.modules.libraries.api import Library
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.patrons.api import Patron, current_librarian, \
+    current_patrons
+from rero_ils.modules.views import check_authentication
+from rero_ils.permissions import request_item_permission
 
 # from rero_ils.modules.utils import profile
 
@@ -56,19 +58,6 @@ def check_logged_user_authentication(func):
     def decorated_view(*args, **kwargs):
         if not current_user.is_authenticated:
             return jsonify({'status': 'error: Unauthorized'}), 401
-        return func(*args, **kwargs)
-
-    return decorated_view
-
-
-def check_authentication(func):
-    """Decorator to check authentication for items HTTP API."""
-    @wraps(func)
-    def decorated_view(*args, **kwargs):
-        if not current_user.is_authenticated:
-            return jsonify({'status': 'error: Unauthorized'}), 401
-        if not librarian_permission.require().can():
-            return jsonify({'status': 'error: Forbidden'}), 403
         return func(*args, **kwargs)
 
     return decorated_view

--- a/rero_ils/modules/items/views/rest.py
+++ b/rero_ils/modules/items/views/rest.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Inventory list REST API."""
+
+from __future__ import absolute_import, print_function
+
+from functools import partial
+
+from invenio_rest import ContentNegotiatedMethodView
+
+from rero_ils.modules.items.api import ItemsSearch
+from rero_ils.modules.items.serializers import csv_item_search
+from rero_ils.query import items_search_factory
+
+
+class InventoryListResource(ContentNegotiatedMethodView):
+    """Inventory List REST resource."""
+
+    # TODO: is candidate for invenio-record-resource ?
+
+    def __init__(self, **kwargs):
+        """Init."""
+        super().__init__(
+            method_serializers={
+                'GET': {
+                    'text/csv': csv_item_search,
+                }
+            },
+            serializers_query_aliases={
+                'csv': 'text/csv',
+            },
+            default_method_media_type={
+                'GET': 'text/csv'
+            },
+            default_media_type='text/csv',
+            **kwargs
+        )
+        self.search_factory = partial(items_search_factory, self)
+
+    def get(self, **kwargs):
+        """Search records."""
+        search_obj = ItemsSearch()
+        search, qs_kwargs = self.search_factory(search_obj)
+
+        return self.make_response(
+            pid_fetcher=None,
+            search_result=search.scan()
+        )

--- a/rero_ils/modules/loans/api_views.py
+++ b/rero_ils/modules/loans/api_views.py
@@ -21,9 +21,9 @@ from flask import Blueprint, abort, jsonify
 from flask_login import login_required
 
 from rero_ils.modules.items.api import Item
-from rero_ils.modules.items.api_views import \
-    check_logged_user_authentication, jsonify_error
 from rero_ils.modules.items.models import ItemCirculationAction
+from rero_ils.modules.items.views.api_views import \
+    check_logged_user_authentication, jsonify_error
 from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.loans.utils import sum_for_fees
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
             'contributions = rero_ils.modules.contributions.views:api_blueprint',
             'holdings = rero_ils.modules.holdings.api_views:api_blueprint',
             'item_types = rero_ils.modules.item_types.views:blueprint',
-            'items = rero_ils.modules.items.api_views:api_blueprint',
+            'items = rero_ils.modules.items.views:api_blueprint',
             'libraries = rero_ils.modules.libraries.api_views:api_blueprint',
             'loans = rero_ils.modules.loans.api_views:api_blueprint',
             'monitoring = rero_ils.modules.monitoring:api_blueprint',

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -109,16 +109,20 @@ def test_items_serializers(
     response = client.get(list_url, headers=rero_json_header)
     assert response.status_code == 200
 
-    list_url = url_for('invenio_records_rest.item_list')
+    list_url = url_for('api_item.inventory_search')
     response = client.get(list_url, headers=csv_header)
     assert response.status_code == 200
     data = get_csv(response)
     assert data
     assert '"pid","document_pid","document_title","document_creator",' \
-           '"document_main_type","document_sub_type","location_name",' \
-           '"barcode","call_number","second_call_number",' \
-           '"enumerationAndChronology","loans_count",' \
-           '"last_transaction_date","status","created"' in data
+           '"document_main_type","document_sub_type","library_name",' \
+           '"location_name","barcode","call_number","second_call_number",' \
+           '"enumerationAndChronology","item_type","temporary_item_type",' \
+           '"temporary_item_type_end_date","general_note","staff_note",' \
+           '"checkin_note","checkout_note","loans_count",' \
+           '"last_transaction_date","status","created","issue_status",' \
+           '"issue_status_date","issue_claims_count","issue_expected_date",' \
+           '"issue_regular"' in data
 
 
 def test_loans_serializers(


### PR DESCRIPTION
The CSV export of the inventory list has an important waiting time.
With this commit, we try to improve the response time.

* Uses ciso8601 to parse date fields instead `format_date_filter`.
* Adds new api endpoint for inventory list.
* Uses streaming to process download csv file.
* Uses bunch request to reduce elasticsearch calls.
* Adds some fields in csv file.
* Closes #1456.
* Closes #1329.

Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which issue does it fix? #1456

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils-ui#576
* rero/ng-core#384

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
