### PR TITLE
acquisition: add notes fields for order/order_line

### DIFF
--- a/rero_ils/modules/acq_order_lines/dumpers.py
+++ b/rero_ils/modules/acq_order_lines/dumpers.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition order line dumpers."""
+
+from invenio_records.dumpers import Dumper as InvenioRecordsDumper
+
+from rero_ils.modules.documents.utils import title_format_text_head
+
+
+class AcqOrderLineESDumper(InvenioRecordsDumper):
+    """ElasticSearch dumper class for an AcqOrderLine."""
+
+    def dump(self, record, data):
+        """Dump an AcqOrderLine instance for ElasticSearch.
+
+        For ElasticSearch integration, we need to dump basic informations from
+        a `AcqOrderLine` object instance, and add some data from related
+        object : related account basic informations and related document basic
+        informations.
+
+        :param record: The record to dump.
+        :param data: The initial dump data passed in by ``record.dumps()``.
+        """
+        # Keep only some attributes from AcqOrderLine object initial dump.
+        for attr in ['status', 'order_date', 'reception_date', 'quantity']:
+            value = record.get(attr)
+            if value:
+                data.update({attr: value})
+
+        # Add account informations: pid, name and reference number.
+        # (remove None values from account metadata)
+        account = record.account
+        data['account'] = {
+            'pid': account.pid,
+            'name': account['name'],
+            'number': account.get('number')
+        }
+        data['account'] = {k: v for k, v in data['account'].items() if v}
+
+        # Add document informations: pid, formatted title and ISBN identifiers.
+        # (remove None values from document metadata)
+        document = record.document
+        data['document'] = {
+            'pid': document.pid,
+            'title': title_format_text_head(document.get('title', [])),
+            'identifiers': document.get_identifier_values(filters=['bf:Isbn'])
+        }
+        data['document'] = {k: v for k, v in data['document'].items() if v}
+        return data

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -14,7 +14,7 @@
     "amount",
     "discount_amount",
     "exchange_rate",
-    "note"
+    "notes"
   ],
   "required": [
     "$schema",
@@ -49,6 +49,10 @@
       ],
       "default": "approved",
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "type": "selectWithSort",
         "options": [
           {
@@ -80,13 +84,23 @@
       "title": "Amount",
       "type": "number",
       "default": 0,
-      "minimum": 0
+      "minimum": 0,
+      "form": {
+        "fieldMap": "amount"
+      }
     },
     "discount_amount": {
       "title": "Discount amount",
       "type": "number",
       "default": 0,
-      "minimum": 0
+      "minimum": 0,
+      "form": {
+        "hide": true,
+        "fieldMap": "amount",
+        "navigation": {
+          "essential": true
+        }
+      }
     },
     "total_amount": {
       "title": "Total amount",
@@ -97,12 +111,91 @@
     "exchange_rate": {
       "title": "Exchange rate",
       "type": "number",
-      "minimum": 0
+      "minimum": 0,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     },
-    "note": {
-      "title": "Note",
-      "type": "string",
-      "minLength": 9
+    "notes": {
+      "title": "Notes",
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "Note",
+        "propertiesOrder": [
+          "type",
+          "content"
+        ],
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "enum": [
+              "staff_note",
+              "vendor_note"
+            ],
+            "default": "staff_note",
+            "form": {
+              "type": "selectWithSort",
+              "options": [
+                {
+                  "label": "vendor_note",
+                  "value": "vendor_note"
+                },
+                {
+                  "label": "staff_note",
+                  "value": "staff_note"
+                }
+              ]
+            }
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "maxLength": 2000,
+            "minLength": 1,
+            "form": {
+              "type": "textarea",
+              "templateOptions": {
+                "rows": 3
+              }
+            }
+          }
+        }
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
+        },
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "type"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one note per type is allowed"
+          }
+        }
+      }
     },
     "order_date": {
       "title": "Order date",
@@ -110,6 +203,10 @@
       "format": "date",
       "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
+        "hideExpression": "field.parent.model.status !== 'ordered' && field.parent.model.status !== 'received'",
+        "expressionProperties": {
+          "templateOptions.required": "field.parent.model.status === 'ordered' || field.parent.model.status === 'received'"
+        },
         "type": "datepicker",
         "placeholder": "Select a date",
         "validation": {
@@ -125,6 +222,10 @@
       "format": "date",
       "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
+        "hideExpression": "field.parent.model.status !== 'received'",
+        "expressionProperties": {
+          "templateOptions.required": "field.parent.model.status === 'received'"
+        },
         "type": "datepicker",
         "placeholder": "Select a date",
         "validation": {

--- a/rero_ils/modules/acq_order_lines/mappings/v7/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/mappings/v7/acq_order_lines/acq_order_line-v0.0.1.json
@@ -87,8 +87,15 @@
       "exchange_rate": {
         "type": "float"
       },
-      "note": {
-        "type": "text"
+      "notes": {
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "content": {
+            "type": "text"
+          }
+        }
       },
       "order_date": {
         "type": "date"

--- a/rero_ils/modules/acq_order_lines/models.py
+++ b/rero_ils/modules/acq_order_lines/models.py
@@ -51,3 +51,10 @@ class AcqOrderLineStatus:
     RECEIVED = 'received'
 
     OPEN = [APPROVED, ORDERED]
+
+
+class AcqOrderLineNoteType:
+    """Type of acquisition order line note."""
+
+    STAFF = 'staff_note'
+    VENDOR = 'vendor_note'

--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -20,6 +20,8 @@
 
 from functools import partial
 
+from flask_babelex import gettext as _
+
 from .extensions import AcquisitionOrderCompleteDataExtension, \
     AcquisitionOrderDynamicFieldsExtension
 from .models import AcqOrderIdentifier, AcqOrderMetadata, AcqOrderStatus
@@ -78,6 +80,19 @@ class AcqOrder(IlsRecord):
             'org': 'organisation'
         }
     }
+
+    def extended_validation(self, **kwargs):
+        """Add additional record validation.
+
+        :return: False if
+            - notes array has multiple notes with same type
+        """
+        # NOTES fields testing
+        note_types = [note.get('type') for note in self.get('notes', [])]
+        if len(note_types) != len(set(note_types)):
+            return _('Can not have multiple notes of same type.')
+
+        return True
 
     @classmethod
     def create(cls, data, id_=None, delete_pid=False,

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -8,7 +8,8 @@
     "vendor",
     "reference",
     "type",
-    "description"
+    "description",
+    "notes"
   ],
   "required": [
     "$schema",
@@ -97,6 +98,80 @@
     },
     "currency": {
       "$ref": "https://bib.rero.ch/schemas/common/currency-v0.0.1.json#/currency"
+    },
+    "notes": {
+      "title": "Notes",
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "Note",
+        "propertiesOrder": [
+          "type",
+          "content"
+        ],
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "enum": [
+              "staff_note",
+              "vendor_note"
+            ],
+            "default": "staff_note",
+            "form": {
+              "type": "selectWithSort",
+              "options": [
+                {
+                  "label": "vendor_note",
+                  "value": "vendor_note"
+                },
+                {
+                  "label": "staff_note",
+                  "value": "staff_note"
+                }
+              ]
+            }
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "maxLength": 2000,
+            "minLength": 1,
+            "form": {
+              "type": "textarea",
+              "templateOptions": {
+                "rows": 3
+              }
+            }
+          }
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
+        },
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "type"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one note per type is allowed"
+          }
+        }
+      }
     },
     "vendor": {
       "title": "Vendor",

--- a/rero_ils/modules/acq_orders/listener.py
+++ b/rero_ils/modules/acq_orders/listener.py
@@ -20,6 +20,7 @@
 
 
 from .api import AcqOrdersSearch
+from ..acq_order_lines.dumpers import AcqOrderLineESDumper
 
 
 def enrich_acq_order_data(sender, json=None, record=None, index=None,
@@ -32,10 +33,11 @@ def enrich_acq_order_data(sender, json=None, record=None, index=None,
     :param doc_type: The document type of the record.
     """
     if index.split('-')[0] == AcqOrdersSearch.Meta.index:
-        # for each related order lines : add some informations
-        json['order_lines'] = []
-        for order_line in record.get_order_lines():
-            json['order_lines'].append(order_line.dump_for_order())
+        # add related order lines metadata
+        json['order_lines'] = [
+            order_line.dumps(dumper=AcqOrderLineESDumper())
+            for order_line in record.get_order_lines()
+        ]
         # other dynamic keys
         json['organisation'] = {
             'pid': record.organisation_pid,

--- a/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -57,6 +57,16 @@
       "total_amount": {
         "type": "float"
       },
+      "notes": {
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "content": {
+            "type": "text"
+          }
+        }
+      },
       "order_lines": {
         "properties": {
           "pid": {

--- a/rero_ils/modules/acq_orders/models.py
+++ b/rero_ils/modules/acq_orders/models.py
@@ -50,3 +50,10 @@ class AcqOrderStatus:
     PENDING = 'pending'
     PARTIALLY_RECEIVED = 'partially_received'
     RECEIVED = 'received'
+
+
+class AcqOrderNoteType:
+    """Type of acquisition order note."""
+
+    STAFF = 'staff_note'
+    VENDOR = 'vendor_note'

--- a/tests/api/acq_order_lines/test_acq_order_lines_rest.py
+++ b/tests/api/acq_order_lines/test_acq_order_lines_rest.py
@@ -26,6 +26,7 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import VerifyRecordPermissionPatch, get_json, postdata, \
     to_relative_url
 
+from rero_ils.modules.acq_order_lines.models import AcqOrderLineNoteType
 from rero_ils.modules.utils import get_ref_for_pid
 
 
@@ -116,7 +117,10 @@ def test_acq_order_lines_post_put_delete(
 
     # Update record/PUT
     data = acq_order_line_fiction_saxon
-    data['note'] = 'Test update note'
+    data['notes'] = [{
+        'type': AcqOrderLineNoteType.STAFF,
+        'content': 'Test update note'
+    }]
     res = client.put(
         item_url,
         data=json.dumps(data),
@@ -126,19 +130,19 @@ def test_acq_order_lines_post_put_delete(
 
     # Check that the returned record matches the given data
     data = get_json(res)
-    assert data['metadata']['note'] == 'Test update note'
+    assert data['metadata']['notes'][0]['content'] == 'Test update note'
 
     res = client.get(item_url)
     assert res.status_code == 200
 
     data = get_json(res)
-    assert data['metadata']['note'] == 'Test update note'
+    assert data['metadata']['notes'][0]['content'] == 'Test update note'
 
     res = client.get(list_url)
     assert res.status_code == 200
 
     data = get_json(res)['hits']['hits'][0]
-    assert data['metadata']['note'] == 'Test update note'
+    assert data['metadata']['notes'][0]['content'] == 'Test update note'
 
     # Delete record/DELETE
     res = client.delete(item_url)
@@ -250,7 +254,10 @@ def test_acq_order_line_secure_api_update(client,
     record_url = url_for('invenio_records_rest.acol_item',
                          pid_value=acq_order_line_fiction_sion.pid)
     data = acq_order_line_fiction_sion
-    data['note'] = 'Test update note'
+    data['notes'] = [{
+        'type': AcqOrderLineNoteType.STAFF,
+        'content': 'Test update note'
+    }]
     res = client.put(
         record_url,
         data=json.dumps(data),

--- a/tests/fixtures/acquisition.py
+++ b/tests/fixtures/acquisition.py
@@ -364,6 +364,12 @@ def acq_order_fiction_martigny_data(acquisition):
     return deepcopy(acquisition.get('acor1'))
 
 
+@pytest.fixture(scope="function")
+def acq_order_fiction_martigny_data_tmp(acquisition):
+    """Load acq_order lib martigny fiction data."""
+    return deepcopy(acquisition.get('acor1'))
+
+
 @pytest.fixture(scope="module")
 def acq_order_fiction_martigny(
         app, lib_martigny, vendor_martigny, acq_order_fiction_martigny_data):
@@ -417,6 +423,12 @@ def acq_order_fiction_sion(
 
 @pytest.fixture(scope="module")
 def acq_order_line_fiction_martigny_data(acquisition):
+    """Load acq_order_line lib martigny fiction data."""
+    return deepcopy(acquisition.get('acol1'))
+
+
+@pytest.fixture(scope="function")
+def acq_order_line_fiction_martigny_data_tmp(acquisition):
     """Load acq_order_line lib martigny fiction data."""
     return deepcopy(acquisition.get('acol1'))
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -86,6 +86,26 @@ def acq_account_schema(monkeypatch):
 
 
 @pytest.fixture()
+def acq_order_schema(monkeypatch):
+    """Acq order Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.acq_orders.jsonschemas',
+        '/acq_orders/acq_order-v0.0.1.json'
+    )
+    return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture()
+def acq_order_line_schema(monkeypatch):
+    """Acq order Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.acq_order_lines.jsonschemas',
+        '/acq_order_lines/acq_order_line-v0.0.1.json'
+    )
+    return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture()
 def budget_schema(monkeypatch):
     """Budget Jsonschema for records."""
     schema_in_bytes = resource_string(

--- a/tests/unit/test_acq_order_lines_jsonschema.py
+++ b/tests/unit/test_acq_order_lines_jsonschema.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition order lines JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+from rero_ils.modules.acq_order_lines.api import AcqOrderLine
+from rero_ils.modules.acq_order_lines.models import AcqOrderLineNoteType
+
+
+def test_notes(app, acq_order_line_schema,
+               acq_order_line_fiction_martigny_data_tmp):
+    """Test notes acq order lines jsonschemas."""
+
+    order_line_data = acq_order_line_fiction_martigny_data_tmp
+    order_line_data['notes'] = [
+        {'type': AcqOrderLineNoteType.STAFF, 'content': 'note content'},
+        {'type': AcqOrderLineNoteType.VENDOR, 'content': 'note content 2'},
+    ]
+    validate(order_line_data, acq_order_line_schema)
+
+    with pytest.raises(ValidationError):
+        order_line_data['notes'] = [
+            {'type': AcqOrderLineNoteType.STAFF, 'content': 'note content'},
+            {'type': AcqOrderLineNoteType.STAFF, 'content': 'note content 2'},
+        ]
+        AcqOrderLine.validate(AcqOrderLine(order_line_data))

--- a/tests/unit/test_acq_orders_jsonschema.py
+++ b/tests/unit/test_acq_orders_jsonschema.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition orders JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+from rero_ils.modules.acq_orders.api import AcqOrder
+from rero_ils.modules.acq_orders.models import AcqOrderNoteType
+
+
+def test_notes(app, acq_order_schema, acq_order_fiction_martigny_data_tmp):
+    """Test notes acq orders jsonschemas."""
+
+    order_data = acq_order_fiction_martigny_data_tmp
+    order_data['notes'] = [
+        {'type': AcqOrderNoteType.STAFF, 'content': 'note content'},
+        {'type': AcqOrderNoteType.VENDOR, 'content': 'note content 2'},
+    ]
+    validate(order_data, acq_order_schema)
+
+    with pytest.raises(ValidationError):
+        order_data['notes'] = [
+            {'type': AcqOrderNoteType.STAFF, 'content': 'note content'},
+            {'type': AcqOrderNoteType.STAFF, 'content': 'note content 2'},
+        ]
+        AcqOrder.validate(AcqOrder(order_data))


### PR DESCRIPTION
* Adds a 'notes' field for AcqOrder resource.
* Adds a 'notes' field for AcqOrderLine resource.
* Improve serialization for AcqOrderLine resource.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
