### PR TITLE
circulation: cancel intransit request with loans

### DIFF
--- a/tests/ui/circulation/test_actions_cancel_request.py
+++ b/tests/ui/circulation/test_actions_cancel_request.py
@@ -320,9 +320,9 @@ def test_cancel_item_request_on_item_in_transit_for_pickup_with_requests(
     item = Item.get_record_by_pid(item.pid)
     loan = Loan.get_record_by_pid(loan.pid)
     requested_loan = Loan.get_record_by_pid(requested_loan.pid)
-    assert item.status == ItemStatus.AT_DESK
+    assert item.status == ItemStatus.IN_TRANSIT
     assert loan['state'] == LoanState.CANCELLED
-    assert requested_loan['state'] == LoanState.ITEM_AT_DESK
+    assert requested_loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
 
 
 def test_cancel_pending_loan_on_item_in_transit_for_pickup_with_requests(

--- a/tests/ui/circulation/test_in_transit_actions.py
+++ b/tests/ui/circulation/test_in_transit_actions.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test item circulation cancel request actions."""
+
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanAction, LoanState
+
+
+def test_in_transit_second_request_at_home(app, item_lib_martigny,
+                                           patron_martigny, patron2_martigny,
+                                           librarian_martigny,
+                                           loc_public_martigny,
+                                           circulation_policies,
+                                           loc_public_fully):
+    """Test cases when in-transit loan is cancelled."""
+    params = {
+        'patron_pid': patron_martigny.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny.pid,
+        'pickup_location_pid': loc_public_fully.pid
+    }
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF
+    item, actions = item_lib_martigny.request(**params)
+    first_loan = Loan.get_record_by_pid(actions[LoanAction.REQUEST].get('pid'))
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF
+    assert first_loan['state'] == LoanState.PENDING
+    item, actions = item.validate_request(**params, pid=first_loan.pid)
+    first_loan = Loan.get_record_by_pid(actions[LoanAction.VALIDATE].get(
+        'pid'))
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert first_loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+
+    params = {
+        'patron_pid': patron2_martigny.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, actions = item.request(**params)
+    second_loan = Loan.get_record_by_pid(actions[LoanAction.REQUEST].get(
+        'pid'))
+    assert item_lib_martigny.status == ItemStatus.IN_TRANSIT
+    assert second_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': first_loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny.pid
+    }
+    item, actions = item.cancel_item_request(**params)
+    first_loan = Loan.get_record_by_pid(first_loan.pid)
+    second_loan = Loan.get_record_by_pid(second_loan.pid)
+    assert item_lib_martigny.status == ItemStatus.IN_TRANSIT
+    assert second_loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+    assert first_loan['state'] == LoanState.CANCELLED
+
+
+def test_in_transit_second_request_externally(app, item2_lib_martigny,
+                                              patron_martigny,
+                                              patron2_martigny,
+                                              librarian_martigny,
+                                              loc_public_martigny,
+                                              circulation_policies,
+                                              loc_public_fully):
+    """Test cases when in-transit loan is cancelled."""
+    params = {
+        'patron_pid': patron_martigny.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny.pid,
+        'pickup_location_pid': loc_public_fully.pid
+    }
+    assert item2_lib_martigny.status == ItemStatus.ON_SHELF
+    item, actions = item2_lib_martigny.request(**params)
+    first_loan = Loan.get_record_by_pid(actions[LoanAction.REQUEST].get('pid'))
+    assert item2_lib_martigny.status == ItemStatus.ON_SHELF
+    assert first_loan['state'] == LoanState.PENDING
+    item, actions = item.validate_request(**params, pid=first_loan.pid)
+    first_loan = Loan.get_record_by_pid(actions[LoanAction.VALIDATE].get(
+        'pid'))
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert first_loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+
+    params = {
+        'patron_pid': patron2_martigny.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny.pid,
+        'pickup_location_pid': loc_public_fully.pid
+    }
+    item, actions = item.request(**params)
+    second_loan = Loan.get_record_by_pid(actions[LoanAction.REQUEST].get(
+        'pid'))
+    assert item2_lib_martigny.status == ItemStatus.IN_TRANSIT
+    assert second_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': first_loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny.pid
+    }
+    item, actions = item.cancel_item_request(**params)
+    first_loan = Loan.get_record_by_pid(first_loan.pid)
+    second_loan = Loan.get_record_by_pid(second_loan.pid)
+    assert item2_lib_martigny.status == ItemStatus.IN_TRANSIT
+    assert second_loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+    assert first_loan['state'] == LoanState.CANCELLED


### PR DESCRIPTION
Case when an item has an in_transit_for_pickup loan with other
pending loans. If the in_transit_for_pickup is cancelled, the
system will validate the first pending loan at the pickup
location of the cancelled loan. This will ensure that the
loan to validate will receive the correct state according
to the validation logic.

* Closes #2454

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
