### PR TITLE
notifications: fix patron address block missing

### DIFF
--- a/rero_ils/modules/notifications/templates/email/_patron_address.txt
+++ b/rero_ils/modules/notifications/templates/email/_patron_address.txt
@@ -1,4 +1,4 @@
-{%- if patron.communication_channel == 'mail' %}
+{%- if patron.patron.communication_channel == 'mail' %}
 {{ patron.first_name }} {{ patron.last_name }}
 {% if patron.street %}{{ patron.street }}{% endif %}
 {% if patron.postal_code %}{{ patron.postal_code }}{% endif %} {% if patron.city %}{{ patron.city }}{% endif %}

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -502,6 +502,8 @@ def test_recall_notification_without_email(
     # one new email for the librarian
     assert mailbox[0].recipients == [email_notification_type(
         lib_martigny, notification['notification_type'])]
+    # check the address block
+    assert patron2_martigny.dumps()['street'] in mailbox[0].body
     mailbox.clear()
 
 


### PR DESCRIPTION
* Adds a patron address block to a printing patron notification.
* Closes #2188.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
