### PR TITLE
wiki: improve flask-wiki integration

### DIFF
--- a/rero_ils/theme/templates/rero_ils/page_wiki.html
+++ b/rero_ils/theme/templates/rero_ils/page_wiki.html
@@ -25,14 +25,15 @@
 {%- endblock %}
 
 
-{%- block body %}
+{%- block page_body %}
+<div class="container-fluid flex-grow-1">
 
 {% block navigation %}
 {%- include "wiki/navigation.html" %}
 {%- endblock navigation %}
 
 {% block content %} {% endblock %}
-{%- endblock body %}
+{%- endblock page_body %}
 
 {%- block javascript %}
 {{ super() }}


### PR DESCRIPTION
* Modifies the flask wiki page template in order to user a wider space
  for content.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To allow flask wiki to use a wider proportion of the available width. 

## Dependencies

My PR depends on the following `flask-wiki`'s PR(s):

* rero/flask-wiki#29

## How to test?

- Update flask-wiki (bootstrap).
- Make sure the rero/flask-wiki#29 is merged.
- Open the help section.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
