### PR TITLE
item types: extend fields max length to 90 chars

### DIFF
--- a/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
@@ -124,7 +124,7 @@
           "label": {
             "title": "Label",
             "type": "string",
-            "maxLength": 30,
+            "maxLength": 90,
             "minLength": 3,
             "form": {
               "templateOptions": {
@@ -182,7 +182,7 @@
           "label": {
             "title": "Label",
             "type": "string",
-            "maxLength": 50,
+            "maxLength": 90,
             "minLength": 3,
             "form": {
               "templateOptions": {


### PR DESCRIPTION
* Closes #2375.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
