### PR TITLE
document: make document `mainTitle` unique

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_title-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_title-v0.0.1.json
@@ -115,6 +115,18 @@
           }
         }
       }
+    },
+    "form": {
+      "validation": {
+        "validators": {
+          "numberOfSpecificValuesInObject": {
+            "min": 1,
+            "keys": {
+              "type": "bf:Title"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a validator to make the document `mainTitle` unique (but only in
the UI editor context - not for document REST loading).

Should be use with https://github.com/rero/ng-core/pull/409

Closes rero/rero-ils#1361.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
