### PR TITLE
notification: disable notifications creation by config

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2705,6 +2705,10 @@ RERO_ILS_STATS_BILLING_TIMEFRAME_IN_MONTHES = 3
 # NOTIFICATIONS MODULE SPECIFIC SETTINGS
 # =============================================================================
 
+# Define which notification types must be disabled. If system try to create a
+# notification with this type, the notification will not be created.
+RERO_ILS_DISABLED_NOTIFICATION_TYPE = []
+
 # Define which files should be considered as a template file. Each full_path
 # file matching one of the specific regular expression will be considered.
 RERO_ILS_NOTIFICATIONS_ALLOWED_TEMPLATE_FILES = [

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -866,10 +866,10 @@ class Loan(IlsRecord):
 
             # create the notification and enqueue it.
             if create:
-                notifications.append(self._create_notification_resource(
-                    record,
-                    dispatch=dispatch
-                ))
+                notification = self._create_notification_resource(
+                    record, dispatch=dispatch)
+                if notification:
+                    notifications.append(notification)
         return notifications
 
     @classmethod
@@ -882,7 +882,7 @@ class Loan(IlsRecord):
         """
         notification = Notification.create(
             data=record, dbcommit=True, reindex=True)
-        if dispatch:
+        if dispatch and notification:
             NotificationDispatcher.dispatch_notifications(
                 notification_pids=[notification.get('pid')]
             )

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -24,6 +24,8 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import partial
 
+from flask import current_app
+
 from .extensions import NotificationSubclassExtension
 from .models import NotificationIdentifier, NotificationMetadata, \
     NotificationStatus
@@ -99,6 +101,11 @@ class Notification(IlsRecord, ABC):
     def create(cls, data, id_=None, delete_pid=False, dbcommit=False,
                reindex=False, **kwargs):
         """Create notification record."""
+        # Check if the notification_type is disabled by app configuration
+        if data.get('notification_type') in current_app.config.get(
+                'RERO_ILS_DISABLED_NOTIFICATION_TYPE', []):
+            return
+
         data.setdefault('status', NotificationStatus.CREATED)
         record = super().create(data, id_, delete_pid, dbcommit, reindex,
                                 **kwargs)


### PR DESCRIPTION
Creates an new configuration variable allowing to disable some
notification creation based on notification type. Using this
configuration it's now possible to disable all 'recall' notification
creations by example.
Closes rero/rero-ils#2665.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
