### PR TITLE
tests: fix temporarly safety check

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -68,7 +68,8 @@ fi
 
 function pretests () {
   info_msg "Check vulnerabilities:"
-  safety check
+  # Ignore 40459 until the next release of flask-caching will be available.
+  safety check -i 40459
   info_msg "Check json:"
   invenio utils check_json tests/data rero_ils/modules data
   info_msg "Check license:"


### PR DESCRIPTION
Fixes temporarly safety check by ignoring the vulnerability `40459` corresponding to `flask-caching`.
This fix can be removed when a new release of `flask-caching` will correct that.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>