### PR TITLE
acquisition: add VAT rate field for receipt line

### DIFF
--- a/rero_ils/modules/acq_receipt_lines/api.py
+++ b/rero_ils/modules/acq_receipt_lines/api.py
@@ -80,9 +80,8 @@ class AcqReceiptLine(IlsRecord):
         # TODO : should be used into `pre_create` hook extensions but seems not
         #        work as expected.
         cls._build_additional_refs(data)
-        record = super().create(
+        return super().create(
             data, id_, delete_pid, dbcommit, reindex, **kwargs)
-        return record
 
     def update(self, data, commit=True, dbcommit=True, reindex=True):
         """Update Acquisition Receipt Line record."""
@@ -153,7 +152,9 @@ class AcqReceiptLine(IlsRecord):
     @property
     def total_amount(self):
         """Shortcut for related acquisition total_amount."""
-        total = self.amount * self.receipt.exchange_rate * self.quantity
+        vat_factor = (100 + self.get('vat_rate', 0)) / 100
+        total = self.amount * self.receipt.exchange_rate * self.quantity * \
+            vat_factor
         return round(total, 2)
 
     @property

--- a/rero_ils/modules/acq_receipt_lines/jsonschemas/acq_receipt_lines/acq_receipt_line-v0.0.1.json
+++ b/rero_ils/modules/acq_receipt_lines/jsonschemas/acq_receipt_lines/acq_receipt_line-v0.0.1.json
@@ -7,6 +7,7 @@
   "propertiesOrder": [
     "quantity",
     "amount",
+    "vat_rate",
     "receipt_date",
     "notes"
   ],
@@ -80,6 +81,24 @@
         "fieldMap": "amount",
         "navigation": {
           "essential": true
+        }
+      }
+    },
+    "vat_rate": {
+      "title": "VAT rate",
+      "type": "number",
+      "description": "percentage of VAT rate to apply on this receipt line",
+      "minimum": 0,
+      "maximum": 100,
+      "default": 0,
+      "form": {
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "addonRight": {
+            "text": "%"
+          }
         }
       }
     },

--- a/rero_ils/modules/acq_receipt_lines/mappings/v7/acq_receipt_lines/acq_receipt_line-v0.0.1.json
+++ b/rero_ils/modules/acq_receipt_lines/mappings/v7/acq_receipt_lines/acq_receipt_line-v0.0.1.json
@@ -55,6 +55,9 @@
       "amount": {
         "type": "float"
       },
+      "vat_rate": {
+        "type": "float"
+      },
       "total_amount": {
         "type": "float"
       },

--- a/tests/api/acquisition/test_acquisition_reception_workflow.py
+++ b/tests/api/acquisition/test_acquisition_reception_workflow.py
@@ -467,6 +467,7 @@ def test_acquisition_reception_workflow(
             'acq_order_line': {'$ref': order_line_1_ref},
             'amount': 10,
             'quantity': 2,
+            'vat_rate': 6,
             'receipt_date': '2021-11-01'
         }],
         url_data=dict(receipt_pid=receipt_1.pid)
@@ -508,8 +509,8 @@ def test_acquisition_reception_workflow(
     assert order.status == AcqOrderStatus.PARTIALLY_RECEIVED
 
     manual_controls = {
-        m_root_acc: ((5000, 9294), (0, 31), (0, 675)),
-        m_books_acc: ((1649, 1649), (21, 0), (330, 0)),
+        m_root_acc: ((5000, 9292.8), (0, 32.2), (0, 675)),
+        m_books_acc: ((1647.8, 1647.8), (22.2, 0), (330, 0)),
         m_serials_acc: ((2645, 2645), (10, 0), (345, 0)),
         s_root_acc: ((13500, 20000), (0, 0), (0, 0)),
         s_books_acc: ((2500, 2500), (0, 0), (0, 0)),
@@ -602,8 +603,8 @@ def test_acquisition_reception_workflow(
     assert order.status == AcqOrderStatus.RECEIVED
     # check account amounts
     manual_controls = {
-        m_root_acc: ((5000, 9294), (0, 706), (0, 0)),
-        m_books_acc: ((1649, 1649), (351, 0), (0, 0)),
+        m_root_acc: ((5000, 9292.8), (0, 707.2), (0, 0)),
+        m_books_acc: ((1647.8, 1647.8), (352.2, 0), (0, 0)),
         m_serials_acc: ((2645, 2645), (355, 0), (0, 0)),
         s_root_acc: ((13500, 20000), (0, 0), (0, 0)),
         s_books_acc: ((2500, 2500), (0, 0), (0, 0)),

--- a/tests/ui/acq_receipt_lines/test_acq_receipt_lines_api.py
+++ b/tests/ui/acq_receipt_lines/test_acq_receipt_lines_api.py
@@ -27,17 +27,27 @@ def test_receipt_lines_properties(acq_receipt_fiction_martigny,
                                   lib_martigny, acq_account_fiction_martigny):
     """Test receipt line properties."""
     acrl1 = acq_receipt_line_1_fiction_martigny
+    acre = acq_receipt_fiction_martigny
     # LIBRARY------------------------------------------------------------------
     assert acrl1.library_pid == acq_receipt_fiction_martigny.library_pid
     # ORGANISATION ------------------------------------------------------------
     assert acrl1.organisation_pid == lib_martigny.organisation_pid
     # ORDER LINE --------------------------------------------------------------
     assert acrl1.order_line_pid == acq_order_line_fiction_martigny.pid
+    acol = acq_order_line_fiction_martigny
+    assert acol.receipt_date.strftime('%Y-%m-%d') == acrl1.get('receipt_date')
+
     # NOTE --------------------------------------------------------------------
     assert acrl1.get_note(AcqReceiptLineNoteType.STAFF)
     # ACQ ACCOUNT -------------------------------------------------------------
     assert acq_account_fiction_martigny.expenditure_amount == (1001.0, 0.0)
 
-    # TEST order_line.reception_date
-    acol = acq_order_line_fiction_martigny
-    assert acol.receipt_date.strftime('%Y-%m-%d') == acrl1.get('receipt_date')
+    # TOTAL AMOUNT ------------------------------------------------------------
+    #   The receipt line total amount has multiple variables : quantity,
+    #   amount, exchange rate and VAT rate
+    #   Starting situation is : qte=1, amount=1000, vat=0, exchange=0
+    assert acrl1.total_amount == 1000
+    acrl1['vat_rate'] = 6.2  # 1000 * 0.062 --> 62
+    assert acrl1.total_amount == 1062
+    acrl1['vat_rate'] = 100  # 1000 * 1.00 --> 1000
+    assert acrl1.total_amount == 2000

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,10 +97,20 @@ def acq_order_schema(monkeypatch):
 
 @pytest.fixture()
 def acq_order_line_schema(monkeypatch):
-    """Acq order Jsonschema for records."""
+    """Acq order line Jsonschema for records."""
     schema_in_bytes = resource_string(
         'rero_ils.modules.acq_order_lines.jsonschemas',
         '/acq_order_lines/acq_order_line-v0.0.1.json'
+    )
+    return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture()
+def acq_receipt_line_schema(monkeypatch):
+    """Acq receipt line Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.acq_receipt_lines.jsonschemas',
+        '/acq_receipt_lines/acq_receipt_line-v0.0.1.json'
     )
     return get_schema(monkeypatch, schema_in_bytes)
 

--- a/tests/unit/test_acq_receipt_lines_jsonschema.py
+++ b/tests/unit/test_acq_receipt_lines_jsonschema.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition receipt lines JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_vat_rate(
+    acq_receipt_line_1_fiction_martigny, acq_receipt_line_schema
+):
+    """Test VAT rate for acq receipt lines jsonschemas."""
+
+    receipt_line_data = acq_receipt_line_1_fiction_martigny
+    validate(receipt_line_data, acq_receipt_line_schema)
+
+    with pytest.raises(ValidationError):
+        receipt_line_data['vat_rate'] = -1
+        validate(receipt_line_data, acq_receipt_line_schema)
+
+    with pytest.raises(ValidationError):
+        receipt_line_data['vat_rate'] = 101
+        validate(receipt_line_data, acq_receipt_line_schema)


### PR DESCRIPTION
Adds a new field into each reception line to specify the VAT rate to use
for this line.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
