### PR TITLE
issues: fix 'received_date' required conditions.

### DIFF
--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -301,7 +301,6 @@
       "title": "Issue",
       "type": "object",
       "required": [
-        "received_date",
         "expected_date",
         "regular",
         "status"
@@ -364,6 +363,10 @@
           "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
           "form": {
             "type": "datepicker",
+            "expressionProperties": {
+              "templateOptions.required": "field.parent.model && field.parent.model.status === 'received'"
+            },
+            "hideExpression": "field.parent.model && field.parent.model.status !== 'received'",
             "templateOptions": {
               "wrappers": [
                 "form-field"


### PR DESCRIPTION
The issue 'received_date' field must be only required when the issue
status is received. Otherwise this field isn't required and should be
hided.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
