### PR TITLE
theme: fix wrong URL on production front pages

### DIFF
--- a/rero_ils/theme/templates/rero_ils/_frontpage_block_global.html
+++ b/rero_ils/theme/templates/rero_ils/_frontpage_block_global.html
@@ -80,7 +80,7 @@
     <li><a href="https://doc.rero.ch/?ln=en">RERO DOC digital library</a></li>
     <li><a href="https://sonar.rero.ch/?ln=en">SONAR - Swiss Open Access Repository</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=en">Swisscovery</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=en_US">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=en">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=en">Helveticat (Swiss National Library)</a></li>
   </ul>
   {% endif %}
@@ -95,7 +95,7 @@
     <li><a href="https://doc.rero.ch/?ln=fr">Bibliothèque numérique RERO DOC</a></li>
     <li><a href="https://sonar.rero.ch/?ln=fr">SONAR - Swiss Open Access Repository</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=fr">Swisscovery</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=FR">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat (Bibliothèque nationale suisse)</a></li>
   </ul>
   {% endif %}
@@ -110,7 +110,7 @@
     <li><a href="https://doc.rero.ch/?ln=de">Digitale Bibliothek RERO DOC</a></li>
     <li><a href="https://sonar.rero.ch/?ln=de">SONAR - Swiss Open Access Repository</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=de">Swisscovery</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=de_DE">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=de">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=de">Helveticat (Schweizerische Nationalbibliothek)</a></li>
   </ul>
   {% endif %}
@@ -125,7 +125,7 @@
     <li><a href="https://doc.rero.ch/?ln=it">Biblioteca digitale RERO DOC</a></li>
     <li><a href="https://sonar.rero.ch/?ln=it">SONAR - Swiss Open Access Repository</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=fr">Swisscovery</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=FR">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=it">Helveticat (Biblioteca nazionale svizzera)</a></li>
   </ul>
   {% endif %}

--- a/rero_ils/theme/templates/rero_ils/_frontpage_block_rbnj.html
+++ b/rero_ils/theme/templates/rero_ils/_frontpage_block_rbnj.html
@@ -158,7 +158,7 @@
   <ul class="list-unstyled">
     <li><a href="/">Tout RERO</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=fr">Swisscovery (universités et hautes écoles)</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr_FR&fromRedirectFilter=true">RenouVaud (Vaud)</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=fr">RenouVaud (Vaud)</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat (Bibliothèque nationale suisse)</a></li>
     <li><a href="https://catalogue-bm.geneve.ch/">Bibliothèque de la Ville de Genève</a></li>
   </ul>
@@ -168,7 +168,7 @@
   <ul class="list-unstyled">
     <li><a href="/">Tout RERO</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=fr">Swisscovery (universités et hautes écoles)</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr_FR&fromRedirectFilter=true">RenouVaud (Vaud)</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=fr">RenouVaud (Vaud)</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat (Bibliothèque nationale suisse)</a></li>
     <li><a href="https://catalogue-bm.geneve.ch/">Bibliothèque de la Ville de Genève</a></li>
   </ul>
@@ -178,7 +178,7 @@
   <ul class="list-unstyled">
     <li><a href="/">Tout RERO</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=fr">Swisscovery (universités et hautes écoles)</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr_FR&fromRedirectFilter=true">RenouVaud (Vaud)</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=fr">RenouVaud (Vaud)</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat (Bibliothèque nationale suisse)</a></li>
     <li><a href="https://catalogue-bm.geneve.ch/">Bibliothèque de la Ville de Genève</a></li>
   </ul>
@@ -188,7 +188,7 @@
   <ul class="list-unstyled">
     <li><a href="/">Tout RERO</a></li>
     <li><a href="https://swisscovery.slsp.ch/discovery/search?vid=41SLSP_NETWORK:VU1_UNION&lang=fr">Swisscovery (universités et hautes écoles)</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr_FR&fromRedirectFilter=true">RenouVaud (Vaud)</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=fr">RenouVaud (Vaud)</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat (Bibliothèque nationale suisse)</a></li>
     <li><a href="https://catalogue-bm.geneve.ch/">Bibliothèque de la Ville de Genève</a></li>
   </ul>

--- a/rero_ils/theme/templates/rero_ils/_frontpage_block_vs.html
+++ b/rero_ils/theme/templates/rero_ils/_frontpage_block_vs.html
@@ -139,7 +139,7 @@
   <ul class="list-unstyled">
     <li><a href="https://www.bibliovalais.ch">Biblio Valais</a></li>
     <li><a href="https://www.vallesiana.ch/#!search">Vallesiana</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=en">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat</a></li>
     <li><a href="https://www.e-rara.ch/?lang=fr">E-rara.ch</a></li>
   </ul>
@@ -154,7 +154,7 @@
   <ul class="list-unstyled">
     <li><a href="https://www.bibliovalais.ch">Biblio Valais</a></li>
     <li><a href="https://www.vallesiana.ch/#!search">Vallesiana</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat</a></li>
     <li><a href="https://www.e-rara.ch/?lang=fr">E-rara.ch</a></li>
   </ul>
@@ -184,7 +184,7 @@
   <ul class="list-unstyled">
     <li><a href="https://www.bibliovalais.ch">Biblio Valais</a></li>
     <li><a href="https://www.vallesiana.ch/#!search">Vallesiana</a></li>
-    <li><a href="https://renouvaud.hosted.exlibrisgroup.com/primo-explore/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
+    <li><a href="https://renouvaud1.primo.exlibrisgroup.com/discovery/search?vid=41BCULAUSA_LIB:VU2&lang=fr">Renouvaud</a></li>
     <li><a href="https://www.helveticat.ch/discovery/search?vid=41SNL_51_INST:helveticat&lang=fr">Helveticat</a></li>
     <li><a href="https://www.e-rara.ch/?lang=fr">E-rara.ch</a></li>
   </ul>


### PR DESCRIPTION
* Corrects the link for Renouvaud on all front pages used in production.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To fix the production front page.

## How to test?

- Check changes. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
