### PR TITLE
document: add Bulgarian script languages

### DIFF
--- a/rero_ils/jsonschemas/common/languages-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/languages-v0.0.1.json
@@ -2450,6 +2450,8 @@
       "awa-latn",
       "bel-cyrl",
       "bel-latn",
+      "bul-latn",
+      "bul-cyrl",
       "bho-deva",
       "bho-latn",
       "bra-deva",


### PR DESCRIPTION
Add `bul-latn` and `bul-cyrl` as language scripts to describe Bulgarian
resources.
Closes rero/rero-ils#2628.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
