### PR TITLE
documents: add identifiedBy subfield on some fields

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
@@ -23,7 +23,6 @@
       "type": "string",
       "readOnly": true,
       "default": "bf:Organisation",
-      "const": "bf:Organisation",
       "form": {
         "templateOptions": {
           "wrappers": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
@@ -22,7 +22,6 @@
       "type": "string",
       "readOnly": true,
       "default": "bf:Person",
-      "const": "bf:Person",
       "form": {
         "templateOptions": {
           "wrappers": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json
@@ -243,7 +243,8 @@
       "type": "object",
       "additionalProperties": false,
       "propertiesOrder": [
-        "label"
+        "label",
+        "identifiedBy"
       ],
       "required": [
         "label"
@@ -252,6 +253,9 @@
         "label": {
           "type": "string",
           "minLength": 1
+        },
+        "identifiedBy": {
+          "$ref": "https://bib.rero.ch/schemas/documents/document_identified_by-v0.0.1.json#/identifiedBy"
         }
       }
     }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
@@ -2,7 +2,6 @@
   "identifiedBy": {
     "title": "Identifiers",
     "type": "array",
-    "minItems": 1,
     "items": {
       "title": "Identifier",
       "type": "object",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
@@ -49,7 +49,8 @@
             "form_subdivision",
             "medium_of_performance_for_music",
             "arranged_statement_for_music",
-            "key_for_music"
+            "key_for_music",
+            "identifiedBy"
           ],
           "required": [
             "title"
@@ -89,7 +90,6 @@
               "title": "Parts",
               "description": "Part, Section, or Supplement",
               "type": "array",
-              "minItems": 1,
               "items": {
                 "title": "Part",
                 "type": "object",
@@ -116,7 +116,6 @@
             "form_subdivision": {
               "title": "Form subdivisions",
               "type": "array",
-              "minItems": 1,
               "items": {
                 "title": "Form subdivision",
                 "type": "string",
@@ -126,7 +125,6 @@
             "medium_of_performance_for_music": {
               "title": "Mediums of performance (music)",
               "type": "array",
-              "minItems": 1,
               "items": {
                 "title": "Medium of performance (music)",
                 "type": "string",
@@ -142,6 +140,9 @@
               "title": "Key (music)",
               "type": "string",
               "minLength": 1
+            },
+            "identifiedBy": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_identified_by-v0.0.1.json#/identifiedBy"
             }
           }
         }


### PR DESCRIPTION
* Adds `identifiedBy` on relationships, series statement and work access point fields.
* Closes #2275.
* Closes #2388.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
