### PR TITLE
documents: remove a trailing dot in a title key

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json
@@ -350,7 +350,7 @@
               }
             },
             "assigner": {
-              "title": "Assigning agency.",
+              "title": "Assigning agency",
               "description": "Used for imported records only. Agency that assigned this classification value.",
               "type": "string",
               "minLength": 1


### PR DESCRIPTION
* The `title` property of `assigner` has a trailing dot, but it should
  not.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To fix a small typo in the document JSON schema. 

## How to test?

- Check changed file. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
