### PR TITLE
fix: show most used values first in lists

### DIFF
--- a/rero_ils/jsonschemas/common/countries-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/countries-v0.0.1.json
@@ -503,7 +503,8 @@
         },
         {
           "label": "country_be",
-          "value": "be"
+          "value": "be",
+          "preferred": true
         },
         {
           "label": "country_bf",
@@ -779,7 +780,8 @@
         },
         {
           "label": "country_fr",
-          "value": "fr"
+          "value": "fr",
+          "preferred": true
         },
         {
           "label": "country_fs",
@@ -863,7 +865,8 @@
         },
         {
           "label": "country_gw",
-          "value": "gw"
+          "value": "gw",
+          "preferred": true
         },
         {
           "label": "country_gy",
@@ -947,7 +950,8 @@
         },
         {
           "label": "country_it",
-          "value": "it"
+          "value": "it",
+          "preferred": true
         },
         {
           "label": "country_iu",
@@ -1559,7 +1563,8 @@
         },
         {
           "label": "country_sz",
-          "value": "sz"
+          "value": "sz",
+          "preferred": true
         },
         {
           "label": "country_ta",
@@ -1887,7 +1892,8 @@
         },
         {
           "label": "country_xxk",
-          "value": "xxk"
+          "value": "xxk",
+          "preferred": true
         },
         {
           "label": "country_xxr",
@@ -1895,7 +1901,8 @@
         },
         {
           "label": "country_xxu",
-          "value": "xxu"
+          "value": "xxu",
+          "preferred": true
         },
         {
           "label": "country_ye",

--- a/rero_ils/jsonschemas/common/languages-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/languages-v0.0.1.json
@@ -958,7 +958,8 @@
         },
         {
           "label": "lang_dut",
-          "value": "dut"
+          "value": "dut",
+          "preferred": true
         },
         {
           "label": "lang_dyu",
@@ -986,7 +987,8 @@
         },
         {
           "label": "lang_eng",
-          "value": "eng"
+          "value": "eng",
+          "preferred": true
         },
         {
           "label": "lang_enm",
@@ -1042,7 +1044,8 @@
         },
         {
           "label": "lang_fre",
-          "value": "fre"
+          "value": "fre",
+          "preferred": true
         },
         {
           "label": "lang_frm",
@@ -1094,7 +1097,8 @@
         },
         {
           "label": "lang_ger",
-          "value": "ger"
+          "value": "ger",
+          "preferred": true
         },
         {
           "label": "lang_gez",
@@ -1302,7 +1306,8 @@
         },
         {
           "label": "lang_ita",
-          "value": "ita"
+          "value": "ita",
+          "preferred": true
         },
         {
           "label": "lang_jav",


### PR DESCRIPTION
* Show be, gw, fr, it, sz, xxk, xxu first in countries list
* Show dut, eng, fre, ger, ita first in languages list

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
