### PR TITLE
public ui: fix missing library facet on org view

### DIFF
--- a/rero_ils/modules/documents/serializers.py
+++ b/rero_ils/modules/documents/serializers.py
@@ -137,7 +137,8 @@ class DocumentJSONSerializer(JSONSerializer):
             if lib_buckets:
                 org_term['library']['buckets'] = lib_buckets
 
-        # TODO: Move this logic in the front end (needs backend adaptation)
+        # TODO: this should be done in the facet factory as we compute
+        #       unused aggs values
         if (viewcode is not None) and (viewcode != global_view_code):
             org = Organisation.get_record_by_viewcode(viewcode)
             org_buckets = results.get('aggregations', {}).get(

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -171,11 +171,49 @@ def test_documents_facets(
     res = client.get(list_url, headers=rero_json_header)
     data = get_json(res)
     aggs = data['aggregations']
+
     # check all facets are present
     for facet in [
         'document_type', 'author', 'language', 'subject', 'status'
     ]:
         assert aggs[facet]
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list', view='global', facets='')
+    res = client.get(list_url, headers=rero_json_header)
+    data = get_json(res)
+    aggs = data['aggregations']
+    assert not aggs
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list', view='global', facets='document_type')
+    res = client.get(list_url, headers=rero_json_header)
+    data = get_json(res)
+    aggs = data['aggregations']
+    assert list(aggs.keys()) == ['document_type']
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list', view='global', facets='document_type')
+    res = client.get(list_url, headers=rero_json_header)
+    data = get_json(res)
+    aggs = data['aggregations']
+    assert list(aggs.keys()) == ['document_type']
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list', view='org1', facets='document_type')
+    res = client.get(list_url, headers=rero_json_header)
+    data = get_json(res)
+    aggs = data['aggregations']
+    assert list(aggs.keys()) == ['document_type']
+
+    # test the patch that the library facet is computed by the serializer
+    list_url = url_for(
+        'invenio_records_rest.doc_list', view='org1',
+        facets='document_type,library,author')
+    res = client.get(list_url, headers=rero_json_header)
+    data = get_json(res)
+    aggs = data['aggregations']
+    assert set(aggs.keys()) == set(['document_type', 'library', 'author'])
 
     # FILTERS
     # contribution


### PR DESCRIPTION
* Forces to compute the `organisation` aggregation values when the view
  is an organisation view and the `library` aggregation is enable.
* Closes #2215.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
