### PR TITLE
notifications: fix request with temporary item type

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -40,6 +40,7 @@ from ..utils import item_pid_to_object
 from ...circ_policies.api import CircPolicy
 from ...documents.api import Document
 from ...errors import NoCirculationAction
+from ...item_types.api import ItemType
 from ...libraries.api import Library
 from ...loans.api import Loan, LoanAction, LoanState, \
     get_last_transaction_loc_for_item, get_request_by_item_pid_by_patron_pid
@@ -1272,6 +1273,15 @@ class ItemCirculation(ItemRecord):
             'language': 'default',
             'label': label
         }]
+
+    @property
+    def temp_item_type_negative_availability(self):
+        """Get the temporary item type neg availability."""
+        if self.get('temporary_item_type'):
+            return ItemType.get_record_by_pid(extracted_data_from_ref(
+                self.get('temporary_item_type'))
+            ).get('negative_availability', False)
+        return False
 
     def get_item_end_date(self, format='short', time_format='medium',
                           language=None):

--- a/rero_ils/modules/loans/listener.py
+++ b/rero_ils/modules/loans/listener.py
@@ -56,8 +56,8 @@ def listener_loan_state_changed(_, initial_loan, loan, trigger):
                         Notification.RECALL_NOTIFICATION_TYPE):
                     checked_out_loan.create_notification(
                         Notification.RECALL_NOTIFICATION_TYPE)
-            # request notification only if the item is not on loan
-            else:
+            elif not item.temp_item_type_negative_availability:
+                # request notification only if the item is not on loan
                 loan.create_notification(
                     notification_type=Notification.REQUEST_NOTIFICATION_TYPE)
     # availability

--- a/rero_ils/modules/stats/mappings/__init__.py
+++ b/rero_ils/modules/stats/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item type Elasticsearch mapping."""
+"""Stat Elasticsearch mapping."""

--- a/rero_ils/modules/stats/mappings/v7/__init__.py
+++ b/rero_ils/modules/stats/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item type Elasticsearch mapping."""
+"""Stat Elasticsearch mapping."""

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -32,6 +32,7 @@ from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
 from rero_ils.modules.notifications.api import Notification, \
     NotificationsSearch, get_notification
 from rero_ils.modules.notifications.tasks import process_notifications
+from rero_ils.modules.utils import get_ref_for_pid
 
 
 def test_availability_notification(
@@ -586,6 +587,56 @@ def test_multiple_notifications(client, patron_martigny, patron_sion,
         'pid': loan.pid
     }
     item_lib_martigny.receive(**params)
+
+
+def test_request_notifications_temp_item_type(
+    client, patron_martigny, patron_sion, lib_martigny, lib_fully,
+    item_lib_martigny, librarian_martigny, loc_public_martigny,
+    circulation_policies, loc_public_fully, item_type_missing_martigny, mailbox
+):
+    """Test request notifications with item type with negative availability."""
+    mailbox.clear()
+    login_user_via_session(client, librarian_martigny.user)
+    item_lib_martigny['temporary_item_type'] = {
+        '$ref': get_ref_for_pid('itty', item_type_missing_martigny.pid)
+    }
+    item_lib_martigny.update(item_lib_martigny, dbcommit=True, reindex=True)
+
+    res, data = postdata(
+        client,
+        'api_item.librarian_request',
+        dict(
+            item_pid=item_lib_martigny.pid,
+            pickup_location_pid=loc_public_fully.pid,
+            patron_pid=patron_martigny.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid
+        )
+    )
+    assert res.status_code == 200
+
+    request_loan_pid = data.get(
+        'action_applied')[LoanAction.REQUEST].get('pid')
+
+    flush_index(NotificationsSearch.Meta.index)
+    assert len(mailbox) == 0
+
+    # cancel request
+    res, _ = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            item_pid=item_lib_martigny.pid,
+            pid=request_loan_pid,
+            transaction_user_pid=librarian_martigny.pid,
+            transaction_library_pid=lib_martigny.pid
+        )
+    )
+    assert res.status_code == 200
+    mailbox.clear()
+
+    del(item_lib_martigny['temporary_item_type'])
+    item_lib_martigny.update(item_lib_martigny, dbcommit=True, reindex=True)
 
 
 def test_request_notifications(client, patron_martigny, patron_sion,


### PR DESCRIPTION
* Does not send request notification when the item has a temporary item
  type with negative availability.
* Closes #2191.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
