### PR TITLE
ui: add a location level in facets

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1785,7 +1785,13 @@ RECORDS_REST_FACETS = dict(
                 aggs=dict(
                     library=dict(
                         terms=dict(field='holdings.organisation.library_pid',
-                                   size=DOCUMENTS_AGGREGATION_SIZE)
+                                   size=DOCUMENTS_AGGREGATION_SIZE),
+                        aggs=dict(
+                            location=dict(
+                                terms=dict(field='holdings.location.pid',
+                                       size=DOCUMENTS_AGGREGATION_SIZE)
+                            )
+                        )
                     )
                 )
             ),
@@ -1807,6 +1813,7 @@ RECORDS_REST_FACETS = dict(
                 'holdings.organisation.organisation_pid'
             ),
             _('library'): and_term_filter('holdings.organisation.library_pid'),
+            _('location'): and_term_filter('holdings.location.pid'),
             _('subject'): and_term_filter('facet_subjects'),
             _('status'): and_term_filter('holdings.items.status'),
             _('new_acquisition'): acquisition_filter(),

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -292,7 +292,7 @@ def test_documents_organisation_facets(
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
-def test_documents_library_facets(
+def test_documents_library_location_facets(
     client, document, org_martigny, item_lib_martigny, rero_json_header
 ):
     """Test record retrieval."""
@@ -303,6 +303,10 @@ def test_documents_library_facets(
     aggs = data['aggregations']
 
     assert 'library' in aggs
+
+    # Test if location sub-buckets exists under each Library hit
+    for hit in aggs['library']['buckets']:
+        assert 'location' in hit
 
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',


### PR DESCRIPTION
ui: add a location level in facets

* Adds a third level in facet Organization/Libraries to filter locations. 

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Benoit Erken <erken.benoit@gmail.com>
Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- To add a third level to organization facet

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

n/a

## How to test?

- Open public view or professional view and expand Organisation/Libraries Facet. You should see 3 levels now.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
