### PR TITLE
acquisition: delete order and its order lines

### DIFF
--- a/rero_ils/modules/acq_orders/extensions.py
+++ b/rero_ils/modules/acq_orders/extensions.py
@@ -22,8 +22,8 @@ from invenio_records.extensions import RecordExtension
 from rero_ils.modules.utils import extracted_data_from_ref
 
 
-class AcquisitionOrderDynamicFieldsExtension(RecordExtension):
-    """Update the total amount by summing the order lines."""
+class AcquisitionOrderExtension(RecordExtension):
+    """Defines the methods needed by an extension."""
 
     def pre_dump(self, record, dumper=None):
         """Called before a record is dumped.
@@ -42,6 +42,18 @@ class AcquisitionOrderDynamicFieldsExtension(RecordExtension):
         """
         data.pop('total_amount', None)
         data.pop('status', None)
+
+    def pre_delete(self, record, force=False):
+        """Called before a record is deleted.
+
+        :param record: the record metadata.
+        """
+        # For pending orders, we are allowed to delete all of its
+        # line orders without futher checks.
+        # there is no need to check if it is a pending order or not because
+        # the can_delete is already execute in the method self.delete
+        for line in record.get_order_lines():
+            line.delete()
 
 
 class AcquisitionOrderCompleteDataExtension(RecordExtension):

--- a/tests/api/acq_orders/test_acq_orders_rest.py
+++ b/tests/api/acq_orders/test_acq_orders_rest.py
@@ -178,8 +178,8 @@ def test_acq_orders_can_delete(
         acq_order_line_fiction_martigny):
     """Test can delete an acq order."""
     can, reasons = acq_order_fiction_martigny.can_delete
-    assert not can
-    assert reasons['links']['acq_order_lines']
+    assert can
+    assert 'links' not in reasons
 
 
 def test_filtered_acq_orders_get(


### PR DESCRIPTION
* Makes cascade deleting of order lines possible when parent order
   status is still PENDING.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/2281

## Dependencies

My PR depends on the US `US_acquisition`


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
