### PR TITLE
documents: escape double quotes in summary

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -184,7 +184,7 @@
               </span>
             {% endif %} -->
             {% if data.value | length > 400 %}
-              <span data-show-more="{{ data.value | nl2br | safe }}">
+              <span data-show-more="{{ data.value | escape | nl2br | safe }}">
                 {{ data.value | nl2br | safe | truncate(400) }}
               </span>
               <a href="#" class="show-more">{{ _('Show more') }}&hellip;</a>


### PR DESCRIPTION
Fixes the issue https://github.com/rero/rero-ils/issues/2691 of the document summary not displaying when it contains double quotes.

Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?

Fixes https://github.com/rero/rero-ils/issues/2691

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
