### PR TITLE
renewals: always uses the checkout library

### DIFF
--- a/rero_ils/modules/loans/extensions.py
+++ b/rero_ils/modules/loans/extensions.py
@@ -111,7 +111,8 @@ class CirculationDatesExtension(RecordExtension):
         """
         from .utils import get_circ_policy
         if record.state == LoanState.ITEM_ON_LOAN and record.get('end_date'):
-            circ_policy = get_circ_policy(record)
+            # find the correct policy based on the checkout location.
+            circ_policy = get_circ_policy(record, checkout_location=True)
             due_date = ciso8601.parse_datetime(record.end_date).replace(
                 tzinfo=timezone.utc)
             days_before = circ_policy.due_soon_interval_days

--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -97,7 +97,9 @@ def get_default_loan_duration(loan, initial_loan):
 
 def get_extension_params(loan=None, initial_loan=None, parameter_name=None):
     """Return extension parameters."""
-    policy = get_circ_policy(loan)
+    # find the correct policy based on the checkout location for the extend
+    # action.
+    policy = get_circ_policy(loan, checkout_location=True)
     end_date = ciso8601.parse_datetime(str(loan.get('end_date')))
     params = {
         'max_count': policy.get('number_renewals'),

--- a/tests/api/circ_policies/test_circ_policies_permissions.py
+++ b/tests/api/circ_policies/test_circ_policies_permissions.py
@@ -67,7 +67,7 @@ def test_circ_policies_permissions_api(client, librarian_martigny,
     assert data['list']['can']
     assert data['read']['can']
     assert not data['create']['can']
-    assert not data['update']['can']
+    assert data['update']['can']
     assert not data['delete']['can']
     res = client.get(cipo_tmp_martigny_permissions_url)
     assert res.status_code == 200
@@ -128,7 +128,7 @@ def test_circ_policies_permissions(patron_martigny,
         assert CirculationPolicyPermission.list(None, cipo)
         assert CirculationPolicyPermission.read(None, cipo)
         assert not CirculationPolicyPermission.create(None, cipo)
-        assert not CirculationPolicyPermission.update(None, cipo)
+        assert CirculationPolicyPermission.update(None, cipo)
         assert not CirculationPolicyPermission.delete(None, cipo)
         assert CirculationPolicyPermission.update(None, cipo_tmp)
 

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -204,7 +204,7 @@ def test_overdue_limit(
      item2_lib_martigny, patron_type_children_martigny,
      item3_lib_martigny, item_lib_martigny_data, item2_lib_martigny_data,
      item3_lib_martigny_data, loc_public_martigny, patron_martigny,
-     circ_policy_short_martigny, lib_saxon, loc_public_saxon):
+     circulation_policies, lib_saxon, loc_public_saxon):
     """Test overdue limit."""
 
     item = item_lib_martigny

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1314,7 +1314,12 @@
     "number_renewals": 1,
     "renewal_duration": 15,
     "is_default": false,
-    "policy_library_level": false,
+    "policy_library_level": true,
+    "libraries": [
+      {
+        "$ref": "https://bib.rero.ch/api/libraries/lib1"
+      }
+    ],
     "settings": [
       {
         "patron_type": {

--- a/tests/fixtures/organisations.py
+++ b/tests/fixtures/organisations.py
@@ -841,7 +841,8 @@ def circ_policy_short_martigny(
         patron_type_adults_martigny,
         item_type_standard_martigny,
         item_type_specific_martigny,
-        circ_policy_short_martigny_data):
+        circ_policy_short_martigny_data,
+        lib_martigny, lib_fully):
     """Create short circ policy for organisation martigny."""
     cipo = CircPolicy.create(
         data=circ_policy_short_martigny_data,

--- a/tests/ui/circulation/test_extend_external.py
+++ b/tests/ui/circulation/test_extend_external.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test item circulation extend actions at external library."""
+
+
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.utils import get_circ_policy
+
+
+def test_extend_on_item_on_loan_with_no_requests_external_library(
+        app, item_on_loan_martigny_patron_and_loan_on_loan,
+        loc_public_martigny, librarian_martigny, lib_martigny, lib_saxon,
+        circulation_policies, loc_public_saxon):
+    """Test extend an on_loan item at an external library."""
+    item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    settings = app.config['CIRCULATION_POLICIES']['extension']
+    app.config['CIRCULATION_POLICIES']['extension']['from_end_date'] = True
+    loan['end_date'] = loan['start_date']
+    initial_loan = loan.update(loan, dbcommit=True, reindex=True)
+    assert get_circ_policy(
+        loan, checkout_location=True) == get_circ_policy(loan)
+    # The cipo used for the checkout or renewal is "short" which is configured
+    # only for lib_martigny. For other libraries it is the default cipo to be
+    # used.
+    params = {
+        'transaction_location_pid': loc_public_saxon.pid,
+        'transaction_user_pid': librarian_martigny.pid
+    }
+    cipo = get_circ_policy(loan)
+    item, actions = item.extend_loan(**params)
+    loan = Loan.get_record_by_pid(initial_loan.pid)
+    # now the extend action does not take into account anymore the transaction
+    # library so it continues to use the "short" policy for the extend action.
+    assert get_circ_policy(
+        loan, checkout_location=True).get('pid') == cipo.get('pid')
+    assert get_circ_policy(loan).get('pid') != cipo.get('pid')

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -191,7 +191,7 @@ def test_item_loans_extend_duration(
             # assert loan_pid
             loan = Loan.get_record_by_pid(loan_pid)
             end_date = ciso8601.parse_datetime(loan.get('end_date'))
-            policy = get_circ_policy(loan)
+            policy = get_circ_policy(loan, checkout_location=True)
             # do the extend one day before the end date at 3pm
             extend_action_date = (
                 end_date - timedelta(days=1)).replace(hour=15)


### PR DESCRIPTION
The circulation action extend, uses the checkout library to
find the right policy, it does not take into consideration
the transaction library to calculate the new end_date and
the field due_soon_date.

* Fixes #2872

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## How to test?

- Login to the admin interface and checkout and item to a patron in the owning library
- Switch to any other library in the same organisation
- Renew the same item for the patron 
- Make sure the new `end_date` will be calculated always according to the owning library `checkout_library` instead of the `transaction_library`
