### PR TITLE
contribution: add mef pid in document contributions

### DIFF
--- a/rero_ils/modules/contributions/api.py
+++ b/rero_ils/modules/contributions/api.py
@@ -88,39 +88,53 @@ class Contribution(IlsRecord):
             return cls.get_record_by_pid(pid)
 
     @classmethod
+    def get_type_and_pid_from_ref(cls, ref):
+        """Extract agent type and pid form the MEF URL.
+
+        :params ref: MEF URL.
+        :returns: the ref type such as idref, and the pid value.
+        """
+        ref_split = ref.split('/')
+        ref_type = ref_split[-2]
+        ref_pid = ref_split[-1]
+        return ref_type, ref_pid
+
+    @classmethod
     def get_record_by_ref(cls, ref):
         """Get a record from DB.
 
         If the record dos not exist get it from MEF and create it.
         """
         online = False
-        ref_split = ref.split('/')
-        ref_type = ref_split[-2]
-        ref_pid = ref_split[-1]
-        db.session.begin_nested()
+        ref_type, ref_pid = cls.get_type_and_pid_from_ref(ref)
         contribution = cls.get_contribution(ref_type, ref_pid)
         if not contribution:
             # We dit not find the record in DB get it from MEF and create it.
+            nested = db.session.begin_nested()
             try:
                 data = cls._get_mef_data_by_type(
                     pid=ref_pid,
                     pid_type=ref_type,
                 )
+                # TODO: create or update
                 contribution = cls.create(
                     data=data,
-                    dbcommit=True,
-                    reindex=True
+                    dbcommit=False,
+                    reindex=False
                 )
                 online = True
+                nested.commit()
             except Exception as err:
-                db.session.rollback()
+                nested.rollback()
                 current_app.logger.error(
                     f'Get MEF record: {ref_type}:{ref_pid} >>{err}<<'
                 )
                 contribution = None
                 # import traceback
                 # traceback.print_exc()
-        db.session.commit()
+            if contribution:
+                contribution.reindex()
+
         return contribution, online
 
     @classmethod
@@ -131,9 +145,6 @@ class Contribution(IlsRecord):
         :param language: language for authorized access point.
         :returns: authorized access point in given language.
         """
-
-        def get_mef(url):
-            """Get data from MEF."""
         url = current_app.config.get('RERO_ILS_MEF_AGENTS_URL')
         if pid_type == 'mef':
             mef_url = f'{url}/mef/?q=pid:"{pid}"'

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -19,14 +19,18 @@
 """API for manipulating documents."""
 
 
+from copy import deepcopy
 from functools import partial
 
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import Q
 from flask import current_app
 from invenio_circulation.search.api import search_by_pid
+from invenio_records.api import _records_state
 from invenio_search import current_search_client
 from jsonschema.exceptions import ValidationError
+
+from rero_ils.modules.documents.extensions import AddMEFPidExtension
 
 from .models import DocumentIdentifier, DocumentMetadata, DocumentSubjectType
 from .utils import edition_format_text, publication_statement_text, \
@@ -76,7 +80,8 @@ class Document(IlsRecord):
     model_cls = DocumentMetadata
 
     _extensions = [
-        OperationLogObserverExtension()
+        OperationLogObserverExtension(),
+        AddMEFPidExtension()
     ]
 
     def _validate(self, **kwargs):
@@ -300,32 +305,66 @@ class Document(IlsRecord):
         for es_document in es_documents:
             yield es_document.pid
 
-    def replace_refs(self):
-        """Replace $ref with real data."""
+    def _expand_contributions(self, data):
+        """Replace the $ref for contributions.
+
+        :params data - dict: the contributions document data.
+        :returns: the modified contributions document data.
+        :rtype: dict
+        """
         from ..contributions.api import Contribution
-        contributions = self.get('contribution', [])
-        # we need to iterate over a copy of the list if we want to remove an
-        # element on the original list
-        for contribution in list(contributions):
-            if ref := contribution['agent'].get('$ref'):
-                agent, _ = Contribution.get_record_by_ref(ref)
-                if agent:
-                    contribution['agent'] = agent
-                else:
-                    contributions.remove(contribution)
+        new_contributions = []
+        for contribution in data.get('contribution', []):
+            if not contribution['agent'].get('$ref'):
+                new_contributions.append(contribution)
+            if mef_pid := contribution['agent'].get('pid'):
+                if agent := Contribution.get_record_by_pid(mef_pid):
+                    _type, _ = Contribution.get_type_and_pid_from_ref(
+                        contribution['agent']['$ref'])
+                    contribution['agent'] = agent.dumps_for_document()
+                    contribution['agent']['primary_source'] = _type
+                    new_contributions.append(contribution)
+            elif contribution['agent'].get('$ref'):
+                current_app.logger.error(
+                    f'Unable to resolve contribution $ref '
+                    f'{contribution["agent"].get("$ref")}'
+                    f' for document {data.get("pid")}')
+        if new_contributions:
+            data['contribution'] = new_contributions
+        return data
+
+    def _expand_subjects(self, data):
+        """Replace the $ref for subjects.
+
+        :params data - dict: the subjects document data.
+        :returns: the modified subject document data.
+        :rtype: dict
+        """
+        from ..contributions.api import Contribution
         for subjects in ['subjects', 'subjects_imported']:
-            for subject in self.get(subjects, []):
+            for subject in data.get(subjects, []):
                 subject_ref = subject.get('$ref')
                 subject_type = subject.get('type')
                 if subject_ref and subject_type in [
                     DocumentSubjectType.PERSON,
                     DocumentSubjectType.ORGANISATION
                 ]:
-                    data, _ = Contribution.get_record_by_ref(subject_ref)
+                    contrib_data, _ = Contribution.get_record_by_ref(
+                        subject_ref)
                     del subject['$ref']
-                    subject.update(data)
+                    subject.update(contrib_data)
+        return data
 
-        return super().replace_refs()
+    def replace_refs(self):
+        """Replace $ref with real data."""
+        data = deepcopy(self)
+        data = self._expand_contributions(data)
+        data = self._expand_subjects(data)
+
+        if self.enable_jsonref:
+            return _records_state.replace_refs(data)
+        else:
+            self
 
     def get_identifiers(self, filters=None, with_alternatives=False):
         """Get the document identifier object filtered by identifier types.

--- a/rero_ils/modules/documents/extensions.py
+++ b/rero_ils/modules/documents/extensions.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2021 RERO
+# Copyright (C) 2021 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""RERO ILS common record extensions."""
+
+
+from invenio_records.extensions import RecordExtension
+
+
+class AddMEFPidExtension(RecordExtension):
+    """Adds the MEF pid for contributions."""
+
+    def add_mef_pid(self, record):
+        """Injects the MEF pid in the contribution.
+
+        :params record: a document record.
+        """
+        from rero_ils.modules.contributions.api import Contribution
+        for contribution in record.get('contribution', []):
+            if contrib_ref := contribution.get('agent', {}).get('$ref'):
+                cont, _ = Contribution.get_record_by_ref(
+                    contrib_ref)
+                if cont:
+                    # inject mef pid
+                    contribution['agent']['pid'] = cont['pid']
+
+    def post_init(self, record, data, model=None, **kwargs):
+        """Called after a record is initialized."""
+        self.add_mef_pid(record)
+
+    def pre_commit(self, record):
+        """Called before a record is committed."""
+        self.add_mef_pid(record)

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation_link-v0.0.1.json
@@ -38,6 +38,11 @@
           "itemCssClass": "col-lg-12"
         }
       }
+    },
+    "pid": {
+      "title": "MEF ID",
+      "type": "string",
+      "minLength": 1
     }
   },
   "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person_link-v0.0.1.json
@@ -38,6 +38,11 @@
           "itemCssClass": "col-lg-12"
         }
       }
+    },
+    "pid": {
+      "title": "MEF ID",
+      "type": "string",
+      "minLength": 1
     }
   },
   "form": {

--- a/rero_ils/modules/documents/listener.py
+++ b/rero_ils/modules/documents/listener.py
@@ -19,7 +19,7 @@
 
 from flask.globals import current_app
 
-from .utils import create_contributions, title_format_text_head
+from .utils import process_literal_contributions, title_format_text_head
 from ..commons.identifiers import IdentifierFactory, IdentifierType
 from ..documents.api import Document, DocumentsSearch
 from ..holdings.api import HoldingsSearch
@@ -29,21 +29,11 @@ from ..local_fields.api import LocalField
 from ...utils import language_mapping
 
 
-def enrich_document_data(sender, json=None, record=None, index=None,
-                         doc_type=None, arguments=None, **dummy_kwargs):
-    """Signal sent before a record is indexed.
-
-    :param json: The dumped record dictionary which can be modified.
-    :param record: The record being indexed.
-    :param index: The index in which the record will be indexed.
-    :param doc_type: The doc_type for the record.
-    """
-    if index.split('-')[0] != DocumentsSearch.Meta.index:
-        return
+def process_holdings(record, json):
+    """Add holding information to the indexed record."""
     holdings = []
-    document_pid = record['pid']
     es_holdings = HoldingsSearch()\
-        .filter('term', document__pid=document_pid)\
+        .filter('term', document__pid=record['pid'])\
         .source().scan()
     for holding in es_holdings:
         holding = holding.to_dict()
@@ -123,44 +113,10 @@ def enrich_document_data(sender, json=None, record=None, index=None,
     if holdings:
         json['holdings'] = holdings
 
-    # MEF contribution ES index update
-    contributions = create_contributions(json.get('contribution', []))
-    if contributions:
-        json.pop('contribution', None)
-        json['contribution'] = contributions
-    # TODO: compare record with those in DB to check which authors have
-    # to be deleted from index
-    # Index host document title in child document (part of)
-    if 'partOf' in json:
-        for part_of in json['partOf']:
-            doc_pid = part_of.get('document', {}).get('pid')
-            document = Document.get_record_by_pid(doc_pid).dumps()
-            titles = [
-                v['_text'] for v in document.get('title', {})
-                if v.get('_text') and v.get('type') == 'bf:Title'
-            ]
-            if titles:
-                part_of['document']['title'] = titles.pop()
 
-    # sort title
-    sort_title = title_format_text_head(
-        json.get('title', []),
-        with_subtitle=True
-    )
-    language = language_mapping(json.get('language')[0].get('value'))
-    if current_app.config.get('RERO_ILS_STOP_WORDS_ACTIVATE', False):
-        sort_title = current_app.\
-            extensions['reroils-normalizer-stop-words'].\
-            normalize(sort_title, language)
-    json['sort_title'] = sort_title
-    # Local fields in JSON
-    local_fields = LocalField.get_local_fields_by_resource(
-        'doc', document_pid)
-    if local_fields:
-        json['local_fields'] = local_fields
-
-    # DOCUMENT IDENTIFIERS MANAGEMENT
-    #   We want to enrich document identifiers with possible alternative
+def process_identifiers(record, json):
+    """Add identifiers informations for indexing."""
+    #   Enrich document identifiers with possible alternative
     #   identifiers. For example, if document data provides an ISBN-10
     #   identifier, the corresponding ISBN-13 identifiers must be
     #   searchable too.
@@ -200,6 +156,63 @@ def enrich_document_data(sender, json=None, record=None, index=None,
             if identifier.type in family_types
         ])):
             json[key] = filtered_identifiers
+
+
+def enrich_document_data(sender, json=None, record=None, index=None,
+                         doc_type=None, arguments=None, **dummy_kwargs):
+    """Signal sent before a record is indexed.
+
+    :param json: The dumped record dictionary which can be modified.
+    :param record: The record being indexed.
+    :param index: The index in which the record will be indexed.
+    :param doc_type: The doc_type for the record.
+    """
+    if index.split('-')[0] != DocumentsSearch.Meta.index:
+        return
+
+    process_holdings(record, json)
+
+    # # MEF contribution ES index update
+    # # TODO: subject and subject links
+    contributions = process_literal_contributions(json.get('contribution', []))
+    if contributions:
+        json.pop('contribution', None)
+        json['contribution'] = contributions
+
+    # TODO: compare record with those in DB to check which authors have
+    # to be deleted from index
+
+    # Index host document title in child document (part of)
+    if 'partOf' in json:
+        for part_of in json['partOf']:
+            doc_pid = part_of.get('document', {}).get('pid')
+            document = Document.get_record_by_pid(doc_pid).dumps()
+            titles = [
+                v['_text'] for v in document.get('title', {})
+                if v.get('_text') and v.get('type') == 'bf:Title'
+            ]
+            if titles:
+                part_of['document']['title'] = titles.pop()
+
+    # sort title
+    sort_title = title_format_text_head(
+        json.get('title', []),
+        with_subtitle=True
+    )
+    language = language_mapping(json.get('language')[0].get('value'))
+    if current_app.config.get('RERO_ILS_STOP_WORDS_ACTIVATE', False):
+        sort_title = current_app.\
+            extensions['reroils-normalizer-stop-words'].\
+            normalize(sort_title, language)
+    json['sort_title'] = sort_title
+
+    # Local fields in JSON
+    local_fields = LocalField.get_local_fields_by_resource(
+        'doc', record['pid'])
+    if local_fields:
+        json['local_fields'] = local_fields
+
+    process_identifiers(record, json)
 
     # Populate sort date new and old for use in sorting
     pub_provisions = [

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -312,6 +312,9 @@
               "type": {
                 "type": "keyword"
               },
+              "primary_source": {
+                "type": "keyword"
+              },
               "pid": {
                 "type": "keyword"
               },

--- a/rero_ils/modules/documents/serializers/dc.py
+++ b/rero_ils/modules/documents/serializers/dc.py
@@ -28,7 +28,7 @@ from werkzeug.local import LocalProxy
 
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.dojson.contrib.jsontodc import dublincore
-from rero_ils.modules.documents.utils import create_contributions
+from rero_ils.modules.documents.utils import process_literal_contributions
 
 DEFAULT_LANGUAGE = LocalProxy(
     lambda: current_app.config.get('BABEL_DEFAULT_LANGUAGE'))
@@ -60,7 +60,7 @@ class DublinCoreSerializer(_DublinCoreSerializer):
                          language=DEFAULT_LANGUAGE, **kwargs):
         """Transform record into an intermediate representation."""
         record = record.replace_refs()
-        contributions = create_contributions(
+        contributions = process_literal_contributions(
             record.get('contribution', [])
         )
         if contributions:

--- a/rero_ils/modules/documents/serializers/ris.py
+++ b/rero_ils/modules/documents/serializers/ris.py
@@ -28,7 +28,7 @@ from rero_ils.utils import get_i18n_supported_languages
 
 from .base import BaseDocumentFormatterMixin
 from ..api import Document
-from ..utils import create_contributions
+from ..utils import process_literal_contributions
 
 
 class RISSerializer(SerializerMixinInterface):
@@ -43,7 +43,7 @@ class RISSerializer(SerializerMixinInterface):
         """
         Document.post_process(record)
         record = record.replace_refs()
-        if contributions := create_contributions(
+        if contributions := process_literal_contributions(
                 record.get('contribution', [])):
             record['contribution'] = contributions
 

--- a/rero_ils/modules/documents/utils.py
+++ b/rero_ils/modules/documents/utils.py
@@ -499,17 +499,11 @@ def create_authorized_access_point(agent):
     return authorized_access_point
 
 
-def create_contributions(contributions):
-    """Create contribution."""
-    from ..contributions.api import Contribution
+def process_literal_contributions(contributions):
+    """Normalize literal contributions."""
     calculated_contributions = []
     for contribution in contributions:
-        cont_pid = contribution['agent'].get('pid')
-        if cont_pid:
-            contrib = Contribution.get_record_by_pid(cont_pid)
-            if contrib:
-                contribution['agent'] = contrib.dumps_for_document()
-        else:
+        if not contribution['agent'].get('pid'):
             # transform local data for indexing
             agent = {
                 'type': contribution['agent']['type'],

--- a/rero_ils/modules/imports/serializers/serializers.py
+++ b/rero_ils/modules/imports/serializers/serializers.py
@@ -25,7 +25,7 @@ from marshmallow import fields
 
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.dojson.contrib.marc21tojson.rero import marc21
-from rero_ils.modules.documents.utils import create_contributions, \
+from rero_ils.modules.documents.utils import process_literal_contributions, \
     title_format_text_head
 
 
@@ -128,7 +128,8 @@ class UIImportsSearchSerializer(ImportsSearchSerializer):
                 agent['type'] = agent_type
             new_contributions.append({'agent': agent})
         if new_contributions:
-            metadata['contribution'] = create_contributions(new_contributions)
+            metadata['contribution'] = \
+                process_literal_contributions(new_contributions)
         return metadata
 
 

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -203,11 +203,10 @@ def test_documents_facets(
     aggs = data['aggregations']
     assert set(aggs.keys()) == {'document_type',
                                 'library', 'author'}
-
     # TEST FILTERS
-    #   Each filter checks is a tuple. First tuple element is argument used to
-    #   call the API, second tuple argument is the number of document that
-    #   should be return by the API call.
+    # Each filter checks is a tuple. First tuple element is argument used to
+    # call the API, second tuple argument is the number of document that
+    # should be return by the API call.
     checks = [
         ({'view': 'global', 'author': 'Peter James'}, 2),
         ({'view': 'global', 'author': 'Great Edition'}, 1),
@@ -223,7 +222,7 @@ def test_documents_facets(
     ]
     for params, value in checks:
         url = url_for('invenio_records_rest.doc_list', **params)
-        res = client.get(url, headers=rero_json_header)
+        res = client.get(url)
         data = get_json(res)
         assert data['hits']['total']['value'] == value
 
@@ -522,6 +521,7 @@ def test_documents_resolve(
     assert res.json['metadata']['contribution'] == [{
         'agent': {
             '$ref': 'https://mef.rero.ch/api/agents/rero/A017671081',
+            'pid': 'cont_pers',
             'type': 'bf:Person'
             },
         'role': ['aut']
@@ -536,9 +536,8 @@ def test_documents_resolve(
         pid_value='doc2',
         resolve='1'
     ))
-    assert res.json['metadata']['contribution'][0]['agent']['sources'] == [
-        'gnd', 'idref', 'rero'
-    ]
+    assert res.json['metadata'][
+        'contribution'][0]['agent']['authorized_access_point_fr']
     assert res.status_code == 200
 
 

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -21,8 +21,9 @@ from __future__ import absolute_import, print_function
 
 from copy import deepcopy
 
+import mock
 import pytest
-from utils import flush_index
+from utils import flush_index, mock_response
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.documents.api import Document, DocumentsSearch, \
@@ -51,6 +52,29 @@ def test_document_create(db, document_data_tmp):
 
     with pytest.raises(IlsRecordError.PidAlreadyUsed):
         new_doc = Document.create(doc)
+
+
+@mock.patch('requests.get')
+def test_document_create_with_mef(
+        mock_contributions_mef_get, app, document_data_ref, document_data,
+        contribution_person_data, contribution_person_response_data):
+    """Load document with mef records reference."""
+    mock_contributions_mef_get.return_value = mock_response(
+        json_data=contribution_person_response_data
+    )
+    doc = Document.create(
+        data=deepcopy(document_data_ref),
+        delete_pid=True, dbcommit=True, reindex=True)
+    flush_index(DocumentsSearch.Meta.index)
+    doc = Document.get_record_by_pid(doc.get('pid'))
+    assert doc['contribution'][0]['agent']['pid'] == \
+        contribution_person_data['pid']
+    hit = DocumentsSearch().execute().to_dict()[
+        'hits']['hits'][0]
+    assert hit['_source']['contribution'][0]['agent'][
+        'pid'] == contribution_person_data['pid']
+    assert hit['_source']['contribution'][0]['agent'][
+        'primary_source'] == 'rero'
 
 
 def test_document_add_cover_url(db, document):
@@ -204,7 +228,6 @@ def test_document_get_links_to_me(document, export_document):
 
 def test_document_indexing(document, export_document):
     """Test document indexing."""
-
     # get the export_document from the es index
     s = DocumentsSearch().filter('term', pid=export_document.pid)
     assert s.count() == 1
@@ -245,6 +268,7 @@ def test_document_indexing(document, export_document):
 
 def test_document_replace_refs(document):
     """Test document replace refs."""
+    orig = deepcopy(document)
     data = document.replace_refs()
     assert len(data.get('contribution')) == 1
 
@@ -253,12 +277,13 @@ def test_document_replace_refs(document):
     contributions.append({
         'agent': {
           'type': 'bf:Person',
-          '$ref': 'https://mef.rero.ch/api/agents/iderf/WRONGIDREF'
+          '$ref': 'https://mef.rero.ch/api/agents/idref/WRONGIDREF'
         },
         'role': [
           'aut'
         ]
       })
+    document.update(document, True, True)
     data = document.replace_refs()
     assert len(data.get('contribution')) == 1
 
@@ -272,5 +297,7 @@ def test_document_replace_refs(document):
             'aut'
         ]
     })
+    document.update(document, True, True)
     data = document.replace_refs()
     assert len(data.get('contribution')) == 2
+    document.update(orig, True, True)


### PR DESCRIPTION
Data Migration Instructions:
* Needs documents reinding at the server side.
* Need to create a mass correction to inject the MEF pid.

Changes:
* Fixes db transaction during the contribution creation.
* Adds an document extensions to add a MEF pid if exists.
* Splits the document indexing enrichment as it is huge.
* Move the $ref contribution resolution in the `resolve_refs` method.
* Makes the document contribution serialization identical for a single
  record or a search REST API.
* Adds primary source in document contributions.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
