### PR TITLE
documentation: fix gh-actions labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,7 @@ data:
   - rero_ils/modules/items/jsonschemas/**/*
   - rero_ils/modules/contributions/jsonschemas/**/*
   - rero_ils/modules/local_fields/jsonschemas/**/*
+  - rero_ils/dojson/**/*
   - rero_ils/modules/**/dojson/**/*
 
 # Add data-export label to any changes in dojson json to dublin core or to
@@ -80,7 +81,7 @@ permissions:
 
 # Add fixtures label to any changes in data folder or subfolders
 fixtures:
-  - rero_ils/data/**/*
+  - data/**/*
 
 # Add serials label to any changes in the following files or folders
 serials:
@@ -92,3 +93,16 @@ activity-logs:
 
 developers:
   - scripts/**/*
+
+monitoring:
+  - rero_ils/modules/monitoring.py
+
+notifications:
+  - rero_ils/modules/notifications/**/*
+
+"public ui":
+  - rero_ils/**/templates/**/*
+  - rero_ils/theme/**/*
+
+"statistics":
+  - rero_ils/modules/stats/**/*


### PR DESCRIPTION
* Fixes the wrong path for the fixture label.
* Adds a rule for the monitoring label.
* Adds rules for the public ui label.
* Completes the rule for the data label.
* Adds a rule for the statistics label.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To fix or extend the gh action labeler rules. 

## How to test?

- Check changed files. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
