### PR TITLE
acquisition: indexing `AcqOrder` related notes

### DIFF
--- a/rero_ils/modules/acq_order_lines/dumpers.py
+++ b/rero_ils/modules/acq_order_lines/dumpers.py
@@ -43,9 +43,6 @@ class AcqOrderLineESDumper(InvenioRecordsDumper):
             value = record.get(attr)
             if value:
                 data.update({attr: value})
-        notes = record.get('notes', [])
-        if notes:
-            data['notes'] = [note['content'] for note in notes]
 
         # Add account informations: pid, name and reference number.
         # (remove None values from account metadata)

--- a/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -61,6 +61,16 @@
           },
           "content": {
             "type": "text"
+          },
+          "source": {
+            "properties": {
+              "pid": {
+                "type": "keyword"
+              },
+              "type": {
+                "type": "keyword"
+              }
+            }
           }
         }
       },
@@ -80,9 +90,6 @@
           },
           "status": {
             "type": "keyword"
-          },
-          "notes": {
-            "type": "text"
           },
           "document": {
             "properties": {

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -271,6 +271,12 @@
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
     },
+    "notes": [
+      {
+        "type": "staff_note",
+        "content": "staff note content here"
+      }
+    ],
     "is_cancelled": false,
     "quantity": 5,
     "priority": 5,

--- a/tests/ui/acq_orders/test_acq_orders_api.py
+++ b/tests/ui/acq_orders/test_acq_orders_api.py
@@ -18,7 +18,8 @@
 
 """Acquisition orders API tests."""
 
-from rero_ils.modules.acq_order_lines.models import AcqOrderLineStatus
+from rero_ils.modules.acq_order_lines.models import AcqOrderLineNoteType, \
+    AcqOrderLineStatus
 from rero_ils.modules.acq_orders.models import AcqOrderNoteType, AcqOrderStatus
 
 
@@ -64,7 +65,7 @@ def test_order_properties(
     del acol2['order_date']
     acol2.update(acol2, dbcommit=True, reindex=True)
 
-    # ORDER NOTE --------------------------------------------------------------
+    # NOTES -------------------------------------------------------------------
     note_content = 'test note content'
     assert acor.get_note(AcqOrderNoteType.VENDOR) is None
     acor.setdefault('notes', []).append({
@@ -73,6 +74,14 @@ def test_order_properties(
     })
     assert acor.get_note(AcqOrderNoteType.VENDOR) == note_content
     del acor['notes']
+
+    # Check that `related notes` content return the note from `acol1`
+    assert any(
+        note[0]['type'] == AcqOrderLineNoteType.STAFF
+        and note[1] == acol1.__class__
+        and note[2] == acol1.pid
+        for note in acor.get_related_notes()
+    )
 
     # ORDER ITEM QUANTITY -----------------------------------------------------
     assert acor.item_quantity == 6


### PR DESCRIPTION
All notes from resources related to an AcqOrder should be indexed into
the AcqOrder index in order to allow searching into any note content.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
