### PR TITLE
public ui: fix wrong label for ReproductionOf

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -148,7 +148,7 @@
     {% endwith %}
 
     <!-- REPRODUCTION OF -->
-    {% with fieldLabel=_('Supplement to'), data=record.reproductionOf, header=true %}
+    {% with fieldLabel=_('Reproduction of'), data=record.reproductionOf, header=true %}
       {% include 'rero_ils/_other_edition.html' %}
     {% endwith %}
 


### PR DESCRIPTION
* fixes reproductionOf label shown as supplementTo
* fixes https://github.com/rero/rero-ils/issues/2801

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
