### PR TITLE
items: add new fields to inventory list

### DIFF
--- a/rero_ils/modules/items/models.py
+++ b/rero_ils/modules/items/models.py
@@ -105,5 +105,10 @@ class ItemNoteTypes:
         GENERAL,
         STAFF,
         CHECKIN,
-        CHECKOUT
+        CHECKOUT,
+        ACQUISITION,
+        BINDING,
+        CONDITION,
+        PATRIMONIAL,
+        PROVENANCE
     ]

--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -25,44 +25,88 @@ from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1
 from .csv import ItemCSVSerializer
 from .json import ItemsJSONSerializer
 
-_csv = ItemCSVSerializer(
-    JSONSerializer,
-    csv_included_fields=[
-        'pid',
+csv_included_fields = [
         'document_pid',
         'document_title',
         'document_creator',
         'document_main_type',
         'document_sub_type',
-        'library_name',
-        'location_name',
-        'barcode',
-        'call_number',
-        'second_call_number',
-        'enumerationAndChronology',
+        'document_masked',
+        'document_isbn',
+        'document_issn',
+        'document_series_statement',
+        'document_edition_statement',
+        'document_publication_year',
+        'document_publisher',
+        'document_local_field_1',
+        'document_local_field_2',
+        'document_local_field_3',
+        'document_local_field_4',
+        'document_local_field_5',
+        'document_local_field_6',
+        'document_local_field_7',
+        'document_local_field_8',
+        'document_local_field_9',
+        'document_local_field_10',
+        'item_acquisition_date',
+        'item_pid',
+        'item_create_date',
+        'item_barcode',
+        'item_call_number',
+        'item_second_call_number',
+        'item_legacy_checkout_count',
         'item_type',
+        'item_library_name',
+        'item_location_name',
+        'item_pac_code',
+        'item_holding_pid',
+        'item_price',
+        'item_status',
+        'item_item_type',
+        'item_general_note',
+        'item_staff_note',
+        'item_checkin_note',
+        'item_checkout_note',
+        'item_acquisition_note',
+        'item_binding_note',
+        'item_condition_note',
+        'item_patrimonial_note',
+        'item_provenance_note',
         'temporary_item_type',
-        'temporary_item_type_end_date',
-        'general_note',
-        'staff_note',
-        'checkin_note',
-        'checkout_note',
-        'loans_count',
-        'checkout_date',
-        'due_date',
-        'last_transaction_date',
-        'status',
-        'created',
+        'temporary_item_type_expiry_date',
+        'item_masked',
+        'item_enumerationAndChronology',
+        'item_local_field_1',
+        'item_local_field_2',
+        'item_local_field_3',
+        'item_local_field_4',
+        'item_local_field_5',
+        'item_local_field_6',
+        'item_local_field_7',
+        'item_local_field_8',
+        'item_local_field_9',
+        'item_local_field_10',
         'issue_status',
         'issue_status_date',
         'issue_claims_count',
         'issue_expected_date',
-        'issue_regular'
-    ]
-)
-csv_item_response = record_responsify(_csv, "text/csv")
-csv_item_search = search_responsify_csv(_csv, "text/csv")
+        'issue_regular',
+        'item_checkouts_count',
+        'item_renewals_count',
+        'last_transaction_date',
+        'checkout_date'
+]
 
-_json = ItemsJSONSerializer(RecordSchemaJSONV1)
-json_item_search = search_responsify(_json, 'application/rero+json')
-json_item_response = record_responsify(_json, 'application/rero+json')
+"""CSV serializer."""
+_csv_item = ItemCSVSerializer(
+    JSONSerializer,
+    csv_included_fields=csv_included_fields
+)
+csv_item_response = record_responsify(_csv_item, "text/csv")
+csv_item_search = search_responsify_csv(_csv_item, "text/csv")
+
+
+"""JSON serializer."""
+_json_item = ItemsJSONSerializer(RecordSchemaJSONV1)
+json_item_search = search_responsify(_json_item, 'application/rero+json')
+json_item_response = record_responsify(_json_item, 'application/rero+json')

--- a/rero_ils/modules/items/serializers/collector.py
+++ b/rero_ils/modules/items/serializers/collector.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Item collector."""
+
+
+import itertools
+
+import ciso8601
+from elasticsearch_dsl import A
+from flask import current_app
+
+from rero_ils.modules.documents.api import DocumentsSearch
+from rero_ils.modules.local_fields.api import LocalField
+from rero_ils.modules.operation_logs.api import OperationLogsSearch
+
+from ..models import ItemCirculationAction, ItemNoteTypes
+
+
+class Collecter():
+    """collect data for csv."""
+
+    # define chunk size
+    chunk_size = 1000
+    separator = ' | '
+
+    role_filter = [
+        'rsp',
+        'cre',
+        'enj',
+        'dgs',
+        'prg',
+        'dsr',
+        'ctg',
+        'cmp',
+        'inv',
+        'com',
+        'pht',
+        'ivr',
+        'art',
+        'ive',
+        'chr',
+        'aut',
+        'arc',
+        'fmk',
+        'pra',
+        'csl'
+    ]
+
+    @classmethod
+    def batch(cls, results):
+        """Chunk search results.
+
+        :param results: search results.
+        :return list of chuncked item pids and search records
+        """
+        records, pids = [], []
+        for result in results:
+            pids.append(result.pid)
+            records.append(result)
+            if len(records) % cls.chunk_size == 0:
+                yield pids, records
+                records, pids = [], []
+        yield pids, records
+
+    @classmethod
+    def get_documents_by_item_pids(cls, item_pids, language):
+        """Get documents for the given item pid list.
+
+        :param item_pids: item pids.
+        :param language: language.
+        :return list of documents.
+        """
+
+        def _build_doc(data):
+            document_data = {
+                'document_title': next(
+                    filter(
+                        lambda x: x.get('type')
+                        == 'bf:Title', data.get('title'))
+                ).get('_text'),
+                'document_masked': 'No'
+            }
+            # process contributions
+            creator = []
+            for contribution in data.get('contribution', []):
+                if any(role in contribution.get('role')
+                        for role in cls.role_filter):
+                    authorized_access_point = \
+                        f'authorized_access_point_{language}'
+                    if authorized_access_point in contribution.get('agent'):
+                        creator.append(
+                            contribution['agent'][
+                                authorized_access_point]
+                        )
+            document_data['document_creator'] = ' ; '.join(creator)
+            document_main_type = []
+            document_sub_type = []
+            for document_type in data.get('type'):
+                # data = document_type.to_dict()
+                document_main_type.append(
+                    document_type.get('main_type'))
+                document_sub_type.append(
+                    document_type.get('subtype', ''))
+            document_data['document_main_type'] = ', '.join(
+                document_main_type)
+            document_data['document_sub_type'] = ', '.join(
+                document_sub_type)
+            # masked
+            document_data['document_masked'] = \
+                'Yes' if data.get('_masked') else 'No'
+            # isbn:
+            document_data['document_isbn'] = cls.separator.join(
+                data.get('isbn', []))
+            # issn:
+            document_data['document_issn'] = cls.separator.join(
+                data.get('issn', []))
+            # document_series_statement
+            document_data['document_series_statement'] = cls.separator.join(
+                data['value']
+                for serie in data.get('seriesStatement', [])
+                for data in serie.get('_text', [])
+            )
+            # document_edition_statement
+            document_data['document_edition_statement'] = cls.separator.join(
+                edition.get('value')
+                for edition_statement in
+                data.get('editionStatement', [])
+                for edition in edition_statement.get('_text', [])
+            )
+            # process provision activity
+            provision_activity = next(
+                filter(lambda x: x.get('type')
+                       == 'bf:Publication', data.get('provisionActivity'))
+            )
+            start_date = provision_activity.get('startDate', '')
+            end_date = provision_activity.get('endDate')
+            document_data['document_publication_year'] = \
+                f'{start_date} - {end_date}' \
+                if end_date else start_date
+
+            document_data['document_publisher'] = cls.separator.join(
+                data['value']
+                for stmt in provision_activity.get('statement', [])
+                for data in stmt.get('label', [])
+                if stmt['type'] == 'bf:Agent'
+            )
+            return document_data
+
+        doc_search = DocumentsSearch() \
+            .filter('terms', holdings__items__pid=list(item_pids)) \
+            .source(['pid', 'title', 'contribution', 'provisionActivity',
+                     'type', '_masked', 'isbn', 'issn', 'seriesStatement',
+                     'editionStatement'])
+        docs = {}
+        for doc in doc_search.scan():
+            docs[doc.pid] = _build_doc(doc.to_dict())
+        return docs
+
+    @staticmethod
+    def get_item_data(hit):
+        """Collect es items data.
+
+        :param hit: ES item hit.
+        :return csv_data: dictionary of data.
+        """
+        hit = hit.to_dict()
+        csv_data = {
+            'item_create_date': ciso8601.parse_datetime(
+                hit['_created']).date(),
+            'item_type_pid': hit.get('item_type', {}).get('pid'),
+            'item_library_pid': hit.get('library', {}).get('pid'),
+            'item_location_pid': hit.get('location', {}).get('pid'),
+            'document_pid': hit.get('document', {}).get('pid'),
+            'item_holding_pid': hit.get('holding', {}).get('pid'),
+            'item_org_pid': hit.get('organisation', {}).get('pid'),
+            'temporary_item_type_pid': hit.get(
+                'temporary_item_type', {}).get('pid'),
+            'item_masked': 'No',
+            'item_status': hit.get('status'),
+            'issue': hit.get('issue', {})
+        }
+        fields = [
+            ('pid', 'item_pid'),
+            ('barcode', 'item_barcode'),
+            ('call_number', 'item_call_number'),
+            ('second_call_number', 'item_second_call_number'),
+            ('legacy_checkout_count', 'item_legacy_checkout_count'),
+            ('pac_code', 'item_pac_code'),
+            ('price', 'item_price'),
+            ('type', 'item_item_type'),
+            ('enumerationAndChronology', 'item_enumerationAndChronology')
+        ]
+        for field_name, new_field_name in fields:
+            csv_data[new_field_name] = hit.get(field_name)
+        # dates fields
+        if end_date := hit.get('temporary_item_type', {}).get('end_date'):
+            csv_data['temporary_item_type_expiry_date'] = \
+                ciso8601.parse_datetime(end_date).date()
+        if acquisition_date := hit.get('acquisition_date'):
+            csv_data['item_acquisition_date'] = \
+                ciso8601.parse_datetime(acquisition_date).date()
+        if item_create_date := hit.get('_created'):
+            csv_data['item_create_date'] = \
+                ciso8601.parse_datetime(item_create_date).date()
+
+        # process notes
+        for note in hit.get('notes', []):
+            if note.get('type') in ItemNoteTypes.INVENTORY_LIST_CATEGORY:
+                csv_data[f"item_{note.get('type')}"] = note.get(
+                    'content')
+        # item masking
+        csv_data['item_masked'] = 'Yes' if hit.get('_masked') else 'No'
+
+        return csv_data
+
+    @staticmethod
+    def append_issue_data(hit, csv_data):
+        """Append issue data.
+
+        :param csv_data: data dictionary.
+        """
+        # process item issue
+        if csv_data['item_item_type'] != 'issue':
+            return
+        issue = csv_data.pop('issue', None)
+        if issue.get('inherited_first_call_number') \
+                and not csv_data.get('item_call_number'):
+            csv_data['item_call_number'] = \
+                issue.get('inherited_first_call_number')
+        csv_data['issue_status'] = issue.get('status')
+        if issue.get('status_date'):
+            csv_data['issue_status_date'] = \
+                ciso8601.parse_datetime(
+                    issue.get('status_date')).date()
+        csv_data['issue_claims_count'] = \
+            issue.get('claims_count', 0)
+        csv_data['issue_expected_date'] = \
+            issue.get('expected_date')
+        csv_data['issue_regular'] = issue.get('regular')
+
+    @staticmethod
+    def append_document_data(csv_data, documents):
+        """Append document data.
+
+        :param csv_data: data dictionary.
+        :param documents: documents data.
+        """
+        try:
+            # update csv data with document
+            csv_data.update(documents.get(csv_data.get('document_pid')))
+        except Exception as err:
+            current_app.logger.error(
+                'ERROR in csv serializer: '
+                '{message} on document: {pid}'.format(
+                    message=str(err),
+                    pid=hit['document']['pid'])
+            )
+
+    @classmethod
+    def append_local_fields(cls, csv_data):
+        """Append local fields data.
+
+        :param csv_data: data dictionary.
+        """
+        def _append_res_local_fields(resource_type, resource_pid, csv_data):
+            """Append local fields data.
+
+            :param csv_data: data dictionary.
+            :param resource_type: resoruce_type.
+            :param resource_pid: resource_pid.
+            """
+            lf_type = 'document' if resource_type == 'doc' else resource_type
+            org_pid = csv_data['item_org_pid']
+            local_fields = LocalField.get_local_fields_by_resource(
+                    resource_type, resource_pid, organisation_pid=org_pid)
+            for field, num in itertools.product(local_fields, range(1, 11)):
+                field_name = f'{lf_type}_local_field_{num}'
+                if field_data := field.get('fields', {}).get(f'field_{num}'):
+                    csv_data[field_name] = cls.separator.join(field_data)
+
+        _append_res_local_fields('item', csv_data['item_pid'], csv_data)
+        _append_res_local_fields('doc', csv_data['document_pid'], csv_data)
+
+    @staticmethod
+    def get_loans_by_item_pids(item_pids=None):
+        """Get loans for the given item pid list.
+
+        :param item_pids: item pids.
+        :return dict of item_pids having the checkouts, renewals,
+                last_transaction_dates, last_checkouts data.
+        """
+        def add_pid(loans, pid):
+            """Add pid to loans."""
+            if pid not in loans:
+                loans[pid] = {}
+
+        # initial es query to return all loans for the given item_pids
+        query = OperationLogsSearch()\
+            .filter('terms', loan__item__pid=item_pids)
+        # adds checkouts aggregation
+        checkout_agg = A(
+            'filter', term={'loan.trigger': ItemCirculationAction.CHECKOUT},
+            aggs=dict(
+                item_pid=A(
+                    'terms', field='loan.item.pid',
+                    aggs=dict(last_op=A('max', field='date')))))
+        query.aggs.bucket('checkout', checkout_agg)
+        # adds renewal aggregation
+        renewal_agg = A(
+            'filter', term={'loan.trigger': ItemCirculationAction.EXTEND},
+            aggs=dict(item_pid=A('terms', field='loan.item.pid')))
+        query.aggs.bucket('renewal', renewal_agg)
+        # adds last transaction aggregation for the fours triggers below.
+        triggers = [
+            ItemCirculationAction.CHECKOUT,
+            ItemCirculationAction.CHECKIN,
+            ItemCirculationAction.EXTEND
+        ]
+        loans_agg = A('filter', terms={'loan.trigger': triggers},
+                      aggs=dict(
+            item_pid=A('terms',
+                       field='loan.item.pid',
+                       aggs=dict(last_op=A('max', field='date')))))
+        query.aggs.bucket('loans', loans_agg)
+        # query execution
+        result = query.execute()
+        # dump output into a dict
+        # checkouts data
+        loans = {
+            term.key: {'checkout_count': term.doc_count,
+                       'last_checkout': ciso8601.parse_datetime(
+                        term.last_op.value_as_string).date()}
+            for term in result.aggregations.checkout.item_pid}
+        # renewal data
+        for term in result.aggregations.renewal.item_pid:
+            if term.key not in loans:
+                add_pid(loans, term.key)
+            loans[term.key]['renewal_count'] = term.doc_count
+        # last_transaction data
+        for term in result.aggregations.loans.item_pid:
+            if term.key not in loans:
+                add_pid(loans, term.key)
+            loans[term.key]['last_transaction'] = \
+                ciso8601.parse_datetime(term.last_op.value_as_string).date()
+        return loans
+
+    @staticmethod
+    def append_loan_data(hit, csv_data, loans):
+        """Append item loan.
+
+        :param hit: item ES record.
+        :param csv_data: dictionary of data.
+        :param loans: loans data.
+        """
+        csv_data['item_checkouts_count'] = loans.get(
+            hit.pid, {}).get('checkout_count', 0)
+        csv_data['item_renewals_count'] = loans.get(
+            hit.pid, {}).get('renewal_count', 0)
+        csv_data['last_transaction_date'] = loans.get(
+            hit.pid, {}).get('last_transaction')
+        csv_data['checkout_date'] = loans.get(
+            hit.pid,  {}).get('last_checkout')

--- a/rero_ils/modules/items/serializers/csv.py
+++ b/rero_ils/modules/items/serializers/csv.py
@@ -18,49 +18,23 @@
 
 """Item serializers."""
 
+
 import csv
 
-import ciso8601
-from elasticsearch_dsl import A
 from flask import current_app, request, stream_with_context
 from invenio_i18n.ext import current_i18n
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 
-from rero_ils.modules.documents.api import DocumentsSearch
-from rero_ils.modules.item_types.api import ItemTypesSearch
-from rero_ils.modules.libraries.api import LibrariesSearch
-from rero_ils.modules.loans.api import LoansSearch
-from rero_ils.modules.loans.models import LoanState
-from rero_ils.modules.locations.api import LocationsSearch
+from rero_ils.modules.item_types.api import ItemType
+from rero_ils.modules.libraries.api import Library
+from rero_ils.modules.locations.api import Location
+from rero_ils.modules.serializers.base import CachedDataSerializerMixin
 from rero_ils.utils import get_i18n_supported_languages
 
-from ..models import ItemNoteTypes
-
-role_filter = [
-    'rsp',
-    'cre',
-    'enj',
-    'dgs',
-    'prg',
-    'dsr',
-    'ctg',
-    'cmp',
-    'inv',
-    'com',
-    'pht',
-    'ivr',
-    'art',
-    'ive',
-    'chr',
-    'aut',
-    'arc',
-    'fmk',
-    'pra',
-    'csl'
-]
+from .collector import Collecter
 
 
-class ItemCSVSerializer(CSVSerializer):
+class ItemCSVSerializer(CSVSerializer, CachedDataSerializerMixin):
     """Serialize item search for csv."""
 
     def serialize_search(self, pid_fetcher, search_result, links=None,
@@ -72,140 +46,38 @@ class ItemCSVSerializer(CSVSerializer):
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """
-        # define chunk size
-        chunk_size = 1000
-
-        # language
-        language = request.args.get("lang", current_i18n.language)
-        if not language or language not in get_i18n_supported_languages():
-            language = current_app.config.get('BABEL_DEFAULT_LANGUAGE', 'en')
-
-        # prepare mapping dictionnaries
-        item_types_map = {}
-        for item_type in ItemTypesSearch().scan():
-            item_types_map[item_type.pid] = item_type.name
-        locations_map = {}
-        for location in LocationsSearch().scan():
-            locations_map[location.pid] = location.name
-        libraries_map = {}
-        for library in LibrariesSearch().scan():
-            libraries_map[library.pid] = library.name
 
         def generate_csv():
-            def batch(results):
-                """Chunk search results.
+            """Generate CSV records."""
 
-                :param results: search results.
-                :return list of chuncked item pids and search records
+            def _process_item_types_libs_locs(csv_data):
+                """Process item types, library and locations data.
+
+                :param csv_data: Dictionary of data.
                 """
-                records = []
-                pids = []
-                for result in results:
-                    pids.append(result.pid)
-                    records.append(result)
-                    if len(records) % chunk_size == 0:
-                        yield pids, records
-                        pids = []
-                        records = []
-                yield pids, records
-
-            def get_documents_by_item_pids(item_pids):
-                """Get documents for the given item pid list."""
-
-                def _build_doc(data):
-                    document_data = {
-                        'document_title': next(
-                            filter(lambda x: x.get('type') == 'bf:Title',
-                                   data.get('title'))
-                        ).get('_text')
-                    }
-                    # process contributions
-                    creator = []
-                    if 'contribution' in data:
-                        for contribution in data.get('contribution'):
-                            if any(role in contribution.get('role')
-                                   for role in role_filter):
-                                authorized_access_point = \
-                                    f'authorized_access_point_{language}'
-                                if authorized_access_point in contribution\
-                                        .get('agent'):
-                                    creator.append(
-                                        contribution['agent'][
-                                            authorized_access_point]
-                                    )
-                    document_data['document_creator'] = ' ; '.join(creator)
-                    document_main_type = []
-                    document_sub_type = []
-                    for document_type in data.get('type'):
-                        # data = document_type.to_dict()
-                        document_main_type.append(
-                            document_type.get('main_type'))
-                        document_sub_type.append(
-                            document_type.get('subtype', ''))
-                    document_data['document_main_type'] = ', '.join(
-                        document_main_type)
-                    document_data['document_sub_type'] = ', '.join(
-                        document_sub_type)
-                    # TODO : build provision activity
-                    return document_data
-
-                doc_search = DocumentsSearch() \
-                    .filter('terms', holdings__items__pid=list(item_pids)) \
-                    .source(
-                    ['pid', 'title', 'contribution', 'provisionActivity',
-                     'type'])
-                docs = {}
-                for doc in doc_search.scan():
-                    docs[doc.pid] = _build_doc(doc.to_dict())
-                return docs
-
-            def get_loans_by_item_pids(item_pids):
-                """Get loans for the given item pid list."""
-                states = \
-                    current_app.config['CIRCULATION_STATES_LOAN_ACTIVE']
-                loan_search = LoansSearch() \
-                    .filter('terms', state=states) \
-                    .filter('terms', item_pid__value=item_pids) \
-                    .source(['pid', 'item_pid.value', 'start_date',
-                            'end_date', 'state', '_created'])
-                agg = A('terms', field='item_pid.value', size=chunk_size)
-                loan_search.aggs.bucket('loans_count', agg)
-
-                loan_search = loan_search.extra(
-                    collapse={
-                        'field': 'item_pid.value',
-                        "inner_hits": {
-                            "name": "most_recent",
-                            "size": 1,
-                            "sort": [{"_created": "desc"}],
-                        }
-                    }
-                )
-                # default results size for the execute method is 10.
-                # We need to set this to the chunk size"
-                results = loan_search[0:chunk_size].execute()
-                agg_buckets = {}
-                for result in results.aggregations.loans_count.buckets:
-                    agg_buckets[result.key] = result.doc_count
-                loans = {}
-                for loan_hit in results:
-                    # get most recent loans
-                    loan_data = loan_hit.meta.inner_hits.most_recent[0]\
-                        .to_dict()
-                    item_pid = loan_data['item_pid']['value']
-                    loans[item_pid] = {
-                        'loans_count': agg_buckets.get(item_pid, 0),
-                        'last_transaction_date': ciso8601.parse_datetime(
-                            loan_data['_created']).date()
-                    }
-                    if loan_data.get('state') == LoanState.ITEM_ON_LOAN:
-                        loans[item_pid]['checkout_date'] = ciso8601.\
-                            parse_datetime(loan_data['start_date']).date()
-                        loans[item_pid]['due_date'] = ciso8601.\
-                            parse_datetime(loan_data['end_date']).date()
-                return loans
+                # TODO: check if cached resources is a good ides for these
+                # fields or not.
+                # item_type
+                csv_data['item_type'] = self.get_resource(
+                    ItemType, csv_data.get('item_type_pid')).get('name')
+                # temporary item_type
+                if temporary_item_type_pid := csv_data.pop(
+                        'temporary_item_type_pid', None):
+                    csv_data['temporary_item_type'] = self.get_resource(
+                        ItemType, temporary_item_type_pid).get('name')
+                # library
+                csv_data['item_library_name'] = self.get_resource(
+                    Library, csv_data.pop('item_library_pid')).get('name')
+                # location
+                csv_data['item_location_name'] = self.get_resource(
+                    Location, csv_data.pop('item_location_pid')).get('name')
 
             headers = dict.fromkeys(self.csv_included_fields)
+
+            language = request.args.get("lang", current_i18n.language)
+            if not language or language not in get_i18n_supported_languages():
+                language = current_app.config.get(
+                    'BABEL_DEFAULT_LANGUAGE', 'en')
 
             # write the CSV output in memory
             line = Line()
@@ -215,80 +87,24 @@ class ItemCSVSerializer(CSVSerializer):
             writer.writeheader()
             yield line.read()
 
-            for pids, batch_results in batch(search_result):
+            for pids, batch_results in Collecter.batch(results=search_result):
                 # get documents
-                documents = get_documents_by_item_pids(pids)
-
+                documents = Collecter.get_documents_by_item_pids(
+                    item_pids=pids, language=language)
                 # get loans
-                loans = get_loans_by_item_pids(pids)
-
+                loans = Collecter.get_loans_by_item_pids(item_pids=pids)
                 for hit in batch_results:
-                    csv_data = hit.to_dict()
-                    csv_data['library_name'] = libraries_map[
-                        hit['library']['pid']]
-                    csv_data['location_name'] = locations_map[
-                        hit['location']['pid']]
-
-                    try:
-                        # update csv data with document
-                        csv_data.update(documents.get(hit['document']['pid']))
-                    except Exception as err:
-                        current_app.logger.error(
-                            'ERROR in csv serializer: '
-                            '{message} on document: {pid}'.format(
-                                message=err,
-                                pid=hit['document']['pid'])
-                        )
-
+                    csv_data = Collecter.get_item_data(hit)
+                    # _process_item_types_libs_locs(self, csv_data)
+                    _process_item_types_libs_locs(csv_data)
+                    Collecter.append_document_data(csv_data, documents)
+                    Collecter.append_local_fields(csv_data)
                     # update csv data with loan
-                    csv_data.update(loans.get(hit['pid'], {'loans_count': 0}))
-
-                    # process item type and temporary item type
-                    csv_data['item_type'] = item_types_map[
-                        hit['item_type']['pid']]
-                    temporary_item_type = csv_data.get('temporary_item_type')
-                    if temporary_item_type:
-                        csv_data['temporary_item_type'] = item_types_map[
-                            temporary_item_type['pid']]
-                        csv_data['temporary_item_type_end_date'] = \
-                            temporary_item_type.get('end_date')
-
-                    # process note
-                    for note in csv_data.get('notes', []):
-                        if any(note_type in note.get('type')
-                               for note_type in
-                               ItemNoteTypes.INVENTORY_LIST_CATEGORY):
-                            csv_data[note.get('type')] = note.get(
-                                'content')
-
-                    csv_data['created'] = ciso8601.parse_datetime(
-                            hit['_created']).date()
-
-                    # process item issue
-                    if hit['type'] == 'issue':
-                        issue = csv_data['issue']
-                        if issue.get('inherited_first_call_number') \
-                                and not csv_data.get('call_number'):
-                            csv_data['call_number'] = \
-                                issue.get('inherited_first_call_number')
-                        csv_data['issue_status'] = issue.get('status')
-                        if issue.get('status_date'):
-                            csv_data['issue_status_date'] = \
-                                ciso8601.parse_datetime(
-                                    issue.get('status_date')).date()
-                        csv_data['issue_claims_count'] = \
-                            issue.get('claims_count', 0)
-                        csv_data['issue_expected_date'] = \
-                            issue.get('expected_date')
-                        csv_data['issue_regular'] = issue.get('regular')
-
-                    # prevent key error
-                    del (csv_data['type'])
-
+                    Collecter.append_loan_data(hit, csv_data, loans)
+                    Collecter.append_issue_data(hit, csv_data)
                     # write csv data
-                    data = self.process_dict(csv_data)
+                    data = self.process_dict(dictionary=csv_data)
                     writer.writerow(data)
                     yield line.read()
 
-        # return streamed content
         return stream_with_context(generate_csv())

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -176,15 +176,36 @@ def test_items_serializers(
     assert response.status_code == 200
     data = get_csv(response)
     assert data
-    assert '"pid","document_pid","document_title","document_creator",' \
-           '"document_main_type","document_sub_type","library_name",' \
-           '"location_name","barcode","call_number","second_call_number",' \
-           '"enumerationAndChronology","item_type","temporary_item_type",' \
-           '"temporary_item_type_end_date","general_note","staff_note",' \
-           '"checkin_note","checkout_note","loans_count","checkout_date",' \
-           '"due_date","last_transaction_date","status","created",' \
-           '"issue_status","issue_status_date","issue_claims_count",' \
-           '"issue_expected_date","issue_regular"' in data
+    fields = [
+        'item_pid', 'item_create_date', 'document_pid', 'document_title',
+        'document_creator', 'document_main_type', 'document_sub_type',
+        'document_masked', 'document_isbn', 'document_issn',
+        'document_series_statement', 'document_edition_statement',
+        'document_publication_year', 'document_publisher',
+        'document_local_field_1', 'document_local_field_2',
+        'document_local_field_3', 'document_local_field_4',
+        'document_local_field_5', 'document_local_field_6',
+        'document_local_field_7', 'document_local_field_8',
+        'document_local_field_9', 'document_local_field_10',
+        'item_acquisition_date', 'item_barcode', 'item_call_number',
+        'item_second_call_number', 'item_legacy_checkout_count',
+        'item_type', 'item_library_name', 'item_location_name',
+        'item_pac_code', 'item_holding_pid', 'item_price', 'item_status',
+        'item_item_type', 'item_general_note', 'item_staff_note',
+        'item_checkin_note', 'item_checkout_note', 'item_acquisition_note',
+        'item_binding_note', 'item_condition_note', 'item_patrimonial_note',
+        'item_provenance_note', 'temporary_item_type',
+        'temporary_item_type_expiry_date', 'item_masked',
+        'item_enumerationAndChronology', 'item_local_field_1',
+        'item_local_field_2', 'item_local_field_3', 'item_local_field_4',
+        'item_local_field_5', 'item_local_field_6', 'item_local_field_7',
+        'item_local_field_8', 'item_local_field_9', 'item_local_field_10',
+        'issue_status', 'issue_status_date', 'issue_claims_count',
+        'issue_expected_date', 'issue_regular', 'item_checkouts_count',
+        'item_renewals_count', 'last_transaction_date', 'checkout_date'
+    ]
+    for field in fields:
+        assert field in data
 
 
 def test_loans_serializers(


### PR DESCRIPTION
* Fixes #2704
* Fixes #2793

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

# How to Test:

- run the `Inventory list` report  for a given instance.
- the fields extracted from the `document` record are now prefixed with the string `document_`
- the fields extracted from the `item` record are now prefixed with the string `item_`
- the `local_fields` are now extracted for both `documents` and `items`
- all the fields mentioned in the issue https://github.com/rero/rero-ils/issues/2704 are added
- loan information are correctly extracted according to https://github.com/rero/rero-ils/issues/2793
