### PR TITLE
core: fix the wrong way to update a record

### DIFF
--- a/rero_ils/modules/acq_invoices/api.py
+++ b/rero_ils/modules/acq_invoices/api.py
@@ -82,10 +82,10 @@ class AcquisitionInvoice(IlsRecord):
             data, id_, delete_pid, dbcommit, reindex, **kwargs)
         return record
 
-    def update(self, data, dbcommit=True, reindex=True):
+    def update(self, data, commit=True, dbcommit=True, reindex=True):
         """Update Acquisition Invoice record."""
         self._build_total_amount_of_invoice(data)
-        super().update(data, dbcommit, reindex)
+        super().update(data, commit, dbcommit, reindex)
         return self
 
     @classmethod

--- a/rero_ils/modules/acq_order_lines/api.py
+++ b/rero_ils/modules/acq_order_lines/api.py
@@ -82,13 +82,13 @@ class AcqOrderLine(IlsRecord):
             data, id_, delete_pid, dbcommit, reindex, **kwargs)
         return record
 
-    def update(self, data, dbcommit=True, reindex=True):
+    def update(self, data, commit=True, dbcommit=True, reindex=True):
         """Update Acquisition Order Line record."""
         new_data = deepcopy(dict(self))
         new_data.update(data)
         self._acq_order_line_build_org_ref(new_data)
         self._build_total_amount_for_order_line(new_data)
-        super().update(new_data, dbcommit, reindex)
+        super().update(new_data, commit, dbcommit, reindex)
         return self
 
     @classmethod

--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -84,10 +84,10 @@ class AcqOrder(IlsRecord):
             data, id_, delete_pid, dbcommit, reindex, **kwargs)
         return record
 
-    def update(self, data, dbcommit=False, reindex=False):
+    def update(self, data,  commit=True, dbcommit=False, reindex=False):
         """Update acq order record."""
         self._acq_order_build_org_ref(data)
-        super().update(data, dbcommit, reindex)
+        super().update(data, commit, dbcommit, reindex)
         return self
 
     @classmethod

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -311,7 +311,8 @@ class Document(IlsRecord):
             'url': url
         })
         self['electronicLocator'] = electronic_locators
-        self = self.update(data=self, dbcommit=dbcommit, reindex=reindex)
+        self = self.update(
+            data=self, commit=True, dbcommit=dbcommit, reindex=reindex)
         return self, True
 
 

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -153,6 +153,8 @@ class ItemCirculation(ItemRecord):
                     'item_pid': item_pid_to_object(item.pid),
                     'patron_pid': patron_pid
                 }
+                data.setdefault(
+                    'transaction_date', datetime.utcnow().isoformat())
                 loan = Loan.create(data, dbcommit=True, reindex=True)
             if not patron_pid and loan:
                 kwargs.setdefault('patron_pid', loan.patron_pid)
@@ -1122,6 +1124,7 @@ class ItemCirculation(ItemRecord):
         else:
             if item['status'] != ItemStatus.MISSING and on_shelf:
                 item['status'] = ItemStatus.ON_SHELF
+        item.commit()
         if dbcommit:
             item.dbcommit(reindex=True, forceindex=True)
 

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -122,7 +122,7 @@ class ItemRecord(IlsRecord):
             holding.commit()
         return record
 
-    def update(self, data, dbcommit=False, reindex=False):
+    def update(self, data, commit=True, dbcommit=False, reindex=False):
         """Update an item record.
 
         :param data: The record to update.
@@ -132,11 +132,11 @@ class ItemRecord(IlsRecord):
         """
         data = self._set_issue_status_date(data)
         data = self._prepare_item_record(data=data, mode='update')
-        super().update(data, dbcommit, reindex)
+        super().update(data, commit, dbcommit, reindex)
         # TODO: some item updates do not require holding re-linking
         return self
 
-    def replace(self, data, dbcommit=False, reindex=False):
+    def replace(self, data, commit=True, dbcommit=False, reindex=False):
         """Replace an item record.
 
         :param data: The record to replace.
@@ -146,7 +146,7 @@ class ItemRecord(IlsRecord):
         """
         # update item record with a generated barcode if does not exist
         data = generate_item_barcode(data=data)
-        super().replace(data, dbcommit, reindex)
+        super().replace(data, commit, dbcommit, reindex)
         return self
 
     @classmethod

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -246,16 +246,17 @@ class Loan(IlsRecord):
             reindex=reindex, **kwargs)
         return record
 
-    def update(self, data, dbcommit=False, reindex=False):
+    def update(self, data, commit=False, dbcommit=False, reindex=False):
         """Update loan record."""
         self._loan_build_org_ref(data)
         # set the field to_anonymize
         if Loan.can_anonymize(loan_data=data) and not self.get('to_anonymize'):
             data['to_anonymize'] = True
-        super(Loan, self).update(data, dbcommit, reindex)
+        super().update(
+            data=data, commit=commit, dbcommit=dbcommit, reindex=reindex)
         return self
 
-    def anonymize(self, loan, dbcommit=False, reindex=False):
+    def anonymize(self, loan, commit=True, dbcommit=False, reindex=False):
         """Anonymize a loan.
 
         :param loan: the loan to update.
@@ -263,7 +264,7 @@ class Loan(IlsRecord):
         :param reindex - index the record after the creation.
         """
         loan['to_anonymize'] = True
-        super().update(loan, dbcommit, reindex)
+        super().update(loan, commit, dbcommit, reindex)
 
         # Anonymize loan operation logs
         # Import at top causes errors...

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -126,7 +126,8 @@ class Notification(IlsRecord):
         """Update process date."""
         self['process_date'] = datetime.utcnow().isoformat()
         self['notification_sent'] = sent
-        return self.update(data=self.dumps(), dbcommit=True, reindex=True)
+        return self.update(
+            data=self.dumps(), commit=True, dbcommit=True, reindex=True)
 
     def replace_pids_and_refs(self):
         """Dumps data."""

--- a/rero_ils/modules/patron_transaction_events/api.py
+++ b/rero_ils/modules/patron_transaction_events/api.py
@@ -91,9 +91,10 @@ class PatronTransactionEvent(IlsRecord):
     # TODO: do we have to set dbcomit and reindex to True so the
     # of the rest api for create and update works properly ?
     # For PatronTransaction we have to set it to True for the tests.
-    def update(self, data, dbcommit=True, reindex=True):
+    def update(self, data, commit=True, dbcommit=True, reindex=True):
         """Update data for record."""
-        record = super().update(data=data, dbcommit=dbcommit, reindex=reindex)
+        record = super().update(
+            data=data, commit=commit, dbcommit=dbcommit, reindex=reindex)
         return record
 
     @classmethod

--- a/rero_ils/modules/patron_transactions/api.py
+++ b/rero_ils/modules/patron_transactions/api.py
@@ -98,9 +98,10 @@ class PatronTransaction(IlsRecord):
     # TODO: do we have to set dbcomit and reindex to True so the
     #       of the rest api for create and update works properly ?
     #       For PatronTransaction we have to set it to True for the tests.
-    def update(self, data, dbcommit=True, reindex=True):
+    def update(self, data, commit=True, dbcommit=True, reindex=True):
         """Update data for record."""
-        record = super().update(data=data, dbcommit=dbcommit, reindex=reindex)
+        record = super().update(
+            data=data, commit=commit, dbcommit=dbcommit, reindex=reindex)
         return record
 
     @classmethod

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -199,11 +199,11 @@ class Patron(IlsRecord):
         record._update_roles()
         return record
 
-    def update(self, data, dbcommit=False, reindex=False):
+    def update(self, data,  commit=True, dbcommit=False, reindex=False):
         """Update data for record."""
         # remove spaces
         data = trim_patron_barcode_for_record(data=data)
-        super().update(data, dbcommit, reindex)
+        super().update(data, commit, dbcommit, reindex)
         self._update_roles()
         return self
 

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -339,7 +339,7 @@ def test_patron_multiple(patron_sion_multiple, patron2_martigny, lib_martigny):
     assert set(patron2_martigny.user.roles) == set(['librarian', 'patron'])
     data['roles'] = ['patron']
     del data['libraries']
-    patron_sion_multiple.update(data, True, True)
+    patron_sion_multiple.update(data, dbcommit=True, reindex=True)
     assert patron2_martigny.user.roles == ['patron']
     assert Patron.get_record_by_pid(patron_sion_multiple.pid).get('roles') == \
         ['patron']

--- a/tests/ui/test_monitoring.py
+++ b/tests/ui/test_monitoring.py
@@ -48,7 +48,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
         '      0     loc          0                  locations          0',
         '      0    lofi          0               local_fields          0',
         '      0   notif          0              notifications          0',
-        '     -2    oplg          0             operation_logs          2',
+        '     -1    oplg          0             operation_logs          1',
         '      0     org          0              organisations          0',
         '      0    ptre          0  patron_transaction_events          0',
         '      0    ptrn          0                    patrons          0',
@@ -93,7 +93,7 @@ def test_monitoring(app, document_sion_items_data, script_info):
         'loc': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'locations'},
         'lofi': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'local_fields'},
         'notif': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'notifications'},
-        'oplg': {'db': 0, 'db-es': -2, 'es': 2, 'index': 'operation_logs'},
+        'oplg': {'db': 0, 'db-es': -1, 'es': 1, 'index': 'operation_logs'},
         'org': {'db': 0, 'db-es': 0, 'es': 0, 'index': 'organisations'},
         'ptre': {'db': 0, 'db-es': 0, 'es': 0,
                  'index': 'patron_transaction_events'},
@@ -123,10 +123,10 @@ def test_monitoring(app, document_sion_items_data, script_info):
     doc.reindex()
     flush_index(DocumentsSearch.Meta.index)
     assert mon.get_es_count('documents') == 1
-    assert mon.check() == {'oplg': {'db_es': -2}}
+    assert mon.check() == {'oplg': {'db_es': -1}}
     assert mon.missing('doc') == {'DB': [], 'ES': [], 'ES duplicate': []}
     doc.delete(dbcommit=True)
     assert mon.get_db_count('doc') == 0
     assert mon.get_es_count('documents') == 1
-    assert mon.check() == {'doc': {'db_es': -1}, 'oplg': {'db_es': -2}}
+    assert mon.check() == {'doc': {'db_es': -1}, 'oplg': {'db_es': -1}}
     assert mon.missing('doc') == {'DB': ['doc3'], 'ES': [], 'ES duplicate': []}

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -1869,7 +1869,6 @@ def test_marc21_to_provisionActivity_1_place_2_agents_with_two_752():
      """
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
-    print('T1000', data)
     assert data.get('provisionActivity') == [
         {
             'type': 'bf:Publication',


### PR DESCRIPTION
core: fix the worng way to update a record 

The way of `invenio-records` has been misunderstood. The `update` method
change only the `dict` value without any db transaction. To push the
transaction on the db, the `commit` method should be called, which is
not the case for the create. The previous implementation called the
validation twice and create two operation logs (create and update) when
a resource was created.

* Avoids multiple validations when a record is created.
* Adds a new `commit` parameter to the update, replace methods in
  `ILSRecord`.
* Fixes two operation logs creation when a resource a created, one for
  create one for update.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## How to test?

- As it is a core modification it is important to test a bit the resource creation, modification and update and also some circulation operations.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
