### PR TITLE
notifications: fix email_notification_type

### DIFF
--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -378,6 +378,7 @@ def email_notification_type(libray, notification_type):
     :return: the email corresponding to the notification type.
     :rtype: string
     """
-    for setting in libray['notification_settings']:
+    # notification_settings is not a required field.
+    for setting in libray.get('notification_settings', []):
         if setting['type'] == notification_type:
             return setting['email']


### PR DESCRIPTION
* `notification_settings` is not a required field for notifications.
  To prevent `KeyError` exceptions we have to use `get`.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
