### PR TITLE
Move test server alert to app header

### DIFF
--- a/rero_ils/theme/templates/rero_ils/frontpage.html
+++ b/rero_ils/theme/templates/rero_ils/frontpage.html
@@ -60,16 +60,6 @@
   </div>
   {% endif %}
 
-  <!-- Info message (not in production) -->
-  {% if not config.RERO_ILS_STATE_PRODUCTION %}
-    <h5 class="text-center bg-danger text-white py-2 mb-0">
-      {{ config.RERO_ILS_STATE_MESSAGE }}
-      {% if config.RERO_ILS_STATE_LINK_MESSAGE %}
-        <a href={{ config.RERO_ILS_STATE_LINK}} class="rero-ils-external-link text-white">{{config.RERO_ILS_STATE_LINK_MESSAGE }}</a>
-      {% endif %}
-    </h5>
-  {% endif %}
-
   <!-- Block links -->
   <div class="container">
     <article class="row mt-md-4">

--- a/rero_ils/theme/templates/rero_ils/header.html
+++ b/rero_ils/theme/templates/rero_ils/header.html
@@ -91,6 +91,17 @@
         {% endfor %}
       </div>
     </nav>
+
+    <!-- Info message (not in production) -->
+    {% if not config.RERO_ILS_STATE_PRODUCTION %}
+      <h5 class="text-center bg-danger text-white py-2 mb-0">
+        {{ config.RERO_ILS_STATE_MESSAGE }}
+        {% if config.RERO_ILS_STATE_LINK_MESSAGE %}
+          <a href={{ config.RERO_ILS_STATE_LINK}} class="rero-ils-external-link text-white">{{config.RERO_ILS_STATE_LINK_MESSAGE }}</a>
+        {% endif %}
+      </h5>
+    {% endif %}
+
     <!-- HIDDEN MENUS :: Only visible from medium to extra small screens == -->
     <nav class="navbar-light bg-light d-lg-none d-xl-none border-bottom collapse" id="mobileHide">
       <!-- User menus -->


### PR DESCRIPTION
Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- The test server alert message is moved just under the navbar in the header template so that it is displayed across the app. 
- On test deployments (including bib.test), use config `RERO_ILS_STATE_PRODUCTION = False` to show the alert
