### PR TITLE
holdings: place a circulation request

### DIFF
--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -38,8 +38,7 @@ from rero_ils.modules.items.models import ItemCirculationAction
 from rero_ils.modules.items.utils import item_pid_to_object
 from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.loans.api import Loan
-from rero_ils.modules.patrons.api import Patron, current_librarian, \
-    current_patrons
+from rero_ils.modules.patrons.api import Patron, current_librarian
 from rero_ils.modules.views import check_authentication
 from rero_ils.permissions import request_item_permission
 
@@ -168,12 +167,7 @@ def patron_request(item, data):
         pickup_location_pid
     """
     # get the patron account of the same org of the location pid
-    def get_patron(item):
-        for ptrn in current_patrons:
-            if ptrn.organisation_pid == item.organisation_pid:
-                return ptrn
-
-    patron_pid = get_patron(item).pid
+    patron_pid = Patron.get_current_patron(item).pid
     data['patron_pid'] = patron_pid
     data['transaction_user_pid'] = patron_pid
     data['transaction_location_pid'] = data['pickup_location_pid']

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -769,6 +769,16 @@ class Patron(IlsRecord):
                 self.reindex()
                 PatronsSearch.flush_and_refresh()
 
+    def get_current_patron(record):
+        """Return the patron account belongs to record's organisation.
+
+        :param record - a valid rero_ils resource/object.
+        :returns: The patron record linked to the organisation.
+        """
+        for ptrn in current_patrons:
+            if ptrn.organisation_pid == record.organisation_pid:
+                return ptrn
+
 
 class PatronsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""

--- a/tests/api/holdings/test_provisional_items.py
+++ b/tests/api/holdings/test_provisional_items.py
@@ -22,10 +22,12 @@ from __future__ import absolute_import, print_function
 
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import get_json
+from utils import get_json, postdata
 
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus, TypeOfItem
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.utils import get_ref_for_pid
 
 
@@ -96,3 +98,140 @@ def test_provisional_items_creation(client, document, org_martigny,
     items = data['hits']['hits']
     assert len(items) == 1
     assert items[0]['metadata']['pid'] == item_lib_martigny.pid
+
+
+def test_holding_requests(client, patron_martigny, loc_public_martigny,
+                          circulation_policies, librarian_martigny,
+                          holding_lib_martigny_w_patterns, lib_martigny):
+    """Test holding patron request."""
+    login_user_via_session(client, patron_martigny.user)
+    holding = holding_lib_martigny_w_patterns
+    description = 'Year: 2000 / volume: 15 / number: 22 / pages: 11-12'
+    # test fails when there is a missing description or holding_pid
+    res, data = postdata(
+        client,
+        'api_holding.patron_request',
+        dict(
+            holding_pid=holding.pid,
+            pickup_location_pid=loc_public_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+    res, data = postdata(
+        client,
+        'api_holding.patron_request',
+        dict(
+            description=description,
+            pickup_location_pid=loc_public_martigny.pid
+        )
+    )
+    assert res.status_code == 404
+    # test passes when all required parameters are given
+    res, data = postdata(
+        client,
+        'api_holding.patron_request',
+        dict(
+            holding_pid=holding.pid,
+            pickup_location_pid=loc_public_martigny.pid,
+            description=description
+        )
+    )
+    assert res.status_code == 200
+    loan = Loan.get_record_by_pid(
+        data.get('action_applied')[LoanAction.REQUEST].get('pid'))
+    assert loan.state == LoanState.PENDING
+    item = Item.get_record_by_pid(loan.item_pid)
+    assert item.get('type') == TypeOfItem.PROVISIONAL
+    assert item.status == ItemStatus.ON_SHELF
+    assert item.holding_pid == holding.pid
+    assert item.get('enumerationAndChronology') == description
+    # checkout the item to the requested patron
+    login_user_via_session(client, librarian_martigny.user)
+    res, data = postdata(client, 'api_item.checkout', dict(
+        item_pid=item.pid,
+        patron_pid=patron_martigny.pid,
+        transaction_location_pid=loc_public_martigny.pid,
+        transaction_user_pid=librarian_martigny.pid,
+    ))
+    assert res.status_code == 200
+    loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
+    assert loan_pid == loan.pid
+    item = Item.get_record_by_pid(item.pid)
+    assert item.status == ItemStatus.ON_LOAN
+    # return the item at the owning library
+    res, data = postdata(
+        client,
+        'api_item.checkin',
+        dict(
+            item_pid=item.pid,
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid
+        )
+    )
+    assert res.status_code == 200
+    item = Item.get_record_by_pid(item.pid)
+    assert item.status == ItemStatus.ON_SHELF
+    # TODO: add additional tests for the task to delete provisional items with
+    # no active loans.
+
+    # test requests made by a librarian
+    # test fails when there are missing parameters
+    res, data = postdata(
+        client,
+        'api_holding.librarian_request',
+        dict(
+            holding_pid=holding.pid,
+            pickup_location_pid=loc_public_martigny.pid,
+            description=description,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+    res, data = postdata(
+        client,
+        'api_holding.librarian_request',
+        dict(
+            holding_pid=holding.pid,
+            pickup_location_pid=loc_public_martigny.pid,
+            description=description,
+            patron_pid=patron_martigny.pid,
+            transaction_library_pid=lib_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+    res, data = postdata(
+        client,
+        'api_holding.librarian_request',
+        dict(
+            holding_pid=holding.pid,
+            pickup_location_pid=loc_public_martigny.pid,
+            patron_pid=patron_martigny.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+    # test passes when all required parameters are given
+    res, data = postdata(
+        client,
+        'api_holding.librarian_request',
+        dict(
+            holding_pid=holding.pid,
+            pickup_location_pid=loc_public_martigny.pid,
+            description=description,
+            patron_pid=patron_martigny.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny.pid
+        )
+    )
+    assert res.status_code == 200
+    loan_2 = Loan.get_record_by_pid(
+        data.get('action_applied')[LoanAction.REQUEST].get('pid'))
+    assert loan_2.state == LoanState.PENDING
+    item_2 = Item.get_record_by_pid(loan_2.item_pid)
+    assert item_2.get('type') == TypeOfItem.PROVISIONAL
+    assert item_2.status == ItemStatus.ON_SHELF
+    assert item_2.holding_pid == holding.pid
+    assert item_2.get('enumerationAndChronology') == description
+    assert item_2.pid != item.pid


### PR DESCRIPTION
When patron places a request on a holdings record, patron
must provide two required information: pickup_location and
description of the issue.
At the receiving of the request, system attempts to create
a new item of type `provisional`, attach it to the holdings
record and finally reserve it to the patron.
This exact same behaviour executed for requests placed by
librarian on behalf of the patron.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/2353

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
