### PR TITLE
users: make user profiles read-only

### DIFF
--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -130,7 +130,10 @@ def logged_user():
             ),
             'librarianRoles': current_app.config.get(
                 'RERO_ILS_LIBRARIAN_ROLES', []
-            )
+            ),
+            'readOnlyProfile': current_app.config.get(
+                'USERPROFILES_READ_ONLY', False
+            ),
         }
     }
     if not current_user.is_authenticated:

--- a/rero_ils/theme/menus.py
+++ b/rero_ils/theme/menus.py
@@ -305,45 +305,50 @@ def init_menu_profile():
         id='profile-menu',
     )
 
-    item = current_menu.submenu('main.profile.edit_profile')
-    rero_register(
-        item,
-        endpoint='invenio_userprofiles.profile',
-        visible_when=lambda: current_user.is_authenticated,
-        text=TextWithIcon(
-            icon='<i class="fa fa-user"></i>',
-            text='Edit my profile'
-        ),
-        order=1,
-        id='profile-menu',
-    )
+    # - Edit user profile
+    if not current_app.config.get('USERPROFILES_READ_ONLY', False):
+        item = current_menu.submenu('main.profile.edit_profile')
+        rero_register(
+            item,
+            endpoint='invenio_userprofiles.profile',
+            visible_when=lambda: current_user.is_authenticated,
+            text=TextWithIcon(
+                icon='<i class="fa fa-user"></i>',
+                text='Edit my profile'
+            ),
+            order=1,
+            id='profile-menu',
+        )
 
-    item = current_menu.submenu('main.profile.change_password')
-    rero_register(
-        item,
-        endpoint='security.change_password',
-        visible_when=lambda: current_user.is_authenticated,
-        text=TextWithIcon(
-            icon='<i class="fa fa-lock"></i>',
-            text='Change password'
-        ),
-        order=1,
-        id='profile-menu',
-    )
+    # - Change password
+    if current_app.config.get('SECURITY_RECOVERABLE', True):
+        item = current_menu.submenu('main.profile.change_password')
+        rero_register(
+            item,
+            endpoint='security.change_password',
+            visible_when=lambda: current_user.is_authenticated,
+            text=TextWithIcon(
+                icon='<i class="fa fa-lock"></i>',
+                text='Change password'
+            ),
+            order=1,
+            id='profile-menu',
+        )
 
     # Endpoint for:
     # Application: invenio_oauth2server_settings.index
     # Security: invenio_accounts.security
-
-    item = current_menu.submenu('main.profile.signup')
-    rero_register(
-        item,
-        endpoint='security.register',
-        visible_when=lambda: not current_user.is_authenticated,
-        text=TextWithIcon(
-            icon='<i class="fa fa-user-plus"></i>',
-            text='Sign Up'
-        ),
-        order=2,
-        id='signup-menu',
-    )
+    # - Sign up user
+    if current_app.config.get('SECURITY_REGISTERABLE', True):
+        item = current_menu.submenu('main.profile.signup')
+        rero_register(
+            item,
+            endpoint='security.register',
+            visible_when=lambda: not current_user.is_authenticated,
+            text=TextWithIcon(
+                icon='<i class="fa fa-user-plus"></i>',
+                text='Sign Up'
+            ),
+            order=2,
+            id='signup-menu',
+        )


### PR DESCRIPTION
* Uses variable configuration to display/hide some menu entries.
* Adds read-only setting to logged_user endpoint.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

There was an error when we disable  

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#728
* rero/invenio-userprofiles#6

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
