### PR TITLE
acquisition: automatic order reference

### DIFF
--- a/rero_ils/modules/acq_orders/extensions.py
+++ b/rero_ils/modules/acq_orders/extensions.py
@@ -81,6 +81,18 @@ class AcquisitionOrderCompleteDataExtension(RecordExtension):
     #     # of just use a vendor reference.
     #     AcquisitionOrderCompleteDataExtension.populate_currency(record)
 
+    def post_create(self, record):
+        """Called after the record is created.
+
+        If no reference is provided, use the PID as auto incremented sequence
+        to use as reference order.
+
+        :param record: the record metadata.
+        """
+        if not record.get('reference'):
+            record['reference'] = f'ORDER-{record.pid}'
+            record.update(record, dbcommit=True, reindex=True)
+
     def pre_commit(self, record):
         """Called before a record is committed.
 

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -15,7 +15,6 @@
     "pid",
     "vendor",
     "library",
-    "reference",
     "type"
   ],
   "properties": {

--- a/tests/api/acquisition/test_acquisition_scenarios.py
+++ b/tests/api/acquisition/test_acquisition_scenarios.py
@@ -393,11 +393,10 @@ def test_acquisition_order(
     order_data = {
         'vendor': {'$ref': get_ref_for_pid('vndr', vendor_martigny.pid)},
         'library': {'$ref': get_ref_for_pid('lib', lib_martigny.pid)},
-        'reference': 'ORDER#1',
         'type': 'monograph',
     }
     order = _make_resource(client, 'acor', order_data)
-    assert order['reference'] == order_data['reference']
+    assert order['reference'] == f'ORDER-{order.pid}'
     assert order.get_order_total_amount() == 0
     assert order.status == AcqOrderStatus.PENDING
     assert order.can_delete


### PR DESCRIPTION
If No reference is specified when creating an `AcqOrder`, the order pid
will be used to populate the reference as an auto-incremented label.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
