### PR TITLE
serialization: fix again caching behavior

### DIFF
--- a/rero_ils/modules/serializers/mixins.py
+++ b/rero_ils/modules/serializers/mixins.py
@@ -106,6 +106,10 @@ class CachedDataSerializerMixin:
         self._resources = {}
         self._limit = limit
 
+    def reset(self):
+        """Resetting the cache."""
+        self._resources.clear()
+
     def append(self, key, resource):
         """Append a resource into the cache.
 

--- a/rero_ils/modules/serializers/response.py
+++ b/rero_ils/modules/serializers/response.py
@@ -22,7 +22,6 @@ Responsible for creating an HTTP response given the output of a serializer.
 """
 from __future__ import absolute_import, print_function
 
-from copy import deepcopy
 from datetime import datetime
 
 from flask import current_app
@@ -51,9 +50,12 @@ def search_responsify(serializer, mimetype):
     """
     def view(pid_fetcher, search_result, code=200, headers=None, links=None,
              item_links_factory=None):
-        copy_serializer = deepcopy(serializer)
+        # Check if the serializer implement a 'reset' function. If yes, then
+        # call this function before perform serialization.
+        if (reset := getattr(serializer, 'reset', None)) and callable(reset):
+            reset()
         response = current_app.response_class(
-            copy_serializer.serialize_search(
+            serializer.serialize_search(
                 pid_fetcher, search_result,
                 links=links, item_links_factory=item_links_factory),
             mimetype=mimetype)

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -23,7 +23,7 @@ from utils import VerifyRecordPermissionPatch, flush_index, get_csv, \
     get_json, item_record_to_a_specific_loan_state, login_user
 
 from rero_ils.modules.loans.models import LoanState
-from rero_ils.modules.locations.api import LocationsSearch
+from rero_ils.modules.locations.api import Location, LocationsSearch
 from rero_ils.modules.operation_logs.api import OperationLogsSearch
 from rero_ils.modules.utils import get_ref_for_pid
 
@@ -461,7 +461,6 @@ def test_cached_serializers(client, rero_json_header, item_lib_martigny,
     location['name'] = 'new location name'
     location = location.update(location, dbcommit=True, reindex=True)
     flush_index(LocationsSearch.Meta.index)
-    from rero_ils.modules.locations.api import Location
     assert Location.get_record_by_pid(location.pid).get('name') == \
            location.get('name')
 


### PR DESCRIPTION
Forces the reset of the cache if a serializer use this behavior.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

