### PR TITLE
acquisition: add data into receipt ElasticSearch index

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1598,10 +1598,14 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
+            ),
+            'application/rero+json': (
+                'rero_ils.modules.acq_receipts.serializers:json_acre_record'
             )
         },
         record_serializers_aliases={
             'json': 'application/json',
+            'rero': 'application/rero+json',
         },
         search_serializers={
             'application/json': (

--- a/rero_ils/modules/acq_order_lines/models.py
+++ b/rero_ils/modules/acq_order_lines/models.py
@@ -51,6 +51,8 @@ class AcqOrderLineStatus:
     RECEIVED = 'received'
     PARTIALLY_RECEIVED = 'partially_received'
 
+    RECEIVED_STATUSES = [RECEIVED, PARTIALLY_RECEIVED]
+
 
 class AcqOrderLineNoteType:
     """Type of acquisition order line note."""

--- a/rero_ils/modules/acq_receipt_lines/api.py
+++ b/rero_ils/modules/acq_receipt_lines/api.py
@@ -130,8 +130,10 @@ class AcqReceiptLine(IlsRecord):
     @cached_property
     def order_line(self):
         """Shortcut for related acquisition order line record."""
-        from rero_ils.modules.acq_order_lines.api import AcqOrderLine
-        return AcqOrderLine.get_record_by_pid(self.order_line_pid)
+        return extracted_data_from_ref(
+            self.get('acq_order_line'),
+            data='record'
+        )
 
     @property
     def acq_account_pid(self):
@@ -151,8 +153,8 @@ class AcqReceiptLine(IlsRecord):
     @property
     def total_amount(self):
         """Shortcut for related acquisition total_amount."""
-        return round(
-            self.amount*self.receipt.exchange_rate*self.quantity, 2)
+        total = self.amount * self.receipt.exchange_rate * self.quantity
+        return round(total, 2)
 
     @property
     def quantity(self):

--- a/rero_ils/modules/acq_receipt_lines/dumpers.py
+++ b/rero_ils/modules/acq_receipt_lines/dumpers.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition receipt line dumpers."""
+
+from invenio_records.dumpers import Dumper as InvenioRecordsDumper
+
+from rero_ils.modules.documents.utils import title_format_text_head
+
+
+class AcqReceiptLineESDumper(InvenioRecordsDumper):
+    """ElasticSearch dumper class for an AcqReceiptLine."""
+
+    def dump(self, record, data):
+        """Dump an AcqReceiptLine instance for ElasticSearch.
+
+        For ElasticSearch integration, we need to dump basic informations from
+        a `AcqReceiptLine` object instance, and add some basic data about
+        related.
+
+        :param record: The record to dump.
+        :param data: The initial dump data passed in by ``record.dumps()``.
+        """
+        # Keep only some attributes from AcqReceiptLine object initial dump.
+        for attr in ['pid', 'receipt_date', 'amount', 'quantity']:
+            value = record.get(attr)
+            if value:
+                data.update({attr: value})
+        notes = record.get('notes', [])
+        if notes:
+            data['notes'] = [note['content'] for note in notes]
+
+        # Add document informations: pid, formatted title and ISBN identifiers.
+        # (remove None values from document metadata)
+        document = record.order_line.document
+        data['document'] = {
+            'pid': document.pid,
+            'title': title_format_text_head(document.get('title', [])),
+            'identifiers': document.get_identifier_values(filters=['bf:Isbn'])
+        }
+        data['document'] = {k: v for k, v in data['document'].items() if v}
+        return data

--- a/rero_ils/modules/acq_receipts/listener.py
+++ b/rero_ils/modules/acq_receipts/listener.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Signals connector for acquisition receipt."""
+
+
+from .api import AcqReceiptsSearch
+from ..acq_receipt_lines.dumpers import AcqReceiptLineESDumper
+
+
+def enrich_acq_receipt_data(sender, json=None, record=None, index=None,
+                            doc_type=None, arguments=None, **dummy_kwargs):
+    """Signal sent before a record is indexed.
+
+    :param json: The dumped record dictionary which can be modified.
+    :param record: The record being indexed.
+    :param index: The index in which the record will be indexed.
+    :param doc_type: The document type of the record.
+    """
+    if index.split('-')[0] == AcqReceiptsSearch.Meta.index:
+        # add related order lines metadata
+        json['receipt_lines'] = [
+            receipt_line.dumps(dumper=AcqReceiptLineESDumper())
+            for receipt_line in record.get_receipt_lines()
+        ]
+        # other dynamic keys
+        json['total_amount'] = record.total_amount
+        json['quantity'] = record.total_item_quantity

--- a/rero_ils/modules/acq_receipts/mappings/v7/acq_receipts/acq_receipt-v0.0.1.json
+++ b/rero_ils/modules/acq_receipts/mappings/v7/acq_receipts/acq_receipt-v0.0.1.json
@@ -42,6 +42,9 @@
       "exchange_rate": {
         "type": "float"
       },
+      "quantity": {
+        "type": "integer"
+      },
       "total_amount": {
         "type": "float"
       },
@@ -73,6 +76,35 @@
           },
           "content": {
             "type": "text"
+          }
+        }
+      },
+      "receipt_lines": {
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "receipt_date": {
+            "type": "date"
+          },
+          "quantity": {
+            "type": "integer"
+          },
+          "document": {
+            "properties": {
+              "pid": {
+                "type": "keyword"
+              },
+              "title": {
+                "type": "text"
+              },
+              "identifiers": {
+                "type": "text"
+              }
+            }
+          },
+          "amount": {
+            "type": "float"
           }
         }
       },

--- a/rero_ils/modules/acq_receipts/serializers.py
+++ b/rero_ils/modules/acq_receipts/serializers.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition receipt serialization."""
+
+from invenio_records_rest.serializers.response import record_responsify
+
+from ..acq_receipt_lines.dumpers import AcqReceiptLineESDumper
+from ..serializers import JSONSerializer, RecordSchemaJSONV1
+
+
+class AcqReceiptReroJSONSerializer(JSONSerializer):
+    """Mixin serializing records as JSON."""
+
+    def preprocess_record(self, pid, record, links_factory=None, **kwargs):
+        """Prepare a record and persistent identifier for serialization."""
+        # add some dynamic key related to the record.
+        record['total_amount'] = record.total_amount
+        record['quantity'] = record.total_item_quantity
+        record['receipt_lines'] = [
+            receipt_line.dumps(dumper=AcqReceiptLineESDumper())
+            for receipt_line in record.get_receipt_lines()
+        ]
+        # add currency to avoid to load related order_line->order to get it
+        record['currency'] = record.order.get('currency')
+        return super().preprocess_record(
+            pid=pid, record=record, links_factory=links_factory, kwargs=kwargs)
+
+
+json_acre = AcqReceiptReroJSONSerializer(RecordSchemaJSONV1)
+
+json_acre_record = record_responsify(json_acre, 'application/rero+json')

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -37,6 +37,7 @@ from .acq_accounts.listener import enrich_acq_account_data
 from .acq_order_lines.listener import enrich_acq_order_line_data
 from .acq_orders.listener import enrich_acq_order_data
 from .acq_receipt_lines.listener import enrich_acq_receipt_line_data
+from .acq_receipts.listener import enrich_acq_receipt_data
 from .apiharvester.signals import apiharvest_part
 from .budgets.listener import budget_is_active_changed
 from .collections.listener import enrich_collection_data
@@ -197,6 +198,7 @@ class REROILSAPP(object):
         #    enrich_patron_data, sender=app, index='patrons-patron-v0.0.1')
         before_record_index.connect(enrich_acq_account_data, sender=app)
         before_record_index.connect(enrich_acq_order_data, sender=app)
+        before_record_index.connect(enrich_acq_receipt_data, sender=app)
         before_record_index.connect(enrich_acq_receipt_line_data, sender=app)
         before_record_index.connect(enrich_acq_order_line_data, sender=app)
         before_record_index.connect(enrich_collection_data, sender=app)


### PR DESCRIPTION
Adds additional data when indexing a `AcqReceipt` :
  * total_item_quantity
  * receipt_lines basic informations
    * document information (title, pid, isbn)
    * reception_date
    * quantity
    * amount
    * notes content
  * total_amount

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
