### PR TITLE
notifications: add due soon date

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -37,6 +37,7 @@ from invenio_jsonschemas import current_jsonschemas
 from rero_ils.modules.circ_policies.api import DUE_SOON_REMINDER_TYPE, \
     OVERDUE_REMINDER_TYPE, CircPolicy
 
+from .extensions import SetDueSoonDate
 from ..api import IlsRecord, IlsRecordError, IlsRecordsIndexer, \
     IlsRecordsSearch
 from ..errors import NoCirculationActionIsPermitted
@@ -118,6 +119,8 @@ class Loan(IlsRecord):
         "start_date",
         "transaction_date"
     ]
+    # Invenio Records extensions
+    _extensions = [SetDueSoonDate()]
 
     def __init__(self, data, model=None):
         """Loan init."""
@@ -470,20 +473,17 @@ class Loan(IlsRecord):
         return False
 
     def is_loan_due_soon(self, tstamp=None):
-        """Check if a loan is due soon."""
-        from .utils import get_circ_policy
-        if self.state != LoanState.ITEM_ON_LOAN:
-            return False
+        """Check if the loan is due soon.
 
-        circ_policy = get_circ_policy(self)
+        :param tstamp: a timestamp to define the execution time of the function
+                       Default to `datetime.now()`
+        :returns: True if is due soon
+        """
         date = tstamp or datetime.now(timezone.utc)
-        due_date = ciso8601.parse_datetime(self.end_date).replace(
-            tzinfo=timezone.utc)
-        days_before = circ_policy.due_soon_interval_days
-        if days_before:
-            start_date = ciso8601.parse_datetime(self.get('start_date'))
-            due_soon_date = due_date - timedelta(days=days_before)
-            return start_date < due_soon_date <= date < due_date
+        due_soon_date = self.get('due_soon_date')
+        """Check if a loan is due soon."""
+        if due_soon_date:
+            return ciso8601.parse_datetime(due_soon_date) <= date
         return False
 
     @property
@@ -1019,17 +1019,17 @@ def get_loans_count_by_library_for_patron_pid(patron_pid, filter_states=None):
 
 def get_due_soon_loans(tstamp=None):
     """Return all due_soon loans."""
-    due_soon_loans = []
-    results = current_circulation.loan_search_cls() \
+    end_date = tstamp or datetime.now()
+    end_date = end_date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+    query = current_circulation.loan_search_cls() \
         .filter('term', state=LoanState.ITEM_ON_LOAN) \
+        .filter('range', due_soon_date={'lte': end_date})
+    results = query\
         .params(preserve_order=True) \
         .sort({'_created': {'order': 'asc'}}) \
-        .source(['pid']).scan()
-    for record in results:
-        loan = Loan.get_record_by_pid(record.pid)
-        if loan.is_loan_due_soon(tstamp):
-            due_soon_loans.append(loan)
-    return due_soon_loans
+        .source(['pid'])
+    for hit in results.scan():
+        yield Loan.get_record_by_pid(hit.pid)
 
 
 def get_overdue_loan_pids(patron_pid=None, tstamp=None):

--- a/rero_ils/modules/loans/extensions.py
+++ b/rero_ils/modules/loans/extensions.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""RERO ILS common record extensions."""
+
+
+from datetime import timedelta, timezone
+
+import ciso8601
+from invenio_records.extensions import RecordExtension
+
+
+class SetDueSoonDate(RecordExtension):
+    """Set the due soon date when the loan is updated."""
+
+    def pre_commit(self, record):
+        """Add the due soon date.
+
+        :param record: the record metadata.
+        """
+        from .api import LoanState
+        from .utils import get_circ_policy
+        if record.state == LoanState.ITEM_ON_LOAN and record.get('end_date'):
+            circ_policy = get_circ_policy(record)
+            due_date = ciso8601.parse_datetime(record.end_date).replace(
+                tzinfo=timezone.utc)
+            days_before = circ_policy.due_soon_interval_days
+            if days_before:
+                due_soon = due_date - timedelta(days=days_before)
+                due_soon = due_soon.replace(
+                    hour=0, minute=0, second=0, microsecond=0)
+                record['due_soon_date'] = due_soon.isoformat()

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -108,6 +108,11 @@
       "format": "date-time",
       "title": "Transaction end datetime"
     },
+    "due_soon_date": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Due Soon Date"
+    },
     "request_expire_date": {
       "format": "date-time",
       "title": "Request expire datetime",

--- a/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
@@ -56,6 +56,9 @@
       "end_date": {
         "type": "date"
       },
+      "due_soon_date": {
+        "type": "date"
+      },
       "extension_count": {
         "type": "long"
       },

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -285,7 +285,7 @@ def test_due_soon_loans(client, librarian_martigny,
     loan['start_date'] = (start_date - timedelta(days=30)).isoformat()
     loan.update(loan, dbcommit=True, reindex=True)
 
-    due_soon_loans = get_due_soon_loans()
+    due_soon_loans = list(get_due_soon_loans())
     assert due_soon_loans[0].get('pid') == loan_pid
 
     # test due date regarding multiple timezones

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -77,7 +77,8 @@ def test_notifications_task(
     end_date = datetime.now(timezone.utc) + timedelta(days=5)
     loan['end_date'] = end_date.isoformat()
     loan.update(loan, dbcommit=True, reindex=True)
-    due_soon_loans = get_due_soon_loans()
+    flush_index(LoansSearch.Meta.index)
+    due_soon_loans = list(get_due_soon_loans())
     assert due_soon_loans[0].get('pid') == loan_pid
 
     create_notifications(types=[


### PR DESCRIPTION
* Adds a new `due_soon_date` property.
* Computes the due soon loan from elasticsearch.
* Creates a loan extension to put the new due soon property at each
  update.

__Note__: need to update the es mapping and do a mass correction for the loan ON_LOAN to update the due_soon_date.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
