### PR TITLE
patron_types: add a limit for unpaid subscription

### DIFF
--- a/data/patron_types.json
+++ b/data/patron_types.json
@@ -6,7 +6,10 @@
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/1"
     },
-    "subscription_amount": 10
+    "subscription_amount": 10,
+    "limits": {
+      "unpaid_subscription": false
+    }
   },
   {
     "pid": "2",
@@ -14,6 +17,9 @@
     "description": "Patron with extended rights: staff, professors, supporting members.",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/1"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   {
@@ -22,6 +28,9 @@
     "description": "Children and teenagers (< 16 years old).",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/1"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   {
@@ -30,6 +39,9 @@
     "description": "Standard patron.",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/2"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   {
@@ -38,6 +50,9 @@
     "description": "Default patron type",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/3"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   {
@@ -46,6 +61,9 @@
     "description": "Children and teenagers (< 16 years old).",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/2"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   {
@@ -54,6 +72,9 @@
     "description": "Standard patron.",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/4"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   {
@@ -64,6 +85,7 @@
       "$ref": "https://bib.rero.ch/api/organisations/1"
     },
     "limits": {
+      "unpaid_subscription": false,
       "checkout_limits": {
         "global_limit": 10,
         "library_limit": 8,

--- a/rero_ils/alembic/90d857fb5c23_unpaid_subscription_limit.py
+++ b/rero_ils/alembic/90d857fb5c23_unpaid_subscription_limit.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+# Copyright (C) 2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""PatronType :: add unpaid subscription limit."""
+
+from logging import getLogger
+
+from rero_ils.modules.patron_types.api import PatronType, PatronTypesIndexer, \
+    PatronTypesSearch
+
+revision = '90d857fb5c23'
+down_revision = '2b0af71048a7'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+
+
+def upgrade():
+    """Upgrade patron type records.
+
+    We need to add the new 'unpaid_subscription' limit to each patron_type
+    records that doesn't already define such a limit. The default value for
+    existing records will be `False` to not generate unstable behavior.
+    """
+    query = PatronTypesSearch()\
+        .exclude('exists', field='limits.unpaid_subscription')\
+        .source('pid')
+    ids = []
+    for hit in query.scan():
+        record = PatronType.get_record_by_pid(hit.pid)
+        record\
+            .setdefault('limits', {})\
+            .setdefault('unpaid_subscription', False)
+        record.update(record, dbcommit=True, reindex=False)
+        LOGGER.info(f'  * Updated PatronType#{record.pid}')
+        ids.append(record.id)
+    _indexing_records(ids)
+    LOGGER.info(f'TOTAL :: {len(ids)}')
+
+
+def downgrade():
+    """Downgrade patron type records."""
+    query = PatronTypesSearch()\
+        .filter('exists', field='limits.unpaid_subscription')\
+        .source('pid')
+    ids = []
+    for hit in query.scan():
+        record = PatronType.get_record_by_pid(hit.pid)
+        del record['limits']['unpaid_subscription']
+        record.update(record, dbcommit=True, reindex=False)
+        LOGGER.info(f'  * Updated PatronType#{record.pid}')
+        ids.append(record.id)
+    _indexing_records(ids)
+    LOGGER.info(f'TOTAL :: {len(ids)}')
+
+
+def _indexing_records(record_ids):
+    """Indexing some record based on record uuid."""
+    if len(record_ids):
+        LOGGER.info(f'Indexing {len(record_ids)} records ....')
+        indexer = PatronTypesIndexer()
+        indexer.bulk_index(record_ids)
+        count = indexer.process_bulk_queue()
+        LOGGER.info(f'{count} records indexed.')

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -379,10 +379,11 @@ def item(item_barcode):
         if circ_policy.can_checkout:
             for action in item_dumps.get('actions', []):
                 if action == 'checkout':
-                    if item.number_of_requests() > 0:
-                        if item.patron_request_rank(patron) == 1:
-                            new_actions.append(action)
-                    else:
+                    if (
+                        item.number_of_requests() > 0
+                        and item.patron_request_rank(patron) == 1
+                        or item.number_of_requests() <= 0
+                    ):
                         new_actions.append(action)
                 elif action == 'receive' and item.number_of_requests() == 0:
                     new_actions.append('checkout')

--- a/rero_ils/modules/patron_transaction_events/api.py
+++ b/rero_ils/modules/patron_transaction_events/api.py
@@ -91,14 +91,13 @@ class PatronTransactionEvent(IlsRecord):
             cls.update_parent_patron_transaction(record)
         return record
 
-    # TODO: do we have to set dbcomit and reindex to True so the
+    # TODO: do we have to set dbcommit and reindex to True so the
     # of the rest api for create and update works properly ?
     # For PatronTransaction we have to set it to True for the tests.
     def update(self, data, commit=True, dbcommit=True, reindex=True):
         """Update data for record."""
-        record = super().update(
+        return super().update(
             data=data, commit=commit, dbcommit=dbcommit, reindex=reindex)
-        return record
 
     @classmethod
     def create_event_from_patron_transaction(
@@ -153,9 +152,9 @@ class PatronTransactionEvent(IlsRecord):
         patron_transaction = self.patron_transaction()
         total_amount = int(patron_transaction.get('total_amount') * 100)
         if self.event_type == 'fee':
-            total_amount = total_amount + int(self.amount * 100)
+            total_amount += int(self.amount * 100)
         elif self.event_type in ('payment', 'cancel'):
-            total_amount = total_amount - int(self.amount * 100)
+            total_amount -= int(self.amount * 100)
         patron_transaction['total_amount'] = total_amount / 100
         if total_amount == 0:
             patron_transaction['status'] = 'closed'

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -79,7 +79,7 @@
       "title": "Amount",
       "description": "Yearly amount due by patrons linked to this patron type.",
       "type": "number",
-      "minimum": 0,
+      "exclusiveMinimum": 0,
       "form": {
         "templateOptions": {
           "wrappers": [
@@ -97,6 +97,7 @@
       "title": "Limits",
       "type": "object",
       "propertiesOrder": [
+        "unpaid_subscription",
         "checkout_limits",
         "fee_amount_limits",
         "overdue_items_limits"
@@ -234,6 +235,14 @@
                 "label": "Limit by overdue items"
               }
             }
+          }
+        },
+        "unpaid_subscription": {
+          "type": "boolean",
+          "title": "Block the patron if the subscription is not paid",
+          "default": true,
+          "form": {
+            "hideExpression": "!field.parent.parent.model.hasOwnProperty('subscription_amount') || field.parent.parent.model.subscription_amount <= 0"
           }
         }
       }

--- a/rero_ils/modules/patron_types/mappings/v7/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/mappings/v7/patron_types/patron_type-v0.0.1.json
@@ -37,6 +37,9 @@
       },
       "limits": {
         "properties": {
+          "unpaid_subscription": {
+            "type": "boolean"
+          },
           "fee_amount_limits": {
             "properties": {
               "default_value": {

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1192,6 +1192,9 @@
     "description": "children patrons",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/org1"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   "ptty2": {
@@ -1201,6 +1204,9 @@
     "description": "adult patrons",
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/org1"
+    },
+    "limits": {
+      "unpaid_subscription": false
     }
   },
   "ptty3": {
@@ -1211,7 +1217,10 @@
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/org2"
     },
-    "subscription_amount": 25
+    "subscription_amount": 25,
+    "limits": {
+      "unpaid_subscription": false
+    }
   },
   "ptty4": {
     "$schema": "https://bib.rero.ch/schemas/patron_types/patron_type-v0.0.1.json",
@@ -1221,7 +1230,10 @@
     "organisation": {
       "$ref": "https://bib.rero.ch/api/organisations/org2"
     },
-    "subscription_amount": 15
+    "subscription_amount": 15,
+    "limits": {
+      "unpaid_subscription": false
+    }
   },
   "cipo1": {
     "$schema": "https://bib.rero.ch/schemas/circ_policies/circ_policy-v0.0.1.json",


### PR DESCRIPTION
Add a circulation operation restriction if a patron has pending unpaid
subscriptions. If this limit is enabled, any output circulation
operation should be denied (checkout/renew/request).
Closes rero/rero-ils#1530.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Migration

An alembic script is available to migrate existing PatronTypes : `90d857fb5c23_unpaid_subscription_limit`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
