### PR TITLE
template: allow to user `type` field into templates

### DIFF
--- a/data/templates.json
+++ b/data/templates.json
@@ -255,7 +255,8 @@
       "barcode": "",
       "call_number": "AO BIB ",
       "item_type": {},
-      "location": {}
+      "location": {},
+      "type": "standard"
     }
   },
   {

--- a/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
@@ -46,7 +46,8 @@
         "type": "keyword"
       },
       "data": {
-        "type": "object"
+        "type": "object",
+        "enabled": false
       },
       "_created": {
         "type": "date"

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3684,7 +3684,11 @@
     },
     "visibility": "public",
     "template_type": "items",
-    "data": {}
+    "data": {
+      "barcode": "barcode_1234",
+      "type": "standard",
+      "call_number": "HB271"
+    }
   },
   "tmpl6": {
     "$schema": "https://ils.rero.ch/schemas/templates/template-v0.0.1.json",

--- a/tests/ui/templates/test_templates_api.py
+++ b/tests/ui/templates/test_templates_api.py
@@ -43,24 +43,24 @@ def test_template_es_mapping(es_clear, db,
     assert mapping == get_mapping(search.Meta.index)
 
 
-def test_template_create(db, es_clear, templ_doc_public_martigny_data,
+def test_template_create(db, es_clear, templ_item_public_martigny_data,
                          org_martigny, system_librarian_martigny):
     """Test template creation."""
-    templ_doc_public_martigny_data['toto'] = 'toto'
+    templ_item_public_martigny_data['toto'] = 'toto'
     with pytest.raises(ValidationError):
-        temp = Template.create(templ_doc_public_martigny_data, delete_pid=True)
+        Template.create(templ_item_public_martigny_data, delete_pid=True)
 
     db.session.rollback()
 
     next_pid = Template.provider.identifier.next()
-    del templ_doc_public_martigny_data['toto']
-    temp = Template.create(templ_doc_public_martigny_data, delete_pid=True)
+    del templ_item_public_martigny_data['toto']
+    temp = Template.create(templ_item_public_martigny_data, delete_pid=True)
     next_pid += 1
-    assert temp == templ_doc_public_martigny_data
+    assert temp == templ_item_public_martigny_data
     assert temp.get('pid') == str(next_pid)
 
     temp = Template.get_record_by_pid(str(next_pid))
-    assert temp == templ_doc_public_martigny_data
+    assert temp == templ_item_public_martigny_data
 
     fetched_pid = fetcher(temp.id, temp)
     assert fetched_pid.pid_value == str(next_pid)


### PR DESCRIPTION
Closes rero/rero-ils#1776.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
