### PR TITLE
search: add default analyzer

### DIFF
--- a/rero_ils/modules/contributions/mappings/v7/contributions/contribution-v0.0.1.json
+++ b/rero_ils/modules/contributions/mappings/v7/contributions/contribution-v0.0.1.json
@@ -108,6 +108,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },
@@ -214,6 +217,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },
@@ -320,6 +326,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -37,7 +37,6 @@
             "properties": {
               "value": {
                 "type": "text",
-                "copy_to": "autocomplete_title",
                 "index": false
               },
               "language": {
@@ -100,6 +99,7 @@
           "_text": {
             "type": "text",
             "index": false,
+            "copy_to": "autocomplete_title",
             "fields": {
               "eng": {
                 "type": "text",
@@ -116,6 +116,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },
@@ -138,6 +141,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           }
@@ -472,6 +478,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },
@@ -553,6 +562,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           }
@@ -674,6 +686,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },
@@ -771,6 +786,9 @@
               "ita": {
                 "type": "text",
                 "analyzer": "italian"
+              },
+              "text": {
+                "type": "text"
               }
             }
           },

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -76,7 +76,7 @@ def doc_title_travailleurs(app):
             'mainTitle': [{
                 'value': 'Les travailleurs assidus sont de retours'
             }],
-            'subtitle': [{'value': 'les jeunes arrivent bientôt ?'}]
+            'subtitle': [{'value': 'les jeunes arrivent bientôt ? Quelle histoire!'}]
         }],
         "provisionActivity": [
           {

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -296,6 +296,15 @@ def test_document_search(
     hits = get_json(res)['hits']
     assert hits['total']['value'] == 0
 
+    # wildcard
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q='histoire*',
+        simple='1'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total']['value'] == 1
 
 def test_patrons_search(
         client,


### PR DESCRIPTION
Some tems such as "histoire" does not works well with a wildcard "*".
If a field is analyzed only with languages analyzer the wildcard is
applied only after the stemming process: "histore*" becomes "histoir*"
and thus does not match "histoire" terms. Adding the default analyzer
solve the problem.

* Adds default analyzer to language analzed fields.

Data Migration Instructions:

* run `poetry run invenio reroils index update_mapping -s -a contributions -a documents`.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
