### PR TITLE
items: delete checked-in provisional items

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -385,6 +385,11 @@ CELERY_BEAT_SCHEDULE = {
         # Every week on Saturday at 22:22 UTC,
         'enabled': False
     },
+    'delete-provisional-items': {
+        'task': 'rero_ils.modules.items.tasks.delete_provisional_items',
+        'schedule': crontab(minute=0, hour=3),  # Every day at 03:00 UTC,
+        'enabled': False,
+    },
     # 'mef-harvester': {
     #     'task': 'rero_ils.modules.apiharvester.tasks.harvest_records',
     #     'schedule': timedelta(minutes=60),

--- a/scripts/setup
+++ b/scripts/setup
@@ -524,7 +524,7 @@ then
 else
     eval ${PREFIX} invenio reroils scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -n collect-stats -v
     eval ${PREFIX} invenio reroils scheduler enable_tasks -n notification-creation -n notification-dispatch-availability -n notification-dispatch-recall -n find-contribution -v
-    eval ${PREFIX} invenio reroils scheduler enable_tasks -n cancel-expired-request -v
+    eval ${PREFIX} invenio reroils scheduler enable_tasks -n cancel-expired-request -n delete-provisional-items -v
     info_msg "For ebooks harvesting run:"
     msg "\tinvenio reroils oaiharvester harvest -n ebooks -a max=100 -q"
 fi


### PR DESCRIPTION
* Adds a daily task to delete checked-in provisional items having not associated fees.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

* Migration instructions:

This task need to be enabled for the production instance
- invenio reroils scheduler enable_tasks -n delete-provisional-items -v

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/2356



## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
