### PR TITLE
notifications: process due soon, overdue almost without delay

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -322,22 +322,6 @@ CELERY_BEAT_SCHEDULE = {
         'enabled': False,
         # TODO: in production set this up once a day
     },
-    'notification-dispatch-due_soon': {
-        'task': 'rero_ils.modules.notifications.tasks.process_notifications',
-        'schedule': crontab(minute="*/15"),
-        'kwargs': {
-            'notification_type': NotificationType.DUE_SOON
-        },
-        'enabled': False,
-    },
-    'notification-dispatch-overdue': {
-        'task': 'rero_ils.modules.notifications.tasks.process_notifications',
-        'schedule': timedelta(minutes=15),
-        'kwargs': {
-            'notification_type': NotificationType.OVERDUE
-        },
-        'enabled': False,
-    },
     'notification-dispatch-availability': {
         'task': 'rero_ils.modules.notifications.tasks.process_notifications',
         'schedule': timedelta(minutes=15),

--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -307,17 +307,18 @@ def update_mapping(aliases):
     if not aliases:
         aliases = current_search.aliases.keys()
     for alias in aliases:
-        index, f_mapping = next(
-            iter(current_search.aliases.get(alias).items()))
-        mapping = json.load(open(f_mapping))
-        res = current_search_client.indices.put_mapping(
-            mapping.get('mappings'), index)
-        if res.get('acknowledged'):
-            click.secho(
-                f'index: {index} has been sucessfully updated', fg='green')
-        else:
-            click.secho(
-                f'error: {res}', fg='red')
+        for index, f_mapping in iter(
+            current_search.aliases.get(alias).items()
+        ):
+            mapping = json.load(open(f_mapping))
+            res = current_search_client.indices.put_mapping(
+                mapping.get('mappings'), index)
+            if res.get('acknowledged'):
+                click.secho(
+                    f'index: {index} has been sucessfully updated', fg='green')
+            else:
+                click.secho(
+                    f'error: {res}', fg='red')
 
 
 @fixtures.command('create')

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -73,7 +73,7 @@ def create_notifications(types=None, tstamp=None, verbose=True):
             loan.create_notification(
                 _type=NotificationType.DUE_SOON)
             notification_counter[NotificationType.DUE_SOON] += 1
-
+        process_notifications(NotificationType.DUE_SOON)
     # OVERDUE NOTIFICATIONS
     if NotificationType.OVERDUE in types:
         logger.debug("OVERDUE_NOTIFICATION_CREATION --------------")
@@ -110,6 +110,7 @@ def create_notifications(types=None, tstamp=None, verbose=True):
                 else:
                     logger.debug(f'  --> Overdue notification#{idx+1} skipped '
                                  f':: already sent')
+        process_notifications(NotificationType.OVERDUE)
     notification_sum = sum(notification_counter.values())
     counters = {k: v for k, v in notification_counter.items() if v > 0}
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -522,7 +522,7 @@ then
     eval ${PREFIX} invenio oaiharvester harvest -n ebooks -q -k
 else
     eval ${PREFIX} invenio scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -n collect-stats -v
-    eval ${PREFIX} invenio scheduler enable_tasks -n notification-creation -n notification-dispatch-due_soon -n notification-dispatch-overdue -n notification-dispatch-availability -n notification-dispatch-recall -v
+    eval ${PREFIX} invenio scheduler enable_tasks -n notification-creation -n notification-dispatch-availability -n notification-dispatch-recall -v
     info_msg "For ebooks harvesting run:"
     msg "\tinvenio oaiharvester harvest -n ebooks -a max=100 -q"
 fi

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1182,7 +1182,7 @@
         "days_delay": 12,
         "fee_amount": 2.0,
         "communication_channel": "mail",
-        "template": "email/overdue2"
+        "template": "email/overdue"
       }
     ],
     "number_renewals": 1,

--- a/tests/unit/test_circ_policies_jsonschema.py
+++ b/tests/unit/test_circ_policies_jsonschema.py
@@ -166,7 +166,7 @@ def test_circ_policy_reminders(circ_policy_schema,
     with pytest.raises(ValidationError):
         overdue_reminder1 = deepcopy(overdue_reminder)
         overdue_reminder2 = deepcopy(overdue_reminder)
-        overdue_reminder2['template'] = 'email/overdue2'
+        overdue_reminder2['template'] = 'email/overdue'
         cipo['reminders'].extend([overdue_reminder1, overdue_reminder2])
         validate(cipo, circ_policy_schema)  # valid for JSON schema
         cipo.validate()  # invalid against extented_validation rules


### PR DESCRIPTION
* Removes celery task to process the due soon and overdue notifications.
* Process due soon and overdue just after creation.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
