### PR TITLE
notifications: not sent after patron changes

### DIFF
--- a/rero_ils/alembic/74ab9da9f078_update_patron_communication_channels.py
+++ b/rero_ils/alembic/74ab9da9f078_update_patron_communication_channels.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""update patron communication channels."""
+
+from logging import getLogger
+
+from elasticsearch_dsl import Q
+from invenio_db import db
+
+from rero_ils.modules.patrons.api import Patron, PatronsIndexer, PatronsSearch
+from rero_ils.modules.patrons.models import CommunicationChannel
+
+# revision identifiers, used by Alembic.
+revision = '74ab9da9f078'
+down_revision = '0387b753585f'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+
+
+def upgrade():
+    """Fix incorrectly set patron communication channels."""
+    query = PatronsSearch()\
+        .filter('term',
+                patron__communication_channel=CommunicationChannel.EMAIL)\
+        .filter('bool', must_not=[
+            Q('exists', field='patron.additional_communication_email')])\
+        .filter('bool', must_not=[Q('exists', field='email')])\
+        .source(includes='pid')
+    pids = [(hit['pid'], hit.meta.id) for hit in query.scan()]
+    errors = 0
+    ids = []
+    for idx, (pid, id) in enumerate(pids, 1):
+        if patron := Patron.get_record_by_pid(pid):
+            ids.append(id)
+            try:
+                patron['patron']['communication_channel'] = \
+                    CommunicationChannel.MAIL
+                db.session.query(patron.model_cls).filter_by(
+                    id=patron.id).update({patron.model_cls.json: patron})
+            except Exception as err:
+                LOGGER.error(f'{idx} * Update patron: {pid} {err}')
+                errors += 1
+    if ids:
+        # commit session
+        db.session.commit()
+        # bulk indexing of patron records.
+        indexer = PatronsIndexer()
+        indexer.bulk_index(ids)
+        indexer.process_bulk_queue()
+
+    LOGGER.info(f'upgraded to version: {revision} errors: {errors}')
+
+
+def downgrade():
+    """Downgrade database."""
+    # Nothing to do :: We can't set a false communication channel for patrons.

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -105,6 +105,7 @@ from .modules.patron_transactions.permissions import \
 from .modules.patron_types.api import PatronType
 from .modules.patron_types.permissions import PatronTypePermission
 from .modules.patrons.api import Patron
+from .modules.patrons.models import CommunicationChannel
 from .modules.patrons.permissions import PatronPermission
 from .modules.permissions import record_permission_factory
 from .modules.selfcheck.permissions import seflcheck_permission_factory
@@ -2749,8 +2750,8 @@ RERO_ILS_NOTIFICATIONS_ALLOWED_TEMPLATE_FILES = [
 # the communication channel, value is the function to call. The used functions
 # should accept one positional argument.
 RERO_ILS_COMMUNICATION_DISPATCHER_FUNCTIONS = {
-    'email': NotificationDispatcher.send_notification_by_email,
-    'mail': NotificationDispatcher.send_mail_for_printing,
+    CommunicationChannel.EMAIL : NotificationDispatcher.send_notification_by_email,
+    CommunicationChannel.MAIL: NotificationDispatcher.send_mail_for_printing,
     #  'sms': not_yet_implemented
     #  'telepathy': self.madness_mind
     #  ...

--- a/rero_ils/modules/patrons/cli.py
+++ b/rero_ils/modules/patrons/cli.py
@@ -37,6 +37,8 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from werkzeug.local import LocalProxy
 
+from rero_ils.modules.patrons.models import CommunicationChannel
+
 from .api import User, create_patron_from_data
 from ..patrons.api import Patron, PatronProvider
 from ..providers import append_fixtures_new_identifiers
@@ -215,8 +217,8 @@ def users_validate(jsonfile, verbose, debug):
         try:
             validate(data, schema)
             patron = data.get('patron', {})
-            if patron and patron.get('communication_channel') == 'email'\
-               and data.get('email') is None \
+            if patron and patron.get('communication_channel') == \
+                    CommunicationChannel.EMAIL and data.get('email') is None \
                and patron.get('additional_communication_email') is None:
                 raise ValidationError('At least one email should be defined '
                                       'for an email communication channel.')

--- a/rero_ils/modules/patrons/models.py
+++ b/rero_ils/modules/patrons/models.py
@@ -41,3 +41,10 @@ class PatronMetadata(db.Model, RecordMetadataBase):
     """Patron record metadata."""
 
     __tablename__ = 'patron_metadata'
+
+
+class CommunicationChannel:
+    """Enum class to list all possible patron communication channels."""
+
+    EMAIL = 'email'
+    MAIL = 'mail'

--- a/rero_ils/modules/users/api.py
+++ b/rero_ils/modules/users/api.py
@@ -131,15 +131,12 @@ class User(object):
                         datetime.strptime(data.get(field), '%Y-%m-%d'))
                 else:
                     setattr(profile, field, data.get(field, ''))
-
             # change password
             if data.get('password'):
                 user.password = hash_password(data['password'])
 
-            # send reset password if email is changed
             if email and email != user.email:
                 user.email = email
-                send_reset_password_instructions(user)
             # remove the email from user data
             elif not email and user.email:
                 user.email = None
@@ -153,8 +150,7 @@ class User(object):
     def _validate(cls, data, **kwargs):
         """Validate user record against schema."""
         format_checker = FormatChecker()
-        schema = data.pop('$schema', None)
-        if schema:
+        if schema := data.pop('$schema', None):
             _records_state.validate(
                 data,
                 schema,
@@ -177,13 +173,12 @@ class User(object):
 
     def dumps(self):
         """Return pure Python dictionary with record metadata."""
-        data = {
+        return {
             'id': self.user.id,
             'links': {'self': url_for(
                 'api_users.users_item', _external=True, id=self.user.id)},
             'metadata': self.dumpsMetadata(patronData=True)
         }
-        return data
 
     def dumpsMetadata(self, patronData=False):
         """Dumps the profile, email, roles metadata."""
@@ -191,8 +186,7 @@ class User(object):
         metadata = {}
         if self.user.profile:
             for field in self.profile_fields:
-                value = getattr(self.user.profile, field)
-                if value:
+                if value := getattr(self.user.profile, field):
                     if field == 'birth_date':
                         value = datetime.strftime(value, '%Y-%m-%d')
                     metadata[field] = value

--- a/rero_ils/modules/users/views.py
+++ b/rero_ils/modules/users/views.py
@@ -27,7 +27,7 @@ from flask_login import current_user
 from invenio_rest import ContentNegotiatedMethodView
 
 from .api import User
-from ...modules.patrons.api import current_librarian
+from ...modules.patrons.api import Patron, current_librarian
 from ...permissions import login_and_librarian
 
 
@@ -131,6 +131,13 @@ class UsersResource(ContentNegotiatedMethodView):
         """Implement the PUT."""
         user = User.get_by_id(id)
         user = user.update(request.get_json())
+        editing_own_public_profile = str(current_user.id) == id and \
+            not (
+                current_user.has_role('system_librarian') and
+                current_user.has_role('librarian')
+        )
+        if editing_own_public_profile:
+            Patron.set_communication_channel(user)
         return user.dumps()
 
 
@@ -195,6 +202,13 @@ class UsersCreateResource(ContentNegotiatedMethodView):
     def post(self):
         """Implement the POST."""
         user = User.create(request.get_json())
+        editing_own_public_profile = str(current_user.id) == user.id and \
+            not (
+                current_user.has_role('system_librarian') and
+                current_user.has_role('librarian')
+        )
+        if editing_own_public_profile:
+            Patron.set_communication_channel(user)
         return user.dumps()
 
 

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -31,6 +31,7 @@ from utils import VerifyRecordPermissionPatch, create_patron, get_json, \
 
 from rero_ils.modules.patron_transactions.api import PatronTransaction
 from rero_ils.modules.patrons.api import Patron
+from rero_ils.modules.patrons.models import CommunicationChannel
 from rero_ils.modules.utils import extracted_data_from_ref, get_ref_for_pid
 from rero_ils.utils import create_user_from_data
 
@@ -371,7 +372,7 @@ def test_patrons_post_without_email(app, client, lib_martigny,
     patron_data['username'] = 'post_without_email'
     del patron_data['pid']
     del patron_data['email']
-    patron_data['patron']['communication_channel'] = 'mail'
+    patron_data['patron']['communication_channel'] = CommunicationChannel.MAIL
     patron_data = create_user_from_data(patron_data)
 
     pids = Patron.count()
@@ -390,7 +391,8 @@ def test_patrons_post_without_email(app, client, lib_martigny,
 
     # Check that the returned record matches the given data
     data = get_json(res)
-    data['metadata']['patron']['communication_channel'] = 'mail'
+    data['metadata']['patron']['communication_channel'] = \
+        CommunicationChannel.MAIL
 
     ds = app.extensions['invenio-accounts'].datastore
     ds.delete_user(ds.find_user(id=patron_data['user_id']))

--- a/tests/api/test_permissions_sys_librarian.py
+++ b/tests/api/test_permissions_sys_librarian.py
@@ -24,6 +24,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
+from rero_ils.modules.patrons.models import CommunicationChannel
 from rero_ils.utils import create_user_from_data
 
 
@@ -73,7 +74,7 @@ def test_system_librarian_permissions(
             'roles': ['patron'],
             'patron': {
                 'expiration_date': '2023-10-07',
-                'communication_channel': 'email',
+                'communication_channel': CommunicationChannel.EMAIL,
                 'communication_language': 'ita',
                 'additional_communication_email': 'test@test.com',
                 'type': {

--- a/tests/api/users/test_users_profile_updates.py
+++ b/tests/api/users/test_users_profile_updates.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Users profile updates tests."""
+
+from __future__ import absolute_import, print_function
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+from rero_ils.modules.patrons.api import Patron
+from rero_ils.modules.patrons.models import CommunicationChannel
+from rero_ils.modules.users.api import User
+
+
+def test_user_profile_updates(
+        client, patron_martigny, system_librarian_martigny, json_header,
+        mailbox):
+    """Test users profile updates."""
+    # login with a patron has only the patron role, this means we are logging
+    # into the public interface
+    assert patron_martigny.patron['communication_channel'] == \
+        CommunicationChannel.MAIL
+    login_user_via_session(client, patron_martigny.user)
+    # mailbox is empty
+    assert not (len(mailbox))
+    user_metadata = User.get_by_id(patron_martigny.user.id).dumpsMetadata()
+    # changing the email by another does not send any reset_password
+    # notification
+    user_metadata['email'] = 'toto@toto.com'
+    res = client.put(
+        url_for(
+            'api_users.users_item',
+            id=patron_martigny.user.id),
+        data=json.dumps(user_metadata),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    assert not (len(mailbox))
+    patron_martigny = Patron.get_record_by_pid(patron_martigny.pid)
+    # an email was added to patron, communication_channel will change
+    # automatically to email
+    assert patron_martigny.patron.get('communication_channel') == \
+        CommunicationChannel.EMAIL
+
+    # removing the email from profile does not send any reset_password
+    # notification
+    user_metadata.pop('email', None)
+    res = client.put(
+        url_for(
+            'api_users.users_item',
+            id=patron_martigny.user.id),
+        data=json.dumps(user_metadata),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    assert not (len(mailbox))
+    # the corresponding patron changes its communication_channel to mail
+    # autmoatically if user has no email configured and patron has no
+    # additional_communication_email configured
+    patron_martigny = Patron.get_record_by_pid(patron_martigny.pid)
+    assert patron_martigny.patron.get('communication_channel') == \
+        CommunicationChannel.MAIL
+
+    # login as a system_librarian this means we are logging into the
+    # professional interface
+    login_user_via_session(client, system_librarian_martigny.user)
+    # adding an email to a profile does not send any reset_password
+    # notification
+    user_metadata['email'] = 'toto@toto.com'
+    res = client.put(
+        url_for(
+            'api_users.users_item',
+            id=patron_martigny.user.id),
+        data=json.dumps(user_metadata),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    assert not (len(mailbox))
+    # removing the email from profile does not send any reset_password
+    # notification
+    user_metadata.pop('email', None)
+    res = client.put(
+        url_for(
+            'api_users.users_item',
+            id=patron_martigny.user.id),
+        data=json.dumps(user_metadata),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    assert not (len(mailbox))
+    patron_martigny = Patron.get_record_by_pid(patron_martigny.pid)
+    assert patron_martigny.patron.get('communication_channel') == \
+        CommunicationChannel.MAIL

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -33,6 +33,7 @@ from rero_ils.modules.notifications.api import NotificationsSearch
 from rero_ils.modules.notifications.models import NotificationType
 from rero_ils.modules.notifications.utils import get_notification
 from rero_ils.modules.patron_transactions.api import PatronTransactionsSearch
+from rero_ils.modules.patrons.models import CommunicationChannel
 from rero_ils.modules.utils import extracted_data_from_ref
 
 
@@ -413,7 +414,7 @@ def patron_sion_without_email1(
     del data['email']
     data['pid'] = 'ptrn10wthoutemail'
     data['username'] = 'withoutemail'
-    data['patron']['communication_channel'] = 'mail'
+    data['patron']['communication_channel'] = CommunicationChannel.MAIL
     yield create_patron(data)
 
 

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -29,6 +29,7 @@ from jsonschema.exceptions import ValidationError
 
 from rero_ils.modules.patrons.api import Patron, PatronsSearch, \
     patron_id_fetcher
+from rero_ils.modules.patrons.models import CommunicationChannel
 from rero_ils.utils import create_user_from_data
 
 
@@ -70,7 +71,7 @@ def test_patron_create(app, roles, lib_martigny, librarian_martigny_data_tmp,
         'type': {
           '$ref': 'https://bib.rero.ch/api/patron_types/ptty2'
         },
-        'communication_channel': 'email',
+        'communication_channel': CommunicationChannel.EMAIL,
         'communication_language': 'ita'
     })
     wrong_librarian_martigny_data_tmp['patron']['subscriptions'] = [{
@@ -148,7 +149,7 @@ def test_patron_create(app, roles, lib_martigny, librarian_martigny_data_tmp,
             'type': {
               '$ref': 'https://bib.rero.ch/api/patron_types/ptty2'
             },
-            'communication_channel': 'email',
+            'communication_channel': CommunicationChannel.EMAIL,
             'communication_language': 'ita'
         }
     }
@@ -199,7 +200,8 @@ def test_patron_create_without_email(app, roles, patron_type_children_martigny,
         )
 
     # create a patron without email
-    patron_martigny_data_tmp['patron']['communication_channel'] = 'mail'
+    patron_martigny_data_tmp['patron']['communication_channel'] = \
+        CommunicationChannel.MAIL
     ptrn = Patron.create(
         patron_martigny_data_tmp,
         dbcommit=True,


### PR DESCRIPTION
No reset password notifications are sent after any changes made
to the patron/user record for both admin and public interfaces.

The communication channel is updated automatically after updates
made to the patron profile by the patron himself.

* Fixes #2313
* Fixes #2281
* Fixes #1580
* Fixes #2887

Co-Authored-by: Aly Badr <aly.badr@rero.ch>


## How to test?
### first test
1.1- connect to the admin interface as librarian or system_librarian
1.2- edit any patron profile and test the adding/changing/removal of email
1.3- there will be no password notifications sent to the patron
### second test
2.1- connect to the public interface as patron
2.2- edit your profile and test the adding/changing/removal of email
2.3- there will be no password notifications sent to the patron
### third test
3.1- connect to the public interface as patron
3.2- edit your profile and test the adding/changing/removal of email
3.3- the communication_channel will change to email/mail accordingly
 
## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
