### PR TITLE
editor: fix subject field performance

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -454,7 +454,7 @@
     "genreForm_subdivisions": {
       "title": "Form subdivisions",
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "title": "Form subdivision",
         "description": "Subject subdivision for a specific kind or genre of material (MARC 6XX$v)",
@@ -471,7 +471,7 @@
     "topic_subdivisions": {
       "title": "Concept subdivisions",
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "title": "Concept subdivision",
         "description": "Subject subdivision for a concept (MARC 6XX$x)",
@@ -488,7 +488,7 @@
     "temporal_subdivisions": {
       "title": "Time-span subdivisions",
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "title": "Time-span subdivision",
         "description": "Subject subdivision for a period of time (MARC 6XX$y)",
@@ -505,7 +505,7 @@
     "place_subdivisions": {
       "title": "Place subdivisions",
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "title": "Place subdivision",
         "description": "Subject subdivision for a place (MARC 6XX$z)",


### PR DESCRIPTION
* Reset minItems=0 for subject subdivisions
* Greatly improves editor performance for documents with many subject
fields

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

With new ng-core version, setting minItems = 1 for subject subdivisions worsens the performance for this field when there are a lot of subjects in a document. This is a workaround. The next formly major version might be better.

## How to test?

- See that for document with many subjects (example https://bib.rero.ch/professional/records/documents/edit/2110433), adding a subject takes even more time in RC 1.12.0 than in production. 
- With this fix, the performance should be greatly improved.