### PR TITLE
notification: fix loan notification candidates

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -1164,11 +1164,12 @@ class ItemCirculation(ItemRecord):
                 LoanState.ITEM_RETURNED,
             ]).source().count()
 
-    def get_requests(self, sort_by=None, count=False):
+    def get_requests(self, sort_by=None, count=False, pids=False):
         """Return sorted pending, item_on_transit, item_at_desk loans.
 
-        :param sort_by: the sort to appy. default sort is _created.
+        :param sort_by: the sort to result. default sort is _created.
         :param count: if True, return the number of request.
+        :param pids: if True, return the only the pids.
         :return a generator of corresponding request or a request counter.
         """
 
@@ -1177,8 +1178,6 @@ class ItemCirculation(ItemRecord):
             sort_term = sort_by or '_created'
             if sort_term.startswith('-'):
                 (sort_term, order_by) = (sort_term[1:], 'desc')
-                print("sort_term", sort_term)
-                print("order_by", order_by)
             es_query = query\
                 .params(preserve_order=True)\
                 .sort({sort_term: {'order': order_by}})
@@ -1191,7 +1190,12 @@ class ItemCirculation(ItemRecord):
                 LoanState.ITEM_AT_DESK,
                 LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
             ]).source(['pid'])
-        return query.count() if count else _list_obj()
+        if pids:
+            return [hit.pid for hit in query.scan()]
+        elif count:
+            return query.count()
+        else:
+            return _list_obj()
 
     def get_first_loan_by_state(self, state=None):
         """Return the first loan with the given state and attached to item.

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -761,7 +761,11 @@ class Loan(IlsRecord):
 
         candidates = []
         item = Item.get_record_by_pid(self.item_pid)
-        has_request = item.number_of_requests() > 0
+        # Get the number of requests on the related item and exclude myself
+        # from the result list.
+        requests = item.get_requests(pids=True)
+        requests = [loan_pid for loan_pid in requests if loan_pid != self.pid]
+        has_request = len(requests) > 0
 
         # AVAILABILITY NOTIFICATION
         #   If loan (items) just arrived at the library desk we can create


### PR DESCRIPTION
When we check about notification candidates on a loan, we need to
exclude the current loan from the current request list on the related
item.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
