### PR TITLE
templates: remove `data` field from ES mapping

### DIFF
--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -55,6 +55,7 @@ from .patron_transactions.listener import enrich_patron_transaction_data
 from .patrons.listener import create_subscription_patron_transaction, \
     enrich_patron_data, update_from_profile
 from .sru.views import SRUDocumentsSearch
+from .templates.listener import prepare_template_data
 from .users.views import UsersCreateResource, UsersResource
 from ..filter import empty_data, format_date_filter, jsondumps, node_assets, \
     text_to_id, to_pretty_json
@@ -195,6 +196,7 @@ class REROILSAPP(object):
                                     sender=app)
         before_record_index.connect(enrich_patron_transaction_data, sender=app)
         before_record_index.connect(enrich_ill_request_data, sender=app)
+        before_record_index.connect(prepare_template_data, sender=app)
 
         after_record_insert.connect(create_subscription_patron_transaction)
         after_record_update.connect(create_subscription_patron_transaction)

--- a/rero_ils/modules/templates/listener.py
+++ b/rero_ils/modules/templates/listener.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Signals connector for Template."""
+
+from .api import TemplatesSearch
+
+
+def prepare_template_data(sender, json=None, record=None, index=None,
+                          doc_type=None, arguments=None, **dummy_kwargs):
+    """Signal sent before a record is indexed.
+
+    :param json: The dumped record dictionary which can be modified.
+    :param record: The record being indexed.
+    :param index: The index in which the record will be indexed.
+    :param doc_type: The document type of the record.
+    """
+    if index.split('-')[0] == TemplatesSearch.Meta.index:
+        # remove `data` fields from ES.
+        #   This metadata isn't required for indexing process and cause some
+        #   troubles with $ref resolution
+        json.pop('data', None)

--- a/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
+++ b/rero_ils/modules/templates/mappings/v7/templates/template-v0.0.1.json
@@ -45,10 +45,6 @@
       "template_type": {
         "type": "keyword"
       },
-      "data": {
-        "type": "object",
-        "enabled": false
-      },
       "_created": {
         "type": "date"
       },

--- a/tests/api/templates/test_templates_rest.py
+++ b/tests/api/templates/test_templates_rest.py
@@ -54,7 +54,10 @@ def test_templates_get(client, templ_doc_public_martigny):
     res = client.get(list_url)
     assert res.status_code == 200
     data = get_json(res)
-    assert data['hits']['hits'][0]['metadata'] == template.replace_refs()
+
+    tmpl_data = template.replace_refs()
+    tmpl_data.pop('data', None)
+    assert data['hits']['hits'][0]['metadata'] == tmpl_data
 
 
 def test_filtered_templates_get(


### PR DESCRIPTION
The template `data` field contains a complete resources structure (
possibly including some other resource reference). This isn't required
into ES and cause some troubles with $ref resolution.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
