### PR TITLE
UI: fix the profile menu name

### DIFF
--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -22,7 +22,8 @@ from __future__ import absolute_import, print_function
 import jinja2
 from flask import Blueprint
 from flask_bootstrap import Bootstrap
-from flask_login.signals import user_loaded_from_cookie, user_logged_in
+from flask_login.signals import user_loaded_from_cookie, user_logged_in, \
+    user_logged_out
 from flask_wiki import Wiki
 from invenio_circulation.signals import loan_state_changed
 from invenio_indexer.signals import before_record_index
@@ -64,7 +65,7 @@ from .patrons.listener import create_subscription_patron_transaction, \
 from .sru.views import SRUDocumentsSearch
 from .templates.listener import prepare_template_data
 from .users.views import UsersCreateResource, UsersResource
-from .utils import set_user_name
+from .utils import remove_user_name, set_user_name
 from ..filter import address_block, empty_data, format_date_filter, \
     get_record_by_ref, jsondumps, node_assets, text_to_id, to_pretty_json
 from ..version import __version__
@@ -234,4 +235,5 @@ class REROILSAPP(object):
 
         # store the username in the session
         user_logged_in.connect(set_user_name)
+        user_logged_out.connect(remove_user_name)
         user_loaded_from_cookie.connect(set_user_name)

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -1061,6 +1061,8 @@ def set_user_name(sender, user):
     """Set the username in the current flask session."""
     from .patrons.api import current_librarian, current_patrons
     user_name = None
+    remove_user_name(sender, user)
+
     if current_librarian:
         user_name = current_librarian.formatted_name
     elif current_patrons:
@@ -1071,7 +1073,14 @@ def set_user_name(sender, user):
         # AnonymousUser
         except AttributeError:
             pass
-    session['user_name'] = user_name
+    if user_name:
+        session['user_name'] = user_name
+
+
+def remove_user_name(sender, user):
+    """Remove the username in the current flask session."""
+    if session.get('user_name'):
+        del session['user_name']
 
 
 def sorted_pids(query):

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -18,8 +18,53 @@
 """Common pytest fixtures and plugins."""
 
 
+from datetime import datetime
+
 import pytest
+from invenio_accounts.ext import hash_password
+from invenio_accounts.models import User
 from invenio_search import current_search_client
+
+
+@pytest.fixture(scope='function')
+def user_with_profile(db):
+    """Create a simple invenio user with a profile."""
+    with db.session.begin_nested():
+        user = User(
+            email='user_with_profile@test.com',
+            password=hash_password('123456'),
+            profile=dict(), active=True)
+        db.session.add(user)
+        profile = user.profile
+        profile.birth_date = datetime(1990, 1, 1)
+        profile.first_name = 'User'
+        profile.last_name = 'With Profile'
+        profile.city = 'Nowhere'
+        profile.username = 'user_with_profile'
+        db.session.merge(user)
+    db.session.commit()
+    user.password_plaintext = '123456'
+    return user
+
+
+@pytest.fixture(scope='function')
+def user_without_email(db):
+    """Create a simple invenio user without email."""
+    with db.session.begin_nested():
+        user = User(
+            password=hash_password('123456'),
+            profile=dict(), active=True)
+        db.session.add(user)
+        profile = user.profile
+        profile.birth_date = datetime(1990, 1, 1)
+        profile.first_name = 'User'
+        profile.last_name = 'With Profile'
+        profile.city = 'Nowhere'
+        profile.username = 'user_without_email'
+        db.session.merge(user)
+    db.session.commit()
+    user.password_plaintext = '123456'
+    return user
 
 
 @pytest.fixture(scope='module')

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 from flask import session, url_for
+from flask_login import login_user, logout_user
 from utils import postdata
 
 from rero_ils.theme.views import nl2br
@@ -176,3 +177,31 @@ def test_language(client, app):
 
     # session is unchanged
     assert session[app.config['I18N_SESSION_KEY']] == 'it'
+
+
+def test_set_user_name(
+        app, librarian_martigny, patron_martigny, user_with_profile,
+        user_without_email):
+    """Test the user_name in the flask session."""
+    # should be the email address
+    login_user(user=user_with_profile)
+    assert 'user_name' in session
+    assert session['user_name'] == user_with_profile.email
+    # should be removed
+    logout_user()
+    assert 'user_name' not in session
+
+    # should not be set
+    login_user(user=user_without_email)
+    assert 'user_name' not in session
+    logout_user()
+
+    # should be the formatted name
+    login_user(user=patron_martigny.user)
+    assert session['user_name'] == patron_martigny.formatted_name
+    logout_user()
+
+    # should be the formatted name
+    login_user(user=librarian_martigny.user)
+    assert session['user_name'] == librarian_martigny.formatted_name
+    logout_user()


### PR DESCRIPTION
* Fixes a crash application when the invenio user does not have email
  address and is not a library user (patron or librarian).
* Clears the user name session when the user is logged out.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
