### PR TITLE
notifications: fix overdue without library open days

### DIFF
--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -19,6 +19,7 @@
 """API for manipulating Circulation policies."""
 from __future__ import absolute_import, print_function
 
+import math
 import sys
 from functools import partial
 
@@ -353,7 +354,8 @@ class CircPolicy(IlsRecord):
         :param limit: the number of day limit. All reminders defined after
                       these limit will not be returned
         """
-        limit = limit or sys.maxsize
+        if limit is None:
+            limit = math.inf
         for reminder in self.get('reminders', []):
             if reminder.get('type') == reminder_type \
                and reminder.get('days_delay') <= limit:


### PR DESCRIPTION
* Does not send overdue notification if the library is closed between
  the end date and the processing date.
* Closes: #2303.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
