### PR TITLE
vendor: allow more flexibility on phone number.

### DIFF
--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -323,8 +323,7 @@
         "phone": {
           "title": "Phone number",
           "description": "Phone number with the international prefix, without spaces.",
-          "type": "string",
-          "pattern": "^\\+[0-9]*$"
+          "type": "string"
         },
         "email": {
           "title": "Email",


### PR DESCRIPTION
Currently the `phone number` field for order section allow only digits.
It isn't flexible enough.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
