### PR TITLE
users: allow to save an user without email

### DIFF
--- a/rero_ils/modules/users/api.py
+++ b/rero_ils/modules/users/api.py
@@ -134,6 +134,9 @@ class User(object):
             if email and email != user.email:
                 user.email = email
                 send_reset_password_instructions(user)
+            # remove the email from user data
+            elif not email and user.email:
+                user.email = None
             db.session.merge(user)
         db.session.commit()
         confirm_user(user)


### PR DESCRIPTION
When a user remove its email and try to save, the email was kept into
DB ; it's now possible to remove user email.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
