### PR TITLE
permissions: patron types

### DIFF
--- a/data/role_policies.json
+++ b/data/role_policies.json
@@ -1,0 +1,15 @@
+{
+  "ptty-read": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_ill_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
+  "ptty-write": [
+    "pro_full_permissions"
+  ]
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1678,6 +1678,29 @@ sqlite = ["invenio-db[versioning] (>=1.0.9,<1.1.0)"]
 tests = ["pytest-invenio (>=1.4.1)"]
 
 [[package]]
+name = "invenio-records-permissions"
+version = "0.13.0"
+description = "Permission policies for Invenio records."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+invenio-access = ">=1.4.2,<2.0.0"
+invenio-i18n = ">=1.2.0"
+invenio-records = ">=1.4.0"
+
+[package.extras]
+all = ["Sphinx (>=3)", "pytest-mock (>=1.6.0)", "pytest-invenio (>=1.4.1)", "invenio-accounts (>=1.4.3)", "invenio-app (>=1.3.0)"]
+docs = ["Sphinx (>=3)"]
+elasticsearch6 = ["invenio-search[elasticsearch6] (>=1.4.1,<2.0.0)"]
+elasticsearch7 = ["invenio-search[elasticsearch7] (>=1.4.1,<2.0.0)"]
+mysql = ["invenio-db[mysql,versioning] (>=1.0.9,<2.0.0)"]
+postgresql = ["invenio-db[postgresql,versioning] (>=1.0.9,<2.0.0)"]
+sqlite = ["invenio-db[versioning] (>=1.0.9,<2.0.0)"]
+tests = ["pytest-mock (>=1.6.0)", "pytest-invenio (>=1.4.1)", "invenio-accounts (>=1.4.3)", "invenio-app (>=1.3.0)", "Sphinx (>=3)"]
+
+[[package]]
 name = "invenio-records-rest"
 version = "1.8.0"
 description = "REST API for invenio-records."
@@ -3387,7 +3410,7 @@ sip2 = ["invenio-sip2"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">= 3.9, <3.10"
-content-hash = "144db26f7e2a6c998613e94e046e230233eda2595d0da8a764e0c22154ca41da"
+content-hash = "14b3d303efc48ddbc6723be0830c0ea12183f01d806acc4dfe9d1ebaa197babb"
 
 [metadata.files]
 alabaster = [
@@ -3908,6 +3931,10 @@ invenio-pidstore = [
 invenio-records = [
     {file = "invenio-records-1.6.1.tar.gz", hash = "sha256:8eb0f0343ecb8c6f968e9b66162046131eef34739a33f26b2c16b84f2e987353"},
     {file = "invenio_records-1.6.1-py2.py3-none-any.whl", hash = "sha256:0dafee31de372969be1f56ed672a535b5cd5d0fdf17c8f1a0b37cc0eab79819e"},
+]
+invenio-records-permissions = [
+    {file = "invenio-records-permissions-0.13.0.tar.gz", hash = "sha256:f061be7633f80fac626a5da1f8116b01dfff5146105e7faf12fda9f8241e84bd"},
+    {file = "invenio_records_permissions-0.13.0-py2.py3-none-any.whl", hash = "sha256:381a37b4c6d7f9900fbdc59f81370b0b566a91c5bcf8bacf763abe088c353437"},
 ]
 invenio-records-rest = [
     {file = "invenio-records-rest-1.8.0.tar.gz", hash = "sha256:70ba741f19f8c9a1ae14a700d82c632175e881fd786ffdc4692f2718482e8dd1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ flask-wiki = {git = "https://github.com/rero/flask-wiki.git", rev = "v0.2.1"}
 pytest-invenio = ">=1.4.0,<1.4.12"
 # to avoid conflict for urllib3
 sentry-sdk = "<1.6.1"
+invenio-records-permissions = "^0.13.0"
 
 [tool.poetry.dev-dependencies]
 ## Python packages development dependencies (order matters)
@@ -399,6 +400,10 @@ patrons = "rero_ils.modules.patrons.mappings"
 stats = "rero_ils.modules.stats.mappings"
 templates = "rero_ils.modules.templates.mappings"
 vendors = "rero_ils.modules.vendors.mappings"
+
+[tool.poetry.plugins."invenio_access.actions"]
+ptty_read = "rero_ils.modules.patron_types.permissions:ptty_read"
+ptty_write = "rero_ils.modules.patron_types.permissions:ptty_write"
 
 [tool.poetry.plugins."invenio_search.templates"]
 operation_logs = "rero_ils.modules.operation_logs.es_templates:list_es_templates"

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -105,7 +105,7 @@ from .modules.patron_transactions.api import PatronTransaction
 from .modules.patron_transactions.permissions import \
     PatronTransactionPermission
 from .modules.patron_types.api import PatronType
-from .modules.patron_types.permissions import PatronTypePermission
+from .modules.patron_types.permissions import PatronTypePermissionPolicy
 from .modules.patrons.api import Patron
 from .modules.patrons.models import CommunicationChannel
 from .modules.patrons.permissions import PatronPermission
@@ -1074,16 +1074,11 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp='rero_ils.query:organisation_search_factory',
-        list_permission_factory_imp=lambda record: record_permission_factory(
-            action='list', record=record, cls=PatronTypePermission),
-        read_permission_factory_imp=lambda record: record_permission_factory(
-            action='read', record=record, cls=PatronTypePermission),
-        create_permission_factory_imp=lambda record: record_permission_factory(
-            action='create', record=record, cls=PatronTypePermission),
-        update_permission_factory_imp=lambda record: record_permission_factory(
-            action='update', record=record, cls=PatronTypePermission),
-        delete_permission_factory_imp=lambda record: record_permission_factory(
-            action='delete', record=record, cls=PatronTypePermission)
+        list_permission_factory_imp=lambda record: PatronTypePermissionPolicy('search', record=record),
+        read_permission_factory_imp=lambda record: PatronTypePermissionPolicy('read', record=record),
+        create_permission_factory_imp=lambda record: PatronTypePermissionPolicy('create', record=record),
+        update_permission_factory_imp=lambda record: PatronTypePermissionPolicy('update', record=record),
+        delete_permission_factory_imp=lambda record: PatronTypePermissionPolicy('delete', record=record)
     ),
     org=dict(
         pid_type='org',

--- a/rero_ils/modules/cli/fixtures.py
+++ b/rero_ils/modules/cli/fixtures.py
@@ -30,6 +30,8 @@ from uuid import uuid4
 import click
 from flask import current_app
 from flask.cli import with_appcontext
+from invenio_access import current_access
+from invenio_access.models import ActionRoles, Role
 from invenio_db import db
 from invenio_jsonschemas.proxies import current_jsonschemas
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
@@ -74,6 +76,33 @@ fixtures.add_command(create_collections)
 fixtures.add_command(create_operation_logs)
 fixtures.add_command(dump_operation_logs)
 fixtures.add_command(destroy_operation_logs)
+
+
+def load_role_policies(data):
+    """Set the action roles policies.
+
+    :param data: dictionary configuration
+    :return: True if success
+    """
+    for action_name, role_names in data.items():
+        action = current_access.actions.get(action_name)
+        for role_name in role_names:
+            role = Role.query.filter(Role.name == role_name).first()
+            db.session.add(ActionRoles.allow(action, role=role))
+    db.session.commit()
+    return True
+
+
+@fixtures.command('import_role_policies')
+@with_appcontext
+@click.argument('infile', type=click.File('r'), default=sys.stdin)
+def import_role_policies(infile):
+    """Import the action roles policies.
+
+    :param infile: Json file
+    """
+    if load_role_policies(json.load(infile)):
+        click.secho('Success', fg='green')
 
 
 @fixtures.command('create')

--- a/rero_ils/modules/patron_types/permissions.py
+++ b/rero_ils/modules/patron_types/permissions.py
@@ -18,78 +18,23 @@
 
 """Permissions for patron types."""
 
-from rero_ils.modules.patrons.api import current_librarian
-from rero_ils.modules.permissions import RecordPermission
+from invenio_access import action_factory
+
+from rero_ils.modules.permissions import AllowedByAction, \
+    LibrarianWithTheSameOrganisation, RecordPermissionPolicy
+
+ptty_read = action_factory('ptty-read')
+ptty_write = action_factory('ptty-write')
 
 
-class PatronTypePermission(RecordPermission):
-    """Patron types permissions."""
+class PatronTypePermissionPolicy(RecordPermissionPolicy):
+    """Patron Type Permission Policy.
 
-    @classmethod
-    def list(cls, user, record=None):
-        """List permission check.
+    Used by the CRUD operations.
+    """
 
-        :param user: Logged user.
-        :param record: Record to check.
-        :return: True is action can be done.
-        """
-        # Operation allowed only for staff members (lib, sys_lib)
-        return bool(current_librarian)
-
-    @classmethod
-    def read(cls, user, record):
-        """Read permission check.
-
-        :param user: Logged user.
-        :param record: Record to check.
-        :return: True is action can be done.
-        """
-        # Check the user is authenticated and a record exists as param.
-        if not record or not current_librarian:
-            return False
-        # Check if record correspond to user owning organisation and that user
-        # is (at least) a librarian
-        return current_librarian.organisation_pid == record.organisation_pid
-
-    @classmethod
-    def create(cls, user, record=None):
-        """Create permission check.
-
-        :param user: Logged user.
-        :param record: Record to check.
-        :return: True is action can be done.
-        """
-        # only system_librarian can create patron types ...
-        if not current_librarian or not current_librarian.has_full_permissions:
-            return False
-        # ... only for its own organisation
-        if record:
-            return current_librarian.organisation_pid == \
-                record.organisation_pid
-        return True
-
-    @classmethod
-    def update(cls, user, record):
-        """Update permission check.
-
-        :param user: Logged user.
-        :param record: Record to check.
-        :return: True is action can be done.
-        """
-        if not record:
-            return False
-        # same as create
-        return cls.create(user, record)
-
-    @classmethod
-    def delete(cls, user, record):
-        """Delete permission check.
-
-        :param user: Logged user.
-        :param record: Record to check.
-        :return: True if action can be done.
-        """
-        if not record:
-            return False
-        # same as create
-        return cls.create(user, record)
+    can_search = [AllowedByAction('ptty-read')]
+    can_read = [LibrarianWithTheSameOrganisation('ptty-read')]
+    can_create = [LibrarianWithTheSameOrganisation('ptty-write')]
+    can_update = [LibrarianWithTheSameOrganisation('ptty-write')]
+    can_delete = [LibrarianWithTheSameOrganisation('ptty-write')]

--- a/scripts/setup
+++ b/scripts/setup
@@ -249,6 +249,9 @@ eval ${PREFIX} "invenio roles create -d 'Professional: User manager' pro_user_ma
 eval ${PREFIX} "invenio roles create -d 'Documentation Editor' editor"
 eval ${PREFIX} "invenio roles create -d 'Document Importing' document_importer"
 
+info_msg "Create action roles policies"
+eval ${PREFIX} "invenio reroils fixtures import_role_policies data/role_policies.json"
+
 # create users
 info_msg "Create users"
 eval ${PREFIX} invenio users create -a admin@rero.ch --password administrator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,13 @@ def data():
 
 
 @pytest.fixture(scope="module")
+def role_policies_data():
+    """Load fixture role policies data file."""
+    with open(join(dirname(__file__), 'data/role_policies.json')) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
 def acquisition():
     """Load fixture acquisition file."""
     with open(join(dirname(__file__), 'data/acquisition.json')) as f:

--- a/tests/data/role_policies.json
+++ b/tests/data/role_policies.json
@@ -1,0 +1,14 @@
+{
+  "ptty-read": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
+  "ptty-write": [
+    "pro_full_permissions"
+  ]
+}


### PR DESCRIPTION
* Uses invenio-records-permmissions for CRUD operations.
* Adds a generic record permission policy compatible with
  invenio-records-rest and invenio-records-resources.
* Adds actions for patron types.
* Adds fixtures and the corresponding cli to the action roles
  permissions.
* Adds two generic permission generators for action role permissions.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

This is a first PR to use action to manage user role permission for CRUD operations. It use https://github.com/inveniosoftware/invenio-records-permissions especially the use of policies and permission generator.

Please pay attention to your review as this will becomes a reference for other resources.

__Note:__  the row of the specification file correspond to the actions and the columns to the roles.

## Why are you opening this PR?

- To implement: https://github.com/rero/rero-ils/issues/2779
