### PR TITLE
notifications: use the library name for pickup_name

### DIFF
--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -154,14 +154,16 @@ class Notification(IlsRecord):
             if pickup_location:
                 data['loan']['pickup_location'] = \
                     pickup_location.replace_refs().dumps()
-                data['loan']['pickup_name'] = pickup_location['pickup_name']
                 pickup_library_pid = \
                     data['loan']['pickup_location']['library']['pid']
                 data['loan']['pickup_library'] = \
                     self._get_library_informations(pickup_library_pid)
-            else:
-                location = self.transaction_location.replace_refs().dumps()
-                data['loan']['pickup_name'] = location['library']['name']
+                data['loan']['pickup_name'] = \
+                    pickup_location.get(
+                        'pickup_name', data['loan']['pickup_library']['name'])
+            elif self.transaction_location:
+                data['loan']['pickup_name'] = \
+                    data['loan']['transaction_library']['name']
 
             document = self.document.replace_refs().dumps()
             data['loan']['document'] = document


### PR DESCRIPTION
* Uses the pickup library name when the location is not pickup anymore.
* Fixes the pickup name when the pickup location is not available.


Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
