### PR TITLE
sip2: use item barcode instead item pid

### DIFF
--- a/rero_ils/modules/selfcheck/utils.py
+++ b/rero_ils/modules/selfcheck/utils.py
@@ -81,11 +81,20 @@ def format_patron_address(patron):
     :param patron: patron instance.
     :return: Formated address like 'street postal code city' for patron.
     """
-    return '{street}, {postal_code} {city}'.format(
-        street=patron.get('street'),
-        postal_code=patron.get('postal_code'),
-        city=patron.get('city')
-    )
+    address = patron.get('second_address')
+    if address:
+        return '{street}, {postal_code} {city}'.format(
+            street=address.get('street'),
+            postal_code=address.get('postal_code'),
+            city=address.get('city')
+        )
+    else:
+        profile = patron.user.profile
+        return '{street}, {postal_code} {city}'.format(
+            street=profile.street.strip(),
+            postal_code=profile.postal_code.strip(),
+            city=profile.city.strip()
+        )
 
 
 def get_patron_status(patron):

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -225,12 +225,13 @@ def test_item_information(client, librarian_martigny,
 
     patron_barcode = selfcheck_patron_martigny\
         .get('patron', {}).get('barcode')[0]
-    item_pid = item_lib_martigny.pid
+    item_barcode = item_lib_martigny.get('barcode')
 
     # get item information
     response = item_information(
         patron_barcode=patron_barcode,
-        item_pid=item_pid
+        item_barcode=item_barcode,
+        institution_id=librarian_martigny.organisation_pid
     )
     assert response
     # check required fields in response


### PR DESCRIPTION
* Fixes patron address for sip2.
* Uses item barcode instead of item pid.

Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
