### PR TITLE
tests: fix tests for the new pydocstyle version

### DIFF
--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -1310,7 +1310,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
         if (self.date_type_from_008 == 'q' or self.date_type_from_008 == 'n'):
             self.date['note'] = 'Date(s) uncertain or unknown'
         start_date = make_year(self.date1_from_008)
-        if not(start_date and start_date >= -9999 and start_date <= 2050):
+        if not (start_date and start_date >= -9999 and start_date <= 2050):
             start_date = None
         if not start_date:
             fields_264 = self.get_fields('264')

--- a/rero_ils/modules/cli/utils.py
+++ b/rero_ils/modules/cli/utils.py
@@ -1250,7 +1250,7 @@ def check_pid_dependencies(dependency_file, directory, verbose):
                 sublist = dependency.get('sublist', [])
                 for sub in sublist:
                     datas = self.record.get(dependency['name'], [])
-                    if not(datas or dependency.get('optional')):
+                    if not (datas or dependency.get('optional')):
                         click.secho(
                             f'{self.name}: sublist not found: '
                             f'{dependency["name"]}',

--- a/rero_ils/modules/holdings/api_views.py
+++ b/rero_ils/modules/holdings/api_views.py
@@ -64,20 +64,15 @@ def jsonify_error(func):
         try:
             return func(*args, **kwargs)
         except (Unauthorized, NotFound) as error:
-            raise(error)
-        except TemplateSyntaxError as error:
-            return jsonify({'status': 'error: {error}'.format(
-                error=error)}), 400
-        except UndefinedError as error:
-            return jsonify({'status': 'error: {error}'.format(
-                error=error)}), 400
+            raise error
+        except (TemplateSyntaxError, UndefinedError) as error:
+            return jsonify(
+                {'status': 'error: {error}'.format(error=error)}), 400
         except Exception as error:
-            # uncomment for debug:
-            # raise(errqor)
             current_app.logger.error(str(error))
             db.session.rollback()
-            return jsonify({'status': 'error: {error}'.format(
-                error=error)}), 500
+            return jsonify(
+                {'status': 'error: {error}'.format(error=error)}), 500
     return decorated_view
 
 

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -220,7 +220,7 @@ class Loan(IlsRecord):
             current_app.config['CIRCULATION_LOAN_INITIAL_STATE']
         )
         if delete_pid and data.get(cls.pid_field):
-            del(data[cls.pid_field])
+            del data[cls.pid_field]
         cls._loan_build_org_ref(data)
         # set the field to_anonymize
         data['to_anonymize'] = \

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -259,7 +259,7 @@ def test_holding_pattern_preview_api(
     assert len(issues) == 15
 
     # test invalid patterns
-    del(patterns['values'])
+    del patterns['values']
     res, data = postdata(
         client,
         'api_holding.pattern_preview',

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -257,7 +257,7 @@ def test_notifications_get(
 
     result = data['hits']['hits'][0]['metadata']
     # organisation has been added during the indexing
-    del(result['organisation'])
+    del result['organisation']
     assert result == record.replace_refs()
 
     record.delete(dbcommit=True, delindex=True)
@@ -773,7 +773,7 @@ def test_request_notifications_temp_item_type(
     assert res.status_code == 200
     mailbox.clear()
 
-    del(item_lib_martigny['temporary_item_type'])
+    del item_lib_martigny['temporary_item_type']
     item_lib_martigny.update(item_lib_martigny, dbcommit=True, reindex=True)
 
 

--- a/tests/api/patron_transaction_events/test_patron_transaction_events_rest.py
+++ b/tests/api/patron_transaction_events/test_patron_transaction_events_rest.py
@@ -101,8 +101,8 @@ def test_patron_transaction_events_get(
     assert res.status_code == 200
     data = get_json(res)
     result = data['hits']['hits'][0]['metadata']
-    del(result['organisation'])
-    del(result['patron'])
+    del result['organisation']
+    del result['patron']
     assert result == patron_event.replace_refs()
 
 

--- a/tests/api/patron_transactions/test_patron_transactions_rest.py
+++ b/tests/api/patron_transactions/test_patron_transactions_rest.py
@@ -107,9 +107,9 @@ def test_patron_transactions_get(client, patron_transaction_overdue_martigny):
     assert res.status_code == 200
     data = get_json(res)
     result = data['hits']['hits'][0]['metadata']
-    del(result['document'])
-    del(result['library'])
-    del(result['item'])
+    del result['document']
+    del result['library']
+    del result['item']
     assert result == transaction.replace_refs()
 
 

--- a/tests/api/patron_types/test_patron_types_rest.py
+++ b/tests/api/patron_types/test_patron_types_rest.py
@@ -329,7 +329,7 @@ def test_patron_types_subscription(
     patron_type_youngsters_sion['subscription_amount'] = 0
     assert not patron_type_youngsters_sion.is_subscription_required
 
-    del(patron_type_youngsters_sion['subscription_amount'])
+    del patron_type_youngsters_sion['subscription_amount']
     assert not patron_type_youngsters_sion.is_subscription_required
 
     # Test the 'get_yearly_subscription_patron_types' function.

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -271,7 +271,7 @@ def test_patrons_get(client, librarian_martigny):
     data = get_json(res)
     result = data['hits']['hits'][0]['metadata']
     # organisation has been added during the indexing
-    del(result['organisation'])
+    del result['organisation']
     assert result == patron.replace_refs().dumps()
 
 

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -94,7 +94,7 @@ def test_holding_extended_validation(client,
 
     # 1.1. test next expected date for regular frequencies
     expected_date = holding_tmp['patterns']['next_expected_date']
-    del(holding_tmp['patterns']['next_expected_date'])
+    del holding_tmp['patterns']['next_expected_date']
     with pytest.raises(ValidationError):
         holding_tmp.validate()
 


### PR DESCRIPTION
The new version of pydocstyle is more strict and returns an error when
the `del` statement is used as a function.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
