### PR TITLE
notification: fix `at_desk` notification context.

### DIFF
--- a/rero_ils/modules/notifications/subclasses/circulation.py
+++ b/rero_ils/modules/notifications/subclasses/circulation.py
@@ -249,9 +249,7 @@ class CirculationNotification(Notification, ABC):
     @cached_property
     def request_loan(self):
         """Get the request loan related to this notification."""
-        for state in [LoanState.ITEM_AT_DESK,
-                      LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
-                      LoanState.PENDING]:
-            loan = self.item.get_first_loan_by_state(state)
-            if loan:
-                return loan
+        return self.item.get_first_loan_by_state(LoanState.ITEM_AT_DESK) \
+            or self.item.get_first_loan_by_state(
+                LoanState.ITEM_IN_TRANSIT_FOR_PICKUP) \
+            or self.item.get_first_loan_by_state(LoanState.PENDING)


### PR DESCRIPTION
Ensures that the patron related to the `at_desk` notification is the
patron related to the AT_DESK loan state.
Closes rero/rero-ils#2938.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>