### PR TITLE
item: fix item serialization

### DIFF
--- a/rero_ils/modules/loans/serializers.py
+++ b/rero_ils/modules/loans/serializers.py
@@ -27,6 +27,7 @@ from .api import Loan
 from .models import LoanState
 from ..documents.api import DocumentsSearch
 from ..items.api import Item
+from ..items.dumpers import ItemCirculationDumper
 from ..libraries.api import Library
 
 
@@ -63,7 +64,8 @@ class LoanJSONSerializer(JSONSerializer):
                 item = Item.get_record_by_pid(item_pid)
                 # check if the item still exists
                 if item:
-                    metadata['item'] = item.replace_refs().dumps()
+                    metadata['item'] = \
+                        item.dumps(dumper=ItemCirculationDumper())
                 # Item loan
                 if metadata['state'] == LoanState.ITEM_ON_LOAN:
                     metadata['overdue'] = loan.is_loan_overdue()

--- a/tests/ui/items/test_items_dumpers.py
+++ b/tests/ui/items/test_items_dumpers.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+# Copyright (C) 2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Items Record dumper tests."""
+from copy import deepcopy
+
+from rero_ils.modules.holdings.api import Holding
+from rero_ils.modules.items.dumpers import ItemCirculationDumper
+
+
+def test_item_circulation_dumper(item_lib_martigny):
+    """Test item circulation dumper."""
+    item = item_lib_martigny
+    item['call_number'] = 'ITEM_MAIN_CN'
+    item['second_call_number'] = 'ITEM_SECOND_CN'
+
+    holdings = Holding.get_record_by_pid(item.holding_pid)
+    original_holding_data = deepcopy(holdings)
+    holdings['call_number'] = 'HOLDING_MAIN_CN'
+    holdings['second_call_number'] = 'HOLDING_SECOND_CN'
+    holdings.update(holdings, dbcommit=True, reindex=True)
+
+    # CHECK_1 :: dumped call_numbers are equivalent to item call numbers
+    dumped_data = item.dumps(dumper=ItemCirculationDumper())
+    assert dumped_data['call_number'] == item['call_number']
+    item.pop('call_number', None)
+    dumped_data = item.dumps(dumper=ItemCirculationDumper())
+    assert 'call_number' not in dumped_data
+    assert dumped_data['second_call_number'] == item['second_call_number']
+
+    # CHECK_2 :: remove all call_numbers from item, dumped date should
+    #            integrate parent holdings call_numbers
+    item.pop('second_call_number', None)
+    dumped_data = item.dumps(dumper=ItemCirculationDumper())
+    assert dumped_data['call_number'] == holdings['call_number']
+    assert dumped_data['second_call_number'] == holdings['second_call_number']
+
+    # RESET HOLDING RECORD
+    holdings.update(original_holding_data, dbcommit=True, reindex=True)


### PR DESCRIPTION
Adds inherited parent holding call numbers into the item dumped data for
item serialization for custom `rero+json` content type.

Part of the solution to solve rero/rero-ils#2751. 
The main resolution part will be in a separate UI PR.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
