### PR TITLE
sru: fix xml format and type

### DIFF
--- a/rero_ils/modules/documents/serializers.py
+++ b/rero_ils/modules/documents/serializers.py
@@ -334,10 +334,13 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
         def dump_record(record):
             """Dump a single record."""
             rec = element.record()
+            rec.append(element.recordPacking('xml'))
+            rec.append(element.recordSchema('marcxml'))
+            rec_data = element.recordData()
 
             leader = record.get('leader')
             if leader:
-                rec.append(element.leader(leader))
+                rec_data.append(element.leader(leader))
 
             if isinstance(record, GroupableOrderedDict):
                 items = record.iteritems(with_order=False, repeated=True)
@@ -350,12 +353,12 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
                     if isinstance(subfields, string_types):
                         controlfield = element.controlfield(subfields)
                         controlfield.attrib['tag'] = df[0:3]
-                        rec.append(controlfield)
+                        rec_data.append(controlfield)
                     elif isinstance(subfields, (list, tuple, set)):
                         for subfield in subfields:
                             controlfield = element.controlfield(subfield)
                             controlfield.attrib['tag'] = df[0:3]
-                            rec.append(controlfield)
+                            rec_data.append(controlfield)
                 else:
                     # Skip leader.
                     if df == 'leader':
@@ -394,7 +397,8 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
                                     datafield.append(element.subfield(
                                         value, code=code))
 
-                            rec.append(datafield)
+                            rec_data.append(datafield)
+                rec.append(rec_data)
             return rec
 
         if isinstance(records, dict):
@@ -606,7 +610,6 @@ class DublinCoreSerializer(BaseDublinCoreSerializer):
                 language=language,
                 **kwargs
             )
-
             element_record = simpledc.dump_etree(
                 record,
                 container=self.container_element,


### PR DESCRIPTION
* Changes xml element `<record>` to `<recordData>`.
* The record type in tag 900 $a and $b are not translated any more.

Co-Authored-by: Peter Weber <ipeter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
