### PR TITLE
permissions: refactoring organisation policy

### DIFF
--- a/data/role_policies.json
+++ b/data/role_policies.json
@@ -1,15 +1,50 @@
 {
+  "ptty-search": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
   "ptty-read": [
     "pro_full_permissions",
     "pro_read_only",
     "pro_catalog_manager",
     "pro_circulation_manager",
-    "pro_ill_manager",
     "pro_user_manager",
     "pro_acquisition_manager",
     "pro_library_administrator"
   ],
-  "ptty-write": [
+  "ptty-create": [
+    "pro_full_permissions"
+  ],
+  "ptty-update": [
+    "pro_full_permissions"
+  ],
+  "ptty-delete": [
+    "pro_full_permissions"
+  ],
+  "org-search": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
+  "org-read": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
+  "org-update": [
     "pro_full_permissions"
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -402,8 +402,16 @@ templates = "rero_ils.modules.templates.mappings"
 vendors = "rero_ils.modules.vendors.mappings"
 
 [tool.poetry.plugins."invenio_access.actions"]
-ptty_read = "rero_ils.modules.patron_types.permissions:ptty_read"
-ptty_write = "rero_ils.modules.patron_types.permissions:ptty_write"
+ptty_search = "rero_ils.modules.patron_types.permissions:search_action"
+ptty_read = "rero_ils.modules.patron_types.permissions:read_action"
+ptty_create = "rero_ils.modules.patron_types.permissions:create_action"
+ptty_update = "rero_ils.modules.patron_types.permissions:update_action"
+ptty_delete = "rero_ils.modules.patron_types.permissions:delete_action"
+org_search = "rero_ils.modules.organisations.permissions:search_action"
+org_read = "rero_ils.modules.organisations.permissions:read_action"
+org_create = "rero_ils.modules.organisations.permissions:create_action"
+org_update = "rero_ils.modules.organisations.permissions:update_action"
+org_delete = "rero_ils.modules.organisations.permissions:delete_action"
 
 [tool.poetry.plugins."invenio_search.templates"]
 operation_logs = "rero_ils.modules.operation_logs.es_templates:list_es_templates"

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -97,7 +97,7 @@ from .modules.notifications.permissions import NotificationPermission
 from .modules.operation_logs.api import OperationLog
 from .modules.operation_logs.permissions import OperationLogPermission
 from .modules.organisations.api import Organisation
-from .modules.organisations.permissions import OrganisationPermission
+from .modules.organisations.permissions import OrganisationPermissionPolicy
 from .modules.patron_transaction_events.api import PatronTransactionEvent
 from .modules.patron_transaction_events.permissions import \
     PatronTransactionEventPermission
@@ -1110,16 +1110,11 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=MAX_RESULT_WINDOW,
         search_factory_imp=('rero_ils.query:'
                             'organisation_organisation_search_factory'),
-        list_permission_factory_imp=lambda record: record_permission_factory(
-            action='list', record=record, cls=OrganisationPermission),
-        read_permission_factory_imp=lambda record: record_permission_factory(
-            action='read', record=record, cls=OrganisationPermission),
-        create_permission_factory_imp=lambda record: record_permission_factory(
-            action='create', record=record, cls=OrganisationPermission),
-        update_permission_factory_imp=lambda record: record_permission_factory(
-            action='update', record=record, cls=OrganisationPermission),
-        delete_permission_factory_imp=lambda record: record_permission_factory(
-            action='delete', record=record, cls=OrganisationPermission)
+        list_permission_factory_imp=lambda record: OrganisationPermissionPolicy('search', record=record),
+        read_permission_factory_imp=lambda record: OrganisationPermissionPolicy('read', record=record),
+        create_permission_factory_imp=lambda record: OrganisationPermissionPolicy('create', record=record),
+        update_permission_factory_imp=lambda record: OrganisationPermissionPolicy('update', record=record),
+        delete_permission_factory_imp=lambda record: OrganisationPermissionPolicy('delete', record=record)
     ),
     lib=dict(
         pid_type='lib',

--- a/rero_ils/modules/patron_types/permissions.py
+++ b/rero_ils/modules/patron_types/permissions.py
@@ -17,24 +17,23 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Permissions for patron types."""
-
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    LibrarianWithTheSameOrganisation, RecordPermissionPolicy
+    AllowedByActionRestrictByOrganisation, RecordPermissionPolicy
 
-ptty_read = action_factory('ptty-read')
-ptty_write = action_factory('ptty-write')
+search_action = action_factory('ptty-search')
+read_action = action_factory('ptty-read')
+create_action = action_factory('ptty-create')
+update_action = action_factory('ptty-update')
+delete_action = action_factory('ptty-delete')
 
 
 class PatronTypePermissionPolicy(RecordPermissionPolicy):
-    """Patron Type Permission Policy.
+    """Patron Type Permission Policy used by the CRUD operations."""
 
-    Used by the CRUD operations.
-    """
-
-    can_search = [AllowedByAction('ptty-read')]
-    can_read = [LibrarianWithTheSameOrganisation('ptty-read')]
-    can_create = [LibrarianWithTheSameOrganisation('ptty-write')]
-    can_update = [LibrarianWithTheSameOrganisation('ptty-write')]
-    can_delete = [LibrarianWithTheSameOrganisation('ptty-write')]
+    can_search = [AllowedByAction(search_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
+    can_create = [AllowedByActionRestrictByOrganisation(create_action)]
+    can_update = [AllowedByActionRestrictByOrganisation(update_action)]
+    can_delete = [AllowedByActionRestrictByOrganisation(delete_action)]

--- a/tests/data/role_policies.json
+++ b/tests/data/role_policies.json
@@ -1,4 +1,13 @@
 {
+  "ptty-search": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
   "ptty-read": [
     "pro_full_permissions",
     "pro_read_only",
@@ -8,7 +17,34 @@
     "pro_acquisition_manager",
     "pro_library_administrator"
   ],
-  "ptty-write": [
+  "ptty-create": [
+    "pro_full_permissions"
+  ],
+  "ptty-update": [
+    "pro_full_permissions"
+  ],
+  "ptty-delete": [
+    "pro_full_permissions"
+  ],
+  "org-search": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
+  "org-read": [
+    "pro_full_permissions",
+    "pro_read_only",
+    "pro_catalog_manager",
+    "pro_circulation_manager",
+    "pro_user_manager",
+    "pro_acquisition_manager",
+    "pro_library_administrator"
+  ],
+  "org-update": [
     "pro_full_permissions"
   ]
 }


### PR DESCRIPTION
* Refactoring Organisation policy access using `Permission` framework.
* Adapts `PatronType` policy.
* Adapts unitest

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
