### PR TITLE
resources: improve organisation ref link validation

### DIFF
--- a/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
@@ -75,6 +75,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
+++ b/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
@@ -301,6 +301,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -174,6 +174,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -214,6 +214,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json
+++ b/rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json
@@ -84,6 +84,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -56,6 +56,10 @@
     },
     "organisation": {
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json
+++ b/rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json
@@ -258,6 +258,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
@@ -215,6 +215,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -427,6 +427,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -82,6 +82,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -121,6 +121,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/local_fields/jsonschemas/local_fields/local_field-v0.0.1.json
+++ b/rero_ils/modules/local_fields/jsonschemas/local_fields/local_field-v0.0.1.json
@@ -28,6 +28,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation",

--- a/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
+++ b/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
@@ -71,6 +71,10 @@
     "organisation": {
       "title": "User organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
@@ -130,6 +130,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -56,6 +56,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json
@@ -52,6 +52,10 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Organisation URI",

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -259,6 +259,7 @@
     "organisation": {
       "title": "Organisation",
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "$ref"
       ],


### PR DESCRIPTION
During the loading of ilspilot it was revealed that additional validation
is needed for the organisation field in all resources. System accepted
bad organisation data mainly for the library resource that prevented users
from logging in. With this commit, organisation field is validated correctly.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
