### PR TITLE
dojson: correct bookFormat transformation

### DIFF
--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -527,7 +527,7 @@ class BookFormatExtraction(object):
             """
             # generic regexp valid for all values
             regexp = \
-                r'(^|[^\d]){val}\s?[°⁰]|in(-|-gr\.)*\s*{val}($|[^\d])'.format(
+                r'(^|[^\d]){val}\s?[°⁰º]|in(-|-gr\.)*\s*{val}($|[^\d])'.format(
                     val=value)
             # add specific value regexp
             if value in self._specific_for_1248:


### PR DESCRIPTION
* Adds º \u00ba to `bookFormat` transformation.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
