### PR TITLE
documents: adapt the field list in quick access

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -299,10 +299,7 @@
         "templateOptions": {
           "cssClass": "editor-title"
         },
-        "hide": true,
-        "navigation": {
-          "essential": true
-        }
+        "hide": true
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json
@@ -159,10 +159,7 @@
       }
     },
     "form": {
-      "hide": true,
-      "navigation": {
-        "essential": true
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
@@ -719,7 +719,10 @@
       ]
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   },
   "definitions": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_dimensions-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_dimensions-v0.0.1.json
@@ -16,10 +16,7 @@
       }
     },
     "form": {
-      "hide": true,
-      "navigation": {
-        "essential": true
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
@@ -86,7 +86,10 @@
       ]
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_illustrative_content-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_illustrative_content-v0.0.1.json
@@ -13,7 +13,10 @@
       }
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_original_language-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_original_language-v0.0.1.json
@@ -9,7 +9,10 @@
       "$ref": "https://bib.rero.ch/schemas/common/languages-v0.0.1.json#/language"
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_responsibility_statement-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_responsibility_statement-v0.0.1.json
@@ -13,10 +13,7 @@
       }
     },
     "form": {
-      "hide": true,
-      "navigation": {
-        "essential": true
-      }
+      "hide": true
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json
@@ -58,7 +58,10 @@
       }
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_table_of_contents-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_table_of_contents-v0.0.1.json
@@ -12,7 +12,10 @@
       }
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_titles_original-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_titles_original-v0.0.1.json
@@ -10,7 +10,10 @@
       "minLength": 1
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }


### PR DESCRIPTION
The following fields are now in the quick access list:
identifiedBy, contentMediaCarrier, genreForm,
originalTitle, contribution, editionStatement,
seriesStatement, extent, note, originalLanguage,
tableOfContents, summary, illustrativeContent,
subjects, partOf

* Closes #1921.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Display

<img width="346" alt="quick-list" src="https://user-images.githubusercontent.com/48578/124222611-5fe20e80-db02-11eb-8e3a-e012d0cbec92.png">

## How to test?

- Document editor: Check quick access fields

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
