### PR TITLE
jsonschemas: extend validation limit for `provisionActivity` dates

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
@@ -226,7 +226,7 @@
           "description": "Normalised date used for sorting and filtering options (MARC 008). A free text date (transcripted) can be added in the field \"Statements\".",
           "type": "integer",
           "minimum": -9999,
-          "maximum": 2050,
+          "maximum": 9999,
           "form": {
             "expressionProperties": {
               "templateOptions.required": "model.type === 'bf:Publication'"
@@ -241,7 +241,7 @@
           "description": "Normalised end date if the provision activity covers more than one year, and used for sorting and filtering options (MARC 008). A free text date (transcripted) can be added in the field \"Statements\"",
           "type": "integer",
           "minimum": -9999,
-          "maximum": 2050,
+          "maximum": 9999,
           "form": {
             "hide": true,
             "templateOptions": {


### PR DESCRIPTION
* Closes https://github.com/rero/rero-ils/issues/2948

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
