### PR TITLE
circulation: restrict ILL request form to patron

### DIFF
--- a/rero_ils/modules/ill_requests/views.py
+++ b/rero_ils/modules/ill_requests/views.py
@@ -26,6 +26,7 @@ from .api import ILLRequest
 from .forms import ILLRequestForm
 from .models import ILLRequestStatus
 from .utils import get_pickup_location_options
+from ..decorators import check_logged_as_patron
 from ..locations.api import Location
 from ..patrons.api import current_patrons
 from ..utils import extracted_data_from_ref, get_ref_for_pid
@@ -42,6 +43,7 @@ blueprint = Blueprint(
 
 @blueprint.route('/create/', methods=['GET', 'POST'])
 @check_user_is_authenticated(redirect_to='security.login')
+@check_logged_as_patron
 def ill_request_form():
     """Return professional view."""
     form = ILLRequestForm(request.form)

--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -25,6 +25,4 @@ def user_has_patron(user=current_user):
     """Test if user has a patron."""
     from .api import Patron
     patrons = Patron.get_patrons_by_user(user=user)
-    if patrons:
-        return True
-    return False
+    return bool(patrons)  # true if `patrons` list isn't empty; false otherwise

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -36,7 +36,6 @@ from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patrons.api import current_librarian, current_patrons
 from rero_ils.permissions import can_access_professional_view
 
-from ..modules.patrons.utils import user_has_patron
 from ..version import __version__
 
 blueprint = Blueprint(
@@ -101,7 +100,7 @@ def init_menu_tools():
     rero_register(
         item,
         endpoint='ill_requests.ill_request_form',
-        visible_when=lambda: user_has_patron,
+        visible_when=lambda: bool(current_patrons),
         text='{icon} {help}'.format(
             icon='<i class="fa fa-shopping-basket"></i>',
             help=_('Interlibrary loan request')


### PR DESCRIPTION
* The "ILLRequest form" user menu entry is now only visible if the
  current logged user has the `patron` role.
* Closes rero/rero-ils#1895.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
