### PR TITLE
collections: fix item brief view.

### DIFF
--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -127,16 +127,19 @@ class Item(ItemCirculation, ItemIssue):
             .params(preserve_order=True) \
             .source(['pid', 'organisation', 'title', 'description'])
         orgs = {}
-        for record in search.scan():
-            if record.organisation.pid not in orgs:
-                orgs[record.organisation.pid] = Organisation \
-                    .get_record_by_pid(record.organisation.pid)
-            output.append({
-                'pid': record.pid,
-                'title': record.title,
-                'description': record.description,
-                'viewcode': orgs[record.organisation.pid].get('code')
-            })
+        for hit in search.scan():
+            hit = hit.to_dict()
+            org_pid = hit['organisation']['pid']
+            if org_pid not in orgs:
+                orgs[org_pid] = Organisation.get_record_by_pid(org_pid)
+            collection_data = {
+                'pid': hit['pid'],  # required property
+                'title': hit['title'],  # required property
+                'description': hit.get('description'),  # optional property
+                'viewcode': orgs[org_pid].get('code')
+            }
+            collection_data = {k: v for k, v in collection_data if v}
+            output.append(collection_data)
         return output
 
     def replace_refs(self):


### PR DESCRIPTION
If a collection not define a 'description' field, the item serializer
generate an error. This error cause a javascript failure when UI try to
display the item brief view related to this collection.

Closes rero/rero-ils#1942.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
