### PR TITLE
requests: hide non available items from the list 

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -409,7 +409,7 @@ class Loan(IlsRecord):
                 if 'temporary_item_type' in item:
                     item_type_pid = item['temporary_item_type']['pid']
                     item_type = item_type_by_pid(item_type_pid)
-                    if item_type is None:
+                    if item_type is not None:
                         add = False
                 if add and item_pid not in item_pids:
                     item_pids.append(item_pid)


### PR DESCRIPTION
* Hides items with a temporary circulation category with negative
  availability from the list of requests to be validated.
* Closes #2225.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Check request list: item with `temporary_item_type` with `negative_availability: true` (In acquisition)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
