### PR TITLE
cli: reindex into a second index

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -486,12 +486,14 @@ class IlsRecordsIndexer(RecordIndexer):
         return_value = super().delete(record, refresh='true')
         return return_value
 
-    def bulk_index(self, record_id_iterator, doc_type=None):
+    def bulk_index(self, record_id_iterator, doc_type=None, index=None):
         """Bulk index records.
 
         :param record_id_iterator: Iterator yielding record UUIDs.
         """
-        self._bulk_op(record_id_iterator, op_type='index', doc_type=doc_type)
+        self._bulk_op(
+            record_id_iterator, op_type='index', doc_type=doc_type,
+            index=index)
 
     def process_bulk_queue(self, es_bulk_kwargs=None, stats_only=True):
         """Process bulk indexing queue.
@@ -570,6 +572,7 @@ class IlsRecordsIndexer(RecordIndexer):
         index, doc_type = self.record_to_index(record)
 
         arguments = {}
+        index = payload.get('index') or index
         body = self._prepare_record(record, index, doc_type, arguments)
         action = {
             '_op_type': 'index',


### PR DESCRIPTION
* Adds a new option to index a resource into a specific index.
* Changes the indexer to get the index from the payload for bulk
  indexing.
* Adds an utility to be able to switch the elasticsearch index for a
  resource.
* Adds an utility to create a new index for a given resource with the
  corresponding mapping and updating the elasticsearch templates.

Co-Authored-by:  Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Sample of Usage

```bash
export OLDINDEX="documents-document-v0.0.1-1634218385"
export NEWINDEX="documents-document-v0.0.1-20211014"
# create the new index
invenio utils create_index documents ${NEWINDEX}
# put existing document in the new index for indexing
invenio utils reindex -t doc --index ${NEWINDEX} --yes-i-know
# index the documents
invenio utils runindex
# Index the changes in the document during the log indexing process
invenio utils reindex -t doc --index ${NEWINDEX} --yes-i-know -f xxxx
# index the documents
invenio utils runindex
# switch the index for the running application
invenio utils switch_index ${OLDINDEX} ${NEWINDEX}
# remove the old index
invenio index delete ${OLDINDEX}

```

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
