### PR TITLE
import: fix links for contributors with DNB identifiers

### DIFF
--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -419,7 +419,7 @@ def get_contribution_link(bibid, reroid, id, key):
     if match and len(match.groups()) == 2 and key[:3] in _CONTRIBUTION_TAGS:
         match_type = match.group(1).lower()
         match_value = match.group(2)
-        match_type.replace('de-588', 'gnd')
+        match_type = match_type.replace('de-588', 'gnd')
         # if we have a viafid, look for the contributor in MEF
         if match_type == "viaf":
             url = f'{mef_url}/mef/?q=viaf_pid:{match_value}'


### PR DESCRIPTION
* Fixes links for contributors with DNB identifiers when importing from the Web (automatic link to MEF).

Co-Authored-by: Benoit Erken <erken.benoit@gmail.com>

## Dependencies

N/A

* rero/rero-ils-ui#<xx>

## How to test?

- In the prof. interface: search for isbn 9783110632439 in SLSP. Try to import the book. You should see contributors automatically linked to MEF entries.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
