### PR TITLE
jsonschema: introduce exclusiveMinimum for fields

### DIFF
--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -172,6 +172,7 @@
           "fee_amount": {
             "type": "number",
             "title": "Amount",
+            "exclusiveMinimum": 0,
             "multipleOf": 0.01,
             "form": {
               "hide": true,
@@ -269,7 +270,7 @@
               "fee_amount": {
                 "type": "number",
                 "title": "Amount",
-                "minimum": 0,
+                "exclusiveMinimum": 0,
                 "multipleOf": 0.01,
                 "form": {
                   "fieldMap": "fee_amount",
@@ -286,7 +287,7 @@
           "type": "number",
           "description": "This defines the maximum fee amount per document, without considering the reminder fees.",
           "title": "Maximum total amount",
-          "minimum": 0,
+          "exclusiveMinimum": 0,
           "multipleOf": 0.01,
           "form": {
             "fieldMap": "amount"

--- a/rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json
+++ b/rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json
@@ -43,7 +43,7 @@
     "amount": {
       "title": "Amount",
       "type": "number",
-      "minimum": 0,
+      "exclusiveMinimum": 0,
       "multipleOf": 0.01
     },
     "steps": {
@@ -60,7 +60,7 @@
           },
           "amount": {
             "type": "number",
-            "minimum": 0.01,
+            "exclusiveMinimum": 0,
             "multipleOf": 0.01
           }
         },

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -80,8 +80,10 @@
           "type": "string",
           "minLength": 1,
           "form": {
+            "type": "textarea",
             "templateOptions": {
-              "itemCssClass": "col-lg-12"
+              "itemCssClass": "col-lg-12",
+              "rows": 2
             }
           }
         },

--- a/rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json
+++ b/rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json
@@ -115,7 +115,13 @@
       "title": "Street",
       "description": "Street and number of the address.",
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "form": {
+        "type": "textarea",
+        "templateOptions": {
+          "rows": 2
+        }
+      }
     },
     "postal_code": {
       "title": "Postal code",

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -133,7 +133,13 @@
           "title": "Street",
           "description": "Street and number of the address, separated by a coma.",
           "type": "string",
-          "minLength": 4
+          "minLength": 4,
+          "form": {
+            "type": "textarea",
+            "templateOptions": {
+              "rows": 2
+            }
+          }
         },
         "postal_code": {
           "title": "Postal code",


### PR DESCRIPTION
The following fields are not allowed normally to have
a value of zero. with exclusiveMinimum, this ensures a
value greater than zero.

cipo.reminders.fee_amount
cipo.overdue_fees.fee_amount
cipo.maximum_total_amount
patron_transaction_event.amount
patron_transaction_event.steps.amount

* Changes street fields to multi-line text input.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
