### PR TITLE
documents: add more facets for documents search 

### DIFF
--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -66746,5 +66746,356 @@
         "$ref": "https://bib.rero.ch/api/documents/2000148"
       }
     ]
+  },
+  {
+    "contentMediaCarrier": [
+      {
+        "carrierType": "rdact:1049",
+        "contentType": [
+          "rdaco:1020",
+          "rdaco:1014"
+        ],
+        "mediaType": "rdamt:1007"
+      }
+    ],
+    "adminMetadata": {
+      "encodingLevel": "Full level",
+      "source": "RERO necfbv"
+    },
+    "contribution": [
+      {
+        "agent": {
+          "type": "bf:Organisation",
+          "preferred_name": "F\u00e9d\u00e9ration luth\u00e9rienne mondiale",
+          "conference": false
+        },
+        "role": [
+          "ctb"
+        ]
+      }
+    ],
+    "extent": "1 volume",
+    "genreForm": [
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021100103"
+        },
+        "term": "Ouvrages pour la jeunesse",
+        "type": "bf:Topic"
+      },
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A027757308"
+        },
+        "term": "Fictions",
+        "type": "bf:Topic"
+      },
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021013611"
+        },
+        "term": "Livres d'images",
+        "type": "bf:Topic"
+      },
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021121588"
+        },
+        "term": "Livres anim\u00e9s",
+        "type": "bf:Topic"
+      },
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021144168"
+        },
+        "term": "Livres tactiles",
+        "type": "bf:Topic"
+      }
+    ],
+    "identifiedBy": [
+      {
+        "type": "bf:Isbn",
+        "value": "9782075160728"
+      }
+    ],
+    "illustrativeContent": [
+      "illustrations"
+    ],
+    "issuance": {
+      "main_type": "rdami:1001",
+      "subtype": "materialUnit"
+    },
+    "language": [
+      {
+        "type": "bf:Language",
+        "value": "fre"
+      }
+    ],
+    "pid": "2093138",
+    "provisionActivity": [
+      {
+        "place": [
+          {
+            "country": "fr",
+            "type": "bf:Place"
+          }
+        ],
+        "startDate": 2021,
+        "statement": [
+          {
+            "label": [
+              {
+                "value": "Paris"
+              }
+            ],
+            "type": "bf:Place"
+          },
+          {
+            "label": [
+              {
+                "value": "Gallimard Jeunesse"
+              }
+            ],
+            "type": "bf:Agent"
+          },
+          {
+            "label": [
+              {
+                "value": "2021"
+              }
+            ],
+            "type": "Date"
+          }
+        ],
+        "type": "bf:Publication"
+      }
+    ],
+    "responsibilityStatement": [
+      [
+        {
+          "value": "Camille Chincholle"
+        }
+      ]
+    ],
+    "seriesStatement": [
+      {
+        "seriesTitle": [
+          {
+            "value": "Les petits coquins"
+          }
+        ]
+      },
+      {
+        "seriesTitle": [
+          {
+            "value": "Mes tout premiers livres"
+          }
+        ]
+      }
+    ],
+    "subjects": [
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021002444"
+        },
+        "term": "Animaux",
+        "type": "bf:Topic"
+      }
+    ],
+    "title": [
+      {
+        "mainTitle": [
+          {
+            "value": "O\u00f9 es-tu, petit coquin ?"
+          }
+        ],
+        "type": "bf:Title"
+      }
+    ],
+    "type": [
+      {
+        "main_type": "docmaintype_children"
+      }
+    ]
+  },
+  {
+    "adminMetadata": {
+      "encodingLevel": "Full level",
+      "source": "RERO necfbv"
+    },
+    "colorContent": [
+      "rdacc:1003"
+    ],
+    "contentMediaCarrier": [
+      {
+        "carrierType": "rdact:1060",
+        "contentType": [
+          "rdaco:1023"
+        ],
+        "mediaType": "rdamt:1008"
+      }
+    ],
+    "contribution": [
+      {
+        "agent": {
+          "type": "bf:Organisation",
+          "preferred_name": "F\u00e9d\u00e9ration luth\u00e9rienne mondiale",
+          "conference": false
+        },
+        "role": [
+          "ctb"
+        ]
+      }
+    ],
+    "copyrightDate": [
+      "\u00a9 2021"
+    ],
+    "credits": [
+      "Interpr\u00e8tes: Alex Lutz ; Ana Girardot ; Kristin Scott Thomas"
+    ],
+    "duration": [
+      "1h48"
+    ],
+    "extent": "1 DVD-vid\u00e9o",
+    "genreForm": [
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021097366"
+        },
+        "source": "rero",
+        "term": "Films de fiction",
+        "type": "bf:Topic"
+      },
+      {
+        "identifiedBy": {
+          "type": "RERO-RAMEAU",
+          "value": "A021121517"
+        },
+        "term": "Films dramatiques",
+        "type": "bf:Topic"
+      }
+    ],
+    "identifiedBy": [
+      {
+        "type": "bf:VideoRecordingNumber",
+        "value": "5053083237080"
+      },
+      {
+        "type": "bf:VideoRecordingNumber",
+        "value": "832 370-8"
+      }
+    ],
+    "issuance": {
+      "main_type": "rdami:1001",
+      "subtype": "materialUnit"
+    },
+    "language": [
+      {
+        "type": "bf:Language",
+        "value": "fre"
+      }
+    ],
+    "note": [
+      {
+        "label": "Une prod.: 22h22 - Apollo Films - Studiocanal - Praesens film, 2020",
+        "noteType": "general"
+      },
+      {
+        "label": "Langues: Fran\u00e7ais. Sous-titres: Fran\u00e7ais pour sourds et malentendants.",
+        "noteType": "general"
+      }
+    ],
+    "pid": "2078628",
+    "provisionActivity": [
+      {
+        "place": [
+          {
+            "country": "xx",
+            "type": "bf:Place"
+          }
+        ],
+        "startDate": 2021,
+        "statement": [
+          {
+            "label": [
+              {
+                "value": "[Lieu de publication non identifi\u00e9]"
+              }
+            ],
+            "type": "bf:Place"
+          },
+          {
+            "label": [
+              {
+                "value": "Studiocanal"
+              }
+            ],
+            "type": "bf:Agent"
+          },
+          {
+            "label": [
+              {
+                "value": "[2021]"
+              }
+            ],
+            "type": "Date"
+          }
+        ],
+        "type": "bf:Publication"
+      }
+    ],
+    "responsibilityStatement": [
+      [
+        {
+          "value": "un film de Quentin Reynaud"
+        }
+      ],
+      [
+        {
+          "value": "musique originale Delphine Malauss\u00e9na"
+        }
+      ]
+    ],
+    "summary": [
+      {
+        "label": [
+          {
+            "value": "\u00c0 presque 38 ans, Thomas est un tennisman qui n\u2019a jamais brill\u00e9\u0301. Pourtant, il y a 17 ans, il \u00e9tait l\u2019un des plus grands espoirs du tennis. Mais une d\u00e9faite en demi-finale l\u2019a traumatis\u00e9 et depuis, il est rest\u00e9 dans les profondeurs du classement. Aujourd\u2019hui, il se pr\u00e9pare \u00e0 ce qui devrait \u00eatre son dernier tournoi. Mais il refuse d\u2019abdiquer. Subitement enivr\u00e9 par un d\u00e9sir de sauver son honneur, il se lance dans un combat hom\u00e9rique improbable au r\u00e9sultat incertain..."
+          }
+        ],
+        "source": "Allocine.fr"
+      }
+    ],
+    "title": [
+      {
+        "mainTitle": [
+          {
+            "value": "5\u00e8me set"
+          }
+        ],
+        "type": "bf:Title"
+      },
+      {
+        "mainTitle": [
+          {
+            "value": "Cinqui\u00e8me set"
+          }
+        ],
+        "type": "bf:VariantTitle"
+      }
+    ],
+    "type": [
+      {
+        "main_type": "docmaintype_movie_series",
+        "subtype": "docsubtype_movie"
+      }
+    ]
   }
 ]

--- a/rero_ils/modules/documents/listener.py
+++ b/rero_ils/modules/documents/listener.py
@@ -59,7 +59,8 @@ def enrich_document_data(sender, json=None, record=None, index=None,
             'organisation': {
                 'organisation_pid': holding['organisation']['pid'],
                 'library_pid': holding['library']['pid']
-            }
+            },
+            'holdings_type': holding['holdings_type']
         }
         # Index additional holdings fields into the document record
         holdings_fields = [

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -476,8 +476,7 @@
             }
           },
           "startDate": {
-            "type": "integer",
-            "index": false
+            "type": "integer"
           },
           "endDate": {
             "type": "integer",
@@ -565,8 +564,7 @@
             "type": "object",
             "properties": {
               "value": {
-                "type": "text",
-                "index": false
+                "type": "keyword"
               },
               "language": {
                 "type": "keyword",
@@ -900,6 +898,9 @@
                 "type": "keyword"
               }
             }
+          },
+          "holdings_type": {
+            "type": "text"
           },
           "local_fields": {
             "properties": {
@@ -1551,7 +1552,7 @@
             "type": "keyword"
           },
           "term": {
-            "type": "text",
+            "type": "keyword",
             "copy_to": "facet_genre_form"
           },
           "identifiedBy": {

--- a/rero_ils/modules/documents/utils.py
+++ b/rero_ils/modules/documents/utils.py
@@ -63,13 +63,14 @@ def filter_document_type_buckets(buckets):
     """Removes unwanted subtypes from `document_type` buckets."""
     # TODO :: write an unitest
     if doc_types := get_document_types_from_schema():
-        for term in buckets:
-            main_type = term['key']
-            term['document_subtype']['buckets'] = [
-                subtype_bucket
-                for subtype_bucket in term['document_subtype']['buckets']
-                if doc_types.get(main_type, {}).get(subtype_bucket['key'])
-            ]
+        if buckets:
+            for term in buckets:
+                main_type = term['key']
+                term['document_subtype']['buckets'] = [
+                    subtype_bucket
+                    for subtype_bucket in term['document_subtype']['buckets']
+                    if doc_types.get(main_type, {}).get(subtype_bucket['key'])
+                ]
 
 
 def clean_text(data):

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -170,7 +170,11 @@ def test_documents_facets(
     url = url_for('invenio_records_rest.doc_list', view='global')
     res = client.get(url, headers=rero_json_header)
     data = get_json(res)
-    facet_keys = ['document_type', 'author', 'language', 'subject', 'status']
+    facet_keys = [
+        'document_type', 'author', 'language', 'subject_no_fiction',
+        'subject_fiction', 'genreForm', 'intendedAudience',
+        'year', 'status'
+    ]
     assert all(key in data['aggregations'] for key in facet_keys)
 
     params = {'view': 'global', 'facets': ''}
@@ -197,7 +201,8 @@ def test_documents_facets(
     res = client.get(url, headers=rero_json_header)
     data = get_json(res)
     aggs = data['aggregations']
-    assert set(aggs.keys()) == {'document_type', 'library', 'author'}
+    assert set(aggs.keys()) == {'document_type',
+                                'library', 'author'}
 
     # TEST FILTERS
     #   Each filter checks is a tuple. First tuple element is argument used to


### PR DESCRIPTION
- Added more facets for documents search
- Implemented post filters
- This PR requires a document re-indexing

Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?

Closes https://github.com/rero/rero-ils/issues/2763

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#867
* https://github.com/rero/ng-core/pull/503/

## How to test
Please test:
* for the OR facets (listed in the [US](https://github.com/rero/rero-ils/issues/2763)) it is possible to select multiple values of the same facet. 
  Example: it is possible to select several values of Document type.
* the results count and the facets counts change accordingly to the selection made.
* a list of chosen filters is displayed. It is possible to remove a filter by clicking on the X next to the filter name.
* when there are no results a banner and 0 results are displayed.

Note: an AND is applied between values of different facets.
