### PR TITLE
holdings: add 'access' note type

### DIFF
--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -610,7 +610,8 @@
               "claim_note",
               "routing_note",
               "binding_note",
-              "acquisition_note"
+              "acquisition_note",
+              "access_note"
             ],
             "form": {
               "type": "selectWithSort",
@@ -646,6 +647,10 @@
                 {
                   "label": "acquisition_note",
                   "value": "acquisition_note"
+                },
+                {
+                  "label": "access_note",
+                  "value": "access_note"
                 }
               ],
               "templateOptions": {


### PR DESCRIPTION
Allows to a specify the new 'access type' note for holdings resources.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
