### PR TITLE
PatronTransaction: fix event creation

### DIFF
--- a/rero_ils/modules/patron_transaction_events/api.py
+++ b/rero_ils/modules/patron_transaction_events/api.py
@@ -82,7 +82,9 @@ class PatronTransactionEvent(IlsRecord):
         """Create patron transaction event record."""
         if 'creation_date' not in data:
             data['creation_date'] = datetime.now(timezone.utc).isoformat()
-        data['amount'] = round(data['amount'], 2)  # ensure multiple of 0.01
+        if 'amount' in data:
+            # ensure multiple of 0.01
+            data['amount'] = round(data['amount'], 2)
         record = super().create(
             data, id_, delete_pid, dbcommit, reindex, **kwargs)
         if update_parent:


### PR DESCRIPTION
It was unable to create a `PatronTransactionEvent` without amount.
However, it must be allowed for some event (like a dispute).

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
