### PR TITLE
patrons: improve patron dumping

### DIFF
--- a/rero_ils/modules/patrons/extensions.py
+++ b/rero_ils/modules/patrons/extensions.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron record extensions."""
+
+from invenio_records.extensions import RecordExtension
+
+from rero_ils.modules.users.api import User
+
+
+class UserDataExtension(RecordExtension):
+    """Add related user data extension."""
+
+    def pre_dump(self, record, data, dumper=None):
+        """Add user data.
+
+        :param record: the record metadata.
+        :param data: The dumped data dictionary.
+        :param dumper: Dumper to use when dumping the record.
+        :return the future dumped data.
+        """
+        user = User.get_by_id(record.get('user_id'))
+        user_info = user.dumpsMetadata()
+        return data.update(user_info)

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -345,3 +345,8 @@ def test_patron_multiple(patron_sion_multiple, patron2_martigny, lib_martigny):
         ['patron']
     assert Patron.get_record_by_pid(patron2_martigny.pid).get('roles') == \
         ['patron']
+
+
+def test_patron_profile_url(org_martigny, patron2_martigny):
+    """Test patron profile url."""
+    assert org_martigny.get('code') in patron2_martigny.profile_url


### PR DESCRIPTION
Use the `pre_dump` extension hook (from invenio-records) to enrich the
patron data with the related User information. This change allow to use
user information with a specific Patron dumper class.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
