### PR TITLE
circulation: compute fees on checkout location

### DIFF
--- a/rero_ils/alembic/54134957af7d_loan_checkout_location_pid.py
+++ b/rero_ils/alembic/54134957af7d_loan_checkout_location_pid.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+# Copyright (C) 2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Loan :: add checkout location pid to current ON_LOAN laons."""
+from logging import getLogger
+
+from elasticsearch_dsl import Q
+from invenio_circulation.proxies import current_circulation
+
+from rero_ils.modules.loans.api import Loan, LoansIndexer
+from rero_ils.modules.loans.models import LoanState
+
+# revision identifiers, used by Alembic.
+revision = '54134957af7d'
+down_revision = '90d857fb5c23'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+indexing_chunck_size = 1000
+
+
+def upgrade():
+    """Upgrade ON_LOAN records.
+
+    For all ON_LOAN records, we will add a new `checkout_location_pid` field
+    used to calculate fees based on checkout library.
+    """
+    query = current_circulation.loan_search_cls() \
+        .filter('term', state=LoanState.ITEM_ON_LOAN) \
+        .filter('bool', must_not=[
+            Q('exists', field='checkout_location_pid')
+        ]) \
+        .source(['pid', 'transaction_location_pid'])\
+        .scan()
+    ids = []
+    for hit in query:
+        loan = Loan.get_record_by_pid(hit.pid)
+        loan['checkout_location_pid'] = hit.transaction_location_pid
+        loan.update(loan, dbcommit=True, reindex=False)
+        LOGGER.info(f'  * Upgrade loan#{loan.pid}')
+        ids.append(loan.id)
+    _indexing_records(ids)
+    LOGGER.info(f'TOTAL :: {len(ids)}')
+
+
+def downgrade():
+    """Downgrade Loan records removing `checkout_location_pid` field."""
+    query = current_circulation.loan_search_cls() \
+        .filter('exists', field='checkout_location_pid') \
+        .source('pid')
+    ids = []
+    for hit in query:
+        loan = Loan.get_record_by_pid(hit.pid)
+        del loan['checkout_location_pid']
+        loan.update(loan, dbcommit=True, reindex=False)
+        LOGGER.info(f'  * Downgrade loan#{loan.pid}')
+        ids.append(loan.id)
+    _indexing_records(ids)
+    LOGGER.info(f'TOTAL :: {len(ids)}')
+
+
+def _indexing_records(record_ids):
+    """Indexing some record based on record uuid."""
+    if not record_ids:
+        return
+
+    LOGGER.info(f'Indexing {len(record_ids)} records ....')
+    indexer = LoansIndexer()
+    chunks = [
+        record_ids[x:x + indexing_chunck_size]
+        for x in range(0, len(record_ids), indexing_chunck_size)
+    ]
+    for chuncked_ids in chunks:
+        indexer.bulk_index(chuncked_ids)
+        count = indexer.process_bulk_queue()
+        LOGGER.info(f'{count} records indexed.')

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -90,6 +90,10 @@
       "type": "string",
       "title": "Transaction location PID"
     },
+    "checkout_location_pid": {
+      "type": "string",
+      "title": "Checkout location PID"
+    },
     "pickup_location_pid": {
       "type": "string",
       "title": "Request pickup location PID"

--- a/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/mappings/v7/loans/loan-ils-v0.0.1.json
@@ -80,6 +80,9 @@
       "transaction_location_pid": {
         "type": "keyword"
       },
+      "checkout_location_pid": {
+        "type": "keyword"
+      },
       "transaction_user_pid": {
         "type": "keyword"
       },

--- a/tests/ui/circulation/test_actions_extend.py
+++ b/tests/ui/circulation/test_actions_extend.py
@@ -16,15 +16,104 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Test item circulation extend actions."""
-
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from invenio_circulation.errors import CirculationException
 from utils import item_record_to_a_specific_loan_state
 
+from rero_ils.modules.circ_policies.api import CircPolicy
 from rero_ils.modules.errors import NoCirculationAction
 from rero_ils.modules.items.models import ItemStatus
-from rero_ils.modules.loans.models import LoanState
+from rero_ils.modules.libraries.api import Library
+from rero_ils.modules.loans.models import LoanAction, LoanState
+from rero_ils.modules.loans.utils import get_circ_policy
+from rero_ils.modules.patron_transactions.utils import \
+    get_last_transaction_by_loan_pid
+from rero_ils.modules.utils import get_ref_for_pid
+
+
+def test_fees_after_extend(
+    item_on_loan_martigny_patron_and_loan_on_loan,
+    loc_public_martigny, loc_public_saxon, librarian_martigny,
+    circulation_policies
+):
+    """Test fees calculation after extend on different location."""
+
+    # STEP#1 :: CREATE A SPECIAL CIPO FOR NEXT EXTEND OPERATION
+    item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    checkout_cipo = get_circ_policy(loan)
+    extend_cipo = deepcopy(checkout_cipo)
+    extend_cipo['policy_library_level'] = True
+    extend_cipo.update({
+        'libraries': [
+            {'$ref': get_ref_for_pid(Library, loc_public_saxon.library_pid)}
+        ],
+        'overdue_fees': {
+            'intervals': [{'from': 1, 'fee_amount': 0.01}]
+        }
+    })
+    del extend_cipo['pid']
+    extend_cipo = CircPolicy.create(extend_cipo)
+    assert extend_cipo
+
+    # Update checkout cipo to set some intervals
+    checkout_cipo_ori = get_circ_policy(loan, checkout_location=True)
+    checkout_cipo = deepcopy(checkout_cipo_ori)
+    checkout_fee_amount = 10
+    checkout_cipo['overdue_fees'] = {
+        'intervals': [{'from': 1, 'fee_amount': checkout_fee_amount}]
+    }
+    checkout_cipo = checkout_cipo.update(
+        checkout_cipo, dbcommit=True, reindex=True)
+
+    # STEP#2 :: EXTEND THE LOAN FOR SAXON LIBRARY.
+    #   The loan should use the new created circulation policy
+    #   Update loan `end_date` to play with "extend" function without problem
+    loan['end_date'] = datetime.now().isoformat()
+    loan.update(loan, dbcommit=True, reindex=True)
+    params = {
+        'transaction_location_pid': loc_public_saxon.pid,
+        'transaction_user_pid': librarian_martigny.pid
+    }
+    item, actions = item.extend_loan(**params)
+    loan = actions[LoanAction.EXTEND]
+    assert item.status == ItemStatus.ON_LOAN
+    assert get_circ_policy(loan).pid == extend_cipo.pid
+    assert loan.get('checkout_location_pid') == loc_public_martigny.pid
+    assert loan.get('transaction_location_pid') == loc_public_saxon.pid
+
+    # STEP#3 :: UPDATE LOAN TO BE OVERDUE
+    interval = 10
+    while not loan.is_loan_overdue():
+        new_end_date = datetime.now(timezone.utc) - timedelta(days=interval)
+        loan['end_date'] = new_end_date.isoformat()
+        interval += 1
+    loan.update(loan, dbcommit=True, reindex=True)
+
+    # STEP#4 :: CHECK-IN THE LOAN
+    #   Execute the check-in circulation operation
+    #   Check that a fee has been created and this fees is related to the
+    #   checkout circulation.
+    params = {
+        'transaction_location_pid': loc_public_saxon.pid,
+        'transaction_user_pid': librarian_martigny.pid
+    }
+    _, actions = item.checkin(**params)
+    loan = actions[LoanAction.CHECKIN]
+    assert loan.state == LoanState.ITEM_IN_TRANSIT_TO_HOUSE
+    params['transaction_location_pid'] = loc_public_martigny.pid
+    _, actions = item.checkin(**params)
+    loan = actions[LoanAction.RECEIVE]
+    assert loan.state == LoanState.ITEM_RETURNED
+
+    pttr = get_last_transaction_by_loan_pid(loan.pid)
+    assert pttr.total_amount >= checkout_fee_amount
+
+    # STEP#X :: RESET DATA
+    checkout_cipo.update(checkout_cipo_ori, dbcommit=True, reindex=True)
+    extend_cipo.delete()
 
 
 def test_extend_on_item_on_shelf(


### PR DESCRIPTION
Calculates overdue fees based on checkout location even if this loan has
been extended on an other libraries.
Closes rero/rero-ils#2640.
Closes rero/rero-ils#2683.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Data migration
Launch the "Alembic" script present into the PR : `54134957af7d_loan_checkout_location_pid`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
