### PR TITLE
templates: suppress links from the data section

### DIFF
--- a/rero_ils/modules/templates/api.py
+++ b/rero_ils/modules/templates/api.py
@@ -19,7 +19,7 @@
 """API for manipulating Templates."""
 from functools import partial
 
-from .extensions import RemoveDataPidExtension
+from .extensions import CleanDataDictExtension
 from .models import TemplateIdentifier, TemplateMetadata
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from ..fetchers import id_fetcher
@@ -56,7 +56,7 @@ class TemplatesSearch(IlsRecordsSearch):
 class Template(IlsRecord):
     """Templates class."""
 
-    _extensions = [RemoveDataPidExtension()]
+    _extensions = [CleanDataDictExtension()]
 
     minter = template_id_minter
     fetcher = template_id_fetcher

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3825,7 +3825,11 @@
     },
     "visibility": "public",
     "template_type": "patrons",
-    "data": {}
+    "data": {
+      "patron": {
+        "source": "imported"
+      }
+    }
   },
   "illr1": {
     "$schema": "https://bib.rero.ch/schemas/ill_requests/ill_request-v0.0.1.json",

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -1001,6 +1001,26 @@ def templ_item_public_martigny(
 
 
 @pytest.fixture(scope="module")
+def templ_hold_public_martigny_data(data):
+    """Load template for a public holding martigny data."""
+    return deepcopy(data.get('tmpl4'))
+
+
+@pytest.fixture(scope="module")
+def templ_hold_public_martigny(
+        app, org_martigny, templ_hold_public_martigny_data,
+        system_librarian_martigny):
+    """Load template for a public holding martigny."""
+    template = Template.create(
+        data=templ_hold_public_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(TemplatesSearch.Meta.index)
+    return template
+
+
+@pytest.fixture(scope="module")
 def templ_patron_public_martigny_data(data):
     """Load template for a public patron martigny data."""
     return deepcopy(data.get('tmpl6'))


### PR DESCRIPTION
* Removes all fields from the template data dictionary that are linked to
  other records or that causes issues with the circulation module and
  with data integrity at the creation of the templates.
* Closes #2385.
* Fixes problem when librarian can be deleted even if they own templates.

## Migration instruction ##

Use the following command to clean up the current templates saved in database:
The current templates will be backed-up in this file `templates.json`

```
poetry run tools.py tools migration clean_templates -o templates.json
```

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

https://tree.taiga.io/project/rero21-reroils/task/2296

## How to test ##

* try to create new records from the current templates (type: document, items, holdings, patrons) and make sure the created record is correctly created.
* create a new template  (type: document, items, holdings, patrons) 
* make sure the new created template is usable
* The following fields are no longer exist in templates:
   items: 'barcode', 'status', 'document', 'holding', 'organisation', 'library'
   holdings: 'organisation', 'library', 'document'
   patrons: 'user_id', 'patron.subscriptions', 'patron.barcode'
* the librarian/owner of the template can not be removed from the database until he deletes his own templates.


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
