### PR TITLE
holdings: extend `note.content` max length

### DIFF
--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -663,7 +663,7 @@
           "content": {
             "type": "string",
             "title": "Content",
-            "maxLength": 2000,
+            "maxLength": 10000,
             "minLength": 1,
             "form": {
               "type": "textarea",


### PR DESCRIPTION
* Closes RT 396.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

