### PR TITLE
circulation: fix `can_extend` check method

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -128,9 +128,11 @@ class Loan(IlsRecord):
     def can_extend(cls, item, **kwargs):
         """Loan can extend."""
         from rero_ils.modules.loans.utils import extend_loan_data_is_valid
-        if 'loan' not in kwargs:  # this method is not relevant
-            return True, []
-        loan = kwargs['loan']
+        loan = kwargs.get('loan')
+        if loan is None:  # try to load the loan from kwargs
+            loan, _unused_data = item.prior_extend_loan_actions(**kwargs)
+            if loan is None:  # not relevant method :: return True
+                return True, []
         if loan.get('state') != LoanState.ITEM_ON_LOAN:
             return False, [_('The loan cannot be extended')]
         patron = Patron.get_record_by_pid(loan.get('patron_pid'))

--- a/tests/api/circulation/scenarios/test_scenario_c.py
+++ b/tests/api/circulation/scenarios/test_scenario_c.py
@@ -22,6 +22,7 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
 from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan
 
 
 def test_circ_scenario_c(
@@ -112,6 +113,11 @@ def test_circ_scenario_c(
     res, data = postdata(
         client, 'api_item.checkout', dict(circ_params))
     assert res.status_code == 200
+
+    # Update loan end_date to allow direct renewal
+    loan = Loan.get_record_by_pid(data['action_applied']['checkout']['pid'])
+    loan['end_date'] = loan['start_date']
+    loan.update(loan, dbcommit=True, reindex=True)
 
     res, data = postdata(
         client, 'api_item.extend_loan', dict(circ_params))

--- a/tests/api/circulation/test_actions_views_extend_loan_request.py
+++ b/tests/api/circulation/test_actions_views_extend_loan_request.py
@@ -81,6 +81,10 @@ def test_extend_loan(
     """Test frontend extend action."""
     login_user_via_session(client, librarian_martigny.user)
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    # Update loan `end_date` to play with "extend" function without problem
+    loan['end_date'] = loan['start_date']
+    loan.update(loan, dbcommit=True, reindex=True)
+
     assert item.status == ItemStatus.ON_LOAN
 
     # Test extend for a blocked patron

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -641,11 +641,14 @@ def test_items_extend_end_date(client, librarian_martigny,
     loan = Loan.get_record_by_pid(loan_pid)
     assert not item.get_extension_count()
 
-    max_count = get_extension_params(loan=loan, parameter_name='max_count')
     renewal_duration_policy = circ_policy_short_martigny['renewal_duration']
     renewal_duration = get_extension_params(
         loan=loan, parameter_name='duration_default')
     assert renewal_duration_policy <= renewal_duration.days
+
+    # Update loan end_date to allow direct renewal
+    loan['end_date'] = loan['start_date']
+    loan.update(loan, dbcommit=True, reindex=True)
 
     # extend loan
     res, data = postdata(


### PR DESCRIPTION
Sometimes, no loan parameter could be send to `can_extend` method. In
this case, the function skip all checks and return True. Now this
function try to load the loan based on others function arguments to be
more relevant.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
