### PR TITLE
documents: add interlibrary loan button on global view

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -136,6 +136,10 @@ RERO_ILS_PERSONALIZED_HOMEPAGE_BY_VIEW = False
 RERO_ILS_HOMEPAGE_GENERAL_BLOCK = 'rero_ils/_frontpage_block_test.html'
 RERO_ILS_HOMEPAGE_GENERAL_SLOGAN = 'rero_ils/_frontpage_slogan_test.html'
 
+# ILL Request config
+RERO_ILS_ILL_REQUEST_ON_GLOBAL_VIEW = True
+RERO_ILS_ILL_DEFAULT_SOURCE = 'RERO +'
+
 # Rate limiting
 # =============
 #: Storage for ratelimiter.

--- a/rero_ils/modules/documents/templates/rero_ils/_ill_request_button.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_ill_request_button.html
@@ -1,0 +1,35 @@
+{# -*- coding: utf-8 -*-
+
+  RERO ILS
+  Copyright (C) 2022 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#}
+{% if
+  config.RERO_ILS_ILL_REQUEST_ON_GLOBAL_VIEW
+  and current_user
+  and current_user.is_authenticated
+  and current_patrons|length > 0
+  and viewcode == config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE
+  and not record.harvested
+%}
+  <a
+    id="ill-request-button"
+    class="my-3 btn btn-outline-primary"
+    href="{{ url_for(
+      'ill_requests.ill_request_form',
+      viewcode=viewcode,
+      record_pid=record.pid) }}"
+  >{{ _('interlibrary_loan') | capitalize }}</a>
+{% endif %}

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -287,6 +287,8 @@
             viewcode="{{ viewcode }}"
           ></public-search-holdings>
         {% endif %}
+        <!-- ILL REQUEST ON GLOBAL VIEW-->
+        {% include('rero_ils/_ill_request_button.html') %}
       </section>
       {% endif %}
       <section class="tab-pane container" id="documents-description" role="tabpanel" aria-labelledby="documents-description-tab">

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -89,7 +89,8 @@ def doc_item_view_method(pid, record, template=None, **kwargs):
         record=record,
         holdings_count=holdings_count,
         viewcode=viewcode,
-        recordType='documents'
+        recordType='documents',
+        current_patrons=current_patrons
     )
 
 

--- a/rero_ils/modules/ill_requests/utils.py
+++ b/rero_ils/modules/ill_requests/utils.py
@@ -29,3 +29,42 @@ def get_pickup_location_options():
             location = Location.get_record_by_pid(pid)
             location_name = location.get('pickup_name', location.get('name'))
             yield (location.pid, location_name)
+
+
+def get_production_activity(doc, types=None):
+    """Get document production activity.
+
+    :param: doc: document
+    :param: types: available types of production activity
+    :return: generator production activity object
+    """
+    assert types
+    for activity in doc.get('provisionActivity', []):
+        if activity['type'] in types:
+            yield activity
+
+
+def get_production_activity_statement(production_activity, types=None):
+    """Get production activity statement.
+
+    :param: production_activity: document production activity
+    :param: types: available types of statement
+    :return: generator statement object
+    """
+    assert types
+    for statement in production_activity.get('statement', []):
+        if statement['type'] in types:
+            yield statement
+
+
+def get_document_identifiers(doc, types=None):
+    """Get document identifiers.
+
+    :param: doc: document
+    :param: types: available types of identifiers
+    :returns: generator of ``rero_ils.commons.Identifier`` object
+    """
+    assert types  # ensure a least one type is asked
+    for identifier in doc.get('identifiedBy', []):
+        if identifier['type'] in types:
+            yield identifier

--- a/rero_ils/modules/ill_requests/views.py
+++ b/rero_ils/modules/ill_requests/views.py
@@ -19,13 +19,19 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask import Blueprint, current_app, flash, redirect, render_template, \
+    request, url_for
 from flask_babelex import gettext as _
+
+from rero_ils.modules.documents.api import Document
+from rero_ils.modules.documents.views import create_title_text
 
 from .api import ILLRequest
 from .forms import ILLRequestForm
 from .models import ILLRequestStatus
-from .utils import get_pickup_location_options
+from .utils import get_document_identifiers, get_pickup_location_options, \
+    get_production_activity, get_production_activity_statement
+from ..commons.identifiers import IdentifierType
 from ..decorators import check_logged_as_patron
 from ..locations.api import Location
 from ..patrons.api import current_patrons
@@ -51,6 +57,14 @@ def ill_request_form(viewcode):
     # can't be "calculated" on the form creation (context free).
     form.pickup_location.choices = [
         *form.pickup_location.choices, *list(get_pickup_location_options())]
+
+    # Populate data only if we are on the global view
+    # and that the function is allowed in the configuration
+    if request.method == 'GET' and 'record_pid' in request.args \
+        and current_app.config.get('RERO_ILS_ILL_REQUEST_ON_GLOBAL_VIEW') \
+            and viewcode == current_app.config.get(
+                'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'):
+        _populate_document_data_form(request.args['record_pid'], form)
 
     if request.method == 'POST' and form.validate_on_submit():
         ill_request_data = form.get_data()
@@ -78,3 +92,54 @@ def ill_request_form(viewcode):
 
     return render_template('rero_ils/ill_request_form.html',
                            form=form, viewcode=viewcode)
+
+
+def _populate_document_data_form(doc_pid, form):
+    """Populate document data in the form.
+
+    :param: doc_pid: Document PID.
+    :param: form: The ill form.
+    """
+    doc = Document.get_record_by_pid(doc_pid)
+    if not doc:
+        return
+    # Document title
+    form.document.title.data = create_title_text(doc.get('title'))
+    # Document authors (only first three)
+    statements = doc.get('responsibilityStatement', [])
+    authors = []
+    for statement in statements:
+        authors.extend(author.get('value') for author in statement)
+    if authors:
+        form.document.authors.data = '; '.join(authors[:3])
+    # Document publisher and year
+    types = ['bf:Publication']
+    if production_activity := next(get_production_activity(doc, types), None):
+        # Document date
+        if date := production_activity.get('startDate'):
+            form.document.year.data = date
+            statement_types = ['bf:Agent']
+        # Document publisher
+        if statement := next(get_production_activity_statement(
+            production_activity,
+            statement_types
+        ), None):
+            if label := statement.get('label'):
+                form.document.publisher.data = label[0].get('value')
+    # Document identifier
+    types = [
+        IdentifierType.ISBN, IdentifierType.EAN, IdentifierType.ISSN,
+        IdentifierType.L_ISSN]
+    if identifier := next(get_document_identifiers(doc, types), None):
+        type = _(identifier.get('type'))
+        value = identifier.get('value')
+        form.document.identifier.data = f'{value} ({type})'
+    # Document source
+    form.source.origin.data = current_app.config.get(
+        'RERO_ILS_ILL_DEFAULT_SOURCE')
+    form.source.url.data = url_for(
+        'invenio_records_ui.doc',
+        viewcode=current_app.config.get(
+            'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'),
+        pid_value=doc_pid,
+        _external=True)


### PR DESCRIPTION
* Adds the configuration to hide/show button on global view.
* Adds the populate ill form with record data.
* Closes #2950.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>


### Display of the new ill request on global view

![ill_button](https://user-images.githubusercontent.com/48578/177100502-3b9aba8a-4902-4396-8f26-52882b83e9fb.png)

### Result of populate form with ill button on global view

![ill_request_form](https://user-images.githubusercontent.com/48578/177100739-c828e74b-fe87-47c4-9e82-c65cc4247938.png)

