### PR TITLE
acquisition: enable select-account widget config

### DIFF
--- a/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
@@ -7,10 +7,10 @@
   "propertiesOrder": [
     "name",
     "number",
+    "parent",
     "allocated_amount",
     "encumbrance_exceedance",
-    "expenditure_exceedance",
-    "parent"
+    "expenditure_exceedance"
   ],
   "required": [
     "$schema",
@@ -51,7 +51,11 @@
       "title": "Allocated amount",
       "description": "The amount allocated for the acquisition account.",
       "type": "number",
-      "minimum": 0
+      "minimum": 0,
+      "default": 0,
+      "form": {
+        "fieldMap": "amount"
+      }
     },
     "encumbrance_exceedance": {
       "title": "Emcumbrance exceedance",
@@ -92,10 +96,8 @@
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/acq_accounts/.*?$",
           "form": {
-            "remoteOptions": {
-              "type": "acq_accounts"
-            },
             "placeholder": "Choose a parent account\u2026",
+            "type": "account-select",
             "templateOptions": {
               "label": ""
             }

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -124,7 +124,7 @@
           "pattern": "^https://ils.rero.ch/api/acq_accounts/.*?$",
           "form": {
             "focus": true,
-            "fieldMap": "acq_account",
+            "type": "account-select",
             "placeholder": "Select an account",
             "templateOptions": {
               "label": ""


### PR DESCRIPTION
Updates JSON schemas to enable the `account-select` widget for account
reference field.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
