### PR TITLE
circulation: fix request with different locations

### DIFF
--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -159,8 +159,9 @@ def can_be_requested(loan):
     if patron.patron.get('blocked', False):
         return False
 
-    # 2) Check if location allows request
-    location = Location.get_record_by_pid(loan.location_pid)
+    # 2) Check if owning location allows request
+    location_pid = Item.get_record_by_pid(loan.item_pid).holding_location_pid
+    location = Location.get_record_by_pid(location_pid)
     if not location or not location.get('allow_request'):
         return False
 


### PR DESCRIPTION
 Checks the owning location `allow_request` property to decide if an item can be requested.
* Closes rero#2234.
* Logs an error and do a db rollback for holding views.
* Fixes tests that failed every two monthes.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
