### PR TITLE
holdings: allow deletion of serials holdings

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -37,6 +37,7 @@ from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_records.api import Record
 from invenio_records_rest.utils import obj_or_import_string
+from invenio_search import current_search
 from invenio_search.api import RecordsSearch
 from jsonschema.exceptions import ValidationError
 from kombu.compat import Consumer
@@ -83,6 +84,11 @@ class IlsRecordsSearch(RecordsSearch):
         facets = {}
 
         default_filter = None
+
+    @classmethod
+    def flush_and_refresh(cls):
+        """Flush and refresh index."""
+        current_search.flush_and_refresh(cls.Meta.index)
 
 
 class IlsRecord(Record):

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -102,10 +102,6 @@ class Item(ItemCirculation, ItemIssue):
         links = self.get_links_to_me()
         if links:
             cannot_delete['links'] = links
-        if self.item_record_type == 'issue' and self.issue_is_regular:
-            cannot_delete['others'] = dict(
-                regular_issue_cannot_be_deleted=True
-            )
         return cannot_delete
 
     def in_collection(self, **kwargs):

--- a/tests/api/items/test_items_issue.py
+++ b/tests/api/items/test_items_issue.py
@@ -47,7 +47,6 @@ def test_issues_permissions(client, json_header,
     assert issue_item is not None
     assert issue_item.issue_is_regular
 
-    # a regular issue cannot be deleted
     res = client.get(
         url_for(
             'api_blueprint.permissions',
@@ -57,4 +56,4 @@ def test_issues_permissions(client, json_header,
     )
     assert res.status_code == 200
     data = get_json(res)
-    assert not data['delete']['can']
+    assert data['delete']['can']


### PR DESCRIPTION
* Closes #1720.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

 Needs adoption in `rero_ils_ui` for confirmation message :

> A confirmation message is displayed before deleting: Do you really want to delete this record? This will also delete all items and issues of the holdings.