### PR TITLE
documents: fix translation on original language field

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_original_language-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_original_language-v0.0.1.json
@@ -4,7 +4,6 @@
     "description": "Language of original work (MARC 041$h)",
     "type": "array",
     "minItems": 1,
-    "uniqueItems": true,
     "items": {
       "$ref": "https://bib.rero.ch/schemas/common/languages-v0.0.1.json#/language"
     },


### PR DESCRIPTION
* Fixes the behavior by going back to several selects (one per language).
* Closes #2416.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
