### PR TITLE
menu: fix bad caret alignment in mobile menu

### DIFF
--- a/rero_ils/theme/templates/rero_ils/header.html
+++ b/rero_ils/theme/templates/rero_ils/header.html
@@ -98,7 +98,7 @@
         {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible %}
           {%- if item.children %}
             <li class="nav-item{{ ' active' if item.active else ''}} w-100 list-group-item bg-light">
-              <a class="nav-link collapsed" href="#{{ item.name }}" data-toggle="collapse" role="button" aria-controls="collapseExample" aria-expanded="false" {{ "id={}".format(item.id) if item.id }}>{{ item.text|safe }} <i class="fa fa-caret-down float-right" aria-hidden="true"></i></a>
+              <a class="nav-link collapsed" href="#{{ item.name }}" data-toggle="collapse" role="button" aria-controls="collapseExample" aria-expanded="false" {{ "id={}".format(item.id) if item.id }}>{{ item.text|safe }} <i class="fa fa-caret-down" aria-hidden="true"></i></a>
               <ul class="nav collapse pl-2" id="{{ item.name }}" data-parent="#mobileHide">
                 {%- for child in item.children if child.visible %}
                   <li class="nav-item {{class_name if class_name}} w-100">


### PR DESCRIPTION
* Removes useless css class on `<i></i>` tag.

Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

Caret in mobile menu isn't correctly align on text

## How to test?

- go to public view with mobile screen (or resize your browser) 
- in the menu, caret will be align to the text

<img width="730" alt="Capture d’écran 2022-02-15 à 14 36 41" src="https://user-images.githubusercontent.com/38690496/154073132-8b7ef9fa-3279-480a-afab-fb58112a39ed.png">

<img width="735" alt="Capture d’écran 2022-02-15 à 14 36 10" src="https://user-images.githubusercontent.com/38690496/154073169-1de6b061-ade9-4dd4-82c8-5929db53340f.png">


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
