### PR TITLE
interface: keep the viewcode in the urls

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -989,6 +989,7 @@ WTForms = "*"
 reference = "bf5338ec8a8ad6cbca5b6991fced3de978aa3966"
 type = "git"
 url = "https://github.com/rero/flask-wiki.git"
+
 [[package]]
 category = "main"
 description = "Simple integration of Flask and WTForms."
@@ -1638,6 +1639,7 @@ tests = ["check-manifest (>=0.35)", "coverage (>=4.3.4)", "isort (4.2.2)", "mock
 reference = "fe55e095a8e78b36cfad875f752f2facc2908bae"
 type = "git"
 url = "https://github.com/inveniosoftware/invenio-oaiharvester.git"
+
 [[package]]
 category = "main"
 description = "Invenio module that implements OAI-PMH server."
@@ -1923,6 +1925,7 @@ tests = ["mock (>=2.0.0)", "pytest-mock (>=1.6.0)", "invenio-app (>=1.2.3)", "in
 reference = "e07fdd2fa6792e5be7eef8dfa0b70117cb1db570"
 type = "git"
 url = "https://github.com/inveniosoftware-contrib/invenio-sip2.git"
+
 [[package]]
 category = "main"
 description = "Invenio standard theme."
@@ -1972,7 +1975,7 @@ sqlite = ["invenio-db (>=1.0.5)"]
 tests = ["pytest-invenio (>=1.4.0)"]
 
 [package.source]
-reference = "2bda428e000c11ca281846da5621916f7d3497f3"
+reference = "41d2b471cde1a93f660ba7bf0037ee3fb80b65fc"
 type = "git"
 url = "https://github.com/rero/invenio-userprofiles.git"
 [[package]]
@@ -3343,7 +3346,7 @@ wsproto = ">=0.14"
 [[package]]
 category = "main"
 description = "Backported and Experimental Type Hints for Python 3.6+"
-marker = "python_version >= \"3.7\" and python_version < \"3.8\" or python_version < \"3.8\""
+marker = "python_version >= \"3.7\" and python_version < \"3.8\" or python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" and (python_version >= \"3.7\" and python_version < \"3.8\" or python_version < \"3.8\")"
 name = "typing-extensions"
 optional = false
 python-versions = ">=3.6"
@@ -4320,12 +4323,28 @@ markdown-captions = [
     {file = "markdown_captions-2.1.1-py3-none-any.whl", hash = "sha256:67e785d6a288cf951e218e555026b9591e699c2572fab97b55fe833a477e1654"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -4334,14 +4353,27 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -4351,6 +4383,12 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ redisbeat = "*"
 jsonpickle = ">=1.4.1"
 ciso8601 = "*"
 # TODO: to be removed when the thumbnail will be refactored
-invenio-userprofiles = {git = "https://github.com/rero/invenio-userprofiles.git", rev = "v1.2.1-rero1.0"}
+invenio-userprofiles = {git = "https://github.com/rero/invenio-userprofiles.git", rev = "41d2b471cde1a93f660ba7bf0037ee3fb80b65fc"}
 
 ## Additionnal constraints on python modules
 flask-wiki = {git = "https://github.com/rero/flask-wiki.git", tag = "v0.0.1"}

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -257,6 +257,18 @@ ACCOUNTS_SESSION_REDIS_URL = 'redis://localhost:6379/1'
 #: proxies) removes these headers again before sending the response to the
 #: client. Set to False, in case of doubt.
 ACCOUNTS_USERINFO_HEADERS = False
+
+#: User profile
+RERO_PUBLIC_USERPROFILES_READONLY = False
+RERO_PUBLIC_USERPROFILES_READONLY_FIELDS = [
+    'first_name',
+    'last_name',
+    'birth_date'
+]
+
+#: USER PROFILES
+USERPROFILES_READ_ONLY = False;
+
 # Disable User Profiles
 USERPROFILES = True
 USERPROFILES_COUNTRIES = get_profile_countries

--- a/rero_ils/modules/ill_requests/templates/rero_ils/ill_request_form.html
+++ b/rero_ils/modules/ill_requests/templates/rero_ils/ill_request_form.html
@@ -27,7 +27,7 @@
     <p class="mb-0">{{ _('A well detailed request is more likely to be satisfied') }}</p>
   </div>
 
-  <form id="ill-public-form" action="{{ url_for('ill_requests.ill_request_form') }}" method="POST" class="form" role="form" novalidate>
+  <form id="ill-public-form" action="{{ url_for('ill_requests.ill_request_form', viewcode=viewcode) }}" method="POST" class="form" role="form" novalidate>
     {{ form.hidden_tag() }}
     {%- if form.csrf_token and form.csrf_token.errors %}
       <div class="alert alert-danger" role="alert">

--- a/rero_ils/modules/ill_requests/views.py
+++ b/rero_ils/modules/ill_requests/views.py
@@ -35,16 +35,16 @@ from ...permissions import check_user_is_authenticated
 blueprint = Blueprint(
     'ill_requests',
     __name__,
-    url_prefix='/ill_requests',
+    url_prefix='/<string:viewcode>',
     template_folder='templates',
     static_folder='static',
 )
 
 
-@blueprint.route('/create/', methods=['GET', 'POST'])
+@blueprint.route('/ill_requests/new', methods=['GET', 'POST'])
 @check_user_is_authenticated(redirect_to='security.login')
 @check_logged_as_patron
-def ill_request_form():
+def ill_request_form(viewcode):
     """Return professional view."""
     form = ILLRequestForm(request.form)
     # pickup locations selection are based on app context then the choices
@@ -58,7 +58,7 @@ def ill_request_form():
             ill_request_data['pickup_location'])
 
         # get the patron account of the same org of the location pid
-        def get_patron(location_pid):
+        def get_patron(loc_pid):
             loc = Location.get_record_by_pid(loc_pid)
             for ptrn in current_patrons:
                 if ptrn.organisation_pid == loc.organisation_pid:
@@ -73,6 +73,7 @@ def ill_request_form():
             _('The request has been transmitted to your library.'),
             'success'
         )
-        return redirect(url_for('patrons.profile', tab='ill_request'))
+        return redirect(url_for('patrons.profile', viewcode=viewcode))
 
-    return render_template('rero_ils/ill_request_form.html', form=form)
+    return render_template('rero_ils/ill_request_form.html',
+                           form=form, viewcode=viewcode)

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -133,7 +133,13 @@ def logged_user():
             ),
             'librarianRoles': current_app.config.get(
                 'RERO_ILS_LIBRARIAN_ROLES', []
-            )
+            ),
+            'userProfile': {
+                'readOnly': current_app.config.get(
+                    'RERO_PUBLIC_USERPROFILES_READONLY', False),
+                'readOnlyFields': current_app.config.get(
+                    'RERO_PUBLIC_USERPROFILES_READONLY_FIELDS', []),
+            }
         }
     }
     if not current_user.is_authenticated:
@@ -169,9 +175,7 @@ def logged_user():
     return jsonify(data)
 
 
-@blueprint.route('/global/patrons/profile', defaults={'viewcode': 'global'},
-                 methods=['GET', 'POST'])
-@blueprint.route('/<string:viewcode>/patrons/profile')
+@blueprint.route('/<string:viewcode>/patrons/profile', methods=['GET', 'POST'])
 @check_logged_as_patron
 @register_menu(
     blueprint,
@@ -186,7 +190,7 @@ def logged_user():
 )
 def profile(viewcode):
     """Patron Profile Page."""
-    return render_template('rero_ils/patron_profile.html')
+    return render_template('rero_ils/patron_profile.html', viewcode=viewcode)
 
 
 @blueprint.app_template_filter('format_currency')

--- a/rero_ils/modules/users/api.py
+++ b/rero_ils/modules/users/api.py
@@ -69,6 +69,11 @@ class User(object):
         """User class initializer."""
         self.user = user
 
+    @property
+    def id(self):
+        """Get user id."""
+        return self.user.id
+
     @classmethod
     def create(cls, data, **kwargs):
         """User record creation.

--- a/rero_ils/modules/users/templates/rero_ils/user_password.html
+++ b/rero_ils/modules/users/templates/rero_ils/user_password.html
@@ -1,7 +1,7 @@
 {# -*- coding: utf-8 -*-
 
   RERO ILS
-  Copyright (C) 2019 RERO
+  Copyright (C) 2022 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -18,17 +18,13 @@
 #}
 {% extends 'rero_ils/page.html' %}
 
-{%- block css %}
-{{ super() }}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile', ['styles.*css'], 'css') }}
-{%- endblock css %}
-
 {%- block body %}
-<public-patron-profile language="{{ current_i18n.locale.language[:2] }}" viewcode="{{ viewcode }}"></public-patron-profile>
+<h1 class="mt-2">{{ _('Change password') }}</h1>
+<public-user-password-change referer="{{ request.referrer }}"></public-user-password-change>
 {%- endblock body %}
 
 {%- block javascript %}
 {{ webpack['reroils_public.js']}}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile', patterns=['polyfills-es5*.js','main-es5*.js'], tags='nomodule defer') }}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile', patterns=['polyfills-es2015*.js','main-es2015*.js'], tags='type="module"') }}
+{{ node_assets('@rero/rero-ils-ui/dist/public-user-password-change', patterns=['polyfills-es5*.js','main-es5*.js'], tags='nomodule defer') }}
+{{ node_assets('@rero/rero-ils-ui/dist/public-user-password-change', patterns=['polyfills-es2015*.js','main-es2015*.js'], tags='type="module"') }}
 {%- endblock javascript %}

--- a/rero_ils/modules/users/templates/rero_ils/user_profile.html
+++ b/rero_ils/modules/users/templates/rero_ils/user_profile.html
@@ -1,7 +1,7 @@
 {# -*- coding: utf-8 -*-
 
   RERO ILS
-  Copyright (C) 2019 RERO
+  Copyright (C) 2022 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -18,17 +18,13 @@
 #}
 {% extends 'rero_ils/page.html' %}
 
-{%- block css %}
-{{ super() }}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile', ['styles.*css'], 'css') }}
-{%- endblock css %}
-
 {%- block body %}
-<public-patron-profile language="{{ current_i18n.locale.language[:2] }}" viewcode="{{ viewcode }}"></public-patron-profile>
+<h1 class="mt-2">{{ _('Profile') }}</h1>
+<public-user-profile-edit referer="{{ request.referrer }}"></public-user-profile-edit>
 {%- endblock body %}
 
 {%- block javascript %}
 {{ webpack['reroils_public.js']}}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile', patterns=['polyfills-es5*.js','main-es5*.js'], tags='nomodule defer') }}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile', patterns=['polyfills-es2015*.js','main-es2015*.js'], tags='type="module"') }}
+{{ node_assets('@rero/rero-ils-ui/dist/public-user-profile-edit', patterns=['polyfills-es5*.js','main-es5*.js'], tags='nomodule defer') }}
+{{ node_assets('@rero/rero-ils-ui/dist/public-user-profile-edit', patterns=['polyfills-es2015*.js','main-es2015*.js'], tags='type="module"') }}
 {%- endblock javascript %}

--- a/rero_ils/theme/menus.py
+++ b/rero_ils/theme/menus.py
@@ -128,6 +128,10 @@ def init_menu_tools():
     rero_register(
         item,
         endpoint='ill_requests.ill_request_form',
+        endpoint_arguments_constructor=lambda: dict(
+            viewcode=request.view_args.get(
+                'viewcode', current_app.config.get(
+                    'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'))),
         visible_when=lambda: bool(current_patrons),
         text=TextWithIcon(
             icon='<i class="fa fa-shopping-basket"></i>',
@@ -246,6 +250,13 @@ def init_menu_lang():
 
 def init_menu_profile():
     """Create the profile header menu."""
+
+    def is_not_read_only():
+        """Hide element menu if the flag is ready only."""
+        return not current_app.config.get(
+            'RERO_PUBLIC_USERPROFILES_READONLY', False) and \
+            current_user.is_authenticated
+
     item = current_menu.submenu('main.profile')
     rero_register(
         item,
@@ -309,6 +320,10 @@ def init_menu_profile():
     rero_register(
         item,
         endpoint=profile_endpoint,
+        endpoint_arguments_constructor=lambda: dict(
+            viewcode=request.view_args.get(
+                'viewcode', current_app.config.get(
+                    'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'))),
         visible_when=lambda: len(current_patrons) > 0,
         text=TextWithIcon(
             icon='<i class="fa fa-book"></i>',
@@ -321,8 +336,12 @@ def init_menu_profile():
     item = current_menu.submenu('main.profile.edit_profile')
     rero_register(
         item,
-        endpoint='invenio_userprofiles.profile',
-        visible_when=lambda: current_user.is_authenticated,
+        endpoint='users.profile',
+        endpoint_arguments_constructor=lambda: dict(
+            viewcode=request.view_args.get(
+                'viewcode', current_app.config.get(
+                    'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'))),
+        visible_when=lambda: is_not_read_only(),
         text=TextWithIcon(
             icon='<i class="fa fa-user"></i>',
             text='Edit my profile'
@@ -334,8 +353,12 @@ def init_menu_profile():
     item = current_menu.submenu('main.profile.change_password')
     rero_register(
         item,
-        endpoint='security.change_password',
-        visible_when=lambda: current_user.is_authenticated,
+        endpoint='users.password',
+        endpoint_arguments_constructor=lambda: dict(
+            viewcode=request.view_args.get(
+                'viewcode', current_app.config.get(
+                    'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'))),
+        visible_when=lambda: is_not_read_only(),
         text=TextWithIcon(
             icon='<i class="fa fa-lock"></i>',
             text='Change password'
@@ -347,12 +370,13 @@ def init_menu_profile():
     # Endpoint for:
     # Application: invenio_oauth2server_settings.index
     # Security: invenio_accounts.security
-
     item = current_menu.submenu('main.profile.signup')
     rero_register(
         item,
         endpoint='security.register',
-        visible_when=lambda: not current_user.is_authenticated,
+        visible_when=lambda: not current_app.config.get(
+            'RERO_PUBLIC_USERPROFILES_READONLY', False) and
+        not current_user.is_authenticated,
         text=TextWithIcon(
             icon='<i class="fa fa-user-plus"></i>',
             text='Sign Up'

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
             'rero_ils = rero_ils.theme.views:blueprint',
             'stats = rero_ils.modules.stats.views:blueprint',
             'templates = rero_ils.modules.templates.views:blueprint',
+            'users = rero_ils.modules.users.views:blueprint',
         ],
         'invenio_base.api_blueprints': [
             'acq_accounts = rero_ils.modules.acq_accounts.views:api_blueprint',

--- a/tests/api/users/test_users_rest.py
+++ b/tests/api/users/test_users_rest.py
@@ -148,7 +148,8 @@ def test_users_search_api(client, librarian_martigny, patron_martigny):
     )
     assert res.status_code == 200
     hits = get_json(res)
-    assert hits['hits']['hits'][0]['id'] == patron_martigny['user_id']
+    assert hits['hits']['hits'][0]['metadata']['username'] == \
+        patron_martigny['username']
     assert hits['hits']['total']['value'] == 1
 
     # all by email
@@ -160,7 +161,8 @@ def test_users_search_api(client, librarian_martigny, patron_martigny):
     )
     assert res.status_code == 200
     hits = get_json(res)
-    assert hits['hits']['hits'][0]['id'] == patron_martigny['user_id']
+    assert hits['hits']['hits'][0]['metadata']['username'] == \
+        patron_martigny['username']
     assert hits['hits']['total']['value'] == 1
 
     # by username
@@ -172,7 +174,8 @@ def test_users_search_api(client, librarian_martigny, patron_martigny):
     )
     assert res.status_code == 200
     hits = get_json(res)
-    assert hits['hits']['hits'][0]['id'] == patron_martigny['user_id']
+    assert hits['hits']['hits'][0]['metadata']['username'] == \
+        patron_martigny['username']
     assert hits['hits']['total']['value'] == 1
 
     # by email
@@ -184,7 +187,8 @@ def test_users_search_api(client, librarian_martigny, patron_martigny):
     )
     assert res.status_code == 200
     hits = get_json(res)
-    assert hits['hits']['hits'][0]['id'] == patron_martigny['user_id']
+    assert hits['hits']['hits'][0]['metadata']['username'] == \
+        patron_martigny['username']
     assert hits['hits']['total']['value'] == 1
 
     # by uppercase email
@@ -196,5 +200,44 @@ def test_users_search_api(client, librarian_martigny, patron_martigny):
     )
     assert res.status_code == 200
     hits = get_json(res)
-    assert hits['hits']['hits'][0]['id'] == patron_martigny['user_id']
+    assert hits['hits']['hits'][0]['metadata']['username'] == \
+        patron_martigny['username']
     assert hits['hits']['total']['value'] == 1
+
+    # Login with patron role
+    login_user_via_session(client, p_martigny.user)
+    res = client.get(
+        url_for(
+            'api_users.users_list',
+            q=patron_martigny['username']
+        )
+    )
+    assert res.status_code == 200
+    hits = get_json(res)
+    assert 'metadata' not in hits['hits']['hits'][0]
+    assert hits['hits']['hits'][0]['id'] == patron_martigny['user_id']
+
+    res = client.get(
+        url_for(
+            'api_users.users_item',
+            id=p_martigny.user.id
+        )
+    )
+    assert res.status_code == 200
+    record = get_json(res)
+    assert patron_martigny['username'] == record.get('metadata', [])\
+        .get('username')
+
+    # Login with librarian role
+    login_user_via_session(client, l_martigny.user)
+    res = client.get(
+        url_for(
+            'api_users.users_list',
+            q=patron_martigny['username']
+        )
+    )
+    assert res.status_code == 200
+    hits = get_json(res)
+    assert 'metadata' in hits['hits']['hits'][0]
+    assert hits['hits']['hits'][0]['metadata']['username'] == \
+        patron_martigny['username']

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -1116,4 +1116,4 @@ def operation_log_data(data):
 @pytest.fixture(scope="module")
 def operation_log(operation_log_data, item_lib_sion):
     """Load operation log record."""
-    return OperationLog.create(operation_log_data)
+    return OperationLog.create(operation_log_data, index_refresh=True)

--- a/tests/ui/ill_requests/test_ill_requests_ui.py
+++ b/tests/ui/ill_requests/test_ill_requests_ui.py
@@ -29,7 +29,8 @@ def test_ill_request_create_request_form(client, app,
                                          loc_public_martigny,
                                          patron_martigny):
     """ test ill request create form."""
-    request_form_url = url_for('ill_requests.ill_request_form')
+    request_form_url = url_for(
+        'ill_requests.ill_request_form', viewcode='global')
 
     # Not logged user don't have access to request_form. It is redirected to
     # login form

--- a/tests/ui/users/test_users_ui.py
+++ b/tests/ui/users/test_users_ui.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests UI view for users."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_users_not_authorized_access(client):
+    """Test profile or change password if the user is not logged."""
+
+    res = client.get(url_for('users.profile', viewcode='global'))
+    assert res.status_code == 401
+
+    res = client.get(url_for('users.password', viewcode='global'))
+    assert res.status_code == 401
+
+
+def test_users_authorized_access(client, patron_martigny):
+    """Test profile and change password if the user is logged."""
+
+    login_user_via_session(client, patron_martigny.user)
+    res = client.get(url_for('users.profile', viewcode='global'))
+    assert res.status_code == 200
+
+    res = client.get(url_for('users.password', viewcode='global'))
+    assert res.status_code == 200
+
+
+def test_users_readonly_not_authorized_access(app, client, patron_martigny):
+    """Test profile and change password with readonly config."""
+
+    app.config['RERO_PUBLIC_USERPROFILES_READONLY'] = True
+    login_user_via_session(client, patron_martigny.user)
+    res = client.get(url_for('users.profile', viewcode='global'))
+    assert res.status_code == 401
+
+    res = client.get(url_for('users.password', viewcode='global'))
+    assert res.status_code == 401


### PR DESCRIPTION
The change of the user's data as well as the change of
the password has been transferred to the Angular user profile.

* Adds functionality for editing user data in angular.
* Adds functionality to change user password in angular.
* Closes https://github.com/rero/rero-ils/issues/2000.
* Closes https://github.com/rero/rero-ils/issues/2101.
* Closes https://github.com/rero/rero-ils/issues/2195.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Dependencies

My PR depends on the following PR(s):

* [patron: select the current profile view](https://github.com/rero/rero-ils-ui/pull/801)
* [users: make user profiles read-only](https://github.com/rero/invenio-userprofiles/pull/6)

## How to test?

- Test the data editing functionality in the "Personal data" tab.
- Test the password change functionality in the "Personal data" tab.
- Test the viewcode on Ill request.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
