### PR TITLE
acquisition: create an entrypoint to create lines

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2567,7 +2567,7 @@ RECORDS_JSON_SCHEMA = {
     'acol': '/acq_order_lines/acq_order_line-v0.0.1.json',
     'acor': '/acq_orders/acq_order-v0.0.1.json',
     'acre': '/acq_receipts/acq_receipt-v0.0.1.json',
-    'acrl': '/acq_receipts/acq_receipt_line-v0.0.1.json',
+    'acrl': '/acq_receipt_lines/acq_receipt_line-v0.0.1.json',
     'acin': '/acq_invoices/acq_invoice-v0.0.1.json',
     'budg': '/budgets/budget-v0.0.1.json',
     'cipo': '/circ_policies/circ_policy-v0.0.1.json',

--- a/rero_ils/modules/acq_receipts/models.py
+++ b/rero_ils/modules/acq_receipts/models.py
@@ -47,3 +47,10 @@ class AcqReceiptNoteType:
     """Type of acquisition receipt note."""
 
     STAFF = 'staff_note'
+
+
+class AcqReceiptLineCreationStatus:
+    """Status following an attempt to create a receipt line."""
+
+    SUCCESS = 'success'
+    FAILURE = 'failure'

--- a/rero_ils/modules/acq_receipts/views.py
+++ b/rero_ils/modules/acq_receipts/views.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Blueprint used for AcqReceipt API."""
+
+from flask import Blueprint, abort, jsonify
+from flask import request as flask_request
+
+from rero_ils.modules.acq_receipts.api import AcqReceipt
+from rero_ils.modules.decorators import check_logged_as_librarian, \
+    jsonify_error
+
+api_blueprint = Blueprint(
+    'api_receipt',
+    __name__,
+    url_prefix='/acq_receipt',
+    template_folder='templates'
+)
+
+
+@api_blueprint.route('/<receipt_pid>/lines', methods=['POST'])
+@check_logged_as_librarian
+@jsonify_error
+def lines(receipt_pid):
+    """HTTP POST for creating multiple acquisition receipt lines.
+
+    Required parameters:
+    :param receipt_pid: the pid of the receipt.
+    :param receipt_lines: the list of receipt lines to create.
+    :returns: a list containing the given data to build the receipt line
+                with a `status` field, either `success` or the validation
+                error.
+                In case of `success`, the created record is returned.
+                In case the line is not created, the erorr message is
+                returned in the field `status`.
+    """
+    receipt = AcqReceipt.get_record_by_pid(receipt_pid)
+    if not receipt:
+        abort(404, "Acquisition receipt not found")
+
+    data = flask_request.get_json()
+    receipt_lines = data.get('receipt_lines')
+    if not receipt_lines:
+        abort(400, "Missing receipt lines data.")
+    created_receipt_lines = receipt.create_receipt_lines(
+        receipt_lines=receipt_lines)
+    return jsonify(response=created_receipt_lines)

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'invenio_base.api_blueprints': [
             'acq_accounts = rero_ils.modules.acq_accounts.views:api_blueprint',
             'acq_orders = rero_ils.modules.acq_orders.views:api_blueprint',
+            'acq_receipts = rero_ils.modules.acq_receipts.views:api_blueprint',
             'api_documents = rero_ils.modules.documents.views:api_blueprint',
             'circ_policies = rero_ils.modules.circ_policies.views:blueprint',
             'contributions = rero_ils.modules.contributions.views:api_blueprint',

--- a/tests/api/acq_receipts/test_acq_receipts_views.py
+++ b/tests/api/acq_receipts/test_acq_receipts_views.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test acquisition receipt API."""
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json, postdata
+
+from rero_ils.modules.acq_receipts.models import AcqReceiptLineCreationStatus
+
+
+def test_create_lines(app, client, librarian_martigny, lib_martigny,
+                      librarian_sion, acq_order_line_fiction_martigny,
+                      acq_order_line2_fiction_martigny,
+                      acq_receipt_fiction_martigny, json_header):
+    """Test create_lines API."""
+    login_user_via_session(client, librarian_martigny.user)
+    receipt = acq_receipt_fiction_martigny
+    receipt_lines = []
+    # test when parent order is not in database
+    res, data = postdata(
+        client,
+        'api_receipt.lines',
+        data=dict(receipt_lines=receipt_lines),
+        url_data=dict(receipt_pid='toto')
+    )
+    assert res.status_code == 404
+    # test when receipt_lines data is not provided
+    res, data = postdata(
+        client,
+        'api_receipt.lines',
+        url_data=dict(receipt_pid=receipt.pid)
+    )
+    assert res.status_code == 400
+    # test when receipt_lines data provided but empty
+    res, data = postdata(
+        client,
+        'api_receipt.lines',
+        data=dict(receipt_lines=receipt_lines),
+        url_data=dict(receipt_pid=receipt.pid)
+    )
+    assert res.status_code == 400
+
+    # test when receipt_lines data provided
+    receipt_lines = [
+        {
+            "acq_order_line": {
+                "$ref": "https://bib.rero.ch/api/acq_order_lines/acol1"
+            },
+            "amount": 1000,
+            "quantity": 1,
+            "receipt_date": "2021-11-01"
+        },
+        {
+            "acq_order_line": {
+                "$ref": "https://bib.rero.ch/api/acq_order_lines/acol2"
+            },
+            "amount": 500,
+            "quantity": 1,
+            "receipt_date": "2021-11-03"
+        },
+        {
+            "acq_order_line": {
+                "$ref": "https://bib.rero.ch/api/acq_order_lines/acol2"
+            }
+        }
+    ]
+
+    res, data = postdata(
+        client,
+        'api_receipt.lines',
+        data=dict(receipt_lines=receipt_lines),
+        url_data=dict(receipt_pid=receipt.pid)
+    )
+    assert res.status_code == 200
+    response = get_json(res).get('response')
+    assert response[0]['status'] == AcqReceiptLineCreationStatus.SUCCESS
+    assert response[1]['status'] == AcqReceiptLineCreationStatus.SUCCESS
+    assert response[2]['status'] == AcqReceiptLineCreationStatus.FAILURE
+    assert response[2]['error_message']


### PR DESCRIPTION
* Adds a new method to create multiple receipt line orders for a receipt.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
