### PR TITLE
notifications: fix overdue notification creation

### DIFF
--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -31,7 +31,7 @@ from rero_ils.modules.loans.models import LoanAction
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher
 from rero_ils.modules.notifications.models import NotificationType
-from rero_ils.modules.notifications.utils import number_of_reminders_sent
+from rero_ils.modules.notifications.utils import get_notification
 from rero_ils.modules.patron_types.api import PatronType
 from rero_ils.modules.utils import get_ref_for_pid
 
@@ -289,14 +289,14 @@ def test_overdue_limit(
     assert loan.is_loan_overdue()
     assert loan.end_date == end_date.isoformat()
     assert overdue_loans[0].get('pid') == loan_pid
-    assert number_of_reminders_sent(loan) == 0
+    assert not get_notification(loan, NotificationType.OVERDUE)
 
     notification = loan.create_notification(
         _type=NotificationType.OVERDUE).pop()
     Dispatcher.dispatch_notifications([notification.get('pid')])
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
-    assert number_of_reminders_sent(loan) == 1
+    assert get_notification(loan, NotificationType.OVERDUE)
 
     # Try a second checkout - limit should be reached
     res, data = postdata(

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -36,7 +36,7 @@ from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher
 from rero_ils.modules.notifications.models import NotificationType
-from rero_ils.modules.notifications.utils import number_of_reminders_sent
+from rero_ils.modules.notifications.utils import number_of_notifications_sent
 
 
 def test_loans_permissions(client, loan_pending_martigny, json_header):
@@ -353,14 +353,14 @@ def test_overdue_loans(client, librarian_martigny,
 
     overdue_loans = list(get_overdue_loans(patron_pid=patron_pid))
     assert overdue_loans[0].get('pid') == loan_pid
-    assert number_of_reminders_sent(loan) == 0
+    assert number_of_notifications_sent(loan) == 0
 
     notification = loan.create_notification(
         _type=NotificationType.OVERDUE).pop()
     Dispatcher.dispatch_notifications([notification.get('pid')])
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
-    assert number_of_reminders_sent(loan) == 1
+    assert number_of_notifications_sent(loan) == 1
 
     # Try a checkout for a blocked user :: It should be blocked
     res, data = postdata(

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -33,7 +33,7 @@ from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.dispatcher import Dispatcher
 from rero_ils.modules.notifications.models import NotificationType
-from rero_ils.modules.notifications.utils import number_of_reminders_sent
+from rero_ils.modules.notifications.utils import number_of_notifications_sent
 from rero_ils.modules.selfcheck.api import authorize_patron, enable_patron, \
     item_information, patron_information, patron_status, selfcheck_checkin, \
     selfcheck_checkout, selfcheck_login, selfcheck_renew, system_status, \
@@ -156,7 +156,7 @@ def test_patron_information(client, librarian_martigny,
     Dispatcher.dispatch_notifications([notification.get('pid')])
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
-    assert number_of_reminders_sent(loan) == 1
+    assert number_of_notifications_sent(loan) == 1
     # create request
     res, data = postdata(
         client,
@@ -239,7 +239,7 @@ def test_item_information(client, librarian_martigny,
     Dispatcher.dispatch_notifications([notification.get('pid')])
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
-    assert number_of_reminders_sent(loan) == 1
+    assert number_of_notifications_sent(loan) == 1
 
     patron_barcode = selfcheck_patron_martigny\
         .get('patron', {}).get('barcode')[0]

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -35,7 +35,7 @@ from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.models import NotificationType
 from rero_ils.modules.notifications.tasks import create_notifications
 from rero_ils.modules.notifications.utils import get_notification, \
-    number_of_reminders_sent
+    number_of_notifications_sent
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.patrons.listener import \
     create_subscription_patron_transaction
@@ -116,7 +116,7 @@ def test_notifications_task(
     # Should not be created
     assert not loan.is_notified(NotificationType.OVERDUE, 1)
     # Should not be sent
-    assert number_of_reminders_sent(
+    assert number_of_notifications_sent(
         loan, notification_type=NotificationType.OVERDUE) == 0
 
     #   For this test, we will update the loan to simulate an overdue of 12
@@ -139,7 +139,7 @@ def test_notifications_task(
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     assert loan.is_notified(NotificationType.OVERDUE, 0)
-    assert number_of_reminders_sent(
+    assert number_of_notifications_sent(
         loan, notification_type=NotificationType.OVERDUE) == 1
 
     # test overdue notification#2
@@ -149,7 +149,7 @@ def test_notifications_task(
         NotificationType.DUE_SOON,
         NotificationType.OVERDUE
     ], tstamp=datetime.now(timezone.utc))
-    assert number_of_reminders_sent(
+    assert number_of_notifications_sent(
         loan, notification_type=NotificationType.OVERDUE) == 1
 
     # test overdue notification#3
@@ -169,7 +169,7 @@ def test_notifications_task(
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     assert loan.is_notified(NotificationType.OVERDUE, 1)
-    assert number_of_reminders_sent(
+    assert number_of_notifications_sent(
         loan, notification_type=NotificationType.OVERDUE) == 2
 
     # checkin the item to put it back to it's original state


### PR DESCRIPTION
The overdue notification creation doesn't work as expected after loan
extension. It's possible to send an overdue notification before the
extension. If the user extend the loan but continue to keep book, this
loan can be overdue again. In this case, a second 'first overdue'
notification must be created.

Closes rero/rero-ils#2470.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
