### PR TITLE
documents: add identifiedBy on some fields

### DIFF
--- a/rero_ils/jsonschemas/common/cantons-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/cantons-v0.0.1.json
@@ -140,7 +140,7 @@
       "templateOptions": {
         "itemCssClass": "col-lg-4"
       },
-      "hideExpression": "field.parent.model.country !== 'sz'"
+      "hideExpression": "field?.parent?.model && field.parent.model.country !== 'sz'"
     }
   }
 }

--- a/rero_ils/jsonschemas/common/languages-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/languages-v0.0.1.json
@@ -2541,7 +2541,7 @@
     ],
     "form": {
       "templateOptions": {
-        "itemCssClass": "col-lg-6"
+        "itemCssClass": "col-lg-12"
       },
       "hide": true
     }
@@ -2568,7 +2568,7 @@
         "minLength": 1,
         "form": {
           "templateOptions": {
-            "itemCssClass": "col-lg-6"
+            "itemCssClass": "col-lg-12"
           }
         }
       },

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -168,9 +168,9 @@
       "format": "date",
       "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
-        "hideExpression": "field.parent.model.status !== 'ordered' && field.parent.model.status !== 'received'",
+        "hideExpression": "field?.parent?.model && field.parent.model.status !== 'ordered' && field.parent.model.status !== 'received'",
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.status === 'ordered' || field.parent.model.status === 'received'"
+          "templateOptions.required": "field?.parent?.model && (field.parent.model.status === 'ordered' || field.parent.model.status === 'received')"
         },
         "type": "datepicker",
         "placeholder": "Select a date",
@@ -187,9 +187,9 @@
       "format": "date",
       "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
-        "hideExpression": "field.parent.model.status !== 'received'",
+        "hideExpression": "field?.parent?.model && field.parent.model.status !== 'received'",
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.status === 'received'"
+          "templateOptions.required": "field?.parent?.model && field.parent.model.status === 'received'"
         },
         "type": "datepicker",
         "placeholder": "Select a date",

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -43,7 +43,10 @@
     "name": {
       "title": "Name",
       "type": "string",
-      "minLength": 2
+      "minLength": 2,
+      "form": {
+        "focus": true
+      }
     },
     "description": {
       "title": "Description",
@@ -104,7 +107,7 @@
       "type": "integer",
       "minimum": 1,
       "form": {
-        "hideExpression": "!model.allow_requests",
+        "hideExpression": "model && !model.allow_requests",
         "templateOptions": {
           "addonRight": {
             "text": "day(s)"
@@ -223,6 +226,10 @@
       "required": [
         "intervals"
       ],
+      "propertiesOrder": [
+        "intervals",
+        "maximum_total_amount"
+      ],
       "properties": {
         "intervals": {
           "type": "array",
@@ -308,7 +315,7 @@
       "minimum": 0,
       "default": 0,
       "form": {
-        "hideExpression": "model.checkout_duration <= 0"
+        "hideExpression": "model && model.checkout_duration <= 0"
       }
     },
     "renewal_duration": {
@@ -316,7 +323,7 @@
       "type": "integer",
       "minimum": 1,
       "form": {
-        "hideExpression": "!model.hasOwnProperty('number_renewals') || model.number_renewals <= 0",
+        "hideExpression": "model && (!model.hasOwnProperty('number_renewals') || model.number_renewals <= 0)",
         "templateOptions": {
           "addonRight": {
             "text": "day(s)"
@@ -364,7 +371,7 @@
         }
       },
       "form": {
-        "hideExpression": "field.parent.model.policy_library_level !== true"
+        "hideExpression": "field?.parent?.model && field.parent.model.policy_library_level !== true"
       }
     },
     "settings": {

--- a/rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json
+++ b/rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json
@@ -107,7 +107,7 @@
             "card"
           ]
         },
-        "hideExpression": "field.parent.model.collection_type !== 'course'",
+        "hideExpression": "field?.parent?.model && field.parent.model.collection_type !== 'course'",
         "expressionProperties": {
           "templateOptions.required": "true"
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
@@ -8,7 +8,7 @@
       "type": "object",
       "oneOf": [
         {
-          "title": "contentType",
+          "title": "unknown media",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType"
@@ -69,7 +69,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1002",
@@ -160,7 +160,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1021",
@@ -254,7 +254,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1011",
@@ -337,7 +337,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1030",
@@ -400,7 +400,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1032",
@@ -488,7 +488,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1042",
@@ -552,7 +552,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1045",
@@ -630,7 +630,7 @@
                 "other"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "rdact:1051",
@@ -696,7 +696,7 @@
                 "unspecified"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "unspecified",
@@ -752,7 +752,7 @@
           "other"
         ],
         "form": {
-          "Type": "selectWithSort",
+          "type": "selectWithSort",
           "options": [
             {
               "label": "rdaco:1002",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
@@ -106,7 +106,18 @@
       }
     },
     "identifiedBy": {
-      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+      "allOf": [
+        {
+          "form": {
+            "templateOptions": {
+              "itemCssClass": "col-12"
+            }
+          }
+        },
+        {
+          "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+        }
+      ]
     }
   },
   "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json
@@ -243,7 +243,8 @@
       "type": "object",
       "additionalProperties": false,
       "propertiesOrder": [
-        "label"
+        "label",
+        "identifiedBy"
       ],
       "required": [
         "label"
@@ -252,6 +253,9 @@
         "label": {
           "type": "string",
           "minLength": 1
+        },
+        "identifiedBy": {
+          "$ref": "https://bib.rero.ch/schemas/documents/document_identified_by-v0.0.1.json#/identifiedBy"
         }
       }
     }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_electronic_locator-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_electronic_locator-v0.0.1.json
@@ -49,7 +49,7 @@
             "noInfo"
           ],
           "form": {
-            "Type": "selectWithSort",
+            "type": "selectWithSort",
             "options": [
               {
                 "label": "resource",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
@@ -63,7 +63,7 @@
                 "bf:Topic"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "bf:Topic",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json
@@ -190,7 +190,10 @@
           "minLength": 1,
           "form": {
             "placeholder": "Examples: LCCN, PMID, DNB",
-            "hide": true,
+            "hideExpression": "field?.parent?.model && field.parent.model.type !== 'bf:Local'",
+            "expressionProperties": {
+              "templateOptions.required": "field?.parent?.model && field.parent.model.type === 'bf:Local'"
+            },
             "templateOptions": {
               "itemCssClass": "col-lg-6"
             }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json
@@ -8,6 +8,10 @@
       "value",
       "source"
     ],
+    "required": [
+      "type",
+      "value"
+    ],
     "properties": {
       "type": {
         "$ref": "#/definitions/type_main"
@@ -34,6 +38,10 @@
       "type",
       "value",
       "source"
+    ],
+    "required": [
+      "type",
+      "value"
     ],
     "properties": {
       "type": {
@@ -88,10 +96,7 @@
           }
         ],
         "templateOptions": {
-          "itemCssClass": "col-lg-4"
-        },
-        "expressionProperties": {
-          "templateOptions.required": "true"
+          "itemCssClass": "col-lg-12"
         }
       }
     },
@@ -124,10 +129,7 @@
           }
         ],
         "templateOptions": {
-          "itemCssClass": "col-lg-4"
-        },
-        "expressionProperties": {
-          "templateOptions.required": "true"
+          "itemCssClass": "col-lg-12"
         }
       }
     },
@@ -137,10 +139,7 @@
       "minLength": 1,
       "form": {
         "templateOptions": {
-          "itemCssClass": "col-lg-4"
-        },
-        "expressionProperties": {
-          "templateOptions.required": "true"
+          "itemCssClass": "col-lg-12"
         }
       }
     },
@@ -151,12 +150,12 @@
       "minLength": 1,
       "form": {
         "templateOptions": {
-          "itemCssClass": "col-lg-4"
+          "itemCssClass": "col-lg-12"
         },
         "expressionProperties": {
           "templateOptions.required": "true"
         },
-        "hideExpression": "field.parent.model && field.parent.model.type !== 'bf:Local'"
+        "hideExpression": "!field?.parent?.model || (field.parent.model && field.parent.model.type !== 'bf:Local')"
       }
     }
   }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json
@@ -68,7 +68,7 @@
                 "target_understanding_caregivers"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "target_understanding_children",
@@ -230,7 +230,7 @@
                 "target_school_master"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "target_school_harmos1",
@@ -335,7 +335,7 @@
                 "pegi_18"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "pegi_3",
@@ -403,7 +403,7 @@
                 "from the age of 2"
               ],
               "form": {
-                "Type": "selectWithSort",
+                "type": "selectWithSort",
                 "options": [
                   {
                     "label": "from the age of 18",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
@@ -56,7 +56,7 @@
               }
             ],
             "templateOptions": {
-              "itemcCssClass": "col-lg-4"
+              "itemcCssClass": "col"
             }
           }
         },
@@ -94,7 +94,18 @@
                 }
               },
               "country": {
-                "$ref": "https://bib.rero.ch/schemas/common/countries-v0.0.1.json#/country"
+                "allOf": [
+                  {
+                    "form": {
+                      "templateOptions": {
+                        "itemCssClass": "col-lg-12"
+                      }
+                    }
+                  },
+                  {
+                    "$ref": "https://bib.rero.ch/schemas/common/countries-v0.0.1.json#/country"
+                  }
+                ]
               },
               "canton": {
                 "$ref": "https://bib.rero.ch/schemas/common/cantons-v0.0.1.json#/canton"
@@ -104,6 +115,7 @@
                 "type": "string",
                 "pattern": "^https://mef.rero.ch/api/places/gnd|idref|rero/.*?$",
                 "form": {
+                  "hide": true,
                   "remoteTypeahead": {
                     "type": "mef-places",
                     "enableGroupField": true
@@ -114,12 +126,18 @@
                 }
               },
               "identifiedBy": {
-                "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
-              }
-            },
-            "form": {
-              "templateOptions": {
-                "containerCssClass": "row"
+                "allOf": [
+                  {
+                    "form": {
+                      "templateOptions": {
+                        "itemCssClass": "col-lg-12"
+                      }
+                    }
+                  },
+                  {
+                    "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+                  }
+                ]
               }
             }
           },
@@ -128,7 +146,7 @@
               "itemCssClass": "col-lg-12"
             },
             "expressionProperties": {
-              "templateOptions.required": "field.parent.model.type === 'bf:Publication'"
+              "templateOptions.required": "field?.parent?.model && field.parent.model.type === 'bf:Publication'"
             }
           }
         },
@@ -190,11 +208,6 @@
                   "templateOptions": {
                     "itemCssClass": "col-lg-8"
                   }
-                }
-              },
-              "form": {
-                "templateOptions": {
-                  "itemCssClass": "col-lg-6"
                 }
               }
             },

--- a/rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json
@@ -23,7 +23,7 @@
             "Other"
           ],
           "form": {
-            "Type": "selectWithSort",
+            "type": "selectWithSort",
             "options": [
               {
                 "label": "Linear scale",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -454,7 +454,7 @@
     "genreForm_subdivisions": {
       "title": "Form subdivisions",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "title": "Form subdivision",
         "description": "Subject subdivision for a specific kind or genre of material (MARC 6XX$v)",
@@ -471,7 +471,7 @@
     "topic_subdivisions": {
       "title": "Concept subdivisions",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "title": "Concept subdivision",
         "description": "Subject subdivision for a concept (MARC 6XX$x)",
@@ -488,7 +488,7 @@
     "temporal_subdivisions": {
       "title": "Time-span subdivisions",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "title": "Time-span subdivision",
         "description": "Subject subdivision for a period of time (MARC 6XX$y)",
@@ -505,7 +505,7 @@
     "place_subdivisions": {
       "title": "Place subdivisions",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "title": "Place subdivision",
         "description": "Subject subdivision for a place (MARC 6XX$z)",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_types-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_types-v0.0.1.json
@@ -980,7 +980,6 @@
       ]
     },
     "form": {
-      "hide": true,
       "templateOptions": {
         "cssClass": "w-md-50"
       }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
@@ -49,7 +49,8 @@
             "form_subdivision",
             "medium_of_performance_for_music",
             "arranged_statement_for_music",
-            "key_for_music"
+            "key_for_music",
+            "identifiedBy"
           ],
           "required": [
             "title"
@@ -142,6 +143,9 @@
               "title": "Key (music)",
               "type": "string",
               "minLength": 1
+            },
+            "identifiedBy": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
             }
           }
         }

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -647,7 +647,7 @@
                     "type": "keyword"
                   },
                   "status": {
-                    "type": "text"
+                    "type": "keyword"
                   }
                 }
               }
@@ -713,7 +713,7 @@
             "type": "keyword"
           },
           "status": {
-            "type": "text"
+            "type": "keyword"
           }
         }
       },
@@ -1102,7 +1102,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1133,7 +1133,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1164,7 +1164,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1195,7 +1195,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1226,7 +1226,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1257,7 +1257,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1288,7 +1288,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1319,7 +1319,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1350,7 +1350,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1381,7 +1381,7 @@
                 "type": "keyword"
               },
               "status": {
-                "type": "text"
+                "type": "keyword"
               }
             }
           }
@@ -1694,10 +1694,10 @@
               "type": {
                 "type": "keyword"
               },
-              "source": {
+              "value": {
                 "type": "keyword"
               },
-              "value": {
+              "source": {
                 "type": "keyword"
               }
             }

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -738,7 +738,7 @@
           }
         ],
         "expressionProperties": {
-          "templateOptions.required": "model.holdings_type === 'serial'"
+          "templateOptions.required": "model && model.holdings_type === 'serial'"
         }
       }
     },

--- a/rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json
+++ b/rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json
@@ -203,9 +203,6 @@
         "source": {
           "type": "object",
           "title": "Source",
-          "required": [
-            "journal_title"
-          ],
           "propertiesOrder": [
             "journal_title",
             "volume",
@@ -215,12 +212,7 @@
             "journal_title": {
               "type": "string",
               "title": "Journal title",
-              "minLength": 3,
-              "form": {
-                "expressionProperties": {
-                  "templateOptions.required": "false"
-                }
-              }
+              "minLength": 3
             },
             "volume": {
               "type": "string",
@@ -250,9 +242,9 @@
       "type": "string",
       "title": "Pages",
       "form": {
-        "hideExpression": "model.copy === false",
+        "hideExpression": "model && model.copy === false",
         "expressionProperties": {
-          "templateOptions.required": "model.copy === true"
+          "templateOptions.required": "model && model.copy === true"
         }
       }
     },
@@ -274,7 +266,7 @@
           "minLength": 3,
           "form": {
             "expressionProperties": {
-              "templateOptions.required": "field.parent.model.url !== undefined && field.parent.model.url !== ''"
+              "templateOptions.required": "field?.parent?.model && (field.parent.model.url !== undefined && field.parent.model.url !== '')"
             }
           }
         },
@@ -287,7 +279,7 @@
           "minLength": 7,
           "form": {
             "expressionProperties": {
-              "templateOptions.required": "field.parent.model.source !== undefined && field.parent.model.source !== ''"
+              "templateOptions.required": "field?.parent?.model && (field.parent.model.source !== undefined && field.parent.model.source !== '')"
             },
             "validation": {
               "messages": {

--- a/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
@@ -140,9 +140,9 @@
         }
       },
       "form": {
-        "hideExpression": "!field.parent.model.negative_availability",
+        "hideExpression": "field?.parent?.model && !field.parent.model.negative_availability",
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.negative_availability"
+          "templateOptions.required": "field?.parent?.model && field.parent.model.negative_availability"
         },
         "validation": {
           "validators": {

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -67,9 +67,6 @@
           "messages": {
             "alreadyTakenMessage": "The barcode is already taken."
           }
-        },
-        "expressionProperties": {
-          "templateOptions.required": "false"
         }
       }
     },
@@ -112,7 +109,7 @@
         },
         "placeholder": "Example: Volume 1",
         "expressionProperties": {
-          "templateOptions.required": "model.type === 'issue'"
+          "templateOptions.required": "model && model.type === 'issue'"
         }
       }
     },
@@ -139,7 +136,7 @@
         "templateOptions": {
           "cssClass": "editor-title"
         },
-        "hideExpression": "field.parent.model.type === 'issue'"
+        "hideExpression": "field?.parent?.model && field.parent.model.type === 'issue'"
       }
     },
     "document": {
@@ -179,7 +176,7 @@
         "templateOptions": {
           "cssClass": "editor-title"
         },
-        "hideExpression": "field.parent.model.type === 'issue'"
+        "hideExpression": "field?.parent?.model && field.parent.model.type === 'issue'"
       }
     },
     "temporary_item_type": {
@@ -365,9 +362,9 @@
           "form": {
             "type": "datepicker",
             "expressionProperties": {
-              "templateOptions.required": "field.parent.model && field.parent.model.status === 'received'"
+              "templateOptions.required": "field?.parent?.model && field.parent.model.status === 'received'"
             },
-            "hideExpression": "field.parent.model && field.parent.model.status !== 'received'",
+            "hideExpression": "field?.parent?.model && field.parent.model.status !== 'received'",
             "templateOptions": {
               "wrappers": [
                 "form-field"
@@ -387,7 +384,7 @@
           "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
           "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
           "form": {
-            "hideExpression": "field.parent.model.regular",
+            "hideExpression": "field?.parent?.model && field.parent.model.regular",
             "type": "datepicker",
             "validation": {
               "messages": {
@@ -416,7 +413,7 @@
         }
       },
       "form": {
-        "hideExpression": "field.parent.model.type !== 'issue'"
+        "hideExpression": "field?.parent?.model && field.parent.model.type !== 'issue'"
       }
     },
     "status": {

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -91,9 +91,9 @@
       "type": "string",
       "description": "Displayed pickup location name, if different from the location name.",
       "form": {
-        "hideExpression": "model.is_pickup === false",
+        "hideExpression": "model && model.is_pickup === false",
         "expressionProperties": {
-          "templateOptions.required": "model.is_pickup === true"
+          "templateOptions.required": "model && model.is_pickup === true"
         },
         "validation": {
           "validators": {
@@ -130,9 +130,9 @@
       "type": "boolean",
       "default": false,
       "form": {
-        "hideExpression": "model.allow_request === false",
+        "hideExpression": "model && model.allow_request === false",
         "expressionProperties": {
-          "templateOptions.required": "model.allow_request === true"
+          "templateOptions.required": "model && model.allow_request === true"
         }
       }
     },
@@ -142,9 +142,9 @@
       "type": "string",
       "format": "email",
       "form": {
-        "hideExpression": "model.allow_request === false || model.send_notification === false",
+        "hideExpression": "model && (model.allow_request === false || model.send_notification === false)",
         "expressionProperties": {
-          "templateOptions.required": "model.send_notification === true && model.allow_request === true"
+          "templateOptions.required": "model && (model.send_notification === true && model.allow_request === true)"
         },
         "templateOptions": {
           "addonLeft": {
@@ -178,7 +178,7 @@
         }
       },
       "form": {
-        "hideExpression": "field.parent.model.allow_request === false",
+        "hideExpression": "field?.parent?.model && field.parent.model.allow_request === false",
         "templateOptions": {
           "label": "",
           "wrappers": [

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -169,7 +169,7 @@
                 }
               },
               "form": {
-                "hideExpression": "!field.parent.model || !field.parent.model.library_limit || field.parent.model.library_limit == 0"
+                "hideExpression": "!field?.parent?.model || !field.parent.model.library_limit || field.parent.model.library_limit == 0"
               }
             }
           },
@@ -242,7 +242,7 @@
           "title": "Block the patron if the subscription is not paid",
           "default": true,
           "form": {
-            "hideExpression": "!field.parent.parent.model.hasOwnProperty('subscription_amount') || field.parent.parent.model.subscription_amount <= 0"
+            "hideExpression": "field?.parent?.parent?.model && (!field.parent.parent.model.hasOwnProperty('subscription_amount') || field.parent.parent.model.subscription_amount <= 0)"
           }
         }
       }

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -114,7 +114,7 @@
             },
             {
               "form": {
-                "hideExpression": "!(field.parent.model && field.parent.model.city)"
+                "hideExpression": "field?.parent?.model && !(field.parent.model && field.parent.model.city)"
               }
             }
           ]
@@ -264,7 +264,7 @@
           "type": "string",
           "format": "email",
           "form": {
-            "hideExpression": "field.parent.model && field.parent.model.communication_channel !== 'email'"
+            "hideExpression": "field?.parent?.model && field.parent.model.communication_channel !== 'email'"
           }
         },
         "communication_language": {
@@ -366,7 +366,7 @@
           "type": "string",
           "description": "The reason is displayed in the circulation module and is visible by the patron in his account.",
           "form": {
-            "hideExpression": "field.parent.model &&  field.parent.model.blocked !== true",
+            "hideExpression": "field?.parent?.model &&  field.parent.model.blocked !== true",
             "expressionProperties": {
               "templateOptions.required": "true"
             }
@@ -374,7 +374,7 @@
         }
       },
       "form": {
-        "hideExpression": "!field.parent.model.roles.some(v => v === 'patron')",
+        "hideExpression": "field?.parent?.model && !field.parent.model.roles.some(v => v === 'patron')",
         "expressionProperties": {
           "templateOptions.required": "true"
         },
@@ -413,9 +413,9 @@
         }
       },
       "form": {
-        "hideExpression": "!field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))",
+        "hideExpression": "field?.parent?.model && !field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))",
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))"
+          "templateOptions.required": "field?.parent?.model && field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))"
         }
       }
     },

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -269,6 +269,13 @@
           "type": "string",
           "format": "email"
         }
+      },
+      "form": {
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
+        }
       }
     },
     "order_contact": {
@@ -320,6 +327,13 @@
           "title": "Email",
           "type": "string",
           "format": "email"
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
         }
       }
     },


### PR DESCRIPTION
Fields involved:
supplement, supplementTo, otherEdition, otherPhysicalFormat,
issuedWith, precededBy, succeededBy, relatedTo, hasReproduction,
reproductionOf, work_access_point

* Removes templateOptions on the country jsonschema.
* Fixes typo on the type entry (lower case t).
* Adds the card wrapper on vendors jsonschema.
* Closes https://github.com/rero/rero-ils/issues/2275.
* Closes https://github.com/rero/rero-ils/issues/2388.
* Closes https://github.com/rero/rero-ils/issues/2766.
* Closes https://github.com/rero/rero-ils/issues/2659.
* Closes https://github.com/rero/rero-ils/issues/2649.
* Closes https://github.com/rero/rero-ils/issues/2340.
* Closes #1924.

⚠️  Elasticsearch reindexing.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Test the above mentioned fields

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
