### PR TITLE
indexer: fix bulk index

### DIFF
--- a/rero_ils/modules/acq_order_lines/api.py
+++ b/rero_ils/modules/acq_order_lines/api.py
@@ -144,19 +144,19 @@ class AcqOrderLinesIndexer(IlsRecordsIndexer):
 
     record_cls = AcqOrderLine
 
-    def index(self, record):
-        """Index an Acquisition Order Line and update total amount of order."""
-        return_value = super().index(record)
+    def after_index_record(self, record):
+        """After bulk index.
+
+        :param record: indexed record.
+        """
         self._update_order_total_amount(record)
 
-        return return_value
+    def after_delete_record(self, record):
+        """After bulk delete.
 
-    def delete(self, record):
-        """Delete a Acquisition Order Line and update total amount of order."""
-        return_value = super().delete(record)
+        :param record: deleted record.
+        """
         self._update_order_total_amount(record)
-
-        return return_value
 
     def _update_order_total_amount(self, record):
         """Update total amount of the order."""

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -320,11 +320,12 @@ class DocumentsIndexer(IlsRecordsIndexer):
 
     record_cls = Document
 
-    def index(self, record):
-        """Index an document."""
-        return_value = super().index(record)
-        record.index_contributions(bulk=True)
-        return return_value
+    def after_index_record(self, record):
+        """After bulk index.
+
+        :param record: indexed record.
+        """
+        record.index_contributions(bulk=False)
 
     def bulk_index(self, record_id_iterator):
         """Bulk index records.

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -721,15 +721,13 @@ class HoldingsIndexer(IlsRecordsIndexer):
 
     record_cls = Holding
 
-    def index(self, record):
-        """Indexing a holding record.
+    def after_index_record(self, record):
+        """After bulk index.
 
-        Parent document is indexed as well.
+        :param record: indexed record.
         """
-        return_value = super().index(record)
         document = Document.get_record_by_pid(record.document_pid)
         document.reindex()
-        return return_value
 
     def bulk_index(self, record_id_iterator):
         """Bulk index records.

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -524,7 +524,7 @@ class ItemRecord(IlsRecord):
         return False
 
     @classmethod
-    def get_number_masked_items_by_holdings_pid(cls, holding_pid):
+    def get_number_unmasked_items_by_holdings_pid(cls, holding_pid):
         """Returns the number of unmasked items and attached to a holding.
 
         :param holding_pid: the pid of the holdings.

--- a/rero_ils/modules/local_fields/api.py
+++ b/rero_ils/modules/local_fields/api.py
@@ -28,7 +28,7 @@ from ..documents.api import Document
 from ..fetchers import id_fetcher
 from ..minters import id_minter
 from ..providers import Provider
-from ...modules.utils import extracted_data_from_ref
+from ..utils import extracted_data_from_ref
 
 # provider
 LocalFieldProvider = type(
@@ -109,27 +109,21 @@ class LocalFieldsIndexer(IlsRecordsIndexer):
 
     record_cls = LocalField
 
-    def index(self, record):
-        """Reindex a resource (documents, items, holdings).
+    def after_index_record(self, record):
+        """After bulk index.
 
-        :param record: Record instance.
+        :param record: indexed record.
         """
-        return_value = super().index(record)
         resource = extracted_data_from_ref(record['parent']['$ref'], 'record')
         if isinstance(resource, Document):
             resource.reindex()
-        return return_value
 
-    def delete(self, record):
-        """Reindex a resource (documents, items, holdings).
+    def after_delete_record(self, record):
+        """After bulk delete.
 
-        :param record: Record instance.
+        :param record: deleted record.
         """
-        return_value = super().delete(record)
-        resource = extracted_data_from_ref(record['parent']['$ref'], 'record')
-        if isinstance(resource, Document):
-            resource.reindex()
-        return return_value
+        self.after_delete_record(record)
 
     def bulk_index(self, record_id_iterator):
         """Bulk index records.

--- a/scripts/setup
+++ b/scripts/setup
@@ -335,18 +335,18 @@ if ${LOADCONTRIBUTIONS}
 then
     info_msg "- CONTRIBUTIONS: ${CONTRIBUTIONS} ${CREATE_LAZY} ${DONT_STOP}"
     eval ${PREFIX} invenio fixtures create --pid_type cont --schema 'http://ils.rero.ch/schemas/contributions/contribution-v0.0.1.json' ${CONTRIBUTIONS} --append ${CREATE_LAZY} ${DONT_STOP}
-    info_msg "Indexing Contributions:"
-    eval ${PREFIX} invenio utils reindex -t cont --yes-i-know --no-info
-    if [ ${INDEX_PARALLEL} -gt 0 ]; then
-        eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
-    fi
-    eval ${PREFIX} invenio utils runindex --raise-on-error
-    if [ ${INDEX_PARALLEL} -gt 0 ]; then
-        eval ${PREFIX} invenio utils reindex_missing -t cont -v
-    fi
 else
     info_msg "- Contributions from MEF: ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE}"
     eval ${PREFIX} invenio fixtures get_all_mef_records ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE}
+fi
+# index contributions
+eval ${PREFIX} invenio utils reindex -t cont --yes-i-know --no-info
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
+eval ${PREFIX} invenio utils runindex --raise-on-error
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils reindex_missing -t cont -v
 fi
 
 info_msg "- Documents: ${DOCUMENTS} ${CREATE_LAZY} ${DONT_STOP}"

--- a/tests/ui/notifications/test_notifications_api.py
+++ b/tests/ui/notifications/test_notifications_api.py
@@ -77,9 +77,6 @@ def test_notification_email_aggregated(notification_availability_martigny,
         notification2_availability_martigny['pid']
     ], verbose=True)
     assert len(mailbox) == 1
-    from pprint import pprint
-    pprint(mailbox[0])
-
     recipient = '???'
     for notification_setting in lib_martigny.get('notification_settings'):
         if notification_setting['type'] == \


### PR DESCRIPTION
The indexing of some record types with the bulk indexer had not the same
results as the direct indexing of the record.

* Adds `after_bulk_index_record` and `after_bulk_delete_record`
  functions to IlsRecordsIndexer.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
