### PR TITLE
circulation: add automatic request expiration

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -8,6 +8,7 @@
     },
     "checkout_duration": 30,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -37,6 +38,7 @@
     },
     "checkout_duration": 30,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -66,6 +68,7 @@
     },
     "checkout_duration": 7,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -110,6 +113,7 @@
     },
     "checkout_duration": 14,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -157,6 +161,7 @@
     },
     "checkout_duration": 28,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -211,6 +216,7 @@
     ],
     "checkout_duration": 84,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "number_renewals": 3,
     "renewal_duration": 84,
     "policy_library_level": false,
@@ -267,6 +273,7 @@
     },
     "checkout_duration": 0,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "number_renewals": 0,
     "policy_library_level": false,
     "is_default": false,
@@ -424,6 +431,7 @@
     ],
     "checkout_duration": 28,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "number_renewals": 3,
     "renewal_duration": 30,
     "policy_library_level": false,
@@ -453,6 +461,7 @@
     ],
     "checkout_duration": 30,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "number_renewals": 3,
     "renewal_duration": 30,
     "policy_library_level": false,

--- a/rero_ils/alembic/2b0af71048a7_add_request_expiration_date.py
+++ b/rero_ils/alembic/2b0af71048a7_add_request_expiration_date.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Loans :: Add request expiration field."""
+
+from datetime import datetime, timedelta
+from logging import getLogger
+
+import ciso8601
+import pytz
+from elasticsearch_dsl import Q
+from invenio_circulation.proxies import current_circulation
+
+from rero_ils.modules.loans.api import Loan, LoansIndexer
+from rero_ils.modules.loans.models import LoanState
+
+# revision identifiers, used by Alembic.
+revision = '2b0af71048a7'
+down_revision = 'cc7ffbe1e078'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+
+
+def upgrade():
+    """Update loans records."""
+    query = current_circulation.loan_search_cls() \
+        .filter('term', state=LoanState.ITEM_AT_DESK) \
+        .filter('bool', must_not=[Q('exists', field='request_expire_date')]) \
+        .source('pid').scan()
+    ids = []
+    for hit in query:
+        loan = Loan.get_record_by_pid(hit.pid)
+        trans_date = ciso8601.parse_datetime(loan.transaction_date)
+        expire_date = trans_date + timedelta(days=10)
+        expire_date = expire_date.replace(
+            hour=23, minute=59, second=00, microsecond=000,
+            tzinfo=None)
+        expire_date = pytz.timezone('Europe/Zurich').localize(expire_date)
+        loan['request_expire_date'] = expire_date.isoformat()
+        loan['request_start_date'] = datetime.now().isoformat()
+        loan.update(loan, dbcommit=True, reindex=False)
+        LOGGER.info(f'  * Updated loan#{loan.pid}')
+        ids.append(loan.id)
+    if len(ids):
+        LOGGER.info(f'Indexing {len(ids)} records ....')
+        indexer = LoansIndexer()
+        indexer.bulk_index(ids)
+        count = indexer.process_bulk_queue()
+        LOGGER.info(f'{count} records indexed.')
+    LOGGER.info(f'TOTAL :: {len(ids)}')
+
+
+def downgrade():
+    """Reset loans records."""
+    # Nothing to do :: We can't remove the `request_expire_date` attribute
+    # because the `CirculationDatesExtension` extension will always add a new
+    # value during the record update

--- a/rero_ils/alembic/cc7ffbe1e078_cipo_request_duration_field_creation.py
+++ b/rero_ils/alembic/cc7ffbe1e078_cipo_request_duration_field_creation.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""cipo request duration field creation."""
+
+from logging import getLogger
+
+from rero_ils.modules.circ_policies.api import CircPoliciesSearch, CircPolicy
+
+# revision identifiers, used by Alembic.
+revision = 'cc7ffbe1e078'
+down_revision = '9e3145d88e64'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+
+
+def upgrade():
+    """Update circulation policy records."""
+    query = CircPoliciesSearch() \
+        .filter('term', allow_requests=True) \
+        .source(['pid']).scan()
+    for hit in query:
+        cipo = CircPolicy.get_record_by_pid(hit.pid)
+        cipo['pickup_hold_duration'] = 10  # default value is 10 days
+        cipo.update(cipo, dbcommit=True, reindex=True)
+        LOGGER.info(f'  * Updated cipo#{cipo.pid}')
+    CircPoliciesSearch.flush_and_refresh()
+    LOGGER.info(f'upgrade to {revision}')
+
+
+def downgrade():
+    """Reset circulation policy records."""
+    query = CircPoliciesSearch() \
+        .filter('exists', field='pickup_hold_duration') \
+        .source(['pid']).scan()
+    for hit in query:
+        cipo = CircPolicy.get_record_by_pid(hit.pid)
+        del cipo['pickup_hold_duration']
+        cipo.update(cipo, dbcommit=True, reindex=True)
+        LOGGER.info(f'  * Updated cipo#{cipo.pid}')
+    CircPoliciesSearch.flush_and_refresh()
+    LOGGER.info(f'downgrade to revision {down_revision}')

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -71,7 +71,8 @@ from .modules.items.utils import item_location_retriever, \
     same_location_validator
 from .modules.libraries.api import Library
 from .modules.libraries.permissions import LibraryPermission
-from .modules.loans.api import Loan, LoanState
+from .modules.loans.api import Loan
+from .modules.loans.models import LoanState
 from .modules.loans.permissions import LoanPermission
 from .modules.loans.utils import can_be_requested, get_default_loan_duration, \
     get_extension_params, is_item_available_for_checkout, \
@@ -350,9 +351,13 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute=15, hour=2),  # Every day at 02:15 UTC,
         'enabled': False
     },
+    'cancel-expired-request': {
+        'task': 'rero_ils.modules.loans.tasks.cancel_expired_request_task',
+        'schedule': crontab(minute=15, hour=3),  # Every day at 03:15 UTC,
+        'enabled': False
+    },
     'anonymize-loans': {
-        'task': ('rero_ils.modules.loans.tasks'
-                 '.loan_anonymizer'),
+        'task': 'rero_ils.modules.loans.tasks.loan_anonymizer',
         'schedule': crontab(minute=0, hour=7),  # Every day at 07:00 UTC,
         'enabled': False
     },
@@ -2565,8 +2570,17 @@ JSONSCHEMAS_LOADER_CLS = 'rero_ils.jsonschemas.utils.JsonLoader'
 # =======
 OAISERVER_ID_PREFIX = 'oai:bib.rero.ch:'
 
+# =============================================================================
+# RERO_ILS LOANS SPECIAL CONFIGURATION
+# =============================================================================
+
+# Specify the default request duration if no data could be found into the
+# circulation policy related to a loan that allows request.
+RERO_ILS_DEFAULT_PICKUP_HOLD_DURATION = 10
+
+# =============================================================================
 # ANONYMISATION PROCESS CONFIGURATION
-# ================================================
+# =============================================================================
 
 # Specify the delay (in days) under which no loan can't be anonymized anyway (
 # for circulation management process).

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -25,6 +25,7 @@ from functools import partial
 
 from elasticsearch_dsl import Q
 
+from .extensions import CircPolicyFieldsExtension
 from .models import CircPolicyIdentifier, CircPolicyMetadata
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from ..fetchers import id_fetcher
@@ -81,6 +82,10 @@ class CircPolicy(IlsRecord):
         }
     }
 
+    _extensions = [
+        CircPolicyFieldsExtension()
+    ]
+
     def extended_validation(self, **kwargs):
         """Validate record against schema.
 
@@ -101,6 +106,7 @@ class CircPolicy(IlsRecord):
             library_pid = extracted_data_from_ref(library)
             if not Library.get_record_by_pid(library_pid):
                 return f"CircPolicy: no library:  {library.get('pid')}"
+
         # check all patron_types & item_types from settings belongs to the
         # same organisation than the cipo
         org = self.get('organisation')

--- a/rero_ils/modules/circ_policies/extensions.py
+++ b/rero_ils/modules/circ_policies/extensions.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Circulation policy record extensions."""
+
+from invenio_records.extensions import RecordExtension
+
+
+class CircPolicyFieldsExtension(RecordExtension):
+    """Extension to manage circulation policy fields."""
+
+    def _pickup_hold_duration_check(self, record):
+        """Manage the pickup hold duration field.
+
+        If the circulation policy doesn't allow request, no need to keep the
+        `pickup_hold_duration` field.
+
+        :param record: the record to check.
+        """
+        if not record.get('allow_requests') \
+           and 'pickup_hold_duration' in record:
+            del record['pickup_hold_duration']
+
+    pre_commit = _pickup_hold_duration_check
+    pre_create = _pickup_hold_duration_check

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -21,6 +21,7 @@
     "renewal_duration",
     "is_default",
     "allow_requests",
+    "pickup_hold_duration",
     "policy_library_level",
     "libraries",
     "reminders",
@@ -96,6 +97,20 @@
       "title": "Allow patron requests",
       "type": "boolean",
       "default": true
+    },
+    "pickup_hold_duration": {
+      "title": "Pickup hold duration in days",
+      "description": "Number of day(s) after which a not-picked up validated request will be cancelled. Keep empty to specify infinite duration.",
+      "type": "integer",
+      "minimum": 1,
+      "form": {
+        "hideExpression": "!model.allow_requests",
+        "templateOptions": {
+          "addonRight": {
+            "text": "day(s)"
+          }
+        }
+      }
     },
     "reminders": {
       "type": "array",

--- a/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/mappings/v7/circ_policies/circ_policy-v0.0.1.json
@@ -77,6 +77,9 @@
           }
         }
       },
+      "pickup_hold_duration": {
+        "type": "integer"
+      },
       "renewal_duration": {
         "type": "integer"
       },

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -159,7 +159,7 @@ class Document(IlsRecord):
         links = {}
         from ..holdings.api import HoldingsSearch
         from ..items.api import ItemsSearch
-        from ..loans.api import LoanState
+        from ..loans.models import LoanState
         hold_query = HoldingsSearch().filter('term', document__pid=self.pid)
         item_query = ItemsSearch().filter('term', document__pid=self.pid)
         loan_query = search_by_pid(

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -45,8 +45,9 @@ from ...documents.api import Document
 from ...errors import NoCirculationAction
 from ...item_types.api import ItemType
 from ...libraries.api import Library
-from ...loans.api import Loan, LoanAction, LoanState, \
-    get_last_transaction_loc_for_item, get_request_by_item_pid_by_patron_pid
+from ...loans.api import Loan, get_last_transaction_loc_for_item, \
+    get_request_by_item_pid_by_patron_pid
+from ...loans.models import LoanAction, LoanState
 from ...locations.api import Location
 from ...patrons.api import Patron
 from ...utils import extracted_data_from_ref, sorted_pids
@@ -494,7 +495,7 @@ class ItemCirculation(ItemRecord):
 
         :param loan : the current loan to cancel
         :param kwargs : all others named arguments
-        :return:  the item record and list of actions performed
+        :return: the item record and list of actions performed
         """
         actions_to_execute = {
             'cancel_loan': False,

--- a/rero_ils/modules/loans/extensions.py
+++ b/rero_ils/modules/loans/extensions.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -18,21 +19,78 @@
 """RERO ILS common record extensions."""
 
 
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 import ciso8601
+from flask import current_app
 from invenio_records.extensions import RecordExtension
 
+from rero_ils.modules.libraries.exceptions import LibraryNeverOpen
+from rero_ils.modules.loans.models import LoanState
 
-class SetDueSoonDate(RecordExtension):
-    """Set the due soon date when the loan is updated."""
 
-    def pre_commit(self, record):
-        """Add the due soon date.
+class CirculationDatesExtension(RecordExtension):
+    """Add some dates to manage circulation operation."""
+
+    @staticmethod
+    def _add_request_expiration_date(record):
+        """Add the request expiration date to record is needed.
+
+        When a request is validated, we need to set the `request_expire_date`
+        field with the expiration date of this request. When this date is
+        reached and item is still AT_DESK, this request should be cancelled.
+
+        This value is consistent only if the loan is a validated request
+        (loan.state == ITEM_AT_DESK). If the loan state is different this
+        value could represent an other concept.
 
         :param record: the record metadata.
         """
-        from .api import LoanState
+        from .utils import get_circ_policy
+        if record.state == LoanState.ITEM_AT_DESK and \
+           'request_expire_date' not in record:
+            cipo = get_circ_policy(record)
+            duration = cipo.get('pickup_hold_duration')
+            library = record.pickup_library
+            if cipo.get('allow_requests') and duration and library:
+                # the expiration date should be calculated using the pickup
+                # library calendar
+                trans_date = ciso8601.parse_datetime(record.transaction_date)
+                try:
+                    expire_date = trans_date + timedelta(days=duration)
+                    expire_date = expire_date.replace(
+                        hour=23, minute=59, second=00, microsecond=000,
+                        tzinfo=None)
+                    expire_date = library.next_open(expire_date)
+                except LibraryNeverOpen:
+                    # 10 days by default ... it's better than place a random
+                    # date value
+                    default_duration = current_app.config.get(
+                        'RERO_ILS_DEFAULT_PICKUP_HOLD_DURATION', 10)
+                    expire_date = trans_date + timedelta(days=default_duration)
+                    expire_date = expire_date.replace(
+                        hour=23, minute=59, second=00, microsecond=000,
+                        tzinfo=None)
+                # localize the date on the library timezone
+                # NOTE: if we create a datetime using `tzinfo`, the conversion
+                # to iso format return very precise timestamp (+00:34 for
+                # Zurich). But using `localize` method we keep rational +01:00
+                # value. This value is well interpreted by browser (+00:34) is
+                # not.
+                #
+                # https://coderedirect.com/questions/421775/python-pytz-
+                # timezone-conversion-returns-values-that-differ-from-
+                # timezone-offset (Search into response with ~45 points)
+                expire_date = library.get_timezone().localize(expire_date)
+                record['request_expire_date'] = expire_date.isoformat()
+                record['request_start_date'] = datetime.now().isoformat()
+
+    @staticmethod
+    def _add_due_soon_date(record):
+        """Set the due soon date when the loan is updated if needed.
+
+        :param record: the record metadata.
+        """
         from .utils import get_circ_policy
         if record.state == LoanState.ITEM_ON_LOAN and record.get('end_date'):
             circ_policy = get_circ_policy(record)
@@ -44,3 +102,8 @@ class SetDueSoonDate(RecordExtension):
                 due_soon = due_soon.replace(
                     hour=0, minute=0, second=0, microsecond=0)
                 record['due_soon_date'] = due_soon.isoformat()
+
+    def pre_commit(self, record):
+        """Called before a record is committed."""
+        CirculationDatesExtension._add_request_expiration_date(record)
+        CirculationDatesExtension._add_due_soon_date(record)

--- a/rero_ils/modules/loans/models.py
+++ b/rero_ils/modules/loans/models.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Define relation between records and buckets."""
+
+
+class LoanState(object):
+    """Class to handle different loan states."""
+
+    CREATED = 'CREATED'
+    PENDING = 'PENDING'
+    ITEM_IN_TRANSIT_FOR_PICKUP = 'ITEM_IN_TRANSIT_FOR_PICKUP'
+    ITEM_IN_TRANSIT_TO_HOUSE = 'ITEM_IN_TRANSIT_TO_HOUSE'
+    ITEM_AT_DESK = 'ITEM_AT_DESK'
+    ITEM_ON_LOAN = 'ITEM_ON_LOAN'
+    ITEM_RETURNED = 'ITEM_RETURNED'
+    CANCELLED = 'CANCELLED'
+
+    CONCLUDED = [CANCELLED, ITEM_RETURNED]
+    ITEM_IN_TRANSIT = [ITEM_IN_TRANSIT_TO_HOUSE, ITEM_IN_TRANSIT_FOR_PICKUP]
+
+
+class LoanAction(object):
+    """Class holding all available circulation loan actions."""
+
+    REQUEST = 'request'
+    CHECKOUT = 'checkout'
+    CHECKIN = 'checkin'
+    VALIDATE = 'validate'
+    RECEIVE = 'receive'
+    RETURN_MISSING = 'return_missing'
+    EXTEND = 'extend_loan'
+    CANCEL = 'cancel'
+    NO = 'no'
+    UPDATE = 'update'

--- a/rero_ils/modules/loans/serializers.py
+++ b/rero_ils/modules/loans/serializers.py
@@ -19,11 +19,12 @@
 
 from invenio_records_rest.serializers.response import search_responsify
 
-from rero_ils.modules.loans.api import Loan, LoanState
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1
 
+from .api import Loan
+from .models import LoanState
 from ..documents.api import DocumentsSearch
 from ..items.api import Item
 from ..libraries.api import Library

--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -26,6 +26,7 @@ from .models import LocationIdentifier, LocationMetadata
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from ..errors import MissingRequiredParameterError
 from ..fetchers import id_fetcher
+from ..loans.models import LoanState
 from ..minters import id_minter
 from ..providers import Provider
 from ..utils import extracted_data_from_ref, sorted_pids
@@ -109,9 +110,7 @@ class Location(IlsRecord):
 
     def get_library(self):
         """Get library."""
-        from ..libraries.api import Library
-        library_pid = extracted_data_from_ref(self.get('library'))
-        return Library.get_record_by_pid(library_pid)
+        return extracted_data_from_ref(self.get('library'), data='record')
 
     def get_links_to_me(self, get_pids=False):
         """Record links.
@@ -120,7 +119,7 @@ class Location(IlsRecord):
                          if False count of linked records
         """
         from ..items.api import ItemsSearch
-        from ..loans.api import LoansSearch, LoanState
+        from ..loans.api import LoansSearch
         item_query = ItemsSearch() \
             .filter('term', location__pid=self.pid)
         exclude_states = [

--- a/rero_ils/modules/notifications/templates/email/availability/eng.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/eng.txt
@@ -7,7 +7,9 @@ The document you requested is now available. You can pick it up at the loan desk
 
 Title: {{ loan.document.title_text }}
 Pick up location: {{ loan.pickup_name }}
-To pick up until: {{ loan.pickup_until }}
+{%- if loan.pickup_until %}
+To pick up until: {{ loan.pickup_until.strftime('%d/%m/%Y') }}
+{%- endif %}
 {%- endfor %}
 
 Should the document not be picked up within the given period, it will be made available for other people.

--- a/rero_ils/modules/notifications/templates/email/availability/fre.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/fre.txt
@@ -7,7 +7,9 @@ Le document que vous avez demandé est maintenant disponible. Vous pouvez venir 
 
 Titre : {{ loan.document.title_text  }}
 Lieu de retrait : {{ loan.pickup_name }}
-A retirer jusqu'au : {{ loan.pickup_until }}
+{%- if loan.pickup_until %}
+A retirer jusqu'au : {{ loan.pickup_until.strftime('%d/%m/%Y') }}
+{%- endif %}
 {%- endfor %}
 
 Si le document n'est pas retiré dans les délais, il sera remis en circulation pour d'autres personnes.

--- a/rero_ils/modules/notifications/templates/email/availability/ger.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/ger.txt
@@ -7,7 +7,9 @@ Das von Ihnen bestellte Dokument ist nun verfügbar und kann an der Ausleihtheke
 
 Titel : {{ loan.document.title_text }}
 Abholort: {{ loan.pickup_name }}
-Abholen bis: {{ loan.pickup_until }}
+{%- if loan.pickup_until %}
+Abholen bis: {{ loan.pickup_until.strftime('%d.%m.%Y') }}
+{%- endif %}
 {%- endfor %}
 
 Wenn das Dokument innerhalb der gegebenen Frist nicht abgeholt wird, wird es anderen Personen zur Verfügung gestellt.

--- a/rero_ils/modules/notifications/templates/email/availability/ita.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/ita.txt
@@ -7,7 +7,9 @@ Il documento che Lei ha domandato è ora disponibile. Lei può ritirarlo al serv
 
 Titolo: {{ loan.document.title_text }}
 Punto di ritiro: {{ loan.pickup_name }}
-Ritirare entro: {{ loan.pickup_until }}
+{%- if loan.pickup_until %}
+Ritirare entro: {{ loan.pickup_until.strftime('%d/%m/%Y') }}
+{%- endif %}
 {%- endfor %}
 
 Se il documento non è ritirato entro detto termine, esso sarà rimesso in circolazione per altre persone.

--- a/rero_ils/modules/patron_types/api.py
+++ b/rero_ils/modules/patron_types/api.py
@@ -29,8 +29,9 @@ from .models import PatronTypeIdentifier, PatronTypeMetadata
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from ..circ_policies.api import CircPoliciesSearch
 from ..fetchers import id_fetcher
-from ..loans.api import LoanState, get_loans_count_by_library_for_patron_pid, \
+from ..loans.api import get_loans_count_by_library_for_patron_pid, \
     get_overdue_loan_pids
+from ..loans.models import LoanState
 from ..minters import id_minter
 from ..patron_transactions.api import PatronTransaction
 from ..patrons.api import Patron, PatronsSearch

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -34,6 +34,7 @@ from .models import PatronIdentifier, PatronMetadata
 from ..api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from ..fetchers import id_fetcher
 from ..libraries.api import Library
+from ..loans.models import LoanState
 from ..minters import id_minter
 from ..organisations.api import Organisation
 from ..patron_transactions.api import PatronTransaction
@@ -489,11 +490,13 @@ class Patron(IlsRecord):
         :param get_pids: if True list of linked pids
                          if False count of linked records
         """
-        from ..loans.api import LoanState
         if self.pid:
             links = {}
-            exclude_states = [LoanState.CANCELLED, LoanState.ITEM_RETURNED,
-                              LoanState.CREATED]
+            exclude_states = [
+                LoanState.CANCELLED,
+                LoanState.ITEM_RETURNED,
+                LoanState.CREATED
+            ]
             loan_query = current_circulation.loan_search_cls()\
                 .filter('term', patron_pid=self.pid)\
                 .exclude('terms', state=exclude_states)

--- a/rero_ils/modules/selfcheck/api.py
+++ b/rero_ils/modules/selfcheck/api.py
@@ -35,8 +35,9 @@ from ..errors import NoCirculationAction
 from ..items.api import Item
 from ..items.models import ItemNoteTypes
 from ..libraries.api import Library
-from ..loans.api import Loan, LoanAction, LoanState, \
-    get_loans_by_item_pid_by_patron_pid, get_loans_by_patron_pid
+from ..loans.api import Loan, get_loans_by_item_pid_by_patron_pid, \
+    get_loans_by_patron_pid
+from ..loans.models import LoanAction, LoanState
 from ..patron_transactions.api import PatronTransaction
 from ..patrons.api import Patron
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -524,6 +524,7 @@ then
 else
     eval ${PREFIX} invenio reroils scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -n collect-stats -v
     eval ${PREFIX} invenio reroils scheduler enable_tasks -n notification-creation -n notification-dispatch-availability -n notification-dispatch-recall -v
+    eval ${PREFIX} invenio reroils scheduler enable_tasks -n cancel-expired-request -v
     info_msg "For ebooks harvesting run:"
     msg "\tinvenio reroils oaiharvester harvest -n ebooks -a max=100 -q"
 fi

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -26,7 +26,8 @@ from invenio_circulation.search.api import LoansSearch
 from utils import flush_index, get_json, postdata
 
 from rero_ils.modules.items.api import Item
-from rero_ils.modules.loans.api import Loan, LoanAction, get_overdue_loans
+from rero_ils.modules.loans.api import Loan, get_overdue_loans
+from rero_ils.modules.loans.models import LoanAction
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher
 from rero_ils.modules.notifications.models import NotificationType

--- a/tests/api/circulation/test_inhouse_cipo.py
+++ b/tests/api/circulation/test_inhouse_cipo.py
@@ -26,7 +26,8 @@ from utils import login_user_via_session, postdata
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
 from rero_ils.modules.libraries.api import Library
-from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
 
 
 def test_less_than_one_day_checkout(

--- a/tests/api/items/test_items_in_transit.py
+++ b/tests/api/items/test_items_in_transit.py
@@ -23,8 +23,7 @@ from utils import postdata
 
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
-# from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
-from rero_ils.modules.loans.api import LoanAction
+from rero_ils.modules.loans.models import LoanAction
 
 
 def test_items_in_transit_between_libraries(

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -30,7 +30,8 @@ from utils import VerifyRecordPermissionPatch, flush_index, get_json, postdata
 from rero_ils.modules.circ_policies.api import CircPoliciesSearch
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemNoteTypes, ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.loans.utils import get_extension_params
 
 

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -30,8 +30,9 @@ from utils import check_timezone_date, flush_index, get_json, postdata
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.utils import item_pid_to_object
 from rero_ils.modules.libraries.api import Library
-from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
-    get_due_soon_loans, get_last_transaction_loc_for_item, get_overdue_loans
+from rero_ils.modules.loans.api import Loan, get_due_soon_loans, \
+    get_last_transaction_loc_for_item, get_overdue_loans
+from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher
 from rero_ils.modules.notifications.models import NotificationType

--- a/tests/api/loans/test_loans_rest_views.py
+++ b/tests/api/loans/test_loans_rest_views.py
@@ -20,7 +20,7 @@
 from flask import url_for
 from utils import get_json, item_record_to_a_specific_loan_state, login_user
 
-from rero_ils.modules.loans.api import LoanState
+from rero_ils.modules.loans.models import LoanState
 
 
 def test_loan_can_extend(client, patron_martigny, item_lib_martigny,

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -31,7 +31,8 @@ from utils import VerifyRecordPermissionPatch, flush_index, get_json, \
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.models import ItemStatus
 from rero_ils.modules.libraries.api import email_notification_type
-from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.notifications.api import Notification, \
     NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher

--- a/tests/api/patrons/test_patrons_views.py
+++ b/tests/api/patrons/test_patrons_views.py
@@ -24,7 +24,7 @@ from utils import postdata
 
 from rero_ils.modules.cli.utils import create_personal
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import LoanAction
+from rero_ils.modules.loans.models import LoanAction
 
 
 def test_patron_can_delete(client, librarian_martigny,

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -28,7 +28,8 @@ from invenio_circulation.search.api import LoansSearch
 from utils import flush_index, postdata
 
 from rero_ils.modules.items.api import Item
-from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher
 from rero_ils.modules.notifications.models import NotificationType

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -29,7 +29,7 @@ from rero_ils.modules.documents.views import can_request
 from rero_ils.modules.holdings.api import Holding
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import LoanAction
+from rero_ils.modules.loans.models import LoanAction
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.utils import get_ref_for_pid
 

--- a/tests/api/test_circ_bug.py
+++ b/tests/api/test_circ_bug.py
@@ -21,7 +21,7 @@
 from invenio_accounts.testutils import login_user_via_session
 from utils import postdata
 
-from rero_ils.modules.loans.api import LoanAction
+from rero_ils.modules.loans.models import LoanAction
 
 
 def test_document_with_one_item_attached_bug(

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -21,7 +21,7 @@ from flask import url_for
 from utils import flush_index, get_csv, get_json, \
     item_record_to_a_specific_loan_state, login_user
 
-from rero_ils.modules.loans.api import LoanState
+from rero_ils.modules.loans.models import LoanState
 from rero_ils.modules.operation_logs.api import OperationLogsSearch
 
 

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1213,6 +1213,7 @@
       }
     ],
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "number_renewals": 3,
     "renewal_duration": 30,
     "policy_library_level": false,
@@ -1228,6 +1229,7 @@
     },
     "checkout_duration": 15,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -1283,6 +1285,7 @@
     },
     "checkout_duration": 7,
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "reminders": [
       {
         "type": "due_soon",
@@ -1343,6 +1346,7 @@
       }
     ],
     "allow_requests": true,
+    "pickup_hold_duration": 10,
     "number_renewals": 3,
     "renewal_duration": 30,
     "policy_library_level": false,

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -27,7 +27,8 @@ from utils import create_patron, flush_index, \
 
 from rero_ils.modules.ill_requests.api import ILLRequest, ILLRequestsSearch
 from rero_ils.modules.items.api import ItemsSearch
-from rero_ils.modules.loans.api import Loan, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanState
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.models import NotificationType
 from rero_ils.modules.notifications.utils import get_notification

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -134,3 +134,21 @@ def test_circ_policy_can_delete(app, circ_policy_martigny_data_tmp):
     can, reasons = cipo.can_delete
     assert can
     assert reasons == {}
+
+
+def test_circ_policy_extended_validation(
+    app,
+    circ_policy_short_martigny,
+    circ_policy_short_martigny_data
+):
+    """Test extended validation for circ policy"""
+    cipo_data = deepcopy(circ_policy_short_martigny_data)
+    cipo_data['allow_requests'] = False
+    cipo_data['pickup_hold_duration'] = 10
+    del cipo_data['pid']
+
+    cipo = CircPolicy.create(cipo_data)
+    assert cipo
+    assert 'pickup_hold_duration' not in cipo
+
+    cipo.delete()

--- a/tests/ui/circulation/test_actions_add_request.py
+++ b/tests/ui/circulation/test_actions_add_request.py
@@ -22,7 +22,7 @@ import pytest
 from invenio_circulation.errors import RecordCannotBeRequestedError
 from utils import item_record_to_a_specific_loan_state
 
-from rero_ils.modules.loans.api import LoanState
+from rero_ils.modules.loans.models import LoanState
 
 
 def test_add_request_on_item_on_shelf(

--- a/tests/ui/circulation/test_actions_cancel_request.py
+++ b/tests/ui/circulation/test_actions_cancel_request.py
@@ -24,7 +24,8 @@ from utils import item_record_to_a_specific_loan_state
 from rero_ils.modules.errors import NoCirculationAction
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanState
 
 
 def test_cancel_request_on_item_on_shelf(

--- a/tests/ui/circulation/test_actions_checkin.py
+++ b/tests/ui/circulation/test_actions_checkin.py
@@ -24,7 +24,8 @@ from utils import item_record_to_a_specific_loan_state
 from rero_ils.modules.errors import NoCirculationAction
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanState
 
 
 def test_checkin_on_item_on_shelf_no_requests(

--- a/tests/ui/circulation/test_actions_checkout.py
+++ b/tests/ui/circulation/test_actions_checkout.py
@@ -27,7 +27,8 @@ from utils import item_record_to_a_specific_loan_state
 
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
 
 
 def test_checkout_on_item_on_shelf(

--- a/tests/ui/circulation/test_actions_extend.py
+++ b/tests/ui/circulation/test_actions_extend.py
@@ -24,7 +24,7 @@ from utils import item_record_to_a_specific_loan_state
 
 from rero_ils.modules.errors import NoCirculationAction
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import LoanState
+from rero_ils.modules.loans.models import LoanState
 
 
 def test_extend_on_item_on_shelf(

--- a/tests/ui/circulation/test_actions_validate_request.py
+++ b/tests/ui/circulation/test_actions_validate_request.py
@@ -24,7 +24,8 @@ from utils import item_record_to_a_specific_loan_state
 
 from rero_ils.modules.errors import NoCirculationAction
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanState
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanState
 
 
 def test_validate_on_item_on_shelf_no_requests(

--- a/tests/ui/circulation/test_loan_utils.py
+++ b/tests/ui/circulation/test_loan_utils.py
@@ -25,8 +25,9 @@ from utils import flush_index, item_record_to_a_specific_loan_state
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.utils import item_pid_to_object
-from rero_ils.modules.loans.api import Loan, LoanState, \
+from rero_ils.modules.loans.api import Loan, \
     get_last_transaction_loc_for_item, get_loans_by_patron_pid
+from rero_ils.modules.loans.models import LoanState
 from rero_ils.modules.loans.utils import can_be_requested
 from rero_ils.modules.locations.api import LocationsSearch
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,8 @@ from rero_ils.modules.items.api import Item, ItemsSearch
 from rero_ils.modules.items.models import ItemStatus
 from rero_ils.modules.items.utils import item_pid_to_object
 from rero_ils.modules.libraries.api import Library
-from rero_ils.modules.loans.api import Loan, LoanAction, LoansSearch, LoanState
+from rero_ils.modules.loans.api import Loan, LoansSearch
+from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patron_types.api import PatronType


### PR DESCRIPTION
* Adds a new `request_duration` option in the `CircPolicies` resource.
* Adds the request expiration date into the loan data when it's
  necessary.
* Updates the availability notification to take care of this new date.
* Moves some related loan classes to new `loans.model` file.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
