### PR TITLE
selfcheck: fix patron informations

### DIFF
--- a/rero_ils/modules/selfcheck/utils.py
+++ b/rero_ils/modules/selfcheck/utils.py
@@ -83,18 +83,21 @@ def format_patron_address(patron):
     """
     address = patron.get('second_address')
     if address:
-        return '{street}, {postal_code} {city}'.format(
+        formated_address = '{street}, {postal_code} {city}'.format(
             street=address.get('street'),
             postal_code=address.get('postal_code'),
             city=address.get('city')
         )
     else:
         profile = patron.user.profile
-        return '{street}, {postal_code} {city}'.format(
+        formated_address = '{street}, {postal_code} {city}'.format(
             street=profile.street.strip(),
             postal_code=profile.postal_code.strip(),
             city=profile.city.strip()
         )
+    # Should never append, but can be imported from an old system
+    return formated_address.replace(r'\n', ' ').replace(r'\r', ' ')\
+        .replace('\n', ' ').replace('\r', ' ')
 
 
 def get_patron_status(patron):


### PR DESCRIPTION
* Sets `institution_id` to the patron organisation `pid`.
* Rounds the fees to cents.
* Fixes patron language, email, phone.
* Removes CR chars `\n`, `\r` from the patron address.
* Adds the `due_date` in a checkout response even if the item has been
  already checked out.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
