### PR TITLE
user profiles: translate username description

### DIFF
--- a/rero_ils/manual_translations.txt
+++ b/rero_ils/manual_translations.txt
@@ -45,3 +45,7 @@ _('Date not available and automatically set to 2050')
 # Harvested source
 _('ebibliomedia')
 _('mv-cantook')
+
+# Userprofile username help message
+_('Username must start with a letter or a number, be at least three characters'
+  ' long and only contain alphanumeric characters, dashes and underscores')


### PR DESCRIPTION
* Translates the username description that comes from
  rero/invenio-userprofiles (`validators.py`).

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- A string is not extracted and translated because it comes from
  rero/invenio-userprofiles. 

## Dependencies

My PR depends on the following `rero/invenio-userprofiles`'s PR(s):

* rero/invenio-userprofiles#5

## How to test?

- Check if the string is extracted. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
