### PR TITLE
documents: improve display of uniform resource locator

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/_documents_description.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_description.html
@@ -118,26 +118,6 @@
   </dd>
   {% endif %}
 
-  <!-- Related resource -->
-  {% set other_accesses = record|get_other_accesses %}
-  {% if other_accesses|length > 0 %}
-  <dt class="col-sm-3">
-    {{ _('Related resource') }}
-  </dt>
-  <dd class="col-sm-7 col-md-9 mb-0">
-    <ul class="list-unstyled mb-0">
-      {% for other_access in other_accesses %}
-      <li>
-        <a class="rero-ils-external-link" href={{ other_access.url }}>{{ other_access.content }}</a>
-        {% if other_access.public_note %}
-          ({{ other_access.public_note }})
-        {% endif %}
-      </li>
-      {% endfor %}
-    </ul>
-  </dd>
-  {% endif %}
-
   <!-- PERMALINK -->
   {% if record.source %}
   {{ dl(_('Source'), '<a href="'+ record.source +'" target="_blank">'+ record.source +'</a>') }}

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -112,12 +112,9 @@
         {% for resource in resources %}
           <li>
             <a href="{{ resource.url }}">
-              <i class="fa fa-link"></i>
-              {{ _(resource.type) }}:
+              {{ _(resource.type) }}
               {% if resource.content %}
-                {{ _(resource.content) }}
-              {% else %}
-                {{ resource.url }}
+                : {{ _(resource.content) }}
               {% endif %}
             </a>
             {% if resource.public_note %}({{ resource.public_note }}){% endif %}


### PR DESCRIPTION
* Removes uniform resource locator in description tab.
* Improves uniform resource locator display link on header.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## New display

<img width="1220" alt="uniform-public" src="https://user-images.githubusercontent.com/48578/123238792-103a8c00-d4df-11eb-9d32-e4f5361ebf4d.png">


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
