### PR TITLE
subjects: change bf:Organization to bf:Organisation

### DIFF
--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -3385,7 +3385,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Allemagne. Gestapo",
         "conference": false
       },
@@ -14216,7 +14216,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "British Rail Pension Fund (Grande-Bretagne)",
         "conference": false,
         "identifiedBy": {
@@ -14529,7 +14529,7 @@
         "preferred_name": "Lubac, Henri de (cardinal) - influence exerc\u00e9e"
       },
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Concile de Vatican 2 (1962-1965) - influence re\u00e7ue",
         "conference": true
       },
@@ -14544,7 +14544,7 @@
     ],
     "subjects_imported": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "source": "LCSH",
         "preferred_name": "Vatican Council - (2nd : - 1962-1965)",
         "conference": true
@@ -45055,7 +45055,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Bureau international du travail",
         "conference": false
       },
@@ -48117,7 +48117,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "F\u00e9d\u00e9ration luth\u00e9rienne mondiale",
         "conference": false,
         "identifiedBy": {
@@ -53643,7 +53643,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Soci\u00e9t\u00e9 suisse du th\u00e9\u00e2tre (Suisse)",
         "conference": false
       },
@@ -55249,12 +55249,12 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Archivio di Stato di Genova (G\u00eanes)",
         "conference": false
       },
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Banco di San Giorgio (G\u00eanes)",
         "conference": false,
         "identifiedBy": {
@@ -58389,7 +58389,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Bureau international du travail",
         "conference": false
       },
@@ -59034,7 +59034,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Bureau international du travail",
         "conference": false
       },
@@ -60358,7 +60358,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Soci\u00e9t\u00e9 suisse du th\u00e9\u00e2tre (Suisse)",
         "conference": false
       },
@@ -61176,7 +61176,7 @@
     ],
     "subjects": [
       {
-        "type": "bf:Organization",
+        "type": "bf:Organisation",
         "preferred_name": "Cin\u00e9math\u00e8que suisse (Lausanne)",
         "conference": false
       }

--- a/rero_ils/alembic/0387b753585f_correct_subjects_bf_Organization.py
+++ b/rero_ils/alembic/0387b753585f_correct_subjects_bf_Organization.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+# Copyright (C) 2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Change subjects bf:Organization to bf:Organisation."""
+
+from logging import getLogger
+
+from elasticsearch_dsl.query import Q
+
+from rero_ils.modules.documents.api import Document, DocumentsSearch
+
+LOGGER = getLogger('alembic')
+
+# revision identifiers, used by Alembic.
+revision = '0387b753585f'
+down_revision = 'ce4923ba5286'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Change subjects bf:Organization to bf:Organisation."""
+    query = DocumentsSearch().filter('bool', should=[
+        Q('term', subjects__type='bf:Organization'),
+        Q('term', subjects_imported='bf:Organization')
+    ])
+
+    LOGGER.info(f'Upgrade to {revision}')
+    LOGGER.info(f'Documents to change: {query.count()}')
+    pids = [hit.pid for hit in query.source('pid').scan()]
+    errors = 0
+    idx = 0
+    for idx, pid in enumerate(pids, 1):
+        LOGGER.info(f'{idx} * Change document: {pid}')
+        doc = Document.get_record_by_pid(pid)
+        for subject in doc.get('subjects', []):
+            if subject['type'] == 'bf:Organization':
+                subject['type'] = 'bf:Organisation'
+        for subjects_imported in doc.get('subjects_imported', []):
+            if subjects_imported['type'] == 'bf:Organization':
+                subjects_imported['type'] = 'bf:Organisation'
+        try:
+            doc.update(data=doc, dbcommit=True, reindex=True)
+        except Exception as err:
+            LOGGER.error(f'\tError: {err}')
+            errors += 1
+    LOGGER.info(f'Updated: {idx} Errors: {errors}')
+
+
+def downgrade():
+    """Change subjects bf:Organisation to bf:Organization."""
+    query = DocumentsSearch().filter('bool', should=[
+        Q('bool', must=[
+            Q('term', subjects__type='bf:Organisation'),
+            Q('exists', field='subjects.preferred_name')
+        ]),
+        Q('bool', must=[
+            Q('term', subjects_imported__type='bf:Organisation'),
+            Q('exists', field='subjects_imported.preferred_name')
+        ])
+    ])
+    LOGGER.info(f'Downgrade to {down_revision}')
+    LOGGER.info(f'Documents to change: {query.count()}')
+    pids = [hit.pid for hit in query.source('pid').scan()]
+    errors = 0
+    idx = 0
+    for idx, pid in enumerate(pids, 1):
+        LOGGER.info(f'{idx} * Change document: {pid}')
+        doc = Document.get_record_by_pid(pid)
+        for subject in doc.get('subjects', []):
+            if subject['type'] == 'bf:Organisation':
+                subject['type'] = 'bf:Organization'
+        for subjects_imported in doc.get('subjects_imported', []):
+            if subjects_imported['type'] == 'bf:Organisation':
+                subjects_imported['type'] = 'bf:Organization'
+        try:
+            doc.update(data=doc, dbcommit=True, reindex=True)
+        except Exception as err:
+            LOGGER.error(f'\tError: {err}')
+            errors += 1
+    LOGGER.info(f'Updated: {idx} Errors: {errors}')

--- a/rero_ils/modules/cli/index.py
+++ b/rero_ils/modules/cli/index.py
@@ -347,6 +347,7 @@ def update_mapping(aliases, settings):
         for index, f_mapping in iter(
             current_search.aliases.get(alias).items()
         ):
+            print('---->', index, f_mapping)
             mapping = json.load(open(f_mapping))
             try:
                 if mapping.get('settings') and settings:

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/dnb/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/dnb/model.py
@@ -301,8 +301,8 @@ def marc21_to_subjects_6XX(self, key, value):
     """
     type_per_tag = {
         '600': 'bf:Person',
-        '610': 'bf:Organization',
-        '611': 'bf:Organization',
+        '610': 'bf:Organisation',
+        '611': 'bf:Organisation',
         '600t': 'bf:Work',
         '610t': 'bf:Work',
         '611t': 'bf:Work',

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/kul/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/kul/model.py
@@ -308,8 +308,8 @@ def marc21_to_subjects_6XX(self, key, value):
     """
     type_per_tag = {
         '600': 'bf:Person',
-        '610': 'bf:Organization',
-        '611': 'bf:Organization',
+        '610': 'bf:Organisation',
+        '611': 'bf:Organisation',
         '600t': 'bf:Work',
         '610t': 'bf:Work',
         '611t': 'bf:Work',

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -535,8 +535,8 @@ def marc21_to_subjects_6XX(self, key, value):
     """
     type_per_tag = {
         '600': 'bf:Person',
-        '610': 'bf:Organization',
-        '611': 'bf:Organization',
+        '610': 'bf:Organisation',
+        '611': 'bf:Organisation',
         '600t': 'bf:Work',
         '610t': 'bf:Work',
         '611t': 'bf:Work',

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
@@ -520,8 +520,8 @@ def marc21_to_subjects(self, key, value):
     """
     type_per_tag = {
         '600': 'bf:Person',
-        '610': 'bf:Organization',
-        '611': 'bf:Organization',
+        '610': 'bf:Organisation',
+        '611': 'bf:Organisation',
         '600t': 'bf:Work',
         '610t': 'bf:Work',
         '611t': 'bf:Work',

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
@@ -322,8 +322,8 @@ def marc21_to_subjects_6XX(self, key, value):
     """
     type_per_tag = {
         '600': 'bf:Person',
-        '610': 'bf:Organization',
-        '611': 'bf:Organization',
+        '610': 'bf:Organisation',
+        '611': 'bf:Organisation',
         '600t': 'bf:Work',
         '610t': 'bf:Work',
         '611t': 'bf:Work',

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/ugent/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/ugent/model.py
@@ -303,8 +303,8 @@ def marc21_to_subjects_imported(self, key, value):
     """
     type_per_tag = {
         '600': 'bf:Person',
-        '610': 'bf:Organization',
-        '611': 'bf:Organization',
+        '610': 'bf:Organisation',
+        '611': 'bf:Organisation',
         '600t': 'bf:Work',
         '610t': 'bf:Work',
         '611t': 'bf:Work',

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
@@ -1605,7 +1605,7 @@ def do_work_access_point(marc21, key, value):
     *   "date_of_birth": "700.2$d - 1ère date",
     *   "date_of_death": "700.2$d - 2e date",
     *   "qualifier": ["700.2$c"]
-    *   "type": "bf:Organization", (710.2)
+    *   "type": "bf:Organisation", (710.2)
     *   "conference": false, (710.2)
     *   "preferred_name": "710.2$a",
     *   "subordinate_unit": ["710.2$b"]

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -79,13 +79,13 @@
             "type": {
               "title": "Type",
               "type": "string",
-              "default": "bf:Organization",
-              "const": "bf:Organization",
+              "default": "bf:Organisation",
+              "const": "bf:Organisation",
               "form": {
                 "options": [
                   {
-                    "label": "bf:Organization",
-                    "value": "bf:Organization"
+                    "label": "bf:Organisation",
+                    "value": "bf:Organisation"
                   }
                 ],
                 "templateOptions": {

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -4794,7 +4794,7 @@ def test_marc21_to_subjects(mock_get):
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
     assert data.get('subjects') == [{
-          'type': 'bf:Organization',
+          'type': 'bf:Organisation',
           'conference': True,
           'preferred_name': 'Belalp Hexe (Blatten)',
           'identifiedBy': {
@@ -5062,7 +5062,7 @@ def test_marc21_to_subjects_imported():
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
     assert data.get('subjects_imported') == [{
-          'type': 'bf:Organization',
+          'type': 'bf:Organisation',
           'conference': False,
           'preferred_name': 'Conference of European Churches',
           'source': 'LCSH'
@@ -5114,7 +5114,7 @@ def test_marc21_to_subjects_imported():
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
     assert data.get('subjects_imported') == [{
-          'type': 'bf:Organization',
+          'type': 'bf:Organisation',
           'preferred_name': 'Catholic Church - Relations - Eastern churches',
           'source': 'LCSH',
           'conference': False


### PR DESCRIPTION
* To unify the writing of bf:Organization we will temporary change
  bf:Organization to bf:Organisation in subjects because it is written
  like this anywhere else.
* In the future we have to change this everywhere to bf:Organization.
  Also in MEF.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
