### PR TITLE
notification: fix `reply-to` recipient

### DIFF
--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -155,7 +155,7 @@ class Dispatcher:
             template_body=template,
             sender=current_app.config.get('DEFAULT_SENDER_EMAIL',
                                           'noreply@rero.ch'),
-            reply_to=reply_to,
+            reply_to=','.join(reply_to),  # the client is unable to manage list
             recipients=recipients,
             ctx=ctx_data
         )
@@ -236,7 +236,7 @@ class Dispatcher:
         # 3. Send the message
         msg = Dispatcher._create_email(
             recipients=[recipient],
-            reply_to=reply_to,
+            reply_to=[reply_to],
             ctx_data=context,
             template=notification.get_template_path()
         )
@@ -255,7 +255,7 @@ class Dispatcher:
             return True
 
         notification = notifications[0]
-        reply_to = notification.get_recipients(RecipientType.REPLY_TO)[0]
+        reply_to = notification.get_recipients(RecipientType.REPLY_TO)
         recipients = notification.get_recipients(RecipientType.TO)
 
         error_reasons = []

--- a/rero_ils/modules/notifications/subclasses/circulation.py
+++ b/rero_ils/modules/notifications/subclasses/circulation.py
@@ -125,7 +125,7 @@ class CirculationNotification(Notification, ABC):
 
     def get_recipients_reply_to(self):
         """Get the notification email address for 'REPLY_TO' recipient type."""
-        return self.library.get('email')
+        return [self.library.get('email')]
 
     def get_recipients_to(self):
         """Get the notification email address for 'TO' recipient type."""

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -50,7 +50,7 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 def test_availability_notification(
         loan_validated_martigny, item2_lib_martigny,
-        mailbox, patron_martigny):
+        mailbox, patron_martigny, lib_martigny):
     """Test availability notification created from a loan."""
     mailbox.clear()
     loan = loan_validated_martigny
@@ -65,6 +65,9 @@ def test_availability_notification(
         process_notifications(notification_type)
     assert len(mailbox)
     assert loan.is_notified(notification_type=NotificationType.AVAILABILITY)
+
+    message = mailbox[-1]
+    assert message.reply_to == lib_martigny.get('email')
     mailbox.clear()
 
 


### PR DESCRIPTION
The `reply-to` recipients should be an array but CirculationNotification
classes returned only a string. This caused bad `reply-to` message header
only containing the first letter of the email.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

before
![image](https://user-images.githubusercontent.com/10031585/150169518-51f74337-41de-4912-a496-75f6ee64edcf.png)

after
![image](https://user-images.githubusercontent.com/10031585/150169604-8b9cd6d6-854e-40ff-ac75-e2d89e04d082.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
