### PR TITLE
templates: prevent resolving $ref from data field

### DIFF
--- a/rero_ils/modules/templates/api.py
+++ b/rero_ils/modules/templates/api.py
@@ -17,7 +17,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """API for manipulating Templates."""
-
 from functools import partial
 
 from .extensions import RemoveDataPidExtension
@@ -69,6 +68,16 @@ class Template(IlsRecord):
             'ptrn': 'creator'
         }
     }
+
+    def replace_refs(self):
+        """Replace the ``$ref`` keys within the JSON."""
+        # For template, we doesn't need to resolve $ref inside the ``data``
+        # attribute. Other $ref should be resolve.
+        data = self.pop('data', {})
+        dumped = super().replace_refs()
+        dumped['data'] = data
+        self['data'] = data
+        return dumped
 
     @property
     def creator_pid(self):


### PR DESCRIPTION
the `$ref` from the template data doesn't need to be resolved when the
record is indexed into ES. This should be cause indexing errors if the
related resource doesn't exists anymore and we will not consider this
spacial case.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
