### PR TITLE
documentation: update PR labeler to new Github label list

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,61 +2,49 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug, triage
+labels: bug
 assignees: ''
 
 ---
 
-<!--
-    Please, fill the bug report as precisely as possible.
-    Write a full sentence in the issue title.
-    Thanks a lot for helping us!
--->
+<!-- Please, fill the report as precisely as possible.
+Be clear and concise. Write a full sentence in the issue title.
+Thanks for your help! -->
 
-**Describe the bug**
+### Bug description:
+<!-- A concise description of the bug you are experiencing -->
 
-<!--
-    A clear and concise description of what the bug is.
--->
+### Expected behavior:
+<!-- A concise description of what you expected to happen -->
 
-**To Reproduce**
+### Steps to Reproduce:
+<!-- Example: Steps to reproduce the problem:
+1. Go to...
+2. Click on...
+3. Scroll down to...
+4. See error -->
 
-<!--
-    Steps to reproduce the behavior:
--->
+### Context
+<!-- In which environment did the problem occur? -->
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Server:**
+* [ ] production: [bib.rero.ch](https://bib.rero.ch) or [ils.bib.uclouvain.be](https://ils.bib.uclouvain.be)
+* [ ] test: [bib.test.rero.ch](https://bib.test.rero.ch)
+* [ ] dev: [ilsdev.test.rero.ch](https://ilsdev.test.rero.ch)
+* [ ] dev test : [ils.test.rero.ch](https://ils.test.rero.ch)
 
-**Expected behavior**
+**Version:**
+<!-- In which version of RERO ILS did this problem happen? -->
 
-<!--
-    A clear and concise description of what you expected to happen.
--->
+`v1.9.0` ; commit hash : `XXXX`
 
-**Context**
+**Browser:**
+<!-- If relevant -->
 
-<!--
-    Tell us on what server did you spotted the issue, using which browser:
--->
+Chrome, Safari, Firefox; version XX
 
-* server: [ils.test.rero.ch][1] or [ilsdev.test.rero.ch][2]?
-* version: `v0.14.0` or the commit hash (see frontpage).
-* browser: [if relevant, e.g. chrome, safari, version 78].
+### Screenshots
+<!-- If relevant, screenshots to help ilustrate the problem -->
 
-[1]: https://ils.test.rero.ch
-[2]: https://ilsdev.test.rero.ch
-
-**Screenshots**
-
-<!--
-    If applicable, add screenshots to help explain your problem.
--->
-
-**Additional context**
-
-<!--
-    Add any other context about the problem here.
--->
+### Anything else?
+<!-- Any other useful information about the problem -->

--- a/.github/ISSUE_TEMPLATE/correction.md
+++ b/.github/ISSUE_TEMPLATE/correction.md
@@ -2,27 +2,18 @@
 name: Wrong implementation report
 about: A feature is implemented, but doesn't work as expected.
 title: ''
-labels: triage, correction
+labels: correction
 assignees: ''
 
 ---
 
-<!--
-    Please, fill the bug report as precisely as possible.
-    Write a full sentence in the issue title.
-    Thanks a lot for helping us!
- -->
+<!-- Please, fill the report as precisely as possible.
+Be clear and concise. Write a full sentence in the issue title.
+Thanks for your help! -->
 
-**How it works**
+### How it works
+<!-- A clear and concise description of how the existing feature currently works. Please mention if it involves the public or professional view, and in which section.-->
 
-<!--
-    A clear and concise description of how works the existing feature.
-    Do not forget to tell if it's on the public or professional interface,
-    and in which section.
--->
-
-**How it should works**
-
-<!--
-    Explain what is wrong, or incorrect, and how it should be amended.
--->
+### Improvement suggestion
+<!-- Explain what is missing, why it is frustrating
+and how this could be improved. -->

--- a/.github/ISSUE_TEMPLATE/developers.md
+++ b/.github/ISSUE_TEMPLATE/developers.md
@@ -1,26 +1,33 @@
 ---
 name: Developers issue report
-about: Create a report to help us improve
+about: Improvement or correction useful from a developer point of view
 title: ''
-labels: developers, triage
+labels: developers
 assignees: ''
 
 ---
 
-<!--
-    Please, fill the bug report as precisely as possible.
-    Write a full sentence in the issue title.
-    Thanks a lot for helping us!
- -->
+<!-- Please, fill the report as precisely as possible.
+Be clear and concise. Write a full sentence in the issue title.
+Thanks for your help! -->
 
-**Describe the issue**
+### Describe the issue
+<!-- A concise description of what the issue is -->
 
-<!--
-    A clear and concise description of what the issue is.
--->
+### What should be done?
 
-**What should be done**
+<!-- A concise description of what has to be done -->
 
-<!--
-    A clear and concise description of what you think has to be done.
--->
+### Context
+<!-- If relevant -->
+
+**Server:**
+* [ ] production: [bib.rero.ch](https://bib.rero.ch) or [ils.bib.uclouvain.be](https://ils.bib.uclouvain.be)
+* [ ] test: [bib.test.rero.ch](https://bib.test.rero.ch)
+* [ ] dev: [ilsdev.test.rero.ch](https://ilsdev.test.rero.ch)
+* [ ] dev test : [ils.test.rero.ch](https://ils.test.rero.ch)
+
+**Version:**
+<!-- In which version of RERO ILS did this problem happen? -->
+
+`v1.9.0` ; commit hash : `XXXX`

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,29 +1,19 @@
 ---
-name: Enhancement proposition
+name: Enhancement suggestion
 about: Suggest an improvement on an existing feature.
 title: ''
-labels: triage, enhancement
+labels: enhancement
 assignees: ''
 
 ---
 
-<!--
-    Please, fill the bug report as precisely as possible.
-    Write a full sentence in the issue title.
-    Thanks a lot for helping us!
- -->
+<!-- Please, fill the report as precisely as possible.
+Be clear and concise. Write a full sentence in the issue title.
+Thanks for your help! -->
 
-**How it works**
+### How it works
+<!-- A clear and concise description of how the existing feature currently works. Please mention if it involves the public or professional view, and in which section.-->
 
-<!--
-    A clear and concise description of how works the existing feature.
-    Do not forget to tell if it's on the public or professional interface,
-    and in which section.
--->
-
-**Improvement suggestion**
-
-<!--
-    Explain what is missing, why is it frustrating
-    and how this could be improved.
--->
+### Improvement suggestion
+<!-- Explain what is missing, why it is frustrating
+and how this could be improved. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,39 +2,26 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: triage, feature_request
+labels: new feature
 assignees: ''
 
 ---
 
-<!--
-    Please, fill the bug report as precisely as possible.
-    Write a full sentence in the issue title.
-    Thanks a lot for helping us!
- -->
+<!-- Please, fill the report as precisely as possible.
+Be clear and concise. Write a full sentence in the issue title.
+Thanks for your help! -->
 
-**Is your feature request related to a problem? Please describe.**
+### Problem description
+<!-- A clear and concise description of what the problem is.
+Example: I'm always frustrated when [...] -->
 
-<!--
-    A clear and concise description of what the problem is.
-    Ex. I'm always frustrated when [...]
--->
+### Missing feature
+<!-- A concise description of a feature 
+that could solve this problem? -->
 
-**Describe the solution you'd like**
+### Alternative solutions
+<!-- Any alternative solutions
+or features you've considered for this. -->
 
-<!--
-    A clear and concise description of what you want to happen.
--->
-
-**Describe alternatives you've considered**
-
-<!--
-    A clear and concise description of any alternative solutions
-    or features you've considered.
--->
-
-**Additional context**
-
-<!--
-    Add any other context or screenshots about the feature request here.
--->
+### Anything else?
+<!-- Any other context or screenshots about the feature request -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,45 +2,40 @@
 name: Question
 about: Ask a question or for help
 title: 'Write a full question: Why should I have to log in to make a request?'
-labels: question, triage
+labels: question
 assignees: ''
 
 ---
 
-<!--
-    Please, fill the bug report as precisely as possible.
-    Write a full sentence in the issue title.
-    Thanks a lot for helping us!
- -->
+<!-- Please, fill the report as precisely as possible.
+Be clear and concise. Write a full sentence in the issue title.
+Thanks for your help! -->
 
-**Describe your question**
+### Describe your question
+<!-- What are you trying to do? 
+What surprised you in the way RERO ILS is functioning? -->
 
-<!--
-    What are you trying to do? What surprised you in the way RERO ILS
-    is functioning?
--->
+### Context
+<!-- In which environment did the problem occur? -->
 
-**Context**
+**Server:**
+* [ ] production: [bib.rero.ch](https://bib.rero.ch) or [ils.bib.uclouvain.be](https://ils.bib.uclouvain.be)
+* [ ] test: [bib.test.rero.ch](https://bib.test.rero.ch)
+* [ ] dev: [ilsdev.test.rero.ch](https://ilsdev.test.rero.ch)
+* [ ] dev test : [ils.test.rero.ch](https://ils.test.rero.ch)
 
-<!--
-    Tell us on which server the question relates to.
--->
+**Version:**
+<!-- In which version of RERO ILS did this problem happen? -->
 
-* server: [ils.test.rero.ch][1] or [ilsdev.test.rero.ch][2]?
-* version: `v0.14.0` or the commit hash (see frontpage).
-* browser: [if relevant, e.g. chrome, safari, version 78]
+`v1.9.0` ; commit hash : `XXXX`
 
-[1]: https://ils.test.rero.ch
-[2]: https://ilsdev.test.rero.ch
+**Browser:**
+<!-- If relevant -->
 
-**Screenshots**
+Chrome, Safari, Firefox; version XX
 
-<!--
-    If applicable, add screenshots to help explain your problem.
--->
+### Screenshots
+<!-- If relevant, screenshots to help ilustrate the problem -->
 
-**Additional context**
-
-<!--
-    Add any other context about the problem here.
--->
+### Anything else?
+<!-- Any other useful information about the problem -->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 # Add documentation label to the following files and folders
-documentation:
+"dev: documentation":
   - Authors.rst
   - CHANGES.md
   - CONTRIBUTING.rst
@@ -19,8 +19,9 @@ translations:
   - rero_ils/translations/**/*
 
 # Add data label to any changes in document and item jsonschemas folders,
-# in DOJSON folders, and templates folders
-data:
+# in DOJSON folders, templates folders, dojson, json to dublin core or to
+# MARC21 folders and in the SRU module:
+"f: data":
   - rero_ils/jsonschemas/**/*
   - rero_ils/modules/documents/jsonschemas/**/*
   - rero_ils/modules/documents/utils.py
@@ -30,31 +31,27 @@ data:
   - rero_ils/dojson/**/*
   - rero_ils/modules/**/dojson/**/*
   - rero_ils/modules/templates/**/*
+  - rero_ils/modules/documents/dojson/contrib/jsontodc/**/*
+  - rero_ils/modules/documents/dojson/contrib/jsontomarc21/**/*
+  - rero_ils/modules/sru/**/*
 
 # Add data-migration label to any changes that may need migration effort for
 # deployment of a new release
-"data-migration":
+"f: data migration":
   - rero_ils/es_templates/**
   - rero_ils/jsonschemas/**
   - rero_ils/**/jsonschemas/**
   - rero_ils/**/mappings/**
   - rero_ils/**/models.py
 
-# Add data-export label to any changes in dojson json to dublin core or to
-# MARC21 folders and in the SRU module:
-data-export:
-  - rero_ils/modules/documents/dojson/contrib/jsontodc/**/*
-  - rero_ils/modules/documents/dojson/contrib/jsontomarc21/**/*
-  - rero_ils/modules/sru/**/*
-
 # Add search label to any changes in mappings files
-search:
+"f: search":
   - rero_ils/**/mappings/**/*json
   - rero_ils/es_templates/v7/record.json
 
 # Add circulation label to any changes in circulation API, circulation
 # policies, item types and loans folders and subfolders
-circulation:
+"f: circulation":
   - rero_ils/modules/items/api/circulation.py
   - rero_ils/modules/circ_policies/**/*
   - rero_ils/modules/item_types/**/*
@@ -66,14 +63,14 @@ circulation:
 
 # Add 'user management' label to any changes in users or patrons folders and
 # subfolders
-"user management":
+"f: user management":
   - rero_ils/modules/users/**/*
   - rero_ils/modules/patrons/**/*
   - rero_ils/modules/patron_types/**/*
 
 # Add acquisition label to any changes in acquisition related folders and
 # subfolders
-acquisitions:
+"f: acquisitions":
   - rero_ils/acquisition/**/*
   - rero_ils/modules/acq_accounts/**/*
   - rero_ils/modules/acq_invoices/**/*
@@ -81,40 +78,36 @@ acquisitions:
   - rero_ils/modules/acq_orders/**/*
   - rero_ils/modules/budgets/**/*
 
-# Add deployment label to any changes in the following files or folders
-deployment:
-  - Dockerfile*
-
 # Add permissions label to any changes in a permissions.py files
-permissions:
+"f: permissions":
   - rero_ils/**/*/permissions.py
 
 # Add fixtures label to any changes in data folder or subfolders
-fixtures:
+"dev: fixtures":
   - data/**/*
 
 # Add serials label to any changes in the following files or folders
-serials:
+"f: serials":
   - rero_ils/modules/items/api/issue.py
 
-activity-logs:
+"f: activity-logs":
   - rero_ils/modules/loans/logs/api.py
   - rero_ils/modules/operation_logs/**/*
 
 developers:
   - scripts/**/*
 
-monitoring:
+"dev: monitoring":
   - rero_ils/modules/monitoring.py
 
-notifications:
+"f: notifications":
   - rero_ils/modules/notifications/**/*
 
-"public ui":
+"f: public ui":
   - any: ['rero_ils/**/templates/**/*', 'rero_ils/theme/**/*', 'rero_ils/**/views.py', '!rero_ils/modules/templates/**/*']
 
-"statistics":
+"f: statistics":
   - rero_ils/modules/stats/**/*
 
-DB:
+"dev: DB":
   - rero_ils/**/models.py

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,5 +22,5 @@ jobs:
         # Set the label added to the PR marked stale
         stale-pr-label: 'stale'
         # Labels on an issue exempted from being marked as stale
-        exempt-issue-labels: 'bug,P: High'
+        exempt-issue-labels: 'bug,bug (critical),p-High'
         exempt-pr-labels: 'translations'


### PR DESCRIPTION
## Why are you opening this PR?

Quick fix for Github labeler to account for current label titles in repo and improvement of the issue templates. 
