### PR TITLE
acquisition: send an order to a vendor

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2526,7 +2526,7 @@ RERO_ILS_NOTIFICATIONS_ALLOWED_TEMPLATE_FILES = [
 # the communication channel, value is the function to call. The used functions
 # should accept one positional argument.
 RERO_ILS_COMMUNICATION_DISPATCHER_FUNCTIONS = {
-    'email': NotificationDispatcher.send_mail_to_patron,
+    'email': NotificationDispatcher.send_notification_by_email,
     'mail': NotificationDispatcher.send_mail_for_printing,
     #  'sms': not_yet_implemented
     #  'telepathy': self.madness_mind

--- a/rero_ils/modules/acq_orders/dumpers.py
+++ b/rero_ils/modules/acq_orders/dumpers.py
@@ -22,6 +22,7 @@ from invenio_records.dumpers import Dumper as InvenioRecordsDumper
 
 from rero_ils.modules.acq_order_lines.dumpers import \
     AcqOrderLineNotificationDumper
+from rero_ils.modules.acq_order_lines.models import AcqOrderLineStatus
 from rero_ils.modules.acq_orders.models import AcqOrderNoteType
 from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.libraries.dumpers import \
@@ -53,7 +54,8 @@ class AcqOrderNotificationDumper(InvenioRecordsDumper):
             dumper=VendorAcquisitionNotificationDumper())
         data['order_lines'] = [
             order_line.dumps(dumper=AcqOrderLineNotificationDumper())
-            for order_line in record.get_order_lines()
+            for order_line in record.get_order_lines(
+                includes=[AcqOrderLineStatus.APPROVED])
         ]
         data = {k: v for k, v in data.items() if v}
         return data

--- a/rero_ils/modules/decorators.py
+++ b/rero_ils/modules/decorators.py
@@ -21,6 +21,7 @@ from functools import wraps
 
 from flask import abort, jsonify, redirect
 from flask_login import current_user
+from werkzeug.exceptions import HTTPException
 
 from rero_ils.permissions import login_and_librarian, login_and_patron
 
@@ -73,6 +74,8 @@ def jsonify_error(func):
     def decorated_view(*args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except HTTPException as httpe:
+            return jsonify({'message': f'{httpe}'}), httpe.code
         except Exception as error:
             # raise error
             # current_app.logger.error(str(error))

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -176,13 +176,14 @@ class Notification(IlsRecord, ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_recipients(self):
+    def get_recipients(self, address_type):
         """Get the notification recipients email address.
 
         If the notification should be dispatched by email (see
         ``Notification.get_communication_channel()``, this method must return
         the list of email addresses where to send the notification to.
 
+        :param address_type: the type of address to get (to, cc, reply_to, ...)
         :return return email addresses list where send the notification to.
         """
         raise NotImplementedError()
@@ -199,10 +200,16 @@ class Notification(IlsRecord, ABC):
         raise NotImplementedError()
 
     # GETTER METHODS ==========================================================
+
     @property
     def type(self):
         """Shortcut for notification type."""
         return self.get('notification_type')
+
+    @property
+    def status(self):
+        """Shortcut for notification status."""
+        return self.get('status')
 
     @property
     def patron_transactions(self):

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -26,7 +26,7 @@ from invenio_mail.tasks import send_email as task_send_email
 from rero_ils.modules.libraries.api import email_notification_type
 
 from .api import Notification
-from .models import NotificationType
+from .models import NotificationType, RecipientType
 
 
 class Dispatcher:
@@ -219,9 +219,7 @@ class Dispatcher:
             error_reasons.append('Missing notification reply_to email')
         if error_reasons:
             current_app.logger.warning(
-                'Notification for printing is lost for patron: '
-                f'{notification.patron.pid} '
-                f'send to library: {library.pid} '
+                f'Notification#{notification.pid} for printing is lost :: '
                 f'({")(".join(error_reasons)})')
             return False
 
@@ -246,7 +244,7 @@ class Dispatcher:
         return True
 
     @staticmethod
-    def send_mail_to_patron(notifications):
+    def send_notification_by_email(notifications):
         """Send the notification by email to the patron.
 
         :param notifications: the notification set to perform.
@@ -257,10 +255,8 @@ class Dispatcher:
             return True
 
         notification = notifications[0]
-        patron = notification.patron
-        library = notification.library
-        reply_to = library.get('email')
-        recipients = notification.get_recipients()
+        reply_to = notification.get_recipients(RecipientType.REPLY_TO)[0]
+        recipients = notification.get_recipients(RecipientType.TO)
 
         error_reasons = []
         if not recipients:
@@ -269,9 +265,7 @@ class Dispatcher:
             error_reasons.append('Missing reply_to email')
         if error_reasons:
             current_app.logger.warning(
-                'Notification is lost for patron: '
-                f'{patron.pid} '
-                f'send to library: {library.pid} '
+                f'Notification#{notification.pid} is lost :: '
                 f'({")(".join(error_reasons)})')
             return False
 

--- a/rero_ils/modules/notifications/extensions.py
+++ b/rero_ils/modules/notifications/extensions.py
@@ -35,6 +35,7 @@ class NotificationSubclassExtension(RecordExtension):
     def _get_circulation_subclass(record):
         """Get the Notification subclass to use based on record data."""
         from .api import Notification
+        from .subclasses.acq_order import AcquisitionOrderNotification
         from .subclasses.availability import \
             AvailabilityCirculationNotification
         from .subclasses.booking import BookingCirculationNotification
@@ -50,6 +51,7 @@ class NotificationSubclassExtension(RecordExtension):
             NotificationType.RECALL: RecallCirculationNotification,
             NotificationType.REQUEST: RequestCirculationNotification,
             NotificationType.TRANSIT_NOTICE: TransitCirculationNotification,
+            NotificationType.ACQUISITION_ORDER: AcquisitionOrderNotification,
         }
         try:
             return mapping[record.type]

--- a/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
+++ b/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
@@ -76,7 +76,8 @@
                 "enum": [
                   "to",
                   "cc",
-                  "bcc"
+                  "bcc",
+                  "reply_to"
                 ]
               },
               "address": {
@@ -142,7 +143,8 @@
         "recall",
         "transit_notice",
         "request",
-        "booking"
+        "booking",
+        "acquisition_order"
       ]
     },
     "context": {

--- a/rero_ils/modules/notifications/models.py
+++ b/rero_ils/modules/notifications/models.py
@@ -53,6 +53,8 @@ class NotificationType:
     - TRANSIT_NOTICE : when an item is sent to the owning location/library
     - DUE_SOON       : when the loaned item is about to expire.
     - OVERDUE        : when the loaned item is expired.
+    - ACQUISITION_ORDER
+                     : when an acquisition order is send to a vendor.
     """
 
     RECALL = 'recall'
@@ -62,6 +64,7 @@ class NotificationType:
     TRANSIT_NOTICE = 'transit_notice'
     REQUEST = 'request'
     BOOKING = 'booking'
+    ACQUISITION_ORDER = 'acquisition_order'
 
     # All notification types
     ALL_NOTIFICATIONS = [
@@ -111,3 +114,12 @@ class NotificationChannel:
     MAIL = 'mail'
     EMAIL = 'email'
     PATRON_SETTING = 'patron_setting'
+
+
+class RecipientType:
+    """Notification recipient type."""
+
+    TO = 'to'
+    CC = 'cc'
+    BCC = 'bcc'
+    REPLY_TO = 'reply_to'

--- a/rero_ils/modules/notifications/subclasses/acq_order.py
+++ b/rero_ils/modules/notifications/subclasses/acq_order.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""API for manipulating "order" acquisition notifications."""
+
+from __future__ import absolute_import, print_function
+
+from abc import ABC, abstractmethod
+
+from werkzeug.utils import cached_property
+
+from rero_ils.modules.acq_orders.api import AcqOrder
+from rero_ils.modules.acq_orders.dumpers import AcqOrderNotificationDumper
+from rero_ils.modules.libraries.api import Library
+from rero_ils.modules.notifications.api import Notification
+from rero_ils.modules.notifications.models import NotificationChannel, \
+    NotificationType, RecipientType
+from rero_ils.modules.utils import extracted_data_from_ref
+
+
+class AcquisitionOrderNotification(Notification, ABC):
+    """Acquisition order notifications class.
+
+    An acquisition order notification is a message send to the vendor to order
+    an acquisition order that contains some acquisition order lines. it should
+    never be cancelled and is always sent by email (for now).
+
+    Acquisition order notification works synchronously. This means it will be
+    send just after the creation. This also means that it should never be
+    aggregated.
+    """
+
+    def extended_validation(self, **kwargs):
+        """Validate record against schema.
+
+        and extended validation to check that notification is indeed of type
+        acquisition order and it has a valid order pid in its context.
+        """
+        if self.type != NotificationType.ACQUISITION_ORDER:
+            return f"'{self.type} isn't an AcquisitionNotification"
+        if not self.acq_order_pid:
+            return '`order` field must be specified into `context` for ' \
+                   'AcquisitionNotification'
+
+        # validate that at least one email of type `to` exist and one email of
+        # type `reply_to` is given in the ist of emails.
+        recipient_types = set([
+            recipient.get('type')
+            for recipient in self.get('context', {}).get('recipients', [])
+        ])
+        if RecipientType.TO not in recipient_types \
+           or RecipientType.REPLY_TO not in recipient_types:
+            return 'Recipient type `to` and `reply_to` are required'
+        return True
+
+    # PARENT ABSTRACT IMPLEMENTATION METHODS ==================================
+    #  Implementation of `Notification` parent class abstract methods.
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for this notification.
+
+        The acquisition order notification inhirts its organistion links from
+        its parent (order) record.
+        """
+        return self.order.organisation_pid
+
+    @property
+    def aggregation_key(self):
+        """Get the aggregation key for this notification.
+
+        No aggregation needed for the acquisition order notification, as such,
+        we return the string type of the notification id.
+        """
+        return str(self.id)
+
+    def can_be_cancelled(self):
+        """Check if a notification can be canceled.
+
+        As notification process can be asynchronous, in some case, when the
+        notification is processed, it's not anymore required to be sent.
+        The acquisition order notification ca not be cancelled.
+
+        :return a tuple with two values: a boolean to know if the notification
+                can be cancelled; the reason why the notification can be
+                cancelled (only present if tuple first value is True).
+        """
+        if not self.order:
+            return True, "Order doesn't exists anymore"
+        return False, None
+
+    def get_communication_channel(self):
+        """Get the communication channel to use for this notification."""
+        # For now, the channel for sending the acquisition order notification
+        # is always email.
+        return NotificationChannel.EMAIL
+
+    def get_language_to_use(self):
+        """Get the language to use for dispatching the notification."""
+        # By default the language to use to build the notification is defined
+        # in the vendor setting. Override this method if needed in the future.
+        return self.order.vendor.get('communication_language')
+
+    def get_template_path(self):
+        """Get the template to use to render the notification."""
+        # By default the template path to use reflects the notification type.
+        # Override this method if necessary
+        return \
+            f'rero_ils/vendor_order_mail/{self.get_language_to_use()}.tpl.txt'
+
+    def get_recipients(self, address_type):
+        """Get the notification recipients email address.
+
+        If the notification should be dispatched by email (see
+        ``Notification.get_communication_channel()``, this method must return
+        the list of email addresses where to send the notification to.
+
+        :param address_type: the recipient address type.
+        :return return email addresses list where send the notification to.
+        """
+        return [
+            recipient.get('address')
+            for recipient in self.get('context', {}).get('recipients', [])
+            if recipient.get('type') == address_type
+        ]
+
+    @classmethod
+    @abstractmethod
+    def get_notification_context(cls, notifications=None):
+        """Get the context to use to render the corresponding template.
+
+        :param notifications: an array of ``Notification`` to parse to extract
+                              the required data to build the template.
+        :return: a ``dict`` containing all required data to build the template.
+        """
+        context = {}
+        notifications = notifications or []
+        if not notifications:
+            return context
+
+        notification = notifications[0]
+        order = notification.order
+        return {'order': order.dumps(dumper=AcqOrderNotificationDumper())}
+
+    # GETTER & SETTER METHODS =================================================
+    #  Shortcuts to easy access notification attributes.
+
+    @property
+    def acq_order_pid(self):
+        """Shortcut for acq order pid of the notification."""
+        return extracted_data_from_ref(self['context']['order'])
+
+    @cached_property
+    def order(self):
+        """Shortcut for acquisition order related to the notification."""
+        return AcqOrder.get_record_by_pid(self.acq_order_pid)
+
+    @property
+    def library_pid(self):
+        """Get the library pid related to the notification."""
+        return self.order.library_pid
+
+    @cached_property
+    def library(self):
+        """Shortcut for library of the notification."""
+        return Library.get_record_by_pid(self.library_pid)

--- a/rero_ils/modules/notifications/subclasses/booking.py
+++ b/rero_ils/modules/notifications/subclasses/booking.py
@@ -70,9 +70,9 @@ class BookingCirculationNotification(CirculationNotification):
         lib = self.pickup_library or self.transaction_library
         return lib.get('communication_language')
 
-    def get_recipients(self):
-        """Get notification recipient email addresses."""
-        # Booking notification will be sent to the laon transaction library.
+    def get_recipients_to(self):
+        """Get notification email addresses for 'TO' recipient type."""
+        # Booking notification will be sent to the loan transaction library.
         return [email_notification_type(self.transaction_library, self.type)]
 
     @classmethod

--- a/rero_ils/modules/notifications/subclasses/internal.py
+++ b/rero_ils/modules/notifications/subclasses/internal.py
@@ -88,7 +88,7 @@ class InternalCirculationNotification(CirculationNotification, ABC):
         """Get the language to use when dispatching the notification."""
         return self.library.get('communication_language')
 
-    def get_recipients(self):
+    def get_recipients_to(self):
         """Get notification recipient email addresses."""
         # Internal notification will be sent to the library, not to the
         # patron related to the loan.

--- a/rero_ils/modules/notifications/subclasses/request.py
+++ b/rero_ils/modules/notifications/subclasses/request.py
@@ -42,15 +42,15 @@ class RequestCirculationNotification(InternalCirculationNotification):
     after the creation. This also means that it should never be aggregated.
     """
 
-    def get_recipients(self):
-        """Get notification recipient email addresses."""
+    def get_recipients_to(self):
+        """Get notification email addresses for 'TO' recipient type."""
         # Request notification will be sent to the item location if a location
         # ``notification_email`` attribute is defined, otherwise to the library
         # address.
         loc_email = self.location.get('notification_email')
         if loc_email:
             return [loc_email]
-        return super().get_recipients()
+        return super().get_recipients_to()
 
     @classmethod
     def get_notification_context(cls, notifications=None):

--- a/rero_ils/modules/notifications/subclasses/transit.py
+++ b/rero_ils/modules/notifications/subclasses/transit.py
@@ -48,7 +48,7 @@ class TransitCirculationNotification(InternalCirculationNotification):
         """Get the template to use to render the notification."""
         return f'email/transit_notice/{self.get_language_to_use()}.txt'
 
-    def get_recipients(self):
+    def get_recipients_to(self):
         """Get notification recipient email addresses."""
         # Transit notification will be sent to the loan transaction library.
         return [email_notification_type(self.transaction_library, self.type)]

--- a/rero_ils/modules/vendors/api.py
+++ b/rero_ils/modules/vendors/api.py
@@ -22,7 +22,6 @@ from functools import partial
 
 from .models import VendorIdentifier, VendorMetadata
 from ..acq_invoices.api import AcquisitionInvoicesSearch
-from ..acq_orders.api import AcqOrdersSearch
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from ..fetchers import id_fetcher
 from ..minters import id_minter
@@ -86,7 +85,9 @@ class Vendor(IlsRecord):
         :param get_pids: if True list of linked pids
                          if False count of linked records
         """
+        from rero_ils.modules.acq_orders.api import AcqOrdersSearch
         from rero_ils.modules.holdings.api import HoldingsSearch
+
         acq_orders_query = AcqOrdersSearch()\
             .filter('term', vendor__pid=self.pid)
         acq_invoices_query = AcquisitionInvoicesSearch()\

--- a/tests/api/acq_orders/test_acq_orders_views.py
+++ b/tests/api/acq_orders/test_acq_orders_views.py
@@ -20,7 +20,15 @@
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import get_json
+from utils import get_json, postdata
+
+from rero_ils.modules.acq_order_lines.api import AcqOrderLine
+from rero_ils.modules.acq_order_lines.models import AcqOrderLineStatus
+from rero_ils.modules.acq_orders.api import AcqOrder
+from rero_ils.modules.acq_orders.models import AcqOrderStatus
+from rero_ils.modules.notifications.api import Notification
+from rero_ils.modules.notifications.models import NotificationChannel, \
+    NotificationStatus, NotificationType, RecipientType
 
 
 def test_order_notification_preview(
@@ -53,3 +61,92 @@ def test_order_notification_preview(
         assert res.status_code == 200
         data = get_json(res)
         assert 'data' in data and 'preview' in data and 'message' in data
+
+
+def test_send_order(
+    app, client, librarian_martigny, lib_martigny,
+    acq_order_fiction_martigny,
+    acq_order_line_fiction_martigny, vendor_martigny,
+    acq_order_line2_fiction_martigny, acq_order_line3_fiction_martigny
+):
+    """Test send order notification API."""
+    login_user_via_session(client, librarian_martigny.user)
+    acor = acq_order_fiction_martigny
+    address = vendor_martigny.get('default_contact').get('email')
+    emails = [{'type': 'cc', 'address': address}]
+    # test when parent order is not in database
+    res, data = postdata(
+        client,
+        'api_order.send_order',
+        data=dict(emails=emails),
+        url_data=dict(order_pid='toto')
+    )
+    assert res.status_code == 404
+    # test when email data is not provided
+    res, data = postdata(
+        client,
+        'api_order.send_order',
+        url_data=dict(order_pid=acor.pid)
+    )
+    assert res.status_code == 400
+    # test when email data provided but empty
+    res, data = postdata(
+        client,
+        'api_order.send_order',
+        data=dict(emails=[]),
+        url_data=dict(order_pid=acor.pid)
+    )
+    assert res.status_code == 400
+    # test when email data provided and has no "to" email address
+    res, data = postdata(
+        client,
+        'api_order.send_order',
+        data=dict(emails=emails),
+        url_data=dict(order_pid=acor.pid)
+    )
+    assert res.status_code == 400
+    assert 'required' in data['message'] and '`to`' in data['message']
+    # have an order line with a status different than approved and ensure it
+    # will not be ordered
+    l3 = AcqOrderLine.get_record_by_pid(acq_order_line3_fiction_martigny.pid)
+    l3['status'] = AcqOrderLineStatus.CANCELLED
+    l3.update(l3, dbcommit=True, reindex=True)
+
+    # test send order with correct input parameters
+    emails = [
+        {'type': 'to', 'address': address},
+        {'type': 'reply_to', 'address': lib_martigny.get('email')}
+    ]
+    res, data = postdata(
+        client,
+        'api_order.send_order',
+        data=dict(emails=emails),
+        url_data=dict(order_pid=acor.pid)
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    acor = AcqOrder.get_record_by_pid(acor.pid)
+    l1 = AcqOrderLine.get_record_by_pid(acq_order_line_fiction_martigny.pid)
+    l2 = AcqOrderLine.get_record_by_pid(acq_order_line2_fiction_martigny.pid)
+    l3 = AcqOrderLine.get_record_by_pid(acq_order_line3_fiction_martigny.pid)
+    # Approved order lines are ordered
+    assert l1.get('status') == AcqOrderLineStatus.ORDERED
+    assert l2.get('status') == AcqOrderLineStatus.ORDERED
+    # Cancelled order lines remain cancelled (not ordered)
+    assert l3.get('status') == AcqOrderLineStatus.CANCELLED
+    assert acor.status == AcqOrderStatus.ORDERED
+    # ensure that created notification is well constructed from the associated
+    # order and vendor
+    notification_pid = data.get('data').get('pid')
+    notif = Notification.get_record_by_pid(notification_pid)
+    assert notif.organisation_pid == acor.organisation_pid
+    assert notif.aggregation_key == str(notif.id)
+    assert notif.type == NotificationType.ACQUISITION_ORDER
+    assert notif.status == NotificationStatus.DONE
+    assert notif.acq_order_pid == acor.pid
+    assert notif.library_pid == acor.library_pid
+    assert notif.can_be_cancelled() == (False, None)
+    assert notif.get_communication_channel() == NotificationChannel.EMAIL
+    assert notif.get_language_to_use() == \
+        vendor_martigny.get('communication_language')
+    assert address in notif.get_recipients(RecipientType.TO)

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -324,6 +324,23 @@
     "quantity": 2,
     "amount": 500
   },
+  "acol5": {
+    "$schema": "https://bib.rero.ch/schemas/acq_order_lines/acq_order_line-v0.0.1.json",
+    "pid": "acol5",
+    "acq_account": {
+      "$ref": "https://bib.rero.ch/api/acq_accounts/acac1"
+    },
+    "acq_order": {
+      "$ref": "https://bib.rero.ch/api/acq_orders/acor1"
+    },
+    "document": {
+      "$ref": "https://bib.rero.ch/api/documents/doc1"
+    },
+    "status": "approved",
+    "quantity": 1,
+    "priority": 5,
+    "amount": 1000
+  },
   "acin1": {
     "$schema": "https://bib.rero.ch/schemas/acq_invoices/acq_invoice-v0.0.1.json",
     "pid": "acin1",

--- a/tests/fixtures/acquisition.py
+++ b/tests/fixtures/acquisition.py
@@ -468,6 +468,26 @@ def acq_order_line2_fiction_martigny(
 
 
 @pytest.fixture(scope="module")
+def acq_order_line3_fiction_martigny_data(acquisition):
+    """Load acq_order_line lib martigny fiction data."""
+    return deepcopy(acquisition.get('acol5'))
+
+
+@pytest.fixture(scope="module")
+def acq_order_line3_fiction_martigny(
+        app, acq_account_fiction_martigny, document,
+        acq_order_fiction_martigny, acq_order_line3_fiction_martigny_data):
+    """Load acq_order_line lib martigny fiction record."""
+    acol = AcqOrderLine.create(
+        data=acq_order_line3_fiction_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqOrderLinesSearch.Meta.index)
+    return acol
+
+
+@pytest.fixture(scope="module")
 def acq_order_line_fiction_saxon_data(acquisition):
     """Load acq_order_line lib saxon fiction data."""
     return deepcopy(acquisition.get('acol3'))


### PR DESCRIPTION
* Adds necessary methods to create a notification of type
acquisition order to be send to a vendor.
* Sends only non-CANCELLED lines orders for vendor.
* Updates order lines statuses after sending an order.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?
https://tree.taiga.io/project/rero21-reroils/task/2263



## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
