### PR TITLE
locations: improve reason not to delete

### DIFF
--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -143,27 +143,14 @@ class Location(IlsRecord):
         loans_count = self.get_number_of_loans()
         if loans_count:
             links['loans'] = loans_count
-
         return links
 
     def reasons_not_to_delete(self):
         """Get reasons not to delete record."""
-        from ..loans.api import LoansSearch
         cannot_delete = {}
         links = self.get_links_to_me()
         if links:
             cannot_delete['links'] = links
-        other = {}
-        pickup_location_count = LoansSearch() \
-            .filter('term', pickup_location_pid=self.pid).count()
-        if pickup_location_count:
-            other['loans pickup locations'] = pickup_location_count
-        transaction_location_count = LoansSearch() \
-            .filter('term', transaction_location_pid=self.pid).count()
-        if transaction_location_count:
-            other['loans transaction locations'] = transaction_location_count
-        if other:
-            cannot_delete['other'] = other
         return cannot_delete
 
     @property

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -1075,7 +1075,6 @@ def test_delete_pickup_location(
     # We can not delete location used as transaction or pickup location
     # # any more.
     reasons_not_to_delete = loc_restricted_martigny.reasons_not_to_delete()
-    assert reasons_not_to_delete == {'links': {
-        'loans': 1}, 'other': {'loans pickup locations': 1}}
+    assert reasons_not_to_delete == {'links': {'loans': 1}}
     with pytest.raises(IlsRecordError.NotDeleted):
         loc_restricted_martigny.delete(dbcommit=True, delindex=True)


### PR DESCRIPTION
* If the location is used in an activ loan as pickup or transaction location,
  the reeason not to delete is now returned as `links` `loans` `count`.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
