### PR TITLE
search: add an option to limit the `i18n_aggs`

### DIFF
--- a/rero_ils/theme/templates/rero_ils/search.html
+++ b/rero_ils/theme/templates/rero_ils/search.html
@@ -28,6 +28,6 @@
 
 {%- block javascript %}
 {{ webpack['reroils_public.js']}}
-{{ node_assets('@rero/rero-ils-ui/dist/public-search', patterns=['polyfills-es5*.js','main-es5*.js','runtime-es5*.js'], tags='nomodule defer') }}
-{{ node_assets('@rero/rero-ils-ui/dist/public-search', patterns=['polyfills-es2015*.js','main-es2015*.js','runtime-es2015*.js'], tags='type="module"') }}
+{{ node_assets('@rero/rero-ils-ui/dist/public-search', patterns=['polyfills-es5*.js','main-es5*.js'], tags='nomodule defer') }}
+{{ node_assets('@rero/rero-ils-ui/dist/public-search', patterns=['polyfills-es2015*.js','main-es2015*.js'], tags='type="module"') }}
 {%- endblock javascript %}


### PR DESCRIPTION
* Adds the `facets` http option support for i18n aggregation to limit
  their computation on a given list.
* Fixes the two calls to the document api in the public search view.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- To increase de performances.


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
