### PR TITLE
statistics: implement basic statistics for librarians

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -381,9 +381,14 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute=30, hour=4),  # Every day at 04:30 UTC,
         'enabled': False
     },
-    'collect-stats': {
-        'task': ('rero_ils.modules.stats.tasks.collect_stats'),
+    'collect-stats-billing': {
+        'task': ('rero_ils.modules.stats.tasks.collect_stats_billing'),
         'schedule': crontab(minute=0, hour=1),  # Every day at 01:00 UTC,
+        'enabled': False
+    },
+    'collect-stats-librarian': {
+        'task': ('rero_ils.modules.stats.tasks.collect_stats_librarian'),
+        'schedule': crontab(minute=30, hour=1, day_of_month='1'),  # First day of the month at 01:30 UTC,
         'enabled': False
     },
     'replace-idby-contribution': {
@@ -2694,7 +2699,7 @@ RERO_ILS_ENABLE_OPERATION_LOG_VALIDATION = False
 # Statistics Configuration
 # ========================
 # Compute the stats with a timeframe given in monthes
-RERO_ILS_STATS_TIMEFRAME_IN_MONTHES = 3
+RERO_ILS_STATS_BILLING_TIMEFRAME_IN_MONTHES = 3
 
 # =============================================================================
 # NOTIFICATIONS MODULE SPECIFIC SETTINGS

--- a/rero_ils/modules/stats/cli.py
+++ b/rero_ils/modules/stats/cli.py
@@ -22,9 +22,10 @@ from pprint import pprint
 
 import arrow
 import click
+from dateutil.relativedelta import relativedelta
 from flask.cli import with_appcontext
 
-from rero_ils.modules.stats.api import Stat, StatsForPricing
+from rero_ils.modules.stats.api import Stat, StatsForLibrarian, StatsForPricing
 
 
 @click.group()
@@ -33,18 +34,104 @@ def stats():
 
 
 @stats.command('dumps')
+@click.argument('type')
 @with_appcontext
-def dumps():
-    """Dumps the current stats value."""
-    pprint(StatsForPricing(to_date=arrow.utcnow()).collect(), indent=2)
+def dumps(type):
+    """Dumps the current stats value.
+
+    :param type: type of statistics can be 'billing' or 'librarian'
+    """
+    if type == 'billing':
+        pprint(StatsForPricing(to_date=arrow.utcnow()).collect(), indent=2)
+    elif type == 'librarian':
+        pprint(StatsForLibrarian(to_date=arrow.utcnow()).collect(), indent=2)
 
 
 @stats.command('collect')
+@click.argument('type')
 @with_appcontext
-def collect():
-    """Extract the stats value and store it."""
-    _stats = StatsForPricing(to_date=arrow.utcnow())
+def collect(type):
+    """Extract the stats value and store it.
+
+    :param type: type of statistics can be 'billing' or 'librarian'
+    """
+    to_date = arrow.utcnow() - relativedelta(days=1)
+    date_range = {}
+    if type == 'billing':
+        _stats = StatsForPricing(to_date=to_date)
+    elif type == 'librarian':
+        _from = f'{to_date.year}-{to_date.month:02d}-01T00:00:00'
+        _to = to_date.format(fmt='YYYY-MM-DDT23:59:59')
+        date_range = {'from': _from, 'to': _to}
+        _stats = StatsForLibrarian(to_date=to_date)
+    else:
+        return
     stat = Stat.create(
-        dict(values=_stats.collect()), dbcommit=True, reindex=True)
+            dict(type=type, date_range=date_range, values=_stats.collect()),
+            dbcommit=True, reindex=True)
     click.secho(
-        f'Stats collected and created. New pid: {stat.pid}', fg='green')
+        f'Statistics of type {stat["type"]} have been collected and created.\
+        New pid: {stat.pid}', fg='green')
+
+
+@stats.command('collect_year')
+@click.argument('type')
+@click.argument('year', type=int)
+@click.argument('timespan', default='yearly')
+@with_appcontext
+def collect_year(type, year, timespan):
+    """Extract the stats values for one year and store them in db.
+
+    :param type: type of statistics can be 'billing' or 'librarian'
+    :param year: year of statistics
+    """
+    if year:
+        if timespan == 'montly':
+            for month in range(1, 13):
+                first_day = f'{year}-{month:02d}-01T23:59:59'\
+                            .format(fmt='YYYY-MM-DDT23:59:59')
+                first_day = arrow.get(first_day, 'YYYY-MM-DDTHH:mm:ss')
+                to_date = first_day + relativedelta(months=1)\
+                    - relativedelta(days=1)
+                _from = f'{to_date.year}-{to_date.month:02d}-01T00:00:00'
+                _to = to_date.format(fmt='YYYY-MM-DDT23:59:59')
+                date_range = {'from': _from, 'to': _to}
+
+                if type == 'billing':
+                    _stats = StatsForPricing(to_date=to_date)
+                elif type == 'librarian':
+                    _stats = StatsForLibrarian(to_date=to_date)
+                else:
+                    return
+                stat = Stat.create(
+                        dict(type=type, date_range=date_range,
+                             values=_stats
+                             .collect()), dbcommit=True, reindex=True)
+                click.secho(
+                    f'Statistics of type {stat["type"]} have been collected\
+                        and created for {year}-{month}.\
+                        New pid: {stat.pid}', fg='green')
+        else:
+            _from = arrow.get(f'{year}-01-01', 'YYYY-MM-DD')\
+                         .format(fmt='YYYY-MM-DDT00:00:00')
+            _to = arrow.get(f'{year}-12-31', 'YYYY-MM-DD')\
+                       .format(fmt='YYYY-MM-DDT23:59:59')
+            date_range = {'from': _from, 'to': _to}
+
+            if type == 'billing':
+                _stats = StatsForPricing()
+            elif type == 'librarian':
+                _stats = StatsForLibrarian()
+            else:
+                return
+
+            _stats.date_range = date_range
+            stat = Stat.create(
+                    dict(type=type, date_range=date_range,
+                         values=_stats.collect()), dbcommit=True, reindex=True)
+            click.secho(
+                f'Statistics of type {stat["type"]} have been collected and\
+                    created for {year}.\
+                    New pid: {stat.pid}', fg='green')
+
+        return

--- a/rero_ils/modules/stats/jsonschemas/stats/stat-v0.0.1.json
+++ b/rero_ils/modules/stats/jsonschemas/stats/stat-v0.0.1.json
@@ -17,6 +17,18 @@
       "minLength": 9,
       "default": "https://bib.rero.ch/schemas/stats/stat-v0.0.1.json"
     },
+    "type": {
+      "title": "Statistics type",
+      "type": "string",
+      "enum": [
+        "billing",
+        "librarian"
+      ]
+    },
+    "date_range": {
+      "title": "Statistics date range",
+      "type": "object"
+    },
     "pid": {
       "title": "Stat ID.",
       "type": "string",

--- a/rero_ils/modules/stats/mappings/v7/stats/stat-v0.0.1.json
+++ b/rero_ils/modules/stats/mappings/v7/stats/stat-v0.0.1.json
@@ -6,11 +6,18 @@
       "$schema": {
         "type": "keyword"
       },
+      "type": {
+        "type": "text"
+      },
+      "date_range": {
+        "type": "object"
+      },
       "pid": {
         "type": "keyword"
       },
       "values": {
-        "type": "object"
+        "type": "object",
+        "enabled": false
       },
       "_created": {
         "type": "date"

--- a/rero_ils/modules/stats/serializers.py
+++ b/rero_ils/modules/stats/serializers.py
@@ -52,6 +52,12 @@ class StatCSVSerializer(CSVSerializer):
             value['library name'] = library['name']
             value['library id'] = library['pid']
             del value['library']
+            for v in value:
+                if isinstance(value[v], dict):
+                    dict_to_text = ''
+                    for k, m in value[v].items():
+                        dict_to_text += f'{k} :{m}\r\n'
+                    value[v] = dict_to_text
             writer.writerow(value)
             yield line.read()
 

--- a/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
+++ b/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
@@ -16,40 +16,63 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #}
-{%- extends 'rero_ils/page.html' %}
-{%- block body %}
-{%- block record_body %}
-{%- if record.pid %}
-<a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa fa-download"></i></a>
-{%- endif %}
-<h2>{{record.created}}</h2>
-<div class="table-responsive">
-  <table class="table table-sm">
-    <thead>
-      <tr>
-        <th scope="col">library id</th>
-        <th scope="col">library name</th>
-        {%- for head in record['values'][0].keys() %}
-        {%- if head != 'library'%}
-        <th scope="col">{{head.replace('_', ' ')}}</th>
-        {%- endif %}
-        {%- endfor%}
-      </tr>
-    </thead>
-    <tbody>
-      {%- for val in record['values'] %}
-      <tr>
-        <th scope="row">{{val.library.pid}}</th>
-        <td scope="row">{{val.library.name}}</td>
-        {%- for head in record['values'][0].keys() %}
-        {%- if head != 'library'%}
-        <td scope="row">{{val[head]}}</td>
-        {%- endif %}
-        {%- endfor%}
-      </tr>
-      {%- endfor %}
-    </tbody>
-  </table>
-</div>
-{%- endblock record_body %}
-{%- endblock body %}
+  {%- extends 'rero_ils/page.html' %}
+  {%- block body %}
+  {%- block record_body %}
+  <div class="mt-2 mb-4">
+    {%- if record.pid %}
+      <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa fa-download"></i></a>
+    {%- endif %}
+    {%- if 'date_range' in record and 'from' in record.date_range %}
+      {% set stat_name = record.date_range.from|yearmonthfilter+
+      ' (from '+record.date_range.from.split('T')[0]+' to '+record.date_range.to.split('T')[0]+')'%}
+      <h2>{{_(stat_name)}}</h2>
+    {% else %}
+      <h2>{{record.created | string | format_date}}</h2>
+    {% endif %}
+    <div class="table-responsive">
+      <table class="table table-hover table-sm">
+        <thead>
+          <tr>
+            <th scope="col">{{_('Library id')}}</th>
+            <th scope="col">{{_('Library name')}}</th>
+            {%- for head in record['values'][0].keys() %}
+              {%- if head != 'library'%}
+                {%- if head == 'number_of_patrons_by_postal_code' %}
+                  <th scope="col">{{_('Postal code: number of patrons')}}</th>
+                {%- elif head == 'number_of_new_items_by_location' %}
+                  <th scope="col">{{_('Location: number of items')}}</th>
+                {%- else %}
+                  {% set other = head[0]|upper+head[1:].replace('_', ' ') %}
+                  <th scope="col">{{_(other)}}</th>
+                {%- endif %}
+              {%- endif %}
+            {%- endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {%- for val in record['values'] %}
+          <tr>
+            <th scope="row">{{val.library.pid}}</th>
+            <td scope="row">{{val.library.name}}</td>
+            {%- for head in record['values'][0].keys() %}
+              {%- if head != 'library'%}
+                {% if val[head] is mapping %}
+                  <td scope="row">
+                    {%- for k, v in val[head].items() %}
+                    <li class="list-unstyled">{{k}}: {{v}}</li>
+                    {%- endfor%}
+                  </td>
+                {%- else %}
+                  <td scope="row">{{val[head]}}</td>
+                {%- endif %}
+              {%- endif %}
+            {%- endfor%}
+          </tr>
+          {%- endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {%- endblock record_body %}
+  {%- endblock body %}

--- a/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
+++ b/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
@@ -17,14 +17,14 @@
 
 #}
   {%- extends 'rero_ils/page.html' %}
-  {%- block body %}
+  {%- block page_body %}
   {%- block record_body %}
-  <div class="mt-2 mb-4">
+  <div class="ml-5 mr-5 mt-2 mb-4">
     {%- if record.pid %}
       <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa fa-download"></i></a>
     {%- endif %}
     {%- if 'date_range' in record and 'from' in record.date_range %}
-      {% set stat_name = record.date_range.from|yearmonthfilter+
+      {% set stat_name = record.date_range.to|yearmonthfilter+
       ' (from '+record.date_range.from.split('T')[0]+' to '+record.date_range.to.split('T')[0]+')'%}
       <h2>{{_(stat_name)}}</h2>
     {% else %}
@@ -41,7 +41,9 @@
                 {%- if head == 'number_of_patrons_by_postal_code' %}
                   <th scope="col">{{_('Postal code: number of patrons')}}</th>
                 {%- elif head == 'number_of_new_items_by_location' %}
-                  <th scope="col">{{_('Location: number of items')}}</th>
+                  <th scope="col">{{_('Location: number of new items')}}</th>
+                {%- elif head == 'number_of_new_patrons_by_postal_code' %}
+                  <th scope="col">{{_('Postal code: number of new patrons')}}</th>
                 {%- else %}
                   {% set other = head[0]|upper+head[1:].replace('_', ' ') %}
                   <th scope="col">{{_(other)}}</th>
@@ -53,18 +55,18 @@
         <tbody>
           {%- for val in record['values'] %}
           <tr>
-            <th scope="row">{{val.library.pid}}</th>
-            <td scope="row">{{val.library.name}}</td>
+            <th scope="row"><small>{{val.library.pid}}</small></th>
+            <td scope="row"><small>{{val.library.name}}</small></td>
             {%- for head in record['values'][0].keys() %}
               {%- if head != 'library'%}
                 {% if val[head] is mapping %}
                   <td scope="row">
                     {%- for k, v in val[head].items() %}
-                    <li class="list-unstyled">{{k}}: {{v}}</li>
+                    <li class="list-unstyled"><small>{{k}}: {{v}}</small></li>
                     {%- endfor%}
                   </td>
                 {%- else %}
-                  <td scope="row">{{val[head]}}</td>
+                  <td scope="row"><small>{{val[head]}}</small></td>
                 {%- endif %}
               {%- endif %}
             {%- endfor%}
@@ -75,4 +77,4 @@
     </div>
   </div>
   {%- endblock record_body %}
-  {%- endblock body %}
+  {%- endblock page_body %}

--- a/rero_ils/modules/stats/templates/rero_ils/stats_list.html
+++ b/rero_ils/modules/stats/templates/rero_ils/stats_list.html
@@ -23,7 +23,6 @@
     <a class="btn btn-primary float-right" href="{{url_for('stats.live_stats_billing')}}" role="button">{{_('Live values')}}</a>
     <h2>{{_('Statistics - billing')}}</h2>
   {% elif type=="librarian" %}
-    <a class="btn btn-primary float-right" href="{{url_for('stats.live_stats_librarian')}}" role="button">{{_('Live values')}}</a>
     <h2>{{_('Statistics')}}</h2>
   {% endif %}
 </div>

--- a/rero_ils/modules/stats/templates/rero_ils/stats_list.html
+++ b/rero_ils/modules/stats/templates/rero_ils/stats_list.html
@@ -19,13 +19,31 @@
 {%- extends 'rero_ils/page.html' %}
 {%- block body %}
 <div class="mt-2 mb-4">
-  <a class="btn btn-primary float-right" href="{{url_for('stats.live_stats')}}" role="button">Live values</a>
-  <h2>Statistics</h2>
+  {% if type=="billing"%}
+    <a class="btn btn-primary float-right" href="{{url_for('stats.live_stats_billing')}}" role="button">{{_('Live values')}}</a>
+    <h2>{{_('Statistics - billing')}}</h2>
+  {% elif type=="librarian" %}
+    <a class="btn btn-primary float-right" href="{{url_for('stats.live_stats_librarian')}}" role="button">{{_('Live values')}}</a>
+    <h2>{{_('Statistics')}}</h2>
+  {% endif %}
 </div>
 <div class="list-group">
   {%- for rec in records %}
   <span class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-    <a href="{{url_for('invenio_records_ui.stats', pid_value=rec._source.pid)}}">{{rec._source._created | format_date}}</a>
+    <a href="{{url_for('invenio_records_ui.stats', pid_value=rec._source.pid)}}">
+      {%- if 'date_range' in rec._source and 'from' in rec._source.date_range  %}
+        {%- if (rec._source.date_range.to|stringtodatetime).month - (rec._source.date_range.from|stringtodatetime).month == 11  %}
+          {% set stat_name = (rec._source.date_range.from|stringtodatetime).year|string+
+          ' (from '+rec._source.date_range.from.split('T')[0]+' to '+rec._source.date_range.to.split('T')[0]+')'%}
+        {%- else %}
+          {% set stat_name = rec._source.date_range.from|yearmonthfilter+
+          ' (from '+rec._source.date_range.from.split('T')[0]+' to '+rec._source.date_range.to.split('T')[0]+')'%}
+        {%- endif %}
+        {{_(stat_name)}}
+      {% else %}
+        {{rec._source._created | format_date}}
+      {% endif %}
+    </a>
     <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=csv" role="button"><i class="fa fa-download"></i></a>
   </span>
   {%- endfor %}

--- a/rero_ils/modules/stats/views.py
+++ b/rero_ils/modules/stats/views.py
@@ -27,9 +27,8 @@ import pytz
 from elasticsearch_dsl import Q
 from flask import Blueprint, render_template
 
-from .api import StatsForLibrarian, StatsForPricing, StatsSearch
-from .permissions import admin_permission, check_logged_as_admin, \
-    check_logged_as_librarian, monitoring_permission
+from .api import StatsForPricing, StatsSearch
+from .permissions import check_logged_as_admin, check_logged_as_librarian
 
 # from pytz import timezone
 
@@ -79,24 +78,6 @@ def stats_librarian():
     return render_template(
         'rero_ils/stats_list.html', records=hits['hits']['hits'],
         type='librarian')
-
-
-@blueprint.route('/librarian/live', methods=['GET'])
-@check_logged_as_librarian
-def live_stats_librarian():
-    """Show the current librarian stats values."""
-    now = arrow.utcnow()
-    _from = f'{now.year}-{now.month:02d}-01T00:00:00'
-    date_range = {'from': _from, 'to': str(now)}
-
-    libraries = StatsForLibrarian().get_all_libraries()
-    if not (admin_permission.require().can() or
-            monitoring_permission.require().can()):
-        libraries = StatsForLibrarian.get_librarian_libraries()
-    stats = StatsForLibrarian(to_date=now).collect(libraries=libraries)
-    return render_template(
-        'rero_ils/detailed_view_stats.html',
-        record=dict(created=now, date_range=date_range, values=stats))
 
 
 @jinja2.contextfilter

--- a/rero_ils/theme/menus.py
+++ b/rero_ils/theme/menus.py
@@ -27,7 +27,7 @@ from invenio_i18n.ext import current_i18n
 
 from rero_ils.modules.patrons.api import current_librarian, current_patrons
 
-from ..permissions import admin_permission
+from ..permissions import admin_permission, librarian_permission
 
 
 # -------------- Utilities -----------------
@@ -137,17 +137,30 @@ def init_menu_tools():
         id='ill-request-menu'
     )
 
-    item = current_menu.submenu('main.tool.stats')
+    item = current_menu.submenu('main.tool.stats_billing')
     rero_register(
         item,
-        endpoint='stats.stats',
+        endpoint='stats.stats_billing',
         visible_when=lambda: admin_permission.require().can(),
         text=TextWithIcon(
             icon='<i class="fa fa-money"></i>',
+            text='Statistics billing'
+        ),
+        order=20,
+        id='stats-menu-billing'
+    )
+
+    item = current_menu.submenu('main.tool.stats_librarian')
+    rero_register(
+        item,
+        endpoint='stats.stats_librarian',
+        visible_when=lambda: librarian_permission.require().can(),
+        text=TextWithIcon(
+            icon='<i class="fa fa-bar-chart"></i>',
             text='Statistics'
         ),
         order=20,
-        id='stats-menu'
+        id='stats-menu-librarian'
     )
 
     item = current_menu.submenu('main.tool.collections')

--- a/scripts/setup
+++ b/scripts/setup
@@ -196,6 +196,9 @@ info_msg "Clean redis"
 eval "${PREFIX} invenio shell --no-term-title -c \"import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')\""
 eval ${PREFIX} invenio reroils scheduler init -r
 
+info_msg "Prefix: "
+info_msg ${PREFIX}
+
 if ${DEPLOYMENT}
 then
   eval ${PREFIX} invenio db drop --yes-i-know
@@ -532,7 +535,7 @@ then
     info_msg "Start OAI harvesting asynchrone"
     eval ${PREFIX} invenio reroils oaiharvester harvest -n ebooks -q -k
 else
-    eval ${PREFIX} invenio reroils scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -n collect-stats -v
+    eval ${PREFIX} invenio reroils scheduler enable_tasks -n scheduler-timestamp -n bulk-indexer -n anonymize-loans -n claims-creation -n accounts -n clear_and_renew_subscriptions -n collect-stats-billing -n collect-stats-librarian -v
     eval ${PREFIX} invenio reroils scheduler enable_tasks -n notification-creation -n notification-dispatch-availability -n notification-dispatch-recall -n find-contribution -v
     eval ${PREFIX} invenio reroils scheduler enable_tasks -n cancel-expired-request -v
     info_msg "For ebooks harvesting run:"
@@ -561,7 +564,7 @@ info_msg "Fine transactions: ${DATA_PATH}/fines.json ${CREATE_LAZY} ${DONT_STOP}
 eval ${PREFIX} invenio reroils fixtures load_virtua_transactions ${DATA_PATH}/fines.json -t fine
 
 info_msg "Collect statistics"
-eval ${PREFIX} invenio reroils stats collect
+eval ${PREFIX} invenio reroils stats collect billing
 
 date
 success_msg "Perfect ${PROGRAM}! See you soon…"


### PR DESCRIPTION
- Adds basic statistics for librarians and system librarians
- Adds view 'Statistics librarian' in Tools

Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?
US Basic statistics
https://tree.taiga.io/project/rero21-reroils/us/1744?milestone=306074

## How to test?

- Log in as admin, librarian or system librarian.
- In section Tools: 
     if logged in as admin there are two options: Statistics billing, Statistics, 
     if logged in as librarian or system librarian there is only Statistics
-  In Statistics there should be the list of statistics from Jan 2021 to Dec 2021
- The monthly statistics contains the statistics for each library: 
    A librarian can see only the statistics for his/her libraries.
    A system librarian can see the statistics for his/her libraries and the libraries of his/her organization. 
    An admin can see the statistics for all libraries. 
- The 'Live values' button calculate the statistics of the current month up to the current day.
- It is possible to download the statistics in .csv format by clicking on the download buttons.
- Permission required should display if attempting to access /stats/ or stats/live when logged in as librarian or system librarian.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
