### PR TITLE
acquisition: sort receipts by receipt_date

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2271,6 +2271,10 @@ RERO_ILS_QUERY_BOOSTING = {
 # sort options
 indexes = [
     'acq_accounts',
+    'acq_orders',
+    'acq_order_lines',
+    'acq_receipts',
+    'acq_receipt_lines',
     'budgets',
     'circ_policies',
     'collections',
@@ -2331,6 +2335,14 @@ RECORDS_REST_SORT_OPTIONS['acq_accounts']['depth'] = dict(
 RECORDS_REST_DEFAULT_SORT['acq_accounts'] = dict(
     query='bestmatch', noquery='name')
 
+# ------ ACQUISITION ORDERS SORT
+RECORDS_REST_SORT_OPTIONS['acq_orders']['receipt_date'] = dict(
+    fields=['-order_lines.receipt_date'], title='Receipt date',
+    default_order='desc'
+)
+RECORDS_REST_DEFAULT_SORT['acq_orders'] = dict(
+    query='bestmatch', noquery='receipt_date')
+
 # ------ ACQUISITION ORDER LINES SORT
 RECORDS_REST_SORT_OPTIONS['acq_order_lines'] = dict(
     pid=dict(
@@ -2345,6 +2357,22 @@ RECORDS_REST_SORT_OPTIONS['acq_order_lines'] = dict(
 )
 RECORDS_REST_DEFAULT_SORT['acq_order_lines'] = dict(
     query='bestmatch', noquery='priority')
+
+# ------ ACQUISITION RECEIPTS SORT
+RECORDS_REST_SORT_OPTIONS['acq_receipts']['receipt_date'] = dict(
+    fields=['-receipt_lines.receipt_date'], title='Receipt date',
+    default_order='desc'
+)
+RECORDS_REST_DEFAULT_SORT['acq_receipts'] = dict(
+    query='bestmatch', noquery='receipt_date')
+
+# ------ ACQUISITION RECEIPT LINES SORT
+RECORDS_REST_SORT_OPTIONS['acq_receipt_lines']['receipt_date'] = dict(
+    fields=['-receipt_date'], title='Receipt date',
+    default_order='desc'
+)
+RECORDS_REST_DEFAULT_SORT['acq_receipt_lines'] = dict(
+    query='bestmatch', noquery='receipt_date')
 
 # ------ BUDGETS SORT
 RECORDS_REST_SORT_OPTIONS['budgets']['name'] = dict(

--- a/rero_ils/modules/acq_order_lines/dumpers.py
+++ b/rero_ils/modules/acq_order_lines/dumpers.py
@@ -39,7 +39,7 @@ class AcqOrderLineESDumper(InvenioRecordsDumper):
         :param data: The initial dump data passed in by ``record.dumps()``.
         """
         # Keep only some attributes from AcqOrderLine object initial dump.
-        for attr in ['status', 'order_date', 'reception_date', 'quantity']:
+        for attr in ['status', 'order_date', 'receipt_date', 'quantity']:
             value = record.get(attr)
             if value:
                 data.update({attr: value})

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -9,7 +9,7 @@
     "document",
     "priority",
     "order_date",
-    "reception_date",
+    "receipt_date",
     "quantity",
     "amount",
     "exchange_rate",
@@ -181,7 +181,7 @@
         }
       }
     },
-    "reception_date": {
+    "receipt_date": {
       "title": "Receipt date",
       "type": "string",
       "format": "date",

--- a/rero_ils/modules/acq_order_lines/mappings/v7/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/mappings/v7/acq_order_lines/acq_order_line-v0.0.1.json
@@ -106,7 +106,7 @@
       "order_date": {
         "type": "date"
       },
-      "reception_date": {
+      "receipt_date": {
         "type": "date"
       },
       "is_cancelled": {

--- a/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -72,7 +72,7 @@
           "order_date": {
             "type": "date"
           },
-          "reception_date": {
+          "receipt_date": {
             "type": "date"
           },
           "quantity": {

--- a/rero_ils/modules/acq_receipt_lines/jsonschemas/acq_receipt_lines/acq_receipt_line-v0.0.1.json
+++ b/rero_ils/modules/acq_receipt_lines/jsonschemas/acq_receipt_lines/acq_receipt_line-v0.0.1.json
@@ -9,7 +9,7 @@
     "notes",
     "quantiy",
     "amount",
-    "reception_date"
+    "receipt_date"
   ],
   "required": [
     "$schema",


### PR DESCRIPTION
Co-Authored-by: Valeria Granata <valeria@chaw.com>

- allow to sort receipts (and orders) by receipt_date

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/2337

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
