### PR TITLE
tests: fix external tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,11 +165,12 @@ def app_config(app_config):
     help_test_dir = join(dirname(__file__), 'data', 'help')
     app_config['WIKI_CONTENT_DIR'] = help_test_dir
     app_config['WIKI_UPLOAD_FOLDER'] = join(help_test_dir, 'files')
-    app_config['ACCOUNTS_SESSION_REDIS_URL'] = 'redis://localhost:6379/1'
     app_config['CACHE_REDIS_URL'] = 'redis://localhost:6379/0'
+    app_config['ACCOUNTS_SESSION_REDIS_URL'] = 'redis://localhost:6379/1'
     app_config['CELERY_RESULT_BACKEND'] = 'redis://localhost:6379/2'
-    app_config['CELERY_REDIS_SCHEDULER_URL'] = 'redis://localhost:6379/4'
     app_config['RATELIMIT_STORAGE_URL'] = 'redis://localhost:6379/3'
+    app_config['CELERY_REDIS_SCHEDULER_URL'] = 'redis://localhost:6379/4'
+    app_config['RERO_IMPORT_CACHE'] = 'redis://localhost:6379/5'
     app_config['WTF_CSRF_ENABLED'] = False
     return app_config
 


### PR DESCRIPTION
The tests where using the wrong REDIS for external tests.

* Allows running of external tests without starting of production docker containers.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
