### PR TITLE
Circulation category: limit fee 'from' day interval field

### DIFF
--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -230,7 +230,7 @@
               "from": {
                 "type": "integer",
                 "title": "From",
-                "minimum": 0,
+                "minimum": 1,
                 "form": {
                   "templateOptions": {
                     "itemCssClass": "col-lg-3"


### PR DESCRIPTION
An incremental fee limit are define by thee fields : from, to and cost.
The 'from' field minimum value must be upper or equal to 1.
Closes rero/rero-ils#1848.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
