### PR TITLE
Document: add host document title into index

### DIFF
--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -51,10 +51,12 @@
             }
           },
           "partOfTitle": {
+            "type": "object",
             "properties": {
               "value": {
                 "type": "text",
-                "index": false
+                "index": false,
+                "copy_to": "title._search"
               },
               "language": {
                 "type": "keyword",
@@ -92,13 +94,36 @@
                 "properties": {
                   "value": {
                     "type": "text",
-                    "index": false
+                    "index": false,
+                    "copy_to": "title._search"
                   }
                 }
               }
             }
           },
           "_text": {
+            "type": "text",
+            "index": false,
+            "fields": {
+              "eng": {
+                "type": "text",
+                "analyzer": "english"
+              },
+              "fre": {
+                "type": "text",
+                "analyzer": "french"
+              },
+              "ger": {
+                "type": "text",
+                "analyzer": "german"
+              },
+              "ita": {
+                "type": "text",
+                "analyzer": "italian"
+              }
+            }
+          },
+          "_search": {
             "type": "text",
             "index": false,
             "fields": {

--- a/scripts/setup
+++ b/scripts/setup
@@ -233,7 +233,7 @@ eval ${PREFIX} "invenio roles create -d 'Patron' patron"
 eval ${PREFIX} "invenio roles create -d 'Librarian' librarian"
 eval ${PREFIX} "invenio roles create -d 'System Librarian' system_librarian"
 eval ${PREFIX} "invenio roles create -d 'Documentation Editor' editor"
-eval ${PREFIX} "invenio roles create -d 'Documment Importing' document_importer"
+eval ${PREFIX} "invenio roles create -d 'Document Importing' document_importer"
 
 # create users
 info_msg "Create users"


### PR DESCRIPTION
Some parts of the document title are already indexed (main title,
subtitle) because there are mapped into the '_text' ES field. But other
parts are not indexed (only include in ES for dump) including the host
document title. This PR includes all not yet indexed title parts into a
new indexed field.

Closes rero/rero-ils#1788.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Search about "sept clef du pouvoir"
- You should find the main book and also the child "Samedi suprême"

![image](https://user-images.githubusercontent.com/10031585/116375540-a91a9700-a80f-11eb-8c84-237de2df124f.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
