### PR TITLE
acquisition: delete receipt and its lines

### DIFF
--- a/rero_ils/modules/acq_order_lines/api.py
+++ b/rero_ils/modules/acq_order_lines/api.py
@@ -266,22 +266,21 @@ class AcqOrderLinesIndexer(IlsRecordsIndexer):
 
     record_cls = AcqOrderLine
 
+    @staticmethod
+    def _reindex_related_resources(record):
+        record.order.reindex()
+        record.account.reindex()
+
     def index(self, record):
         """Index an Acquisition Order Line and update total amount of order."""
-        from ..acq_orders.api import AcqOrder
         return_value = super().index(record)
-        order = AcqOrder.get_record_by_pid(record.order_pid)
-        order.reindex()
-        record.account.reindex()
+        AcqOrderLinesIndexer._reindex_related_resources(record)
         return return_value
 
     def delete(self, record):
         """Delete a Acquisition Order Line and update total amount of order."""
-        from ..acq_orders.api import AcqOrder
         return_value = super().delete(record)
-        order = AcqOrder.get_record_by_pid(record.order_pid)
-        order.reindex()
-        record.account.reindex()
+        AcqOrderLinesIndexer._reindex_related_resources(record)
         return return_value
 
     def bulk_index(self, record_id_iterator):

--- a/rero_ils/modules/acq_receipt_lines/api.py
+++ b/rero_ils/modules/acq_receipt_lines/api.py
@@ -187,14 +187,15 @@ class AcqReceiptLinesIndexer(IlsRecordsIndexer):
     record_cls = AcqReceiptLine
 
     def index(self, record):
-        """Index an acq receipt line record.
-
-        Reindex the parent acq receipt, acq_order and acq_account records.
-        """
-        from rero_ils.modules.acq_order_lines.api import AcqOrderLine
+        """Index an AcqReceiptLine line record."""
         return_value = super().index(record)
-        order_line = AcqOrderLine.get_record_by_pid(record.order_line_pid)
-        order_line.reindex()
-        order_line.order.reindex()
-        order_line.account.reindex()
+        # The reindexing of the parent order_line will also fired the
+        # indexing of the parent order and related account
+        record.order_line.reindex()
+        return return_value
+
+    def delete(self, record):
+        """Delete an AcqReceiptLine record from indexer."""
+        return_value = super().delete(record)
+        record.order_line.reindex()
         return return_value

--- a/rero_ils/modules/acq_receipts/extensions.py
+++ b/rero_ils/modules/acq_receipts/extensions.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition Receipt record extensions."""
+
+from invenio_records.extensions import RecordExtension
+
+
+class AcqReceiptExtension(RecordExtension):
+    """Defines hooks about API functions calls for AcqReceipt."""
+
+    def pre_delete(self, record, force=False):
+        """Called before a record is deleted.
+
+        :param record: the record metadata.
+        :param force: force the deleting of the record.
+        """
+        # For receipts, we are allowed to delete all of its receipt lines
+        # without further checks.
+        for line in record.get_receipt_lines():
+            line.delete(force=force, delindex=True)

--- a/rero_ils/modules/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json
+++ b/rero_ils/modules/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json
@@ -5,7 +5,6 @@
   "description": "JSON schema for Acquisition Receipt.",
   "additionalProperties": false,
   "propertiesOrder": [
-    "acq_order",
     "exchange_rate",
     "amount_adjustments",
     "notes"
@@ -13,7 +12,8 @@
   "required": [
     "$schema",
     "pid",
-    "acq_order"
+    "acq_order",
+    "exchange_rate"
   ],
   "properties": {
     "$schema": {
@@ -39,17 +39,7 @@
         "$ref": {
           "title": "Order",
           "type": "string",
-          "pattern": "^https://bib.rero.ch/api/acq_orders/.*?$",
-          "form": {
-            "focus": true,
-            "remoteOptions": {
-              "type": "acq_orders"
-            },
-            "placeholder": "Choose an order",
-            "templateOptions": {
-              "label": ""
-            }
-          }
+          "pattern": "^https://bib.rero.ch/api/acq_orders/.*?$"
         }
       }
     },
@@ -57,6 +47,7 @@
       "title": "Exchange rate",
       "type": "number",
       "exclusiveMinimum": 0,
+      "default": 1,
       "form": {
         "hide": true,
         "navigation": {
@@ -116,13 +107,19 @@
             }
           }
         }
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
       }
     },
     "notes": {
       "title": "Notes",
       "type": "array",
       "minItems": 0,
-      "maxItems": 2,
+      "maxItems": 1,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -168,6 +165,10 @@
         }
       },
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "templateOptions": {
           "wrappers": [
             "card"

--- a/tests/api/acq_receipts/test_acq_receipts_rest.py
+++ b/tests/api/acq_receipts/test_acq_receipts_rest.py
@@ -158,9 +158,11 @@ def test_acq_receipts_can_delete(
         client, document, acq_receipt_fiction_martigny,
         acq_receipt_line_1_fiction_martigny):
     """Test can delete an acq receipt."""
+    # We can delete an AcqReceipt even if some children AcqReceiptLines exists
+    # because they will be cascading deleted if we delete the parent AcqReceipt
     can, reasons = acq_receipt_fiction_martigny.can_delete
-    assert not can
-    assert reasons['links']['acq_receipt_lines']
+    assert can
+    assert 'acq_receipt_lines' not in reasons.get('links', {})
 
 
 def test_filtered_acq_receipts_get(


### PR DESCRIPTION
* Deletes all receipt lines when attempting to delete a receipt.
* Reindexes corresponding order lines after deletion.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/2350


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
