### PR TITLE
patrons: allow external service to authenticate users

### DIFF
--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -6,10 +6,10 @@
   "additionalProperties": false,
   "propertiesOrder": [
     "name",
+    "code",
     "description",
     "subscription_amount",
-    "limits",
-    "code"
+    "limits"
   ],
   "required": [
     "$schema",

--- a/scripts/setup
+++ b/scripts/setup
@@ -464,6 +464,27 @@ eval ${PREFIX} invenio fixtures create_loans ${DATA_PATH}/loans.json
 # process notifications
 eval ${PREFIX} invenio notifications process
 
+# create token access for system librarians
+info_msg "create an access token for all system librarians"
+if [ -z ${INVENIO_RERO_ACCESS_TOKEN_AOSTA_LIBRARIAN} ]
+then
+    eval ${PREFIX} invenio utils tokens_create -n organisation_aosta_token -u reroilstest@gmail.com
+else
+    eval ${PREFIX} invenio utils tokens_create -n organisation_aosta_token -u reroilstest@gmail.com -t ${INVENIO_RERO_ACCESS_TOKEN_AOSTA_LIBRARIAN}
+fi
+if [ -z ${INVENIO_RERO_ACCESS_TOKEN_SCOLAND_LIBRARIAN} ]
+then
+    eval ${PREFIX} invenio utils tokens_create -n organisation_scotland_token -u reroilstest+irma@gmail.com
+else
+    eval ${PREFIX} invenio utils tokens_create -n organisation_scotland_token -u reroilstest+irma@gmail.com -t ${INVENIO_RERO_ACCESS_TOKEN_SCOLAND_LIBRARIAN}
+fi
+if [ -z ${INVENIO_RERO_ACCESS_TOKEN_FICTIVE_LIBRARIAN} ]
+then
+    eval ${PREFIX} invenio utils tokens_create -n organisation_fictive_token -u reroilstest+imagination@gmail.com
+else
+    eval ${PREFIX} invenio utils tokens_create -n organisation_fictive_token -u reroilstest+imagination@gmail.com -t ${INVENIO_RERO_ACCESS_TOKEN_FICTIVE_LIBRARIAN}
+fi
+
 # create token access for monitoring
 # if the environement variable INVENIO_RERO_ACCESS_TOKEN_MONITORING is not set
 # a new token will be generated


### PR DESCRIPTION
The patron authenticate api entrypoint allows to return
information about the user according to his username and password.

* Changes the position of the code field in the form.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- use API Rest client and test url (https://localhost:5000/api/patron/authenticate?access_token=xxx)
- method `POST` and Body: `{"username":"xxx", "password":"xxx"}`

xxx = Get token to user `reroilstest@gmail.com`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
