### PR TITLE
acquisition: fix send_order API

### DIFF
--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -17,7 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """API for manipulating Acquisition Orders."""
-
+from datetime import datetime
 from functools import partial
 
 from flask_babelex import gettext as _
@@ -274,10 +274,12 @@ class AcqOrder(IlsRecord):
         # reindex myself. Reload the notification to obtain the right
         # notification metadata (status, process_date, ...)
         if dispatcher_result.get('sent', 0):
+            order_date = datetime.now().strftime('%Y-%m-%d')
             order_lines = self.get_order_lines(
                 includes=[AcqOrderLineStatus.APPROVED])
             for order_line in order_lines:
                 order_line['status'] = AcqOrderLineStatus.ORDERED
+                order_line['order_date'] = order_date
                 order_line.update(order_line, dbcommit=True, reindex=True)
             self.reindex()
             notif = Notification.get_record_by_id(notif.id)


### PR DESCRIPTION
* Adds a test about required `emails` data argument for `send_order` API.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
