### PR TITLE
locations: allow to sort pickup locations

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -80,6 +80,7 @@ from .modules.local_fields.api import LocalField
 from .modules.local_fields.permissions import LocalFieldPermission
 from .modules.locations.api import Location
 from .modules.locations.permissions import LocationPermission
+from .modules.locations.utils import default_pickup_location_sort
 from .modules.notifications.api import Notification
 from .modules.notifications.dispatcher import \
     Dispatcher as NotificationDispatcher
@@ -2550,6 +2551,10 @@ RERO_ILS_CONTRIBUTIONS_LABEL_ORDER = {
 
 #: Admin roles
 RERO_ILS_LIBRARIAN_ROLES = ['librarian', 'system_librarian']
+
+#: Locations
+RERO_ILS_PICKUP_LOCATIONS_SORT_METHOD = \
+    default_pickup_location_sort
 
 
 # JSONSchemas

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -39,6 +39,7 @@ from ..holdings.models import HoldingNoteTypes
 from ..items.models import ItemCirculationAction
 from ..libraries.api import Library
 from ..locations.api import Location
+from ..locations.utils import default_pickup_location_sort
 from ..organisations.api import Organisation
 from ..patrons.api import current_patrons
 from ..utils import cached, extracted_data_from_ref
@@ -374,10 +375,13 @@ def item_library_pickup_locations(item):
                 pickup_locations.append(
                     Location.get_record_by_pid(location_pid))
 
-    return sorted(
-        list(filter(None, pickup_locations)),
-        key=lambda location: location.get('pickup_name', location.get('code'))
+    # Sort pickup location based on method specified into configuration file.
+    # If the configuration isn't specified, then use a default sort method
+    sort_method = current_app.config.get(
+        'RERO_ILS_PICKUP_LOCATIONS_SORT_METHOD',
+        default_pickup_location_sort
     )
+    return sort_method(item, pickup_locations)
 
 
 @blueprint.app_template_filter()

--- a/rero_ils/modules/locations/utils.py
+++ b/rero_ils/modules/locations/utils.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for locations."""
+
+
+def default_pickup_location_sort(item, pickup_locations):
+    """Sort pickup location by default by name.
+
+    :param item: the requested item.
+    :param pickup_locations: the pickup locations to sort.
+    """
+    return sorted(
+        list(filter(None, pickup_locations)),
+        key=lambda loc: loc.get('pickup_name', loc.get('code'))
+    )
+
+
+def sort_pickup_locations_item_location_first(item, pickup_locations):
+    """Sort pickup location by name with item location at first position.
+
+    :param item: the requested item.
+    :param pickup_locations: the pickup locations to sort.
+    """
+    pickup_locations = pickup_locations or []
+    # first sort by name
+    pickup_locations = sorted(
+        list(filter(None, pickup_locations)),
+        key=lambda loc: loc.get('pickup_name', loc.get('code'))
+    )
+    # place item location at top of the list
+    item_loc_pid = item.location_pid
+    item_pickup_location = next(
+        (loc for loc in pickup_locations if loc.pid == item_loc_pid),
+        None
+    )
+    if item_pickup_location:
+        cleaned_pickup_location = [loc for loc in pickup_locations
+                                   if loc.pid != item_pickup_location.pid]
+        pickup_locations = [item_pickup_location] + cleaned_pickup_location
+    return pickup_locations

--- a/tests/ui/locations/test_locations_utils.py
+++ b/tests/ui/locations/test_locations_utils.py
@@ -22,6 +22,8 @@
 """
 
 from rero_ils.modules.locations.api import Location
+from rero_ils.modules.locations.utils import default_pickup_location_sort, \
+    sort_pickup_locations_item_location_first
 
 
 def test_location_get_all_pickup_locations(
@@ -32,3 +34,20 @@ def test_location_get_all_pickup_locations(
 
     locations = Location.get_pickup_location_pids(patron_martigny.pid)
     assert set(locations) == {loc_public_martigny.pid}
+
+
+def test_sort_pickup_locations(locations, item_lib_martigny):
+    """Test sorting methods for pickup locations"""
+    item = item_lib_martigny
+    pickups_locations = [
+        Location.get_record_by_pid(pid)
+        for pid in Location.get_pickup_location_pids()
+    ]
+
+    sorted_locations = default_pickup_location_sort(item, pickups_locations)
+    assert sorted_locations[0].pid == 'loc5'
+
+    sorted_locations = sort_pickup_locations_item_location_first(
+        item, pickups_locations)
+    assert sorted_locations[0].pid == 'loc1'
+    assert sorted_locations[1].pid == 'loc5'


### PR DESCRIPTION
Adds a configuration key to allow pickup locations sortering on the
item request form.
Closes rero/rero-ils#1899.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
