### PR TITLE
patrons: display user PID in error message

### DIFF
--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -314,7 +314,7 @@ class Patron(IlsRecord):
         patrons = cls.get_patrons_by_user(user)
         librarians = list(filter(lambda ptrn: ptrn.is_librarian, patrons))
         if len(librarians) > 1:
-            raise Exception('more than one librarian account for a user')
+            raise Exception(f'more than one librarian account for {user}')
         if len(librarians) == 0:
             return None
         return librarians[0]


### PR DESCRIPTION
* Adds user information for `more than one librarian account` problem.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
