### PR TITLE
notifications: fix creation

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -1193,8 +1193,11 @@ def get_overdue_loan_pids(patron_pid=None, tstamp=None):
         .params(preserve_order=True) \
         .sort({'_created': {'order': 'asc'}}) \
         .source(['pid']).scan()
-    for hit in results:
-        yield hit.pid
+    # We will return all pids here to prevent folowing error during long
+    # operations:
+    #  elasticsearch.helpers.errors.ScanError:
+    #  Scroll request has only succeeded on X (+0 skipped) shards out of Y.
+    return [hit.pid for hit in results]
 
 
 def get_overdue_loans(patron_pid=None, tstamp=None):


### PR DESCRIPTION
* Fixes `elasticsearch.helpers.errors.ScanError: Scroll request has only
  succeeded on X (+0 skipped) shards out of Y.` error during
  notification reation.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
