### PR TITLE
documents: fix libraries aggregations

### DIFF
--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -64,9 +64,8 @@ class LibrariesSearch(IlsRecordsSearch):
         query = self.filter('term', organisation__pid=org_pid)
         if fields:
             query = query.source(includes=fields)
-        response = query.execute()
-        for hit in response.hits.hits:
-            yield hit._source
+        for result in query.scan():
+            yield result
 
 
 class Library(IlsRecord):


### PR DESCRIPTION
* Limits the number of terms in the libraries aggregations facets from
10 to 50.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
