### PR TITLE
acquisition: calculate account encumbrance

### DIFF
--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -42,7 +42,7 @@
       "type": "string",
       "enum": [
         "approved",
-        "canceled",
+        "cancelled",
         "ordered",
         "received"
       ],
@@ -59,8 +59,8 @@
             "label": "approved"
           },
           {
-            "value": "canceled",
-            "label": "canceled"
+            "value": "cancelled",
+            "label": "cancelled"
           },
           {
             "value": "ordered",

--- a/rero_ils/modules/acq_order_lines/listener.py
+++ b/rero_ils/modules/acq_order_lines/listener.py
@@ -17,7 +17,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Signals connector for acquisition order line."""
-from rero_ils.modules.acq_invoices.api import AcquisitionInvoicesSearch
 from rero_ils.modules.acq_order_lines.api import AcqOrderLine, \
     AcqOrderLinesSearch
 
@@ -35,14 +34,3 @@ def enrich_acq_order_line_data(sender, json=None, record=None, index=None,
         order_line = record
         if not isinstance(record, AcqOrderLine):
             order_line = AcqOrderLine.get_record_by_pid(record.get('pid'))
-
-        # Link to invoice
-        #   To compute account encumbrance/expenditure, we need to know if the
-        #   order line is already linked to an invoice.
-        es_query = AcquisitionInvoicesSearch()\
-            .filter('term', invoice_items__acq_order_line__pid=order_line.pid)\
-            .source(['pid']).scan()
-        _exhausted = object()
-        hit = next(es_query, _exhausted)
-        if hit != _exhausted:
-            json['acq_invoice'] = dict(pid=hit.pid, type='acin')

--- a/rero_ils/modules/acq_order_lines/models.py
+++ b/rero_ils/modules/acq_order_lines/models.py
@@ -46,7 +46,7 @@ class AcqOrderLineStatus:
     """Available statuses about an Acquisition Order Line."""
 
     APPROVED = 'approved'
-    CANCELED = 'canceled'
+    CANCELLED = 'cancelled'
     ORDERED = 'ordered'
     RECEIVED = 'received'
 

--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -138,7 +138,7 @@ class AcqOrder(IlsRecord):
                 AcqOrderLineStatus.APPROVED: AcqOrderStatus.PENDING,
                 AcqOrderLineStatus.ORDERED: AcqOrderStatus.ORDERED,
                 AcqOrderLineStatus.RECEIVED: AcqOrderStatus.RECEIVED,
-                AcqOrderLineStatus.CANCELED: AcqOrderStatus.CANCELED,
+                AcqOrderLineStatus.CANCELLED: AcqOrderStatus.CANCELLED,
             }
             if statues[0] in map:
                 status = map[statues[0]]

--- a/rero_ils/modules/acq_orders/models.py
+++ b/rero_ils/modules/acq_orders/models.py
@@ -45,7 +45,7 @@ class AcqOrderMetadata(db.Model, RecordMetadataBase):
 class AcqOrderStatus:
     """Available statuses for an acquisition order."""
 
-    CANCELED = 'canceled'
+    CANCELLED = 'cancelled'
     ORDERED = 'ordered'
     PENDING = 'pending'
     PARTIALLY_RECEIVED = 'partially_received'

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -147,9 +147,9 @@ class Dispatcher:
         #    notification 'status' and stop the notification processing.
         can_cancel, reason = Dispatcher._can_cancel_notification(data, item)
         if can_cancel:
-            msg = f'Notification #{notification.pid} canceled: {reason}'
+            msg = f'Notification #{notification.pid} cancelled: {reason}'
             current_app.logger.info(msg)
-            notification.update_process_date(sent=False, status='canceled')
+            notification.update_process_date(sent=False, status='cancelled')
             return
 
         # 3. Find the communication channel to use to dispatch this
@@ -290,7 +290,7 @@ class Dispatcher:
 
     @staticmethod
     def _can_cancel_notification(data, item):
-        """Check if a notification must be be canceled.
+        """Check if a notification must be be cancelled.
 
         As notification process could be asynchronous, in some case, when the
         notification is processed, it's not anymore required to be sent.
@@ -299,7 +299,7 @@ class Dispatcher:
 
         :param data: the notification data to check.
         :param item: the notification related item
-        :return True if the notification can be canceled, False otheriwse.
+        :return True if the notification can be cancelled, False otheriwse.
         """
         n_type = data['notification_type']
         loan = data['loan']
@@ -317,7 +317,7 @@ class Dispatcher:
         #      corresponding notification has already been sent.
         # b.3) Otherwise, check if the notification type is available into
         #      notification candidates related to the loan. If not, the
-        #      notification can be canceled.
+        #      notification can be cancelled.
         if n_type not in NotificationType.INTERNAL_NOTIFICATIONS:
             if n_type == NotificationType.RECALL:
                 if item.status != ItemStatus.ON_LOAN:

--- a/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
+++ b/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
@@ -58,7 +58,7 @@
       "default": "created",
       "enum": [
         "created",
-        "canceled",
+        "cancelled",
         "done"
       ]
     },

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -991,7 +991,7 @@ def test_cancel_notifications(
     mailbox.clear()
     process_notifications(NotificationType.AVAILABILITY)
     notification = get_notification(loan, NotificationType.AVAILABILITY)
-    notification['status'] == 'canceled'
+    notification['status'] == 'cancelled'
     assert len(mailbox) == 0
     # restore to initial state
     res, data = postdata(
@@ -1048,7 +1048,7 @@ def test_booking_notifications(client, patron_martigny, patron_sion,
         'transaction_user_pid': librarian_fully.pid
     }
     _, actions = item_lib_martigny.checkin(**params)
-    # the checked in loan is canceled and the requested loan is in transit for
+    # the checked in loan is cancelled and the requested loan is in transit for
     # pickup
     loan = Loan.get_record_by_pid(request_loan_pid)
     assert loan.state == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP


### PR DESCRIPTION
* Calculates account encumbrance for ordered and approved order lines.
* Ignores cancelled order lines when calculating account encumbrance.
* Sets account expenditure to 0 until the invoicing logic is added.
* Replaces canceled by cancelled when found.


Co-Authored-by: Aly Badr <aly.badr@rero.ch>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
