### PR TITLE
database: fix orphan pids

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -253,14 +253,13 @@ class IlsRecord(Record):
         cls.pid_check = pidcheck
         try:
             record = super().create(data=data, id_=id_, **kwargs)
-            if dbcommit:
+            if record and dbcommit:
                 record.dbcommit(reindex)
+        # TODO: remove validation error once the angular editor
+        #       validation is complete
         except Exception as err:
-            # delete the created persistent identifier
-            db.session.delete(persistent_identifier)
-            db.session.commit()
             current_app.logger.error(
-                f'{cls.__name__} data:{data} err:{err}')
+                f'{cls.__name__} err:{err} data:{data}')
             raise
         return record
 


### PR DESCRIPTION
When a resource is created but the data are invalid, a pid is created
without an attached create. The record becomes orphan.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
