### PR TITLE
acquisition: fix unique fields detection

### DIFF
--- a/data/acq_accounts.json
+++ b/data/acq_accounts.json
@@ -78,7 +78,7 @@
   {
     "pid": "6",
     "name": "Aoste-Cant monography",
-    "number": "AOSTE/2020.020.000",
+    "number": "AOSTE/2020.030.000",
     "allocated_amount": 17000,
     "budget": {
       "$ref": "https://bib.rero.ch/api/budgets/1"
@@ -90,7 +90,7 @@
   {
     "pid": "7",
     "name": "Aoste-Cant monography / Hard cover",
-    "number": "AOSTE/2020.020.001",
+    "number": "AOSTE/2020.030.001",
     "allocated_amount": 15000,
     "expenditure_exceedance": 5,
     "parent": {
@@ -106,7 +106,7 @@
   {
     "pid": "8",
     "name": "Aoste-Cant monography / Soft cover",
-    "number": "AOSTE/2020.020.002",
+    "number": "AOSTE/2020.030.002",
     "allocated_amount": 2000,
     "encumbrance_exceedance": 10,
     "expenditure_exceedance": 10,

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2370,7 +2370,7 @@ for index in indexes:
 
 # ------ ACQUISITION ACCOUNTS SORT
 RECORDS_REST_SORT_OPTIONS['acq_accounts']['name'] = dict(
-    fields=['name_sort'], title='Account name',
+    fields=['name.raw'], title='Account name',
     default_order='asc'
 )
 RECORDS_REST_SORT_OPTIONS['acq_accounts']['depth'] = dict(

--- a/rero_ils/modules/acq_accounts/api.py
+++ b/rero_ils/modules/acq_accounts/api.py
@@ -81,8 +81,8 @@ class AcqAccount(IlsRecord):
     }
 
     unique_value_fields = [
-        ('name', 'name_sort'),
-        ('number', 'number_sort')
+        ('name', 'name.raw'),
+        ('number', 'number.raw')
     ]
 
     _extensions = [

--- a/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
@@ -41,7 +41,9 @@
         "focus": true,
         "validation": {
           "validators": {
-            "valueAlreadyExists": {}
+            "valueAlreadyExists": {
+              "term": "name.raw"
+            }
           },
           "messages": {
             "alreadyTakenMessage": "The name is already taken."
@@ -57,7 +59,9 @@
       "form": {
         "validation": {
           "validators": {
-            "valueAlreadyExists": {}
+            "valueAlreadyExists": {
+              "term": "number.raw"
+            }
           },
           "messages": {
             "alreadyTakenMessage": "The number is already taken."

--- a/rero_ils/modules/acq_accounts/mappings/v7/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/mappings/v7/acq_accounts/acq_account-v0.0.1.json
@@ -11,17 +11,21 @@
       },
       "name": {
         "type": "text",
-        "copy_to": "name_sort"
-      },
-      "name_sort": {
-        "type": "keyword"
+        "fields": {
+          "raw": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "number": {
         "type": "text",
-        "copy_to": "number_sort"
-      },
-      "number_sort": {
-        "type": "keyword"
+        "fields": {
+          "raw": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "allocated_amount": {
         "type": "float"

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -38,7 +38,7 @@
         "validation": {
           "validators": {
             "valueAlreadyExists": {
-              "term": "reference"
+              "term": "reference.raw"
             }
           },
           "messages": {

--- a/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -40,7 +40,13 @@
         }
       },
       "reference": {
-        "type": "keyword"
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "type": {
         "type": "keyword"


### PR DESCRIPTION
Updates the mapping of `AcqAccount` and `AcqOrder` resources for unique
fields detection. Fields must be indexed as 'text' for search but also
as 'keyword' for unique value detection/facet.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
