### PR TITLE
notifications: at desk notification gets cancelled

### DIFF
--- a/rero_ils/modules/notifications/subclasses/at_desk.py
+++ b/rero_ils/modules/notifications/subclasses/at_desk.py
@@ -84,7 +84,11 @@ class AtDeskCirculationNotification(InternalCirculationNotification):
     @classmethod
     def get_notification_context(cls, notifications=None):
         """Get the context to render the notification template."""
-        context = {}
+        # Use a delay to be sure the notification is sent AFTER the loan has
+        # been indexed (avoid problem due to server load).
+        context = {
+            'delay': 30
+        }
         notifications = notifications or []
         if not notifications:
             return context


### PR DESCRIPTION
Use a delay to be sure the notification is sent AFTER the loan has
been indexed (avoid problem due to server load).

* Adds a delay before notification sent.
* Closes #3005.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
