### PR TITLE
holdings: add item counts

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -42,6 +42,7 @@ from ..locations.api import Location
 from ..minters import id_minter
 from ..organisations.api import Organisation
 from ..providers import Provider
+from ..record_extensions import OrgLibRecordExtension
 from ..utils import extracted_data_from_ref, get_ref_for_pid, \
     get_schema_for_resource
 from ..vendors.api import Vendor
@@ -79,6 +80,8 @@ class HoldingsSearch(RecordsSearch):
 
 class Holding(IlsRecord):
     """Holding class."""
+
+    _extensions = [OrgLibRecordExtension()]
 
     minter = holding_id_minter
     fetcher = holding_id_fetcher
@@ -570,13 +573,13 @@ class Holding(IlsRecord):
         forced_data = {
             '$schema': get_schema_for_resource(Item),
             'acquisition_date': datetime.now().strftime('%Y-%m-%d'),
+            'organisation': self.get('organisation'),
+            'library': self.get('library'),
             'location': self.get('location'),
             'document': self.get('document'),
             'item_type': self.get('circulation_category'),
             'type': 'issue',
-            'holding': {'$ref': get_ref_for_pid('hold', self.pid)},
-            'organisation':
-                {'$ref': get_ref_for_pid('org', self.organisation_pid)}
+            'holding': {'$ref': get_ref_for_pid('hold', self.pid)}
         }
         data.update(forced_data)
         return data

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -9,6 +9,8 @@
     "pid",
     "holdings_type",
     "circulation_category",
+    "organisation",
+    "library",
     "location",
     "document"
   ],
@@ -81,6 +83,32 @@
               "label": ""
             }
           }
+        }
+      }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "title": "Organisation URI",
+          "type": "string",
+          "pattern": "^https://bib.rero.ch/api/organisations/.*?$"
+        }
+      }
+    },
+    "library": {
+      "title": "Library",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Library URI",
+          "type": "string",
+          "pattern": "^https://bib.rero.ch/api/libraries/.*?$"
         }
       }
     },

--- a/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
@@ -9,6 +9,12 @@
       "pid": {
         "type": "keyword"
       },
+      "items_count": {
+        "type": "integer"
+      },
+      "public_items_count": {
+        "type": "integer"
+      },
       "call_number": {
         "type": "keyword"
       },

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -7,6 +7,8 @@
   "required": [
     "$schema",
     "pid",
+    "organisation",
+    "library",
     "location",
     "item_type",
     "type",
@@ -485,6 +487,17 @@
           "title": "Organisation URI",
           "type": "string",
           "pattern": "^https://bib.rero.ch/api/organisations/.*?$"
+        }
+      }
+    },
+    "library": {
+      "title": "Library",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Library URI",
+          "type": "string",
+          "pattern": "^https://bib.rero.ch/api/libraries/.*?$"
         }
       }
     },

--- a/rero_ils/modules/items/listener.py
+++ b/rero_ils/modules/items/listener.py
@@ -19,7 +19,6 @@
 
 from .api import Item, ItemsSearch
 from ..documents.api import Document
-from ..utils import extracted_data_from_ref
 
 
 def enrich_item_data(sender, json=None, record=None, index=None,
@@ -35,15 +34,6 @@ def enrich_item_data(sender, json=None, record=None, index=None,
         item = record
         if not isinstance(record, Item):
             item = Item.get_record_by_pid(record.get('pid'))
-        library = item.get_library()
-        json['organisation'] = {
-            'pid': extracted_data_from_ref(library.get('organisation')),
-            'type': 'org'
-        }
-        json['library'] = {
-            'pid': library.pid,
-            'type': 'lib'
-        }
         # add vendor name
         if item.vendor_pid:
             json['vendor'] = {

--- a/rero_ils/modules/record_extensions.py
+++ b/rero_ils/modules/record_extensions.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""RERO ILS common record extensions."""
+
+
+from invenio_records.extensions import RecordExtension
+
+from .locations.api import Location, LocationsSearch
+from .utils import extracted_data_from_ref, get_base_url
+
+
+class OrgLibRecordExtension(RecordExtension):
+    """Defines the methods needed by an extension."""
+
+    def pre_create(self, record):
+        """Called before a record is created.
+
+        :param record: the record metadata.
+        """
+        # do nothing if already exists
+        if record.get('organisation') and record.get('library'):
+            return
+        self._add_org_and_lib(record)
+        # required for validation
+        if record.model:
+            record.model.data = record
+
+    def pre_commit(self, record):
+        """Called before a record is committed.
+
+        :param record: the record metadata.
+        """
+        self._add_org_and_lib(record)
+
+    def _add_org_and_lib(cls, record):
+        """Build $ref for the organisation and library of the item.
+
+        :param record: the record metadata.
+        """
+        location_pid = extracted_data_from_ref(record.get('location'))
+        # try on the elasticsearch location index
+        try:
+            es_loc = next(
+                LocationsSearch()
+                .filter('term', pid=location_pid)
+                .source(['organisation', 'library'])
+                .scan()
+            )
+            organisation_pid = es_loc.organisation.pid
+            library_pid = es_loc.library.pid
+        except StopIteration:
+            # ok go to the db
+            library = Location.get_record_by_pid(location_pid).get_library()
+            library_pid = library.pid
+            organisation_pid = library.organisation_pid
+        url_api = '{base_url}/api/{doc_type}/{pid}'
+        org_ref = {
+            '$ref': url_api.format(
+                base_url=get_base_url(),
+                doc_type='organisations',
+                pid=organisation_pid)
+        }
+        record['organisation'] = org_ref
+        lib_ref = {
+            '$ref': url_api.format(
+                base_url=get_base_url(),
+                doc_type='libraries',
+                pid=library_pid)
+        }
+        record['library'] = lib_ref

--- a/scripts/setup
+++ b/scripts/setup
@@ -378,14 +378,7 @@ fi
 
 info_msg "- Holdings: ${HOLDINGS} ${CREATE_LAZY} ${DONT_STOP}"
 eval ${PREFIX} invenio fixtures create --pid_type hold --schema 'http://bib.rero.ch/schemas/holdings/holding-v0.0.1.json' ${HOLDINGS} --append ${CREATE_LAZY} ${DONT_STOP}
-eval ${PREFIX} invenio utils reindex -t hold --yes-i-know --no-info
-if [ ${INDEX_PARALLEL} -gt 0 ]; then
-    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
-fi
-eval ${PREFIX} invenio utils runindex --raise-on-error
-if [ ${INDEX_PARALLEL} -gt 0 ]; then
-    eval ${PREFIX} invenio utils reindex_missing -t hold -v
-fi
+
 
 info_msg "- Items: ${ITEMS} ${CREATE_LAZY} ${DONT_STOP}"
 eval ${PREFIX} invenio fixtures create --pid_type item --schema 'http://bib.rero.ch/schemas/items/item-v0.0.1.json' ${ITEMS} --append ${CREATE_LAZY} ${DONT_STOP}
@@ -398,6 +391,16 @@ fi
 eval ${PREFIX} invenio utils runindex --raise-on-error
 if [ ${INDEX_PARALLEL} -gt 0 ]; then
     eval ${PREFIX} invenio utils reindex_missing -t item -v
+fi
+
+# index holdings
+eval ${PREFIX} invenio utils reindex -t hold --yes-i-know --no-info
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils runindex -d -c ${INDEX_PARALLEL} --raise-on-error
+fi
+eval ${PREFIX} invenio utils runindex --raise-on-error
+if [ ${INDEX_PARALLEL} -gt 0 ]; then
+    eval ${PREFIX} invenio utils reindex_missing -t hold -v
 fi
 
 # index documents

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import, print_function
 
+from copy import deepcopy
 from datetime import datetime
 
 import pytest
@@ -27,6 +28,7 @@ from invenio_accounts.models import User
 from utils import flush_index
 
 from rero_ils.modules.documents.api import Document, DocumentsSearch
+from rero_ils.modules.items.api import Item, ItemsSearch
 
 
 @pytest.fixture(scope='function')
@@ -150,3 +152,24 @@ def doc_title_travailleuses(app):
         reindex=True)
     flush_index(DocumentsSearch.Meta.index)
     return doc
+
+
+@pytest.fixture(scope="function")
+def item_lib_martigny_masked(
+        app,
+        document,
+        item_lib_martigny_data,
+        loc_public_martigny,
+        item_type_standard_martigny):
+    """Create item of martigny library."""
+    data = deepcopy(item_lib_martigny_data)
+    data['pid'] = f'maked-{data["pid"]}'
+    data['_masked'] = True
+    item = Item.create(
+        data=data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(ItemsSearch.Meta.index)
+    yield item
+    item.delete(True, True, True)

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -152,7 +152,7 @@ def test_documents_newacq_filters(app, client,
         'invenio_records_rest.doc_list',
         view='global',
         new_acquisition='{0}:{1}'.format(past, today),
-        locatiin='loc3'
+        location='loc3'
     )
     res = client.get(doc_list, headers=rero_json_header)
     data = get_json(res)

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3052,6 +3052,12 @@
     "location": {
       "$ref": "https://bib.rero.ch/api/locations/loc1"
     },
+    "library": {
+      "$ref": "https://bib.rero.ch/api/libraries/lib1"
+    },
+    "organisation": {
+      "$ref": "https://bib.rero.ch/api/organisations/org1"
+    },
     "item_type": {
       "$ref": "https://bib.rero.ch/api/item_types/itty1"
     },
@@ -3554,6 +3560,12 @@
     },
     "location": {
       "$ref": "https://bib.rero.ch/api/locations/loc1"
+    },
+    "library": {
+      "$ref": "https://bib.rero.ch/api/libraries/lib1"
+    },
+    "organisation": {
+      "$ref": "https://bib.rero.ch/api/organisations/org1"
     }
   },
   "holding2": {

--- a/tests/data/holdings.json
+++ b/tests/data/holdings.json
@@ -168,6 +168,12 @@
     "location": {
       "$ref": "https://bib.rero.ch/api/locations/loc1"
     },
+    "library": {
+      "$ref": "https://bib.rero.ch/api/libraries/lib1"
+    },
+    "organisation": {
+      "$ref": "https://bib.rero.ch/api/organisations/org1"
+    },
     "holdings_type": "standard"
   },
   "holding2": {
@@ -227,6 +233,12 @@
     },
     "location": {
       "$ref": "https://bib.rero.ch/api/locations/loc1"
+    },
+    "library": {
+      "$ref": "https://bib.rero.ch/api/libraries/lib1"
+    },
+    "organisation": {
+      "$ref": "https://bib.rero.ch/api/organisations/org1"
     },
     "vendor": {
       "$ref": "https://bib.rero.ch/api/vendors/vndr1"
@@ -348,10 +360,10 @@
       "$ref": "https://bib.rero.ch/api/documents/ebook5"
     },
     "circulation_category": {
-      "$ref": "https://bib.rero.ch/api/item_types/itty7"
+      "$ref": "https://bib.rero.ch/api/item_types/itty8"
     },
     "location": {
-      "$ref": "https://bib.rero.ch/api/locations/loc1"
+      "$ref": "https://bib.rero.ch/api/locations/loc7"
     },
     "holdings_type": "electronic",
     "electronic_location": [

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -764,18 +764,18 @@ def holding_lib_sion_w_patterns(
 
 
 @pytest.fixture(scope="module")
-def holding_lib_martiny_electronic_data(holdings):
+def holding_lib_sion_electronic_data(holdings):
     """Load electronic holding of Martigny library."""
     return deepcopy(holdings.get('holding7'))
 
 
 @pytest.fixture(scope="module")
-def holding_lib_martiny_electronic(
-    app, ebook_5, holding_lib_martiny_electronic_data,
-        loc_public_martigny, item_type_online_martigny):
+def holding_lib_sion_electronic(
+    app, ebook_5, holding_lib_sion_electronic_data,
+        loc_public_sion, item_type_online_sion):
     """Create electronic holding of Martigny library."""
     holding = Holding.create(
-        data=holding_lib_martiny_electronic_data,
+        data=holding_lib_sion_electronic_data,
         delete_pid=False,
         dbcommit=True,
         reindex=True)

--- a/tests/unit/test_holdings_jsonschema.py
+++ b/tests/unit/test_holdings_jsonschema.py
@@ -71,6 +71,8 @@ def test_holdings_all_jsonschema_keys_values(
         {'key': 'second_call_number', 'value': 25},
         {'key': 'document', 'value': 25},
         {'key': 'circulation_category', 'value': 25},
+        {'key': 'organisation', 'value': 25},
+        {'key': 'library', 'value': 25},
         {'key': 'location', 'value': 25},
         {'key': 'holdings_type', 'value': 25},
         {'key': 'patterns', 'value': 25},

--- a/tests/unit/test_items_jsonschema.py
+++ b/tests/unit/test_items_jsonschema.py
@@ -58,6 +58,7 @@ def test_item_all_jsonschema_keys_values(
         {'key': 'status', 'value': 25},
         {'key': 'holding', 'value': 25},
         {'key': 'organisation', 'value': 25},
+        {'key': 'library', 'value': 25},
         {'key': 'ur', 'value': 25},
         {'key': 'pac_code', 'value': 25},
         {'key': 'price', 'value': '25'},


### PR DESCRIPTION
* Adds the number of items in the holding index.
* Changes the indexing chain to items -> holdings -> documents.
* Fixes test fixtures.
* Removes some useless index flush in the tests.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
