### PR TITLE
import: fix `subject_imported` field

### DIFF
--- a/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
@@ -17,7 +17,6 @@
 
 """rero-ils UNIMARC model definition."""
 
-
 import jsonref
 from dojson import utils
 from dojson.utils import GroupableOrderedDict
@@ -995,7 +994,7 @@ def unimarc_notes(self, key, value):
     return None
 
 
-@unimarc.over('subjects', '^6((0[0-9])|(1[0-7]))..')
+@unimarc.over('subjects_imported', '^6((0[0-9])|(1[0-7]))..')
 @utils.for_each_value
 @utils.ignore_value
 def unimarc_subjects(self, key, value):
@@ -1016,10 +1015,12 @@ def unimarc_subjects(self, key, value):
     if value.get('f'):
         to_return += ', ' + ', '.join(utils.force_list(value.get('f')))
     if to_return:
-        return {
+        data = {
             'type': "bf:Topic",
-            'term': to_return
+            'term': to_return,
+            'source': value.get('2', None)
         }
+        return {k: v for k, v in data.items() if v}
 
 
 @unimarc.over('electronicLocator', '^8564.')

--- a/tests/unit/test_documents_dojson_unimarc.py
+++ b/tests/unit/test_documents_dojson_unimarc.py
@@ -1541,6 +1541,7 @@ def test_unimarc_subjects():
     <record>
       <datafield tag="600" ind1=" " ind2=" ">
         <subfield code="a">subjects 600</subfield>
+        <subfield code="2">rameau</subfield>
       </datafield>
       <datafield tag="616" ind1=" " ind2=" ">
         <subfield code="a">Capet</subfield>
@@ -1553,10 +1554,14 @@ def test_unimarc_subjects():
     """
     unimarcjson = create_record(unimarcxml)
     data = unimarc.do(unimarcjson)
-    assert data.get('subjects') == [
-        {'term': 'subjects 600', 'type': 'bf:Topic'},
-        {'term': 'Capet, Louis III, Jr., 1700-1780', 'type': 'bf:Topic'}
-    ]
+    assert data.get('subjects_imported') == [{
+        'term': 'subjects 600',
+        'type': 'bf:Topic',
+        'source': 'rameau'
+    }, {
+        'term': 'Capet, Louis III, Jr., 1700-1780',
+        'type': 'bf:Topic'
+    }]
 
 
 def test_unimarc_to_electronicLocator_from_856():


### PR DESCRIPTION
Closes rero/rero-ils#2175.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
