### PR TITLE
documents: export record

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -608,6 +608,10 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/rero+json': (
                 'rero_ils.modules.documents.serializers:json_doc_response'
             ),
+            'application/export+json': (
+                'rero_ils.modules.documents.serializers:'
+                'json_export_doc_response'
+            ),
             'application/x-research-info-systems': (
                 'rero_ils.modules.documents.serializers:ris_doc_response'
             )
@@ -615,6 +619,7 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers_aliases={
             'json': 'application/json',
             'rero': 'application/rero+json',
+            'raw': 'application/export+json',
             'ris': 'application/x-research-info-systems'
         },
         search_serializers={
@@ -624,6 +629,10 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/rero+json': (
                 'rero_ils.modules.documents.serializers:json_doc_search'
             ),
+            'application/export+json': (
+                'rero_ils.modules.documents.serializers:'
+                'json_export_doc_search'
+            ),
             'application/x-research-info-systems': (
                 'rero_ils.modules.documents.serializers:ris_doc_search'
             )
@@ -631,6 +640,7 @@ RECORDS_REST_ENDPOINTS = dict(
         search_serializers_aliases={
             'json': 'application/json',
             'rero': 'application/rero+json',
+            'raw': 'application/export+json',
             'ris': 'application/x-research-info-systems'
         },
         record_loaders={
@@ -2685,13 +2695,13 @@ RECORDS_UI_ENDPOINTS = {
 
 RECORDS_UI_EXPORT_FORMATS = {
     'doc': {
-        'json': dict(
+        'raw': dict(
             title='JSON',
             serializer='invenio_records_rest.serializers:json_v1',
             order=1,
         ),
         'ris': dict(
-            title='RIS',
+            title='RIS (Endnote, Zotero, ...)',
             serializer='rero_ils.modules.documents.serializers:ris_v1',
             order=2,
         ),

--- a/rero_ils/modules/documents/serializers/__init__.py
+++ b/rero_ils/modules/documents/serializers/__init__.py
@@ -22,16 +22,20 @@ from invenio_records_rest.serializers.response import record_responsify, \
     search_responsify
 
 from rero_ils.modules.documents.serializers.dc import DublinCoreSerializer
-from rero_ils.modules.documents.serializers.json import DocumentJSONSerializer
+from rero_ils.modules.documents.serializers.json import \
+    DocumentExportJSONSerializer, DocumentJSONSerializer
 from rero_ils.modules.documents.serializers.marcxml import \
     DocumentMARCXMLSerializer, DocumentMARCXMLSRUSerializer
 from rero_ils.modules.documents.serializers.ris import RISSerializer
-from rero_ils.modules.response import search_responsify_file
+from rero_ils.modules.response import record_responsify_file, \
+    search_responsify_file
 from rero_ils.modules.serializers import RecordSchemaJSONV1
 
 # Serializers
 # ===========
 json_doc = DocumentJSONSerializer(RecordSchemaJSONV1)
+"""JSON v1 serializer."""
+json_export_doc = DocumentExportJSONSerializer()
 """JSON v1 serializer."""
 xml_dc = DublinCoreSerializer(RecordSchemaJSONV1)
 """XML DUBLIN CORE v1 serializer."""
@@ -46,11 +50,16 @@ ris_v1 = RISSerializer()
 # ========================
 json_doc_search = search_responsify(json_doc, 'application/rero+json')
 json_doc_response = record_responsify(json_doc, 'application/rero+json')
+json_export_doc_search = \
+    search_responsify_file(json_export_doc, 'application/export+json', 'json')
+json_export_doc_response = \
+    record_responsify_file(json_export_doc, 'application/export+json', 'json')
 ris_doc_search = \
     search_responsify_file(ris_v1,
                            'application/x-research-info-systems', 'ris')
 ris_doc_response = \
-    record_responsify(ris_v1, 'application/x-research-info-systems')
+    record_responsify_file(ris_v1,
+                           'application/x-research-info-systems', 'ris')
 xml_dc_search = search_responsify(xml_dc, 'application/xml')
 xml_dc_response = record_responsify(xml_dc, 'application/xml')
 xml_marcxml_search = search_responsify(xml_marcxml, 'application/xml')

--- a/rero_ils/modules/documents/serializers/dc.py
+++ b/rero_ils/modules/documents/serializers/dc.py
@@ -85,6 +85,7 @@ class DublinCoreSerializer(BaseDublinCoreSerializer):
         :param pid_fetcher: Persistent identifier fetcher.
         :param search_result: Elasticsearch search result.
         :param links: Dictionary of links to add to response.
+        :param item_links_factory: Factory function for record links.
         """
         total = search_result['hits']['total']['value']
         sru = search_result['hits'].get('sru', {})

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -23,6 +23,26 @@
 <header class="row py-2">
     <a href="javascript:history.back()" class="col-12"><i class="fa fa-arrow-left"></i> {{ _('Back') }}</a>
 </header>
+{%- set formats = export_formats(pid.pid_type) %}
+{%- if formats %}
+<div class="d-flex flex-row-reverse">
+  <div class="p-2 d-none d-sm-block">
+    <div class="dropdown">
+      <a class="btn btn-sm btn-outline-primary dropdown-toggle" href="#" role="button" id="dropdown-export" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i class="fa fa-download pr-1"></i>{{ _('Export as ...') }}
+      </a>
+      <div class="dropdown-menu" aria-labelledby="dropdown-export">
+        {%- for slug, fmt in formats %}
+        <a class="dropdown-item"
+           href="/api/documents/{{ pid.pid_value }}?format={{ slug }}">
+          {{ fmt.title }}
+        </a>
+        {%- endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+{%- endif %}
 <div class="row">
   {%- set icon_name = record | document_main_type(false) %}
   <figure id="thumbnail" class="figure-img col-sm-2 d-sm-block figure text-center">
@@ -56,7 +76,6 @@
         {{ alternate_graphic }}
       </h3>
     {% endfor %}
-
     <!-- CONTRIBUTION -->
     {% if record.contribution %}
     {{ div(record.pid | contribution_format(current_i18n.language, viewcode, true)) }}

--- a/rero_ils/modules/serializers.py
+++ b/rero_ils/modules/serializers.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Record serialization."""
+
 from flask import json, request, url_for
 from invenio_records_rest.schemas import \
     RecordSchemaJSONV1 as _RecordSchemaJSONV1
@@ -82,6 +83,7 @@ class JSONSerializer(_JSONSerializer):
         :param pid_fetcher: Persistent identifier fetcher.
         :param search_result: Elasticsearch search result.
         :param links: Dictionary of links to add to response.
+        :param item_links_factory: Factory function for record links.
         """
         results = dict(
             hits=dict(

--- a/tests/api/documents/test_export_serializers.py
+++ b/tests/api/documents/test_export_serializers.py
@@ -19,17 +19,42 @@
 """Tests Serializers."""
 
 from flask import url_for
+from utils import get_json
 
 
-def test_ris_formatter(client, ris_header, document, export_document):
+def test_json_export_serializers(client, export_json_header, document,
+                                 export_document):
+    """Test JSON export serializers for documents."""
+    item_url = url_for('invenio_records_rest.doc_item',
+                       pid_value=export_document.pid)
+    response = client.get(item_url, headers=export_json_header)
+    assert response.status_code == 200
+    # Get the first result.
+    data = get_json(response)
+    # Check if all desired keys not in data
+    for key in ['created', 'updated', 'id', 'links', 'metadata']:
+        assert key not in data
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list', q=f'pid:{export_document.pid}'
+    )
+    response = client.get(list_url, headers=export_json_header)
+    assert response.status_code == 200
+    data = get_json(response)
+    for key in ['created', 'updated', 'id', 'links', 'metadata']:
+        assert key not in data
+
+
+def test_ris_serializer(client, ris_header, document, export_document):
     """Test RIS formatter"""
     ris_tag = [
-        'TY -', 'ID -', 'TI -', 'T2 -', 'AU -', 'A2 -', 'DA -', 'SP -', 'EP -',
-        'CY -', 'LA -', 'PB -', 'SN -', 'UR -', 'KW -', 'ET -', 'DO -', 'VL -',
-        'IS -', 'PP -', 'Y1 -', 'PY -', 'ER -'
+        'TY  -', 'ID  -', 'TI  -', 'T2  -', 'AU  -', 'A2  -', 'DA  -',
+        'SP  -', 'EP  -', 'CY  -', 'LA  -', 'PB  -', 'SN  -', 'UR  -',
+        'KW  -', 'ET  -', 'DO  -', 'VL  -', 'IS  -', 'PP  -', 'Y1  -',
+        'PY  -', 'ER  -'
     ]
     list_url = url_for('invenio_records_rest.doc_list',
-                       q='pid:doc8')
+                       q=f'pid:{export_document.pid}')
     response = client.get(list_url, headers=ris_header)
     assert response.status_code == 200
     ris_data = response.get_data(as_text=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,15 @@ def rero_json_header():
 
 
 @pytest.fixture(scope="session")
+def export_json_header():
+    """Load json headers."""
+    return [
+        ('Accept', 'application/export+json'),
+        ('Content-Type', 'application/json')
+    ]
+
+
+@pytest.fixture(scope="session")
 def can_delete_json_header():
     """Load can_delete json headers."""
     return [


### PR DESCRIPTION
This commit add a new JSON serializer to process only document
metadata without any other information like the aggregations, links...
The search serialization implements also a stream results with context.
It mainly used to export documents.

* Adds export button in detail view.
* Adds custom JSON serializer to export record.
* Closes #2780.
    
Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#848

## How to test?

1. **Test export button**

    a. _Export documents in public search:_
        - Go to the public search. 
        - A new export button is added on right top of the search.
        - Test JSON and RIS export.

    b. _Export document in public detail view:_
        - Go to detail view of a document in public interface.
        - A new export button is added on right top on detail view.
        - Test JSON and RIS export.
        
    Export file must be downloaded by clicking on button

2. **Check RIS mapping for documents**

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
