### PR TITLE
circulation: fix overdue fees timestamp calculation

### DIFF
--- a/rero_ils/modules/patron_transactions/api.py
+++ b/rero_ils/modules/patron_transactions/api.py
@@ -310,14 +310,13 @@ class PatronTransaction(IlsRecord):
                     'timestamp': fee[1].isoformat(),
                     'amount': fee[0]
                 })
-            record = cls.create(
+            return cls.create(
                 data,
                 dbcommit=dbcommit,
                 reindex=reindex,
                 delete_pid=delete_pid,
                 steps=steps
             )
-            return record
 
     @classmethod
     def create_patron_transaction_from_notification(


### PR DESCRIPTION
The overdue fees steps was not correctly calculated depending of the
related library timezone.
Closes rero/rero-ils#2550.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## How to test?

![image](https://user-images.githubusercontent.com/10031585/145542175-70128e1d-fdf0-4e21-9934-eb5d7848c332.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
