### PR TITLE
mappings: index call_numbers as text

### DIFF
--- a/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v7/holdings/holding-v0.0.1.json
@@ -16,10 +16,10 @@
         "type": "integer"
       },
       "call_number": {
-        "type": "keyword"
+        "type": "text"
       },
       "second_call_number": {
-        "type": "keyword"
+        "type": "text"
       },
       "circulation_category": {
         "properties": {

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -40,10 +40,10 @@
         "search_analyzer": "standard"
       },
       "call_number": {
-        "type": "keyword"
+        "type": "text"
       },
       "second_call_number": {
-        "type": "keyword"
+        "type": "text"
       },
       "enumerationAndChronology": {
         "type": "keyword"
@@ -188,7 +188,7 @@
             "type": "keyword"
           },
           "inherited_first_call_number": {
-            "type": "keyword"
+            "type": "text"
           },
           "status_date": {
             "type": "date"


### PR DESCRIPTION
* Fixes inconsistent mapping between documents and items/holdings for
call numbers.
* Closes #2908.

:warning: Requires ES update mapping!
:warning: Requires reindexing of `call_number` and `second_call_number`
for all items and holdings, as well as `inherited_first_call_number` for
items of type `issue`.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
