### PR TITLE
acquisition: add multiples notes on `Vendor`

### DIFF
--- a/data/vendors.json
+++ b/data/vendors.json
@@ -3,7 +3,12 @@
     "pid": "1",
     "name": "Payot Aoste",
     "website": "http://www.payot.it",
-    "note": "Personne de contact litiges: Mme di Marzo",
+    "notes": [
+      {
+        "type": "claim_note",
+        "content": "Personne de contact litiges: Mme di Marzo"
+      }
+    ],
     "communication_language": "ita",
     "default_contact": {
       "city": "Aosta",
@@ -23,7 +28,12 @@
     "pid": "2",
     "name": "Payot Aoste",
     "website": "http://www.payot.it",
-    "note": "Personne de contact litiges: Mme di Marzo",
+    "notes": [
+      {
+        "type": "claim_note",
+        "content": "Personne de contact litiges: Mme di Marzo"
+      }
+    ],
     "communication_language": "ita",
     "default_contact": {
       "city": "Aosta",
@@ -43,7 +53,12 @@
     "pid": "3",
     "name": "Payot Aoste",
     "website": "http://www.payot.it",
-    "note": "Personne de contact litiges: Mme di Marzo",
+    "notes": [
+      {
+        "type": "claim_note",
+        "content": "Personne de contact litiges: Mme di Marzo"
+      }
+    ],
     "communication_language": "ita",
     "default_contact": {
       "city": "Aosta",
@@ -120,6 +135,16 @@
     "pid": "7",
     "name": "Association des Alpes",
     "communication_language": "ita",
+    "notes": [
+      {
+        "type": "claim_note",
+        "content": "contact = Daisy Derata"
+      },
+      {
+        "type": "payment_note",
+        "content": "accept all currencies"
+      }
+    ],
     "default_contact": {
       "city": "Saint-Vincent",
       "email": "reroilstest+vendor3@gmail.com",
@@ -171,7 +196,12 @@
     "pid": "10",
     "name": "Flourish and Blotts Bookseller",
     "website": "http://www.flourishandblotts.com",
-    "note": "Reduction 5%",
+    "notes": [
+      {
+        "type": "receipt_note",
+        "content": "Reduction 5%"
+      }
+    ],
     "communication_language": "eng",
     "default_contact": {
       "city": "London",
@@ -190,7 +220,12 @@
     "pid": "11",
     "name": "Flourish and Blotts Bookseller",
     "website": "http://www.flourishandblotts.com",
-    "note": "Reduction 5%",
+    "notes": [
+      {
+        "type": "receipt_note",
+        "content": "Reduction 5%"
+      }
+    ],
     "communication_language": "eng",
     "default_contact": {
       "city": "London",
@@ -209,7 +244,12 @@
     "pid": "12",
     "name": "Flourish and Blotts Bookseller",
     "website": "http://www.flourishandblotts.com",
-    "note": "Reduction 5%",
+    "notes": [
+      {
+        "type": "receipt_note",
+        "content": "Reduction 5%"
+      }
+    ],
     "communication_language": "eng",
     "default_contact": {
       "city": "London",
@@ -263,7 +303,6 @@
   {
     "pid": "16",
     "name": "Sempere and Sons",
-    "note": "Reduction 5% for libraries of the fictive network",
     "communication_language": "eng",
     "default_contact": {
       "city": "Barcelona",
@@ -282,7 +321,6 @@
   {
     "pid": "17",
     "name": "Sempere and Sons",
-    "note": "Reduction 5% for libraries of the fictive network",
     "communication_language": "eng",
     "default_contact": {
       "city": "Barcelona",
@@ -301,7 +339,6 @@
   {
     "pid": "18",
     "name": "Sempere and Sons",
-    "note": "Reduction 5% for libraries of the fictive network",
     "communication_language": "eng",
     "default_contact": {
       "city": "Barcelona",

--- a/rero_ils/modules/acq_receipt_lines/dumpers.py
+++ b/rero_ils/modules/acq_receipt_lines/dumpers.py
@@ -37,7 +37,7 @@ class AcqReceiptLineESDumper(InvenioRecordsDumper):
         :param data: The initial dump data passed in by ``record.dumps()``.
         """
         # Keep only some attributes from AcqReceiptLine object initial dump.
-        for attr in ['pid', 'receipt_date', 'amount', 'quantity']:
+        for attr in ['pid', 'receipt_date', 'amount', 'quantity', 'vat_rate']:
             value = record.get(attr)
             if value:
                 data.update({attr: value})

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -8,11 +8,11 @@
     "name",
     "website",
     "communication_language",
-    "note",
     "currency",
     "vat_rate",
     "default_contact",
-    "order_contact"
+    "order_contact",
+    "notes"
   ],
   "required": [
     "$schema",
@@ -66,10 +66,113 @@
         }
       }
     },
-    "note": {
-      "title": "Note",
-      "type": "string",
-      "minLength": 1
+    "notes": {
+      "title": "Notes",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "Note",
+        "propertiesOrder": [
+          "type",
+          "content"
+        ],
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "enum": [
+              "order_note",
+              "claim_note",
+              "return_note",
+              "invoice_note",
+              "payment_note",
+              "receipt_note",
+              "credit_note",
+              "staff_note",
+              "general_note"
+            ],
+            "default": "general_note",
+            "form": {
+              "type": "selectWithSort",
+              "options": [
+                {
+                  "label": "order_note",
+                  "value": "order_note"
+                },
+                {
+                  "label": "claim_note",
+                  "value": "claim_note"
+                },
+                {
+                  "label": "return_note",
+                  "value": "return_note"
+                },
+                {
+                  "label": "invoice_note",
+                  "value": "invoice_note"
+                },
+                {
+                  "label": "payment_note",
+                  "value": "payment_note"
+                },
+                {
+                  "label": "receipt_note",
+                  "value": "receipt_note"
+                },
+                {
+                  "label": "credit_note",
+                  "value": "credit_note"
+                },
+                {
+                  "label": "staff_note",
+                  "value": "staff_note"
+                },
+                {
+                  "label": "general_note",
+                  "value": "general_note"
+                }
+              ]
+            }
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "maxLength": 2000,
+            "minLength": 1,
+            "form": {
+              "type": "textarea",
+              "templateOptions": {
+                "rows": 3
+              }
+            }
+          }
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
+        },
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "type"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one note per type is allowed"
+          }
+        }
+      }
     },
     "communication_language": {
       "title": "Communication language",

--- a/rero_ils/modules/vendors/mappings/v7/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/mappings/v7/vendors/vendor-v0.0.1.json
@@ -16,8 +16,15 @@
       "vendor_name": {
         "type": "keyword"
       },
-      "note": {
-        "type": "text"
+      "notes": {
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "content": {
+            "type": "text"
+          }
+        }
       },
       "website": {
         "type": "keyword"

--- a/rero_ils/modules/vendors/models.py
+++ b/rero_ils/modules/vendors/models.py
@@ -40,3 +40,17 @@ class VendorMetadata(db.Model, RecordMetadataBase):
     """Vendor record metadata."""
 
     __tablename__ = 'vendor_metadata'
+
+
+class VendorNoteType:
+    """Type of vendor note."""
+
+    ORDER = 'order_note'
+    CLAIM = 'claim_note'
+    RETURN = 'return_note'
+    INVOICE = 'invoice_note'
+    PAYMENT = 'payment_note'
+    RECEIPT = 'receipt_note'
+    CREDIT = 'credit_note'
+    STAFF = 'staff_note'
+    GENERAL = 'general_note'

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -4,7 +4,16 @@
     "pid": "vndr1",
     "name": "Payot Aoste",
     "website": "http://www.payot.it",
-    "note": "Personne de contact litiges: Mme di Marzo",
+    "notes": [
+      {
+        "type": "claim_note",
+        "content": "Personne de contact litiges: Mme di Marzo"
+      },
+      {
+        "type": "staff_note",
+        "content": "note content only for staff"
+      }
+    ],
     "communication_language": "ita",
     "default_contact": {
       "city": "Aosta",
@@ -63,7 +72,12 @@
     "pid": "vndr4",
     "name": "Flourish and Blotts Bookseller",
     "website": "http://www.flourishandblotts.com",
-    "note": "Reduction 5%",
+    "notes": [
+      {
+        "type": "receipt_note",
+        "content": "Reduction 5%"
+      }
+    ],
     "communication_language": "eng",
     "default_contact": {
       "city": "London",

--- a/tests/fixtures/acquisition.py
+++ b/tests/fixtures/acquisition.py
@@ -73,7 +73,7 @@ def vendor2_martigny_data(acquisition):
 
 
 @pytest.fixture(scope="module")
-def vendor2_martigny(app, vendor2_martigny_data):
+def vendor2_martigny(app, org_martigny, vendor2_martigny_data):
     """Load vendor record."""
     vendor = Vendor.create(
         data=vendor2_martigny_data,
@@ -91,7 +91,7 @@ def vendor3_martigny_data(acquisition):
 
 
 @pytest.fixture(scope="module")
-def vendor3_martigny(app, vendor3_martigny_data):
+def vendor3_martigny(app, org_martigny, vendor3_martigny_data):
     """Load vendor record."""
     vendor = Vendor.create(
         data=vendor3_martigny_data,
@@ -109,7 +109,7 @@ def vendor_sion_data(acquisition):
 
 
 @pytest.fixture(scope="module")
-def vendor_sion(app, vendor_sion_data):
+def vendor_sion(app, org_sion, vendor_sion_data):
     """Load vendor record."""
     vendor = Vendor.create(
         data=vendor_sion_data,
@@ -127,7 +127,7 @@ def vendor2_sion_data(acquisition):
 
 
 @pytest.fixture(scope="module")
-def vendor2_sion(app, vendor2_sion_data):
+def vendor2_sion(app, org_sion, vendor2_sion_data):
     """Load vendor record."""
     vendor = Vendor.create(
         data=vendor2_sion_data,

--- a/tests/ui/vendors/test_vendors_api.py
+++ b/tests/ui/vendors/test_vendors_api.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Vendors API tests."""
+from rero_ils.modules.vendors.models import VendorNoteType
+
+
+def test_vendors_properties(vendor_martigny, vendor_sion):
+    """Test order properties."""
+
+    # NOTES -------------------------------------------------------------------
+    assert vendor_martigny.get_note(VendorNoteType.CLAIM) is not None
+    assert vendor_martigny.get_note(VendorNoteType.GENERAL) is None
+    assert vendor_sion.get_note(VendorNoteType.RECEIPT) is not None


### PR DESCRIPTION
Replaces the single field note, by the common notes array already used
in other acquisition resources.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
