### PR TITLE
items: make the aggregations optional

### DIFF
--- a/rero_ils/modules/items/serializers/json.py
+++ b/rero_ils/modules/items/serializers/json.py
@@ -124,8 +124,9 @@ class ItemsJSONSerializer(JSONSerializer):
             vendor_term['name'] = vendor.get('name')
 
         # Correct document type buckets
-        buckets = results['aggregations']['document_type']['buckets']
-        results['aggregations']['document_type']['buckets'] = \
-            filter_document_type_buckets(buckets)
+        if results.get('aggregations', {}).get('document_type'):
+            buckets = results['aggregations']['document_type']['buckets']
+            results['aggregations']['document_type']['buckets'] = \
+                filter_document_type_buckets(buckets)
 
         return super().post_process_serialize_search(results, pid_fetcher)


### PR DESCRIPTION
* Makes the aggragations optional in the rero specific items serializer.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
