### PR TITLE
orders: remove the total amount from the DB

### DIFF
--- a/rero_ils/modules/acq_order_lines/api.py
+++ b/rero_ils/modules/acq_order_lines/api.py
@@ -146,26 +146,21 @@ class AcqOrderLinesIndexer(IlsRecordsIndexer):
 
     def index(self, record):
         """Index an Acquisition Order Line and update total amount of order."""
+        from ..acq_orders.api import AcqOrder
         return_value = super().index(record)
-        self._update_order_total_amount(record)
+        order = AcqOrder.get_record_by_pid(record.order_pid)
+        order.reindex()
 
         return return_value
 
     def delete(self, record):
         """Delete a Acquisition Order Line and update total amount of order."""
+        from ..acq_orders.api import AcqOrder
         return_value = super().delete(record)
-        self._update_order_total_amount(record)
+        order = AcqOrder.get_record_by_pid(record.order_pid)
+        order.reindex()
 
         return return_value
-
-    def _update_order_total_amount(self, record):
-        """Update total amount of the order."""
-        from ..acq_orders.api import AcqOrder
-
-        order_pid = extracted_data_from_ref(record.get('acq_order'))
-        order = AcqOrder.get_record_by_pid(order_pid)
-        order['total_amount'] = order.get_order_total_amount()
-        order.update(order, dbcommit=True, reindex=True)
 
     def bulk_index(self, record_id_iterator):
         """Bulk index records.

--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -20,6 +20,7 @@
 
 from functools import partial
 
+from .extensions import TotalAmountExtension
 from .models import AcqOrderIdentifier, AcqOrderMetadata
 from ..acq_order_lines.api import AcqOrderLinesSearch
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
@@ -57,6 +58,8 @@ class AcqOrdersSearch(IlsRecordsSearch):
 
 class AcqOrder(IlsRecord):
     """AcqOrder class."""
+
+    _extensions = [TotalAmountExtension()]
 
     minter = acq_order_id_minter
     fetcher = acq_order_id_fetcher

--- a/rero_ils/modules/acq_orders/extensions.py
+++ b/rero_ils/modules/acq_orders/extensions.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition Order record extensions."""
+
+from invenio_records.extensions import RecordExtension
+
+
+class TotalAmountExtension(RecordExtension):
+    """Update the total amount by summing the order lines."""
+
+    def pre_dump(self, record, dumper=None):
+        """Called before a record is dumped.
+
+        :param record: the record metadata.
+        :param dumper: the record dumper.
+        """
+        record['total_amount'] = record.get_order_total_amount()
+
+    def pre_load(self, data, loader=None):
+        """Called before a record is loaded.
+
+        :param record: the record metadata.
+        :param loader: the record loader.
+        """
+        data.pop('total_amount', None)

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -170,12 +170,6 @@
         }
       }
     },
-    "total_amount": {
-      "title": "Total amount",
-      "type": "number",
-      "minLength": 1,
-      "default": 0
-    },
     "vendor": {
       "title": "Vendor",
       "type": "object",

--- a/tests/api/acq_orders/test_acq_orders_rest.py
+++ b/tests/api/acq_orders/test_acq_orders_rest.py
@@ -18,6 +18,7 @@
 """Tests REST API acquisition orders."""
 
 import json
+from copy import deepcopy
 
 import mock
 from flask import url_for
@@ -70,7 +71,7 @@ def test_acq_orders_permissions(client, acq_order_fiction_martigny,
 def test_acq_order_get(client, acq_order_fiction_martigny):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.acor_item', pid_value='acor1')
-    acq_order = acq_order_fiction_martigny
+    acq_order = deepcopy(acq_order_fiction_martigny)
     res = client.get(item_url)
     assert res.status_code == 200
 
@@ -119,11 +120,13 @@ def test_acq_orders_post_put_delete(client, org_martigny, vendor2_martigny,
     assert res.status_code == 201
 
     # Check that the returned record matches the given data
+    assert data['metadata'].pop('total_amount') == 0.0
     assert data['metadata'] == acq_order_fiction_saxon
 
     res = client.get(item_url)
     assert res.status_code == 200
     data = get_json(res)
+    assert data['metadata'].pop('total_amount') == 0.0
     assert acq_order_fiction_saxon == data['metadata']
 
     # Update record/PUT
@@ -241,7 +244,7 @@ def test_acq_order_secure_api_create(client, json_header,
     )
     assert res.status_code == 403
 
-    data = acq_order_fiction_martigny
+    data = deepcopy(acq_order_fiction_martigny)
     del data['pid']
     res, _ = postdata(
         client,

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -256,8 +256,7 @@
     "description": "Commande fictive",
     "order_status": "pending",
     "currency": "CHF",
-    "order_date": "2020-01-06",
-    "total_amount": 0
+    "order_date": "2020-01-06"
   },
   "acor2": {
     "$schema": "https://bib.rero.ch/schemas/acq_orders/acq_order-v0.0.1.json",
@@ -273,8 +272,7 @@
     "description": "Commande fictive 2",
     "order_status": "pending",
     "currency": "EUR",
-    "order_date": "2020-01-06",
-    "total_amount": 0
+    "order_date": "2020-01-06"
   },
   "acor3": {
     "$schema": "https://bib.rero.ch/schemas/acq_orders/acq_order-v0.0.1.json",
@@ -290,8 +288,7 @@
     "description": "Commande fictive 3",
     "order_status": "pending",
     "currency": "CHF",
-    "order_date": "2020-01-06",
-    "total_amount": 0
+    "order_date": "2020-01-06"
   },
   "acol1": {
     "$schema": "https://bib.rero.ch/schemas/acq_order_lines/acq_order_line-v0.0.1.json",


### PR DESCRIPTION
* Reindexes the corresponding order when an order line is indexed.
* Adds an invenio records extension to update the total before the
  indexing.
* Removes the `total_amount` from the order JSONSchema.
* Adapts the test fixtures.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
