### PR TITLE
documents: improve online access information

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -97,7 +97,37 @@
     {% endfor %}
     {% endif %}
 
-    <!-- SUBJECTS -->
+    <!-- ABSTRACT -->
+    {% if record.abstracts|length > 0 %}
+    <div class="pt-2">
+    {{ div_list(record.abstracts) }}
+    </div>
+    {% endif %}
+
+    <!-- ELECTRONIC LOCATOR (Other accesses, types in filters) -->
+    {% if record.electronicLocator %}
+      {% set resources = record | get_other_accesses %}
+      {% if resources | length > 0 %}
+        <ul class="list-unstyled mb-0">
+        {% for resource in resources %}
+          <li>
+            <a href="{{ resource.url }}">
+              <i class="fa fa-link"></i>
+              {{ _(resource.type) }}:
+              {% if resource.content %}
+                {{ _(resource.content) }}
+              {% else %}
+                {{ resource.url }}
+              {% endif %}
+            </a>
+            {% if resource.public_note %}({{ resource.public_note }}){% endif %}
+          </li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endif %}
+
+    <!-- SUBJECTS TERM -->
     {% if record.subjects %}
     <div class="pt-2">
     {% for subject in record.subjects %}

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -397,11 +397,9 @@ def get_other_accesses(record):
 
     def filter_type(electronic_locator):
         """Filter electronic locator for related resources and no info."""
-        if electronic_locator.get('type') in ['relatedResource', 'noInfo'] \
-                and electronic_locator.get('content') != 'coverImage':
-            return True
-        else:
-            return False
+        return electronic_locator.get('type') in [
+            'noInfo', 'resource', 'relatedResource', 'versionOfResource'
+        ] and electronic_locator.get('content') != 'coverImage'
 
     filtered_electronic_locators = filter(
         filter_type,

--- a/rero_ils/theme/assets/scss/rero_ils/styles.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/styles.scss
@@ -122,6 +122,13 @@ div.tooltip div.tooltip-inner{
   max-width: 400px;
 }
 
+.rero-ils-external-link:after {
+  font-family: 'FontAwesome';
+  font-size: $font-size-very-small;
+  vertical-align: top;
+  content: " \f08e";
+}
+
 /*
  *********************************
 

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -4716,7 +4716,14 @@ def test_marc21_to_electronicLocator_from_856(mock_cover_get):
         }
     ]
     assert get_cover_art(data) is None
-    assert get_other_accesses(data) == []
+    assert get_other_accesses(data) == [
+        {
+            'url': 'http://reader.digitale-s.de/r/d/XXX.html',
+            'type': 'versionOfResource',
+            'content': 'fullText',
+            'public_note': 'Vol. 1'
+        }
+    ]
 
     marc21xml = """
     <record>


### PR DESCRIPTION
* Moves online resources from the "Descriptions" tab to the header.
* Closes #1722.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- https://github.com/rero/rero-ils/issues/1722

- Check link on header for online resources

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
