### PR TITLE
patron type: add `code` field

### DIFF
--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -8,7 +8,8 @@
     "name",
     "description",
     "subscription_amount",
-    "limits"
+    "limits",
+    "code"
   ],
   "required": [
     "$schema",
@@ -52,6 +53,12 @@
       "title": "Description",
       "description": "The description of the patron type.",
       "type": "string"
+    },
+    "code": {
+      "title": "Code",
+      "description": "Code to identify the patron type.",
+      "type": "string",
+      "minLength": 1
     },
     "organisation": {
       "title": "Organisation",

--- a/rero_ils/modules/patron_types/mappings/v7/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/mappings/v7/patron_types/patron_type-v0.0.1.json
@@ -19,6 +19,9 @@
       "description": {
         "type": "text"
       },
+      "code": {
+        "type": "keyword"
+      },
       "organisation": {
         "properties": {
           "type": {


### PR DESCRIPTION
Adds a `code` field to the patron type. This field is mainly useful to store the code from Virtua and keep the OAuth server working.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>