### PR TITLE
serialization: fix caching reset problem

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -718,7 +718,7 @@ RECORDS_REST_ENDPOINTS = dict(
         indexer_class='rero_ils.modules.items.api:ItemsIndexer',
         record_serializers={
             'application/json': 'rero_ils.modules.serializers:json_v1_response',
-            'application/rero+json': 'rero_ils.modules.items.serializers:json_item_search'
+            'application/rero+json': 'rero_ils.modules.items.serializers:json_item_response'
         },
         search_serializers_aliases={
             'json': 'application/json',

--- a/rero_ils/modules/acq_invoices/serializers.py
+++ b/rero_ils/modules/acq_invoices/serializers.py
@@ -17,11 +17,11 @@
 
 """Acquisition invoice serialization."""
 
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+from invenio_records_rest.serializers.response import record_responsify
 
 from rero_ils.modules.libraries.api import LibrariesSearch
-from rero_ils.modules.serializers import ACQJSONSerializer, RecordSchemaJSONV1
+from rero_ils.modules.serializers import ACQJSONSerializer, JSONSerializer, \
+    RecordSchemaJSONV1, search_responsify
 
 
 class AcquisitionInvoiceJSONSerializer(ACQJSONSerializer):
@@ -29,7 +29,7 @@ class AcquisitionInvoiceJSONSerializer(ACQJSONSerializer):
 
     def _postprocess_search_aggregations(self, aggregations: dict) -> None:
         """Post-process aggregations from a search result."""
-        ACQJSONSerializer.enrich_bucket_with_data(
+        JSONSerializer.enrich_bucket_with_data(
             aggregations.get('library', {}).get('buckets', []),
             LibrariesSearch, 'name'
         )

--- a/rero_ils/modules/acq_orders/serializers.py
+++ b/rero_ils/modules/acq_orders/serializers.py
@@ -17,12 +17,12 @@
 
 """Acquisition order serialization."""
 
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+from invenio_records_rest.serializers.response import record_responsify
 
 from rero_ils.modules.acq_accounts.api import AcqAccountsSearch
 from rero_ils.modules.libraries.api import LibrariesSearch
-from rero_ils.modules.serializers import ACQJSONSerializer, RecordSchemaJSONV1
+from rero_ils.modules.serializers import ACQJSONSerializer, JSONSerializer, \
+    RecordSchemaJSONV1, search_responsify
 from rero_ils.modules.vendors.api import VendorsSearch
 
 
@@ -31,15 +31,15 @@ class AcqOrderJSONSerializer(ACQJSONSerializer):
 
     def _postprocess_search_aggregations(self, aggregations: dict) -> None:
         """Post-process aggregations from a search result."""
-        self.enrich_bucket_with_data(
+        JSONSerializer.enrich_bucket_with_data(
             aggregations.get('library', {}).get('buckets', []),
             LibrariesSearch, 'name'
         )
-        self.enrich_bucket_with_data(
+        JSONSerializer.enrich_bucket_with_data(
             aggregations.get('vendor', {}).get('buckets', []),
             VendorsSearch, 'name'
         )
-        self.enrich_bucket_with_data(
+        JSONSerializer.enrich_bucket_with_data(
             aggregations.get('account', {}).get('buckets', []),
             AcqAccountsSearch, 'name'
         )

--- a/rero_ils/modules/acq_receipt_lines/serializers.py
+++ b/rero_ils/modules/acq_receipt_lines/serializers.py
@@ -18,12 +18,12 @@
 
 """Acquisition receipt line serialization."""
 
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+from invenio_records_rest.serializers.response import record_responsify
 
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.dumpers import DocumentAcquisitionDumper
-from rero_ils.modules.serializers import ACQJSONSerializer, RecordSchemaJSONV1
+from rero_ils.modules.serializers import ACQJSONSerializer, \
+    RecordSchemaJSONV1, search_responsify
 
 
 class AcqReceiptLineJSONSerializer(ACQJSONSerializer):

--- a/rero_ils/modules/collections/serializers.py
+++ b/rero_ils/modules/collections/serializers.py
@@ -17,10 +17,9 @@
 
 """Collection serialization."""
 
-from invenio_records_rest.serializers.response import search_responsify
-
 from rero_ils.modules.libraries.api import LibrariesSearch
-from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1
+from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1, \
+    search_responsify
 
 
 class CollectionJSONSerializer(JSONSerializer):

--- a/rero_ils/modules/documents/serializers/__init__.py
+++ b/rero_ils/modules/documents/serializers/__init__.py
@@ -18,8 +18,7 @@
 
 """RERO Document serialization."""
 
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+from invenio_records_rest.serializers.response import record_responsify
 
 from rero_ils.modules.documents.serializers.dc import DublinCoreSerializer
 from rero_ils.modules.documents.serializers.json import \
@@ -28,7 +27,7 @@ from rero_ils.modules.documents.serializers.marc import \
     DocumentMARCXMLSerializer, DocumentMARCXMLSRUSerializer
 from rero_ils.modules.documents.serializers.ris import RISSerializer
 from rero_ils.modules.serializers import RecordSchemaJSONV1, \
-    record_responsify_file, search_responsify_file
+    record_responsify_file, search_responsify, search_responsify_file
 
 # Serializers
 # ===========

--- a/rero_ils/modules/holdings/serializers.py
+++ b/rero_ils/modules/holdings/serializers.py
@@ -17,13 +17,11 @@
 
 """Holdings serialization."""
 
-from invenio_records_rest.serializers.response import search_responsify
-
 from rero_ils.modules.item_types.api import ItemType
 from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.serializers import CachedDataSerializerMixin, \
-    JSONSerializer, RecordSchemaJSONV1
+    JSONSerializer, RecordSchemaJSONV1, search_responsify
 
 from .api import Holding
 

--- a/rero_ils/modules/ill_requests/serializers.py
+++ b/rero_ils/modules/ill_requests/serializers.py
@@ -17,13 +17,12 @@
 
 """ILL Request serialization."""
 
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+from invenio_records_rest.serializers.response import record_responsify
 
 from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.serializers import CachedDataSerializerMixin, \
-    JSONSerializer, RecordSchemaJSONV1
+    JSONSerializer, RecordSchemaJSONV1, search_responsify
 
 
 class ILLRequestJSONSerializer(JSONSerializer, CachedDataSerializerMixin):

--- a/rero_ils/modules/imports/serializers/__init__.py
+++ b/rero_ils/modules/imports/serializers/__init__.py
@@ -18,7 +18,7 @@
 
 """Import serialization."""
 
-from invenio_records_rest.serializers.response import search_responsify
+from rero_ils.modules.serializers import search_responsify
 
 from .response import record_responsify
 from .serializers import ImportSchemaJSONV1, ImportsMarcSearchSerializer, \

--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -16,11 +16,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Items serializers."""
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+
+from invenio_records_rest.serializers.response import record_responsify
 
 from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1, \
-    search_responsify_file
+    search_responsify, search_responsify_file
 
 from .csv import ItemCSVSerializer
 from .json import ItemsJSONSerializer

--- a/rero_ils/modules/items/serializers/json.py
+++ b/rero_ils/modules/items/serializers/json.py
@@ -63,7 +63,7 @@ class ItemsJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
            and 'pid' in temp_loc:
             temp_loc_pid = temp_loc['pid']
             temp_loc['name'] = self\
-                .get_resource(LocationsSearch, temp_loc_pid).get('name')
+                .get_resource(LocationsSearch(), temp_loc_pid).get('name')
 
         # Organisation
         org_pid = metadata['organisation']['pid']

--- a/rero_ils/modules/loans/serializers/__init__.py
+++ b/rero_ils/modules/loans/serializers/__init__.py
@@ -17,10 +17,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """RERO-ILS Loan resource serializers."""
-from invenio_records_rest.serializers import search_responsify
-
 from rero_ils.modules.serializers import RecordSchemaJSONV1, \
-    search_responsify_file
+    search_responsify, search_responsify_file
 
 from .csv import LoanStreamedCSVSerializer
 from .json import LoanJSONSerializer

--- a/rero_ils/modules/operation_logs/serializers.py
+++ b/rero_ils/modules/operation_logs/serializers.py
@@ -16,12 +16,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Operation Logs serialization."""
-from invenio_records_rest.serializers.response import search_responsify
-
 from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.serializers import CachedDataSerializerMixin, \
-    JSONSerializer, RecordSchemaJSONV1
+    JSONSerializer, RecordSchemaJSONV1, search_responsify
 
 
 class OperationLogsJSONSerializer(JSONSerializer, CachedDataSerializerMixin):

--- a/rero_ils/modules/patron_transaction_events/serializers.py
+++ b/rero_ils/modules/patron_transaction_events/serializers.py
@@ -17,11 +17,9 @@
 
 """Patron transactions serialization."""
 
-from invenio_records_rest.serializers.response import search_responsify
-
 from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.serializers import CachedDataSerializerMixin, \
-    JSONSerializer, RecordSchemaJSONV1
+    JSONSerializer, RecordSchemaJSONV1, search_responsify
 
 
 class PatronTransactionEventsJSONSerializer(JSONSerializer,

--- a/rero_ils/modules/patron_transactions/serializers.py
+++ b/rero_ils/modules/patron_transactions/serializers.py
@@ -17,13 +17,11 @@
 
 """Patron transactions serialization."""
 
-from invenio_records_rest.serializers.response import search_responsify
-
 from rero_ils.modules.documents.api import DocumentsSearch
 from rero_ils.modules.items.api.api import Item
 from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.serializers import CachedDataSerializerMixin, \
-    JSONSerializer, RecordSchemaJSONV1
+    JSONSerializer, RecordSchemaJSONV1, search_responsify
 
 
 class PatronTransactionsJSONSerializer(JSONSerializer,
@@ -38,7 +36,7 @@ class PatronTransactionsJSONSerializer(JSONSerializer,
         metadata = hit.get('metadata', {})
         # Serialize document (if exists)
         document_pid = metadata.get('document', {}).get('pid')
-        if document := self.get_resource(DocumentsSearch, document_pid):
+        if document := self.get_resource(DocumentsSearch(), document_pid):
             metadata['document'] = document
         # Serialize loan & item
         loan_pid = metadata.get('loan', {}).get('pid')

--- a/rero_ils/modules/patrons/serializers.py
+++ b/rero_ils/modules/patrons/serializers.py
@@ -17,10 +17,9 @@
 
 """Patrons serialization."""
 
-from invenio_records_rest.serializers.response import search_responsify
-
 from rero_ils.modules.patron_types.api import PatronTypesSearch
-from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1
+from rero_ils.modules.serializers import JSONSerializer, RecordSchemaJSONV1, \
+    search_responsify
 
 
 class PatronJSONSerializer(JSONSerializer):

--- a/rero_ils/modules/serializers/__init__.py
+++ b/rero_ils/modules/serializers/__init__.py
@@ -18,12 +18,14 @@
 
 """RERO ILS Record serialization."""
 
-from invenio_records_rest.serializers.response import record_responsify, \
-    search_responsify
+from invenio_records_rest.serializers.response import record_responsify
+from invenio_records_rest.serializers.response import \
+    search_responsify as _search_responsify
 
 from .base import ACQJSONSerializer, JSONSerializer
 from .mixins import CachedDataSerializerMixin, StreamSerializerMixin
-from .response import record_responsify_file, search_responsify_file
+from .response import record_responsify_file, search_responsify, \
+    search_responsify_file
 from .schema import RecordSchemaJSONV1
 
 __all__ = [
@@ -35,11 +37,12 @@ __all__ = [
     'json_v1',
     'json_v1_search',
     'json_v1_response',
+    'search_responsify',
     'search_responsify_file',
     'record_responsify_file'
 ]
 
 
 json_v1 = JSONSerializer(RecordSchemaJSONV1)
-json_v1_search = search_responsify(json_v1, 'application/json')
+json_v1_search = _search_responsify(json_v1, 'application/json')
 json_v1_response = record_responsify(json_v1, 'application/json')


### PR DESCRIPTION
As the serializer object is instancied once during the initialization of
the application, the cache was never reset. This PR introduce a new
method to serialize search where the serializer object is reset for each
serialization request ; so the cache will reset.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
