### PR TITLE
documents: add default value on hidden type field

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_usage_and_access_policy-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_usage_and_access_policy-v0.0.1.json
@@ -20,6 +20,7 @@
         "type": {
           "title": "Type",
           "type": "string",
+          "default": "bf:UsageAndAccessPolicy",
           "const": "bf:UsageAndAccessPolicy",
           "form": {
             "templateOptions": {


### PR DESCRIPTION
The usageAndAccessPolicy field has a type field that is hidden.
You have to set it to a default value to avoid form validation errors.

* Closes #2202.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
