### PR TITLE
theme: fix missing ILL request menu

### DIFF
--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -108,6 +108,8 @@ def init_menu_tools():
         order=10,
         id='ill-request-menu'
     )
+
+    item = current_menu.submenu('main.tool.stats')
     rero_register(
         item,
         endpoint='stats.stats',
@@ -116,7 +118,7 @@ def init_menu_tools():
             icon='<i class="fa fa-money"></i>',
             help=_('Statistics')
         ),
-        order=11,
+        order=20,
         id='stats-menu'
     )
 


### PR DESCRIPTION
* Restores the ILL request menu after the implementation of the
  statistics menu available to an administrator. Issue spotted on the
  `v1.4.0` release candidate (see #2118).

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To fix the missing ILL request menu.

## How to test?

1. Log in as a patron and check that the ILL request menu is still there.
1. Navigate to an organisation view, and check that the collection menu is
   still there.
1. Log in as and administrator and check that the statistics menu is available.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
