### PR TITLE
acquisition: fix acquisition notification templates

### DIFF
--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -362,7 +362,7 @@ class AcqOrder(IlsRecord):
         links.pop('order_lines', None)
         if self.status != AcqOrderStatus.PENDING:
             cannot_delete['others'] = {
-                _(f'Order status is %s') % _(self.status): True
+                _('Order status is %s') % _(self.status): True
             }
         if links:
             cannot_delete['links'] = links
@@ -381,10 +381,10 @@ class AcqOrder(IlsRecord):
         """
         # Create the notification and dispatch it synchronously.
         record = {
-            "notification_type": NotificationType.ACQUISITION_ORDER,
-            "context": {
-                "order": {'$ref': get_ref_for_pid('acor', self.pid)},
-                "recipients": emails
+            'notification_type': NotificationType.ACQUISITION_ORDER,
+            'context': {
+                'order': {'$ref': get_ref_for_pid('acor', self.pid)},
+                'recipients': emails
             }
         }
         notif = Notification.create(data=record, dbcommit=True, reindex=True)

--- a/rero_ils/modules/acq_orders/dumpers.py
+++ b/rero_ils/modules/acq_orders/dumpers.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Acquisition order dumpers."""
+from datetime import date
 
 from invenio_records.dumpers import Dumper as InvenioRecordsDumper
 
@@ -41,9 +42,10 @@ class AcqOrderNotificationDumper(InvenioRecordsDumper):
         :param record: The record to dump.
         :param data: The initial dump data passed in by ``record.dumps()``.
         """
+        today = date.today().strftime('%Y-%m-%d')
         data.update({
             'reference': record.get('reference'),
-            'order_date': record.order_date,
+            'order_date': record.order_date or today,
             'note': record.get_note(AcqOrderNoteType.VENDOR),
         })
         library = Library.get_record_by_pid(record.library_pid)

--- a/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/eng.tpl.txt
+++ b/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/eng.tpl.txt
@@ -3,7 +3,7 @@
 Our reference: {{ order.reference }}
 Date : {{ order.order_date }}
 
-Dear Sir,
+Dear Sir or Madam,
 
 We would like to order the following list of books:
 
@@ -18,15 +18,15 @@ Document :
   Series : {{ line.document.serie_statement }}
   {%- endif %}
   {%- if line.document.identifiers %}
-  ISBN : {{ line.document.identifiers | join(', ') }}
+  ISBN : {{ line.document.identifiers | join(' ; ') }}
   {%- endif %}
-{%- if line.note %}
-Note : {{ line.note }}
-{%- endif %}
-Quantity : {{ line.quantity }}
-Local account : {{ line.account.name }} {% if line.account.number: -%}
- [{{ line.account.number }}]
-{%- endif %}
+  {%- if line.note %}
+  Note : {{ line.note }}
+  {%- endif %}
+  Quantity : {{ line.quantity }}
+  Local account : {{ line.account.name }} {% if line.account.number: -%}
+  [{{ line.account.number }}]
+  {%- endif %}
 ------------------------------------------------------------
 {%- endfor -%}
 {%- if order.note %}
@@ -43,7 +43,7 @@ Best regards,
 Shipping address:
 {{ order.library.shipping_informations | address_block(language=order.vendor.language) }}
 
-{% if order.billing_informations -%}
+{% if order.library.billing_informations -%}
 Billing address:
 {{ order.library.billing_informations | address_block(language=order.vendor.language) }}
 {%- endif %}

--- a/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/fre.tpl.txt
+++ b/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/fre.tpl.txt
@@ -18,15 +18,15 @@ Document :
   Collection : {{ line.document.serie_statement }}
   {%- endif %}
   {%- if line.document.identifiers %}
-  ISBN : {{ line.document.identifiers | join(', ') }}
+  ISBN : {{ line.document.identifiers | join(' ; ') }}
   {%- endif %}
-{%- if line.note %}
-Note : {{ line.note }}
-{%- endif %}
-Quantité : {{ line.quantity }}
-Compte local : {{ line.account.name }} {% if line.account.number: -%}
- [{{ line.account.number }}]
-{%- endif %}
+  {%- if line.note %}
+  Note : {{ line.note }}
+  {%- endif %}
+  Quantité : {{ line.quantity }}
+  Compte local : {{ line.account.name }} {% if line.account.number: -%}
+  [{{ line.account.number }}]
+  {%- endif %}
 ------------------------------------------------------------
 {%- endfor -%}
 {%- if order.note %}
@@ -43,7 +43,7 @@ Bien à vous,
 Adresse de livraison:
 {{ order.library.shipping_informations | address_block(language=order.vendor.language) }}
 
-{% if order.billing_informations -%}
+{% if order.library.billing_informations -%}
 Adresse de facturation:
 {{ order.library.billing_informations | address_block(language=order.vendor.language) }}
 {%- endif %}

--- a/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/ger.tpl.txt
+++ b/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/ger.tpl.txt
@@ -3,7 +3,7 @@
 Unsere Referenz: {{ order.reference }}
 Datum : {{ order.order_date }}
 
-Sehr geehrter Herr,
+Sehr geehrte/r Frau/Herr,
 
 Wir möchten die folgende Liste von Büchern bestellen:
 
@@ -18,15 +18,15 @@ Dokument :
   Reihe : {{ line.document.serie_statement }}
   {%- endif %}
   {%- if line.document.identifiers %}
-  ISBN : {{ line.document.identifiers | join(', ') }}
+  ISBN : {{ line.document.identifiers | join(' ; ') }}
   {%- endif %}
-{%- if line.note %}
-Anmerkung : {{ line.note }}
-{%- endif %}
-Anzahl : {{ line.quantity }}
-Lokales Konto : {{ line.account.name }} {% if line.account.number: -%}
- [{{ line.account.number }}]
-{%- endif %}
+  {%- if line.note %}
+  Anmerkung : {{ line.note }}
+  {%- endif %}
+  Anzahl : {{ line.quantity }}
+  Lokales Konto : {{ line.account.name }} {% if line.account.number: -%}
+  [{{ line.account.number }}]
+  {%- endif %}
 ------------------------------------------------------------
 {%- endfor -%}
 {%- if order.note %}
@@ -43,7 +43,7 @@ Mit freundlichen Grüßen,
 Lieferadresse:
 {{ order.library.shipping_informations | address_block(language=order.vendor.language) }}
 
-{% if order.billing_informations -%}
+{% if order.library.billing_informations -%}
 Rechnungsadresse:
 {{ order.library.billing_informations | address_block(language=order.vendor.language) }}
 {%- endif %}

--- a/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/ita.tpl.txt
+++ b/rero_ils/modules/acq_orders/templates/rero_ils/vendor_order_mail/ita.tpl.txt
@@ -3,7 +3,7 @@
 Il nostro riferimento: {{ order.reference }}
 Data : {{ order.order_date }}
 
-Caro signore,
+Signora, signore,
 
 Vorremmo ordinare la seguente lista di libri:
 
@@ -18,15 +18,15 @@ Documento :
   Serie : {{ line.document.serie_statement }}
   {%- endif %}
   {%- if line.document.identifiers %}
-  ISBN : {{ line.document.identifiers | join(', ') }}
+  ISBN : {{ line.document.identifiers | join(' ; ') }}
   {%- endif %}
-{%- if line.note %}
-Nota : {{ line.note }}
-{%- endif %}
-Quantità : {{ line.quantity }}
-Conto locale : {{ line.account.name }} {% if line.account.number: -%}
- [{{ line.account.number }}]
-{%- endif %}
+  {%- if line.note %}
+  Nota : {{ line.note }}
+  {%- endif %}
+  Quantità : {{ line.quantity }}
+  Conto locale : {{ line.account.name }} {% if line.account.number: -%}
+  [{{ line.account.number }}]
+  {%- endif %}
 ------------------------------------------------------------
 {%- endfor -%}
 {%- if order.note %}
@@ -43,7 +43,7 @@ Cordiali saluti,
 Indirizzo di spedizione:
 {{ order.library.shipping_informations | address_block(language=order.vendor.language) }}
 
-{% if order.billing_informations -%}
+{% if order.library.billing_informations -%}
 Indirizzo di fatturazione:
 {{ order.library.billing_informations | address_block(language=order.vendor.language) }}
 {%- endif %}

--- a/rero_ils/modules/commons/identifiers.py
+++ b/rero_ils/modules/commons/identifiers.py
@@ -153,13 +153,14 @@ class Identifier:
 
     def dump(self) -> dict:
         """Dump this identifier."""
+        status = self.status if self.is_valid() else IdentifierStatus.INVALID
         data = {
             'type': self.type,
             'value': self.normalize(),
             'note': self.note,
             'qualifier': self.qualifier,
             'source': self.source,
-            'status': self.status
+            'status': status
         }
         return {k: v for k, v in data.items() if v}
 

--- a/rero_ils/modules/documents/dumpers.py
+++ b/rero_ils/modules/documents/dumpers.py
@@ -19,7 +19,8 @@
 """Documents dumpers."""
 from invenio_records.dumpers import Dumper as InvenioRecordsDumper
 
-from rero_ils.modules.commons.identifiers import IdentifierType
+from rero_ils.modules.commons.identifiers import IdentifierType, \
+    QualifierIdentifierRenderer
 from rero_ils.modules.documents.utils import publication_statement_text, \
     series_statement_format_text, title_format_text_head
 
@@ -77,9 +78,13 @@ class DocumentAcquisitionDumper(DocumentGenericDumper):
         # identifiers -------------------------------
         identifiers = record.get_identifiers(
             filters=[IdentifierType.ISBN],
-            with_alternatives=True
+            with_alternatives=False
         )
-        identifiers = [identifier.normalize() for identifier in identifiers]
+        render_class = QualifierIdentifierRenderer()
+        identifiers = [
+            identifier.render(render_class=render_class)
+            for identifier in identifiers
+        ]
 
         data.update({
             'identifiers': identifiers,


### PR DESCRIPTION
* Fixes missing order date. Because order date derivates from order
  lines, and order lines are updated after notification dispatch, the
  order date was always missing. Now we use the current timestamp as
  notification order date.
* Fixes notification template indentation problem.
* Fixes billing informations into template.
* Adds qualifier for ISBN included into notification.
* Closes rero/rero-ils#2647.
* Closes rero/rero-ils#2880.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
