### PR TITLE
notifications: fix patron with additional email

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -116,7 +116,6 @@
     "pid": "5",
     "birth_date": "2004-10-11",
     "city": "Aosta",
-    "email": "reroilstest+helder@gmail.com",
     "username": "helder",
     "first_name": "Helder",
     "roles": [
@@ -135,7 +134,8 @@
         "$ref": "https://bib.rero.ch/api/patron_types/2"
       },
       "communication_channel": "email",
-      "communication_language": "ita"
+      "communication_language": "ita",
+      "additional_communication_email": "reroilstest+helder@gmail.com"
     }
   },
   {

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -287,12 +287,14 @@ class Dispatcher:
         """
         # get the recipient email from loan.patron.patron.email
         error_reason = ''
-        recipients = [ctx_data['patron'].get('email')]
-        # additional recipient
-        add_recipient = ctx_data['patron'].get(
-            'additional_communication_email')
-        if add_recipient:
-            recipients.append(add_recipient)
+        recipients = []
+        patron = ctx_data['patron']
+        for email in [
+            patron.get('email'),
+            patron['patron'].get('additional_communication_email')
+        ]:
+            if email:
+                recipients.append(email)
         if not recipients:
             error_reason = '(Missing notification recipients)'
         reply_to = ctx_data['library'].get('email')

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -373,6 +373,23 @@ def patron_sion_without_email1(
     yield create_patron(data)
 
 
+@pytest.fixture(scope="module")
+def patron_sion_with_additional_email(
+        app,
+        roles,
+        lib_sion,
+        patron_type_grown_sion,
+        patron_sion_data):
+    """Create Sion patron with an additional email only."""
+    data = deepcopy(patron_sion_data)
+    del data['email']
+    data['pid'] = 'ptrn10additionalemail'
+    data['username'] = 'additionalemail'
+    data['patron']['additional_communication_email'] = \
+        'additional+jules@gmail.com'
+    yield create_patron(data)
+
+
 # ------------ Loans: pending loan ----------
 @pytest.fixture(scope="module")
 def loan_pending_martigny(


### PR DESCRIPTION
* Sends the notification to the patron additional email if exists
  instead of the library.
* Closes #2152.
* Adapts the fixtures to have a user with an additional email only.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
