### PR TITLE
item editor: add acquisition_date to quick access

### DIFF
--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -627,6 +627,9 @@
             "label": "New acquisition",
             "description": "If this option is enabled, this item is going to appear in the new acquisition list of the library."
           }
+        },
+        "navigation": {
+          "essential": true
         }
       }
     },


### PR DESCRIPTION
* Adds field to the quick access for easy adding.
* Closes #3032.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
