### PR TITLE
item types: deny deletion with temporary item type

### DIFF
--- a/rero_ils/modules/item_types/api.py
+++ b/rero_ils/modules/item_types/api.py
@@ -125,9 +125,10 @@ class ItemType(IlsRecord):
     def get_number_of_items(self):
         """Get number of items."""
         from ..items.api import ItemsSearch
-        return ItemsSearch() \
-            .filter('term', item_type__pid=self.pid) \
-            .source().count()
+        return ItemsSearch().filter('bool', should=[
+            Q('term', item_type__pid=self.pid),
+            Q('term', temporary_item_type__pid=self.pid)
+        ]).count()
 
     def get_number_of_circ_policies(self):
         """Get number of circulation policies."""


### PR DESCRIPTION
* Denies the deletion of item type when it's used by any item.
* Closes #2159.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
