### PR TITLE
stats: add an admin views to visualize the stats 

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -371,7 +371,12 @@ CELERY_BEAT_SCHEDULE = {
                  '.delete_standard_holdings_having_no_items'),
         'schedule': crontab(minute=30, hour=4),  # Every day at 04:30 UTC,
         'enabled': False
-    }
+    },
+    'collect-stats': {
+        'task': ('rero_ils.modules.stats.tasks.collect_stats'),
+        'schedule': crontab(minute=0, hour=1),  # Every day at 01:00 UTC,
+        'enabled': False
+    },
     # 'mef-harvester': {
     #     'task': 'rero_ils.modules.apiharvester.tasks.harvest_records',
     #     'schedule': timedelta(minutes=60),
@@ -2316,7 +2321,6 @@ RECORDS_REST_SORT_OPTIONS['collections']['title'] = dict(
 RECORDS_REST_DEFAULT_SORT['collections'] = dict(
     query='bestmatch', noquery='start_date')
 
-
 # Detailed View Configuration
 # ===========================
 RECORDS_UI_ENDPOINTS = {
@@ -2341,6 +2345,13 @@ RECORDS_UI_ENDPOINTS = {
         view_imp='invenio_records_ui.views.export',
         template='rero_ils/export_documents.html',
         record_class='rero_ils.modules.documents.api:Document',
+    ),
+    'stats': dict(
+        pid_type='stat',
+        route='/stats/<pid_value>',
+        template='rero_ils/detailed_view_stats.html',
+        record_class='rero_ils.modules.stats.api:Stat',
+        permission_factory_imp='rero_ils.modules.stats.permissions:stats_ui_permission_factory',
     )
 }
 

--- a/rero_ils/modules/stats/tasks.py
+++ b/rero_ils/modules/stats/tasks.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Celery tasks for stats records."""
+
+from celery import shared_task
+
+from .api import Stat, StatsForPricing
+
+
+@shared_task()
+def collect_stats():
+    """Collect and store the current statistics."""
+    stats_for_pricing = StatsForPricing()
+    stat = Stat.create(
+        dict(values=stats_for_pricing.collect()), dbcommit=True, reindex=True)
+    return f'New stat has been created with a pid of: {stat.pid}'

--- a/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
+++ b/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
@@ -1,0 +1,55 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+{%- extends 'rero_ils/page.html' %}
+{%- block body %}
+{%- block record_body %}
+{%- if record.pid %}
+<a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa fa-download"></i></a>
+{%- endif %}
+<h2>{{record.created}}</h2>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th scope="col">library id</th>
+        <th scope="col">library name</th>
+        {%- for head in record['values'][0].keys() %}
+        {%- if head != 'library'%}
+        <th scope="col">{{head.replace('_', ' ')}}</th>
+        {%- endif %}
+        {%- endfor%}
+      </tr>
+    </thead>
+    <tbody>
+      {%- for val in record['values'] %}
+      <tr>
+        <th scope="row">{{val.library.pid}}</th>
+        <td scope="row">{{val.library.name}}</td>
+        {%- for head in record['values'][0].keys() %}
+        {%- if head != 'library'%}
+        <td scope="row">{{val[head]}}</td>
+        {%- endif %}
+        {%- endfor%}
+      </tr>
+      {%- endfor %}
+    </tbody>
+  </table>
+</div>
+{%- endblock record_body %}
+{%- endblock body %}

--- a/rero_ils/modules/stats/templates/rero_ils/stats_list.html
+++ b/rero_ils/modules/stats/templates/rero_ils/stats_list.html
@@ -1,0 +1,33 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+{%- extends 'rero_ils/page.html' %}
+{%- block body %}
+<div class="mt-2 mb-4">
+  <a class="btn btn-primary float-right" href="{{url_for('stats.live_stats')}}" role="button">Live values</a>
+  <h2>Statistics</h2>
+</div>
+<div class="list-group">
+  {%- for rec in records %}
+  <span class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+    <a href="{{url_for('invenio_records_ui.stats', pid_value=rec._source.pid)}}">{{rec._source._created | format_date}}</a>
+    <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=csv" role="button"><i class="fa fa-download"></i></a>
+  </span>
+  {%- endfor %}
+</div>
+{%- endblock body %}

--- a/rero_ils/modules/stats/views.py
+++ b/rero_ils/modules/stats/views.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Blueprint used for loading templates."""
+
+from __future__ import absolute_import, print_function
+
+import arrow
+from flask import Blueprint, render_template
+
+from .api import StatsForPricing, StatsSearch
+from .permissions import check_logged_as_admin
+
+blueprint = Blueprint(
+    'stats',
+    __name__,
+    url_prefix='/stats',
+    template_folder='templates',
+    static_folder='static',
+)
+
+
+@blueprint.route('/', methods=['GET'])
+@check_logged_as_admin
+def stats():
+    """Show the list of the first 100 items on the stats list."""
+    s = StatsSearch().sort('-_created').source(['pid', '_created'])
+    hits = s[0:100].execute().to_dict()
+    return render_template(
+        'rero_ils/stats_list.html', records=hits['hits']['hits'])
+
+
+@blueprint.route('/live', methods=['GET'])
+@check_logged_as_admin
+def live_stats():
+    """Show the current stats values."""
+    now = arrow.utcnow()
+    stats = StatsForPricing(to_date=now).collect()
+    return render_template(
+        'rero_ils/detailed_view_stats.html',
+        record=dict(created=now, values=stats))

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -34,8 +34,8 @@ from invenio_jsonschemas.errors import JSONSchemaNotFound
 
 from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patrons.api import current_librarian, current_patrons
-from rero_ils.permissions import can_access_professional_view
 
+from ..permissions import admin_permission, can_access_professional_view
 from ..version import __version__
 
 blueprint = Blueprint(
@@ -107,6 +107,17 @@ def init_menu_tools():
         ),
         order=10,
         id='ill-request-menu'
+    )
+    rero_register(
+        item,
+        endpoint='stats.stats',
+        visible_when=lambda: admin_permission.require().can(),
+        text='{icon} {help}'.format(
+            icon='<i class="fa fa-money"></i>',
+            help=_('Statistics')
+        ),
+        order=11,
+        id='stats-menu'
     )
 
     item = current_menu.submenu('main.tool.collections')

--- a/scripts/setup
+++ b/scripts/setup
@@ -521,7 +521,7 @@ then
     info_msg "Start OAI harvesting asynchrone"
     eval ${PREFIX} invenio oaiharvester harvest -n ebooks -q -k
 else
-    eval ${PREFIX} invenio scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -v
+    eval ${PREFIX} invenio scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -n collect-stats -v
     eval ${PREFIX} invenio scheduler enable_tasks -n notification-creation -n notification-dispatch-due_soon -n notification-dispatch-overdue -n notification-dispatch-availability -n notification-dispatch-recall -v
     info_msg "For ebooks harvesting run:"
     msg "\tinvenio oaiharvester harvest -n ebooks -a max=100 -q"
@@ -549,7 +549,7 @@ info_msg "Fine transactions: ${DATA_PATH}/fines.json ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio fixtures load_virtua_transactions ${DATA_PATH}/fines.json -t fine
 
 info_msg "Collect statistics"
-eval ${PREFIX} poetry run invenio stats collect
+eval ${PREFIX} invenio stats collect
 
 date
 success_msg "Perfect ${PROGRAM}! See you soon…"

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
             'notifications = rero_ils.modules.notifications.views:blueprint',
             'patrons = rero_ils.modules.patrons.views:blueprint',
             'rero_ils = rero_ils.theme.views:blueprint',
+            'stats = rero_ils.modules.stats.views:blueprint',
             'templates = rero_ils.modules.templates.views:blueprint',
         ],
         'invenio_base.api_blueprints': [
@@ -306,6 +307,7 @@ setup(
             'rero_ils_collections = rero_ils.modules.collections.tasks',
             'claims = rero_ils.modules.items.tasks',
             'loans = rero_ils.modules.loans.tasks',
+            'stats = rero_ils.modules.stats.tasks',
         ],
         'invenio_records.jsonresolver': [
             'acq_accounts = rero_ils.modules.acq_accounts.jsonresolver',


### PR DESCRIPTION
* Adds a stats detailed view.
* Adds a view to see the stats in live.
* Adds a list view for stats.
* Adds a new stats entry in the tools menu for admin user.
* Adds stats admin view permissions.
* Adds a recurrent task to collect the stats every night at 01:00 UTC.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/us/1848?milestone=294722

## How to test?

- bootstrap/setup
- logged in as admin
- select stats in the tools menu
- explore the interface

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
