### PR TITLE
cli: fix wait_empty_tasks

### DIFF
--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -43,7 +43,7 @@ import requests
 import xmltodict
 import yaml
 from babel import Locale, core
-from celery.bin.control import inspect
+from celery import current_app as current_celery
 from dojson.contrib.marc21.utils import create_record
 from elasticsearch_dsl.query import Q
 from flask import current_app
@@ -138,15 +138,15 @@ utils.add_command(users_validate)
 
 def queue_count():
     """Count tasks in celery."""
-    inspector = inspect()
+    inspector = current_celery.control.inspect()
     task_count = 0
     reserved = inspector.reserved()
     if reserved:
-        for key, values in reserved.items():
+        for _, values in reserved.items():
             task_count += len(values)
     active = inspector.active()
     if active:
-        for key, values in active.items():
+        for _, values in active.items():
             task_count += len(values)
     return task_count
 


### PR DESCRIPTION
* The `wait_empty_tasks` had to be change because of celery version changes.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
