### PR TITLE
library: add `extra` field for acquisition setting

### DIFF
--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -439,6 +439,12 @@
             },
             "address": {
               "$ref": "#/definitions/address_block"
+            },
+            "extra": {
+              "title": "Extra information",
+              "description": "VAT number, note, ...",
+              "type": "string",
+              "minLength": 3
             }
           }
         },
@@ -470,6 +476,12 @@
             },
             "address": {
               "$ref": "#/definitions/address_block"
+            },
+            "extra": {
+              "title": "Extra information",
+              "description": "VAT number, note, ...",
+              "type": "string",
+              "minLength": 3
             }
           }
         }

--- a/rero_ils/modules/libraries/mappings/v7/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/mappings/v7/libraries/library-v0.0.1.json
@@ -122,6 +122,9 @@
               "phone": {
                 "type": "text"
               },
+              "extra": {
+                "type": "text"
+              },
               "address": {
                 "properties": {
                   "street": {
@@ -155,6 +158,9 @@
                 }
               },
               "phone": {
+                "type": "text"
+              },
+              "extra": {
                 "type": "text"
               },
               "address": {

--- a/rero_ils/theme/templates/rero_ils/address_block/eng.tpl.txt
+++ b/rero_ils/theme/templates/rero_ils/address_block/eng.tpl.txt
@@ -7,4 +7,7 @@ Email: {{ data.email }}
 {%- endif %}
 {%- if data.phone %}
 Phone: {{ data.phone }}
+{%- if data.extra %}
+{{ data.extra }}
+{%- endif %}
 {%- endif %}

--- a/rero_ils/theme/templates/rero_ils/address_block/fre.tpl.txt
+++ b/rero_ils/theme/templates/rero_ils/address_block/fre.tpl.txt
@@ -7,4 +7,7 @@ E-mail: {{ data.email }}
 {%- endif %}
 {%- if data.phone %}
 Tél: {{ data.phone }}
+{%- if data.extra %}
+{{ data.extra }}
+{%- endif %}
 {%- endif %}

--- a/rero_ils/theme/templates/rero_ils/address_block/ger.tpl.txt
+++ b/rero_ils/theme/templates/rero_ils/address_block/ger.tpl.txt
@@ -7,4 +7,7 @@ E-mail: {{ data.email }}
 {%- endif %}
 {%- if data.phone %}
 Telefon: {{ data.phone }}
+{%- if data.extra %}
+{{ data.extra }}
+{%- endif %}
 {%- endif %}

--- a/rero_ils/theme/templates/rero_ils/address_block/ita.tpl.txt
+++ b/rero_ils/theme/templates/rero_ils/address_block/ita.tpl.txt
@@ -7,4 +7,7 @@ E-mail: {{ data.email }}
 {%- endif %}
 {%- if data.phone %}
 Telefono: {{ data.phone }}
+{%- if data.extra %}
+{{ data.extra }}
+{%- endif %}
 {%- endif %}

--- a/tests/api/acq_orders/test_acq_orders_views.py
+++ b/tests/api/acq_orders/test_acq_orders_views.py
@@ -67,13 +67,15 @@ def test_send_order(
     app, client, librarian_martigny, lib_martigny,
     acq_order_fiction_martigny,
     acq_order_line_fiction_martigny, vendor_martigny,
-    acq_order_line2_fiction_martigny, acq_order_line3_fiction_martigny
+    acq_order_line2_fiction_martigny, acq_order_line3_fiction_martigny,
+    mailbox
 ):
     """Test send order notification API."""
     login_user_via_session(client, librarian_martigny.user)
     acor = acq_order_fiction_martigny
     address = vendor_martigny.get('default_contact').get('email')
     emails = [{'type': 'cc', 'address': address}]
+    mailbox.clear()
     # test when parent order is not in database
     res, data = postdata(
         client,
@@ -156,3 +158,8 @@ def test_send_order(
     assert notif.get_language_to_use() == \
         vendor_martigny.get('communication_language')
     assert address in notif.get_recipients(RecipientType.TO)
+
+    # Check mail content
+    message = mailbox[-1]
+    shipping = lib_martigny['acquisition_settings']['shipping_informations']
+    assert shipping.get('extra') and shipping.get('extra') in message.body

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -174,7 +174,8 @@
           "city": "Martigny",
           "zip_code": "1920",
           "country": "sz"
-        }
+        },
+        "extra": "VAT number: 123456-78-90"
       },
       "billing_informations": {
         "name": "martigny billing dept",


### PR DESCRIPTION
Adds a field to allow extra setting (VAT number, special note, ...) for
any informations related to acquisition setting into the `Library`
resource.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
