### PR TITLE
notifications: fix request and recall

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -312,7 +312,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'notification-creation': {
         'task': 'rero_ils.modules.notifications.tasks.create_notifications',
-        'schedule': crontab(minute="*/5"),
+        'schedule': crontab(minute=0, hour=5),  # Every day at 05:00 UTC,
         'kwargs': {
             'types': [
                 Notification.DUE_SOON_NOTIFICATION_TYPE,

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -761,10 +761,12 @@ class Loan(IlsRecord):
             # create the notification and enqueue it.
             return self._send_notification(record)
 
-        # recall + availibility
+        # availibility
         if notif_type in [
-                Notification.RECALL_NOTIFICATION_TYPE,
-                Notification.AVAILABILITY_NOTIFICATION_TYPE]:
+                Notification.AVAILABILITY_NOTIFICATION_TYPE,
+                # recall
+                Notification.RECALL_NOTIFICATION_TYPE
+        ]:
             return self._send_notification(record)
 
         if notif_type in [

--- a/rero_ils/modules/notifications/templates/email/availability/eng.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/eng.txt
@@ -9,12 +9,12 @@ Title: {{ document.title_text }} / {{ document.responsibility_statement }}
 Pick up location: {{ pickup_name }}
 {%- endfor %}
 
-To pick up until: {{ library.next_open }}
+To pick up until: {{ pickup_library.next_open }}
 
 Should the document not be picked up within the given period, it will be made available for other people.
 You can consult your account and extend the loan period of your documents at: {{ profile_url }}
 
 Best regards
 
-{{ library.name }}
-{{ library.address }}
+{{ pickup_library.name }}
+{{ pickup_library.address }}

--- a/rero_ils/modules/notifications/templates/email/availability/fre.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/fre.txt
@@ -9,12 +9,12 @@ Titre : {{ document.title_text }} / {{ document.responsibility_statement }}
 Lieu de retrait : {{ pickup_name }}
 {%- endfor %}
 
-A retirer jusqu'au : {{ library.next_open }}
+A retirer jusqu'au : {{ pickup_library.next_open }}
 
 Si le document n'est pas retiré dans les délais, il sera remis en circulation pour d'autres personnes.
 Vous pouvez consulter votre compte et prolonger la durée de prêt de vos documents à l'adresse : {{ profile_url }}
 
 Avec nos compliments
 
-{{ library.name }}
-{{ library.address }}
+{{ pickup_library.name }}
+{{ pickup_library.address }}

--- a/rero_ils/modules/notifications/templates/email/availability/ger.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/ger.txt
@@ -9,12 +9,12 @@ Titel : {{ document.title_text }} / {{ document.responsibility_statement }}
 Abholort: {{ pickup_name }}
 {%- endfor %}
 
-Abholen bis: {{ library.next_open }}
+Abholen bis: {{ pickup_library.next_open }}
 
 Wenn das Dokument innerhalb der gegebenen Frist nicht abgeholt wird, wird es anderen Personen zur Verfügung gestellt.
 Unter folgender Adresse können Sie Ihr Konto einsehen und die Ausleihfrist Ihrer Dokumente verlängern: {{ profile_url }}
 
 Freundliche Grüsse
 
-{{ library.name }}
-{{ library.address }}
+{{ pickup_library.name }}
+{{ pickup_library.address }}

--- a/rero_ils/modules/notifications/templates/email/availability/ita.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/ita.txt
@@ -9,12 +9,12 @@ Titolo: {{ document.title_text }} / {{ document.responsibility_statement }}
 Punto di ritiro: {{ pickup_name }}
 {%- endfor %}
 
-Ritirare entro: {{ library.next_open }}
+Ritirare entro: {{ pickup_library.next_open }}
 
 Se il documento non è ritirato entro detto termine, esso sarà rimesso in circolazione per altre persone.
 Lei può consultare il Suo conto et prorogare la durata di prestito dei Suoi documenti al seguente indirizzo: {{ profile_url }}
 
 Cordiali saluti
 
-{{ library.name }}
-{{ library.address }}
+{{ pickup_library.name }}
+{{ pickup_library.address }}

--- a/rero_ils/modules/notifications/templates/email/transit_notice/eng.txt
+++ b/rero_ils/modules/notifications/templates/email/transit_notice/eng.txt
@@ -9,6 +9,6 @@ Call number: {% if document.item.call_number %}{{ document.item.call_number }}{%
 {%- if document.item.call_number and document.item.second_call_number %} / {{ document.item.second_call_number }}{%-endif %}
 {%- endif %}
 {% endif %}
-Origin: {{ transaction.library_name }}
+Origin: {{ transaction_library.name }}
 Destination: {{ document.item.library_name }}: {{ document.item.location_name }}
 {% endfor %}

--- a/rero_ils/modules/notifications/templates/email/transit_notice/fre.txt
+++ b/rero_ils/modules/notifications/templates/email/transit_notice/fre.txt
@@ -9,6 +9,6 @@ Cote: {% if document.item.call_number %}{{ document.item.call_number }}{% endif 
 {%- if document.item.call_number and document.item.second_call_number %} / {{ document.item.second_call_number }}{%-endif %}
 {%- endif %}
 {% endif %}
-Origine: {{ transaction.library_name }}
+Origine: {{ transaction_library.name }}
 Destination: {{ document.item.library_name }}: {{ document.item.location_name }}
 {% endfor %}

--- a/rero_ils/modules/notifications/templates/email/transit_notice/ger.txt
+++ b/rero_ils/modules/notifications/templates/email/transit_notice/ger.txt
@@ -9,6 +9,6 @@ Signatur: {% if document.item.call_number %}{{ document.item.call_number }}{% en
 {%- if document.item.call_number and document.item.second_call_number %} / {{ document.item.second_call_number }}{%-endif %}
 {%- endif %}
 {% endif %}
-Herkunft: {{ transaction.library_name }}
+Herkunft: {{ transaction_library.name }}
 Ziel: {{ document.item.library_name }}: {{ document.item.location_name }}
 {% endfor %}

--- a/rero_ils/modules/notifications/templates/email/transit_notice/ita.txt
+++ b/rero_ils/modules/notifications/templates/email/transit_notice/ita.txt
@@ -9,6 +9,6 @@ Segnatura: {% if document.item.call_number %}{{ document.item.call_number }}{% e
 {%- if document.item.call_number and document.item.second_call_number %} / {{ document.item.second_call_number }}{%-endif %}
 {%- endif %}
 {% endif %}
-Origine: {{ transaction.library_name }}
+Origine: {{ transaction_library.name }}
 Destinazione: {{ document.item.library_name }}: {{ document.item.location_name }}
 {% endfor %}

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -384,7 +384,7 @@ def test_overdue_loans(client, librarian_martigny,
     assert res.status_code == 200
 
 
-def test_checkout_item_transit(client, item2_lib_martigny,
+def test_checkout_item_transit(client, mailbox, item2_lib_martigny,
                                librarian_martigny,
                                librarian_saxon,
                                patron_martigny,
@@ -393,6 +393,7 @@ def test_checkout_item_transit(client, item2_lib_martigny,
                                circulation_policies):
     """Test checkout of an item in transit."""
     assert item2_lib_martigny.available
+    mailbox.clear()
 
     # request
     login_user_via_session(client, librarian_martigny.user)
@@ -419,6 +420,10 @@ def test_checkout_item_transit(client, item2_lib_martigny,
     actions = data.get('action_applied')
     loan_pid = actions[LoanAction.REQUEST].get('pid')
     assert not item2_lib_martigny.available
+
+    assert len(mailbox) == 1
+    assert mailbox[-1].recipients == [
+        loc_public_martigny['notification_email']]
 
     loan = Loan.get_record_by_pid(loan_pid)
     assert loan['state'] == LoanState.PENDING

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -268,27 +268,27 @@
     "notification_settings": [
       {
         "type": "due_soon",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saxon@gmail.com"
       },
       {
         "type": "overdue",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saxon@gmail.com"
       },
       {
         "type": "recall",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saxon@gmail.com"
       },
       {
         "type": "request",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saxon@gmail.com"
       },
       {
         "type": "transit_notice",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saxon@gmail.com"
       },
       {
         "type": "booking",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saxon@gmail.com"
       }
     ],
     "communication_language": "fre"
@@ -396,27 +396,27 @@
     "notification_settings": [
       {
         "type": "due_soon",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+fully@gmail.com"
       },
       {
         "type": "overdue",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+fully@gmail.com"
       },
       {
         "type": "recall",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+fully@gmail.com"
       },
       {
         "type": "request",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+fully@gmail.com"
       },
       {
         "type": "transit_notice",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+fully@gmail.com"
       },
       {
         "type": "booking",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+fully@gmail.com"
       }
     ],
     "communication_language": "fre"
@@ -524,32 +524,32 @@
     "notification_settings": [
       {
         "type": "availability",
-        "email": "reroilstest+martigny@gmail.com",
+        "email": "reroilstest+sion@gmail.com",
         "delay": 5
       },
       {
         "type": "due_soon",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+sion@gmail.com"
       },
       {
         "type": "overdue",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+sion@gmail.com"
       },
       {
         "type": "recall",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+sion@gmail.com"
       },
       {
         "type": "request",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+sion@gmail.com"
       },
       {
         "type": "transit_notice",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+sion@gmail.com"
       },
       {
         "type": "booking",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+sion@gmail.com"
       }
     ],
     "communication_language": "fre"
@@ -657,27 +657,27 @@
     "notification_settings": [
       {
         "type": "due_soon",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+aproz@gmail.com"
       },
       {
         "type": "overdue",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+aproz@gmail.com"
       },
       {
         "type": "recall",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+aproz@gmail.com"
       },
       {
         "type": "request",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+aproz@gmail.com"
       },
       {
         "type": "transit_notice",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+aproz@gmail.com"
       },
       {
         "type": "booking",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+aproz@gmail.com"
       }
     ],
     "communication_language": "fre"
@@ -785,27 +785,27 @@
     "notification_settings": [
       {
         "type": "due_soon",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saillon@gmail.com"
       },
       {
         "type": "overdue",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saillon@gmail.com"
       },
       {
         "type": "recall",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saillon@gmail.com"
       },
       {
         "type": "request",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saillon@gmail.com"
       },
       {
         "type": "transit_notice",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saillon@gmail.com"
       },
       {
         "type": "booking",
-        "email": "reroilstest+martigny@gmail.com"
+        "email": "reroilstest+saillon@gmail.com"
       }
     ],
     "communication_language": "fre"


### PR DESCRIPTION
* Does not create a request notification when the item is on loan.
* Prevents sending multiple recall notifications.
* Fixes bad notification emails in the tests fixtures.
* Ensures booking notification are always sent.
* Fixes email recipient for transit notice and booking notifications.
* Improves availiblity notification templates.

_Note:_ Fixes A, B, D of #2152.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
