### PR TITLE
notifications: fix multiple notification creation

### DIFF
--- a/rero_ils/modules/notifications/utils.py
+++ b/rero_ils/modules/notifications/utils.py
@@ -36,7 +36,9 @@ def get_notification(loan, notification_type):
     from .api import Notification
     results = NotificationsSearch()\
         .filter('term', context__loan__pid=loan.pid)\
-        .filter('term', notification_type=notification_type)\
+        .filter('term', notification_type=notification_type) \
+        .params(preserve_order=True) \
+        .sort({'creation_date': {"order": "desc"}}) \
         .source().scan()
     try:
         pid = next(results).pid


### PR DESCRIPTION
Before creating a reminder notification, we need to known if a previous
notification was already created since the last transaction date. We
can't just let the notification process cancel this notification because
a `PatronTransaction` could be created when a reminder notification is
created, despite if this notification is cancelled during notification
dispatch process.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
