### PR TITLE
document: fix `title_format_text` for a document

### DIFF
--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -234,7 +234,7 @@ class Document(IlsRecord):
         """Post process data after a dump.
 
         :param dump: a dictionary of a resulting Record dumps
-        "return: a modified dictionary
+        :return: a modified dictionary
         """
         provision_activities = dump.get('provisionActivity', [])
         for provision_activity in provision_activities:

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -466,15 +466,6 @@ def test_documents_post_put_delete(
     res = client.get(item_url)
     assert res.status_code == 200
 
-    data = get_json(res)
-    assert data['metadata']['title'] == expected_title
-
-    res = client.get(list_url)
-    assert res.status_code == 200
-
-    data = get_json(res)['hits']['hits'][0]
-    assert data['metadata']['title'] == expected_title
-
     # Delete record/DELETE
     res = client.delete(item_url)
     assert res.status_code == 204

--- a/tests/unit/test_documents_dojson_dc.py
+++ b/tests/unit/test_documents_dojson_dc.py
@@ -66,8 +66,9 @@ def test_title_to_dc():
     }
     result = dublincore.do(record)
     assert result == {'titles': [
-        'Statistique : exercices corrigés avec rappels de cours. Section '
-        '2, Grandes écoles / Edmond Berrebi'
+        'Statistique : exercices corrigés avec rappels de cours. T. 1, '
+        'Licence ès sciences économiques, 1ère année, étudiants de Grandes '
+        'écoles, Section 2, Grandes écoles / Edmond Berrebi'
     ]}
 
     record = {

--- a/tests/unit/test_documents_utils.py
+++ b/tests/unit/test_documents_utils.py
@@ -25,53 +25,55 @@ from rero_ils.modules.documents.utils import title_format_text_head
 def test_title_format_text_head():
     """Test title format text head."""
     data = [{
-        "mainTitle": [
-            {
-                "value": "Dingding lixianji"
-            },
-            {
-                "value": "\u4e01\u4e01\u5386\u9669\u8bb0",
-                "language": "und-hani"
-            }
-        ],
-        "type": "bf:Title"
+        'mainTitle': [{
+            'value': 'Dingding lixianji'
+        }, {
+            'value': '\u4e01\u4e01\u5386\u9669\u8bb0',
+            'language': 'und-hani'
+        }],
+        'type': 'bf:Title'
     }]
-    assert "\u4e01\u4e01\u5386\u9669\u8bb0" == title_format_text_head(data)
+    assert '\u4e01\u4e01\u5386\u9669\u8bb0' == title_format_text_head(data)
 
     data = [{
-        "mainTitle": [
-            {
-                "value": "Die russischen orthodoxen Bischöfe von 1893",
-            }
-        ],
-        "subtitle": [
-            {
-                "value": "Bio-Bibliographie"
-            }
-        ],
-        "type": "bf:Title"
-      }
-    ]
-    assert "Die russischen orthodoxen Bischöfe von 1893 " \
-           ": Bio-Bibliographie" == title_format_text_head(data)
+        'mainTitle': [{
+            'value': 'Die russischen orthodoxen Bischöfe von 1893',
+        }],
+        'subtitle': [{
+            'value': 'Bio-Bibliographie'
+        }],
+        'type': 'bf:Title'
+    }]
+    assert 'Die russischen orthodoxen Bischöfe von 1893 ' \
+           ': Bio-Bibliographie' == title_format_text_head(data)
 
     data = [{
-        "mainTitle": [
-            {
-                "value": "Die russischen orthodoxen Bischöfe von 1893",
-            },
-            {
-                "value": "The Russian Orthodox Bishops of 1893",
-                "language": "eng"
-            }
-        ],
-        "subtitle": [
-            {
-                "value": "Bio-Bibliographie"
-            }
-        ],
-        "type": "bf:Title"
-      }
-    ]
-    assert "The Russian Orthodox Bishops of 1893" == \
+        'mainTitle': [{
+            'value': 'Die russischen orthodoxen Bischöfe von 1893',
+        }, {
+            'value': 'The Russian Orthodox Bishops of 1893',
+            'language': 'eng'
+        }],
+        'subtitle': [{
+            'value': 'Bio-Bibliographie'
+        }],
+        'type': 'bf:Title'
+    }]
+    assert 'The Russian Orthodox Bishops of 1893' == \
         title_format_text_head(data)
+
+    data = [{
+        'mainTitle': [{
+            'value': 'main_title_text',
+        }],
+        'subtitle': [{
+            'value': 'subtitle_text'
+        }],
+        'part': [
+            {'partName': [{'value': 'part1'}, {'value': 'part1.1'}]},
+            {'partName': [{'value': 'part2'}]}
+        ],
+        'type': 'bf:Title'
+    }]
+    assert 'main_title_text : subtitle_text. part1, part1.1, part2' == \
+           title_format_text_head(data)


### PR DESCRIPTION
* All parts of a title are included into the title label to display for
  end-user.
* Closes rero/rero-ils#2703.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/10031585/162740590-183c4784-d2dd-4d5a-b3d0-2021b1f5335f.png">

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/10031585/162740545-061a78fe-15d2-4a64-976b-a66a212dd0a5.png">

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
