### PR TITLE
documents: prevent referenced document deletion

### DIFF
--- a/rero_ils/modules/acq_order_lines/api.py
+++ b/rero_ils/modules/acq_order_lines/api.py
@@ -136,12 +136,6 @@ class AcqOrderLine(IlsRecord):
         from ..acq_orders.api import AcqOrder
         return AcqOrder.get_record_by_pid(self.order_pid)
 
-    def get_number_of_acq_order_lines(self):
-        """Get number of aquisition order lines."""
-        results = AcqOrderLinesSearch().filter(
-            'term', acq_order__pid=self.order_pid).source().count()
-        return results
-
 
 class AcqOrderLinesIndexer(IlsRecordsIndexer):
     """Indexing Acquisition Order Line in Elasticsearch."""

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -434,8 +434,12 @@ class IlsRecord(Record):
         """Get Persistent Identifier."""
         return self.get_persistent_identifier(self.id)
 
-    def get_links_to_me(self):
-        """Record links."""
+    def get_links_to_me(self, get_pids=False):
+        """Record links.
+
+        :param get_pids: if True list of linked pids
+                         if False count of linked records
+        """
         return {}
 
     def reasons_not_to_delete(self):

--- a/rero_ils/modules/budgets/api.py
+++ b/rero_ils/modules/budgets/api.py
@@ -27,6 +27,7 @@ from ..fetchers import id_fetcher
 from ..minters import id_minter
 from ..organisations.api import Organisation
 from ..providers import Provider
+from ..utils import sorted_pids
 
 # provider
 BudgetProvider = type(
@@ -67,16 +68,18 @@ class Budget(IlsRecord):
         }
     }
 
-    def get_number_of_acq_accounts(self):
-        """Get number of acq accounts."""
-        results = AcqAccountsSearch().filter(
-            'term', budget__pid=self.pid).source().count()
-        return results
+    def get_links_to_me(self, get_pids=False):
+        """Record links.
 
-    def get_links_to_me(self):
-        """Get number of links."""
+        :param get_pids: if True list of linked pids
+                         if False count of linked records
+        """
         links = {}
-        acq_accounts = self.get_number_of_acq_accounts()
+        query = AcqAccountsSearch().filter('term', budget__pid=self.pid)
+        if get_pids:
+            acq_accounts = sorted_pids(query)
+        else:
+            acq_accounts = query.count()
         if acq_accounts:
             links['acq_accounts'] = acq_accounts
         return links

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -292,11 +292,6 @@ class CircPolicy(IlsRecord):
             others['is_default'] = is_default
         return others
 
-    def get_links_to_me(self):
-        """Get number of links to policy."""
-        links = {}
-        return links
-
     def reasons_not_to_delete(self):
         """Get reasons not to delete policy."""
         cannot_delete = {}

--- a/rero_ils/modules/documents/serializers.py
+++ b/rero_ils/modules/documents/serializers.py
@@ -265,8 +265,8 @@ class DocumentMARCXMLSerializer(JSONSerializer):
                 contribution_pid = contribution.get('agent', {}).get('pid')
                 if contribution_pid:
                     contribution_pids.append(contribution_pid)
-        search = ContributionsSearch(). \
-            filter('terms', pid=list(set(contribution_pids)))
+        search = ContributionsSearch() \
+            .filter('terms', pid=list(set(contribution_pids)))
         es_contributions = {}
         for hit in search.scan():
             contribution = hit.to_dict()

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -45,7 +45,7 @@ from ..organisations.api import Organisation
 from ..providers import Provider
 from ..record_extensions import OrgLibRecordExtension
 from ..utils import extracted_data_from_ref, get_ref_for_pid, \
-    get_schema_for_resource
+    get_schema_for_resource, sorted_pids
 from ..vendors.api import Vendor
 from ...filter import format_date_filter
 
@@ -370,22 +370,19 @@ class Holding(IlsRecord):
                         item['call_number'] = issue_call_number
                     yield item
 
-    def get_number_of_items(self):
-        """Get holding number of items."""
-        results = ItemsSearch().filter(
-            'term', holding__pid=self.pid).source().count()
-        return results
+    def get_links_to_me(self, get_pids=False):
+        """Record links.
 
-    def get_links_to_me(self):
-        """Get links that can block the holding deletion.
-
-        Attached items to a holding record blocks the deletion.
-
-        :return: a list of records links to the holding record.
+        :param get_pids: if True list of linked pids
+                         if False count of linked records
         """
         links = {}
+        query = ItemsSearch().filter('term', holding__pid=self.pid)
+        if get_pids:
+            items = sorted_pids(query)
+        else:
+            items = query.count()
         # get number of attached items
-        items = self.get_number_of_items()
         if items:
             links['items'] = items
         return links

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -88,17 +88,6 @@ class Item(ItemCirculation, ItemIssue):
         except NotFoundError:
             pass
 
-    def get_links_to_me(self):
-        """Get number of links."""
-        links = {}
-        loans = self.get_number_of_loans()
-        if loans:
-            links['loans'] = loans
-        fees = self.get_number_of_loans_with_fees()
-        if fees:
-            links['fees'] = fees
-        return links
-
     def reasons_not_to_delete(self):
         """Get reasons not to delete record."""
         cannot_delete = {}

--- a/rero_ils/modules/organisations/api.py
+++ b/rero_ils/modules/organisations/api.py
@@ -29,6 +29,7 @@ from ..item_types.api import ItemTypesSearch
 from ..libraries.api import LibrariesSearch, Library
 from ..minters import id_minter
 from ..providers import Provider
+from ..utils import sorted_pids
 from ..vendors.api import Vendor, VendorsSearch
 
 # provider
@@ -164,15 +165,19 @@ class Organisation(IlsRecord):
         for pid in pids:
             yield Vendor.get_record_by_pid(pid)
 
-    def get_number_of_libraries(self):
-        """Get number of libraries."""
-        return LibrariesSearch()\
-            .filter('term', organisation__pid=self.pid).source().count()
+    def get_links_to_me(self, get_pids=False):
+        """Record links.
 
-    def get_links_to_me(self):
-        """Get number of links."""
+        :param get_pids: if True list of linked pids
+                         if False count of linked records
+        """
+        query = LibrariesSearch()\
+            .filter('term', organisation__pid=self.pid)
         links = {}
-        libraries = self.get_number_of_libraries()
+        if get_pids:
+            libraries = sorted_pids(query)
+        else:
+            libraries = query.count()
         if libraries:
             links['libraries'] = libraries
         return links

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -1067,3 +1067,13 @@ def set_user_name(sender, user):
         except AttributeError:
             pass
     session['user_name'] = user_name
+
+
+def sorted_pids(query):
+    """Get sorted pids from a ES query."""
+    pids = [hit.pid for hit in query.source('pid').scan()]
+    try:
+        return sorted(pids, key=int)
+    except Exception as err:
+        current_app.logger.info(f'Can not sort pids from query: {err}')
+    return pids

--- a/tests/api/patron_transactions/test_patron_transactions_rest.py
+++ b/tests/api/patron_transactions/test_patron_transactions_rest.py
@@ -479,7 +479,8 @@ def test_patron_subscription_transaction(
         reindex=True,
         delete_pid=True
     )
-    assert subscription.get_number_of_patron_transaction_events() == 1
+    assert subscription.get_links_to_me() == {'events': 1}
+    assert subscription.get_links_to_me(get_pids=True) == {'events': ['9']}
     event = list(subscription.events)[0]
     assert event.get('type') == 'fee'
     assert event.get('subtype') == 'other'

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, print_function
 
 from copy import deepcopy
 
-import mock
 import pytest
 from jsonschema.exceptions import ValidationError
 
@@ -135,10 +134,3 @@ def test_circ_policy_can_delete(app, circ_policy_martigny_data_tmp):
     can, reasons = cipo.can_delete
     assert can
     assert reasons == {}
-
-    with mock.patch(
-            'rero_ils.modules.circ_policies.api.CircPolicy.get_links_to_me'
-    ) as a:
-        a.return_value = {'object': 1}
-        reasons = cipo.reasons_not_to_delete()
-        assert 'links' in reasons

--- a/tests/ui/holdings/test_holdings_item.py
+++ b/tests/ui/holdings/test_holdings_item.py
@@ -123,4 +123,4 @@ def test_holding_delete_after_item_edition(
     assert item.holding_pid == holding_lib_fully.pid
 
     holding = Holding.get_record_by_pid(holding_lib_saxon.pid)
-    assert not holding.get_number_of_items()
+    assert holding.get_links_to_me() == {}

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -254,14 +254,17 @@ def test_items_availability(item_type_missing_martigny,
     item.delete()
 
 
-def test_get_number_of_loans_with_fees(patron_transaction_overdue_saxon):
+def test_get_links_to_me_with_fees(patron_transaction_overdue_saxon):
     """Test for number loans with fees."""
     pttr = patron_transaction_overdue_saxon
     loan = pttr.loan
     item = Item.get_record_by_pid(loan.item_pid)
-    assert item.get_number_of_loans_with_fees() == 1
+    assert item.get_links_to_me() == {'fees': 1, 'loans': 1}
+    assert item.get_links_to_me(get_pids=True) == {
+        'fees': ['1'], 'loans': ['1']}
 
     pttr['status'] = 'closed'
     pttr['total_amount'] = 0
     pttr = pttr.update(pttr, reindex=True, dbcommit=True)
-    assert item.get_number_of_loans_with_fees() == 0
+    assert item.get_links_to_me() == {'loans': 1}
+    assert item.get_links_to_me(get_pids=True) == {'loans': ['1']}


### PR DESCRIPTION
* Adds to the documents `reasons_not_to_delete` function the part of documents count.
* Adds `get_pids` to all `get_links_to_me` functions to get all attached pids or counts.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
