### PR TITLE
acquisition: rollover script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ var/
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Application logs
+logs/*
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -234,12 +234,6 @@ THEME_TRACKINGCODE_TEMPLATE = 'rero_ils/trackingcode.html'
 THEME_JAVASCRIPT_TEMPLATE = 'rero_ils/javascript.html'
 
 # WEBPACKEXT_PROJECT = 'rero_ils.webpack.project'
-# Logings
-# =======
-#: Sentry level
-LOGGING_SENTRY_LEVEL = "ERROR"
-#: Sentry: use celery or not
-LOGGING_SENTRY_CELERY = True
 
 # Email configuration
 # ===================
@@ -2769,6 +2763,45 @@ RERO_ILS_ENABLE_OPERATION_LOG_VALIDATION = False
 # ========================
 # Compute the stats with a timeframe given in monthes
 RERO_ILS_STATS_BILLING_TIMEFRAME_IN_MONTHES = 3
+
+
+# =============================================================================
+# LOGGING CONFIGURATION
+# =============================================================================
+#: Sentry level
+LOGGING_SENTRY_LEVEL = "ERROR"
+#: Sentry: use celery or not
+LOGGING_SENTRY_CELERY = True
+
+ROLLOVER_LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s [%(levelname)s] :: %(message)s'
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        },
+        'file': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': 'logs/rollover_log',
+            'backupCount': 10,
+            'formatter': 'standard'
+        }
+    },
+    'loggers': {
+        'rero_ils.modules.acquisition.rollover': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False
+        }
+    }
+}
+
 
 # =============================================================================
 # NOTIFICATIONS MODULE SPECIFIC SETTINGS

--- a/rero_ils/modules/acquisition/acq_accounts/serializers/csv.py
+++ b/rero_ils/modules/acquisition/acq_accounts/serializers/csv.py
@@ -41,9 +41,8 @@ class AcqAccountCSVSerializer(CSVSerializer):
 
             # write the CSV output in memory
             line = Line()
-            writer = csv.DictWriter(line,
-                                    quoting=csv.QUOTE_ALL,
-                                    fieldnames=headers)
+            writer = csv.DictWriter(
+                line, quoting=csv.QUOTE_ALL, fieldnames=headers)
             writer.writeheader()
             yield line.read()
 
@@ -51,17 +50,19 @@ class AcqAccountCSVSerializer(CSVSerializer):
                 account = result.to_dict()
                 csv_data = {
                     'account_pid': account['pid'],
-                    'account_name': account['name'],
-                    'account_number': account['number'],
-                    'account_allocated_amount': account['allocated_amount'],
+                    'account_name': account.get('name'),
+                    'account_number': account.get('number'),
+                    'account_allocated_amount':
+                        account.get('allocated_amount'),
                     'account_available_amount':
-                        account['allocated_amount'] - account['distribution'],
+                        account.get('allocated_amount', 0)
+                        - account.get('distribution', 0),
                     'account_current_encumbrance':
-                        account['encumbrance_amount']['self'],
+                        account.get('encumbrance_amount', {}).get('self'),
                     'account_current_expenditure':
-                        account['expenditure_amount']['self'],
+                        account.get('expenditure_amount', {}).get('self'),
                     'account_available_balance':
-                        account['remaining_balance']['self']
+                        account.get('remaining_balance').get('self')
                 }
                 # write csv data
                 data = self.process_dict(csv_data)

--- a/rero_ils/modules/acquisition/acq_accounts/utils.py
+++ b/rero_ils/modules/acquisition/acq_accounts/utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities about acquisition accounts."""
+
+
+def sort_accounts_as_tree(accounts):
+    """Sort a list of acquisition account as a hierarchical tree.
+
+    :param accounts: the accounts to sort.
+    :return: the same account list sorted as a hierarchical tree.
+    """
+    def sort_by_name_key(acc):
+        return acc.get('name')
+
+    def _get_children_account(acc):
+        children = filter(lambda a: a.parent_pid == acc.pid, accounts)
+        return sorted(children, key=sort_by_name_key)
+
+    def _build_tree(accounts_parts):
+        tree = []
+        for acc in sorted(accounts_parts, key=sort_by_name_key):
+            tree.append(acc)
+            tree.extend(_build_tree(_get_children_account(acc)))
+        return tree
+
+    return _build_tree([a for a in accounts if a.is_root])

--- a/rero_ils/modules/acquisition/acq_invoices/api.py
+++ b/rero_ils/modules/acquisition/acq_invoices/api.py
@@ -20,7 +20,8 @@
 
 from functools import partial
 
-from rero_ils.modules.api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
+from rero_ils.modules.acquisition.api import AcquisitionIlsRecord
+from rero_ils.modules.api import IlsRecordsIndexer, IlsRecordsSearch
 from rero_ils.modules.fetchers import id_fetcher
 from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.minters import id_minter
@@ -56,7 +57,7 @@ class AcquisitionInvoicesSearch(IlsRecordsSearch):
         default_filter = None
 
 
-class AcquisitionInvoice(IlsRecord):
+class AcquisitionInvoice(AcquisitionIlsRecord):
     """AcquisitionInvoice class."""
 
     minter = acq_invoice_id_minter

--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -25,11 +25,13 @@ from functools import partial
 from flask_babelex import gettext as _
 from werkzeug.utils import cached_property
 
-from rero_ils.modules.api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
+from rero_ils.modules.acquisition.api import AcquisitionIlsRecord
+from rero_ils.modules.api import IlsRecordsIndexer, IlsRecordsSearch
 from rero_ils.modules.fetchers import id_fetcher
 from rero_ils.modules.minters import id_minter
 from rero_ils.modules.providers import Provider
-from rero_ils.modules.utils import extracted_data_from_ref, get_ref_for_pid
+from rero_ils.modules.utils import extracted_data_from_ref, get_ref_for_pid, \
+    sorted_pids
 
 from .extensions import AcqOrderLineValidationExtension
 from .models import AcqOrderLineIdentifier, AcqOrderLineMetadata, \
@@ -61,7 +63,7 @@ class AcqOrderLinesSearch(IlsRecordsSearch):
         default_filter = None
 
 
-class AcqOrderLine(IlsRecord):
+class AcqOrderLine(AcquisitionIlsRecord):
     """Acquisition Order Line class."""
 
     minter = acq_order_line_id_minter

--- a/rero_ils/modules/acquisition/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -33,19 +33,7 @@
     "reference": {
       "title": "Reference",
       "type": "string",
-      "minLength": 3,
-      "form": {
-        "validation": {
-          "validators": {
-            "valueAlreadyExists": {
-              "term": "reference.raw"
-            }
-          },
-          "messages": {
-            "alreadyTakenMessage": "This reference number already exists."
-          }
-        }
-      }
+      "minLength": 3
     },
     "type": {
       "title": "Type",
@@ -218,6 +206,21 @@
           "title": "Organisation URI",
           "type": "string",
           "pattern": "^https://bib.rero.ch/api/organisations/.*?$"
+        }
+      }
+    },
+    "previousVersion": {
+      "title": "Previous version",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "title": "Acquisition order URI",
+          "type": "string",
+          "pattern": "^https://bib.rero.ch/api/acq_orders/.*?$"
         }
       }
     }

--- a/rero_ils/modules/acquisition/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -29,6 +29,16 @@
           }
         }
       },
+      "previousVersion": {
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          }
+        }
+      },
       "library": {
         "properties": {
           "pid": {

--- a/rero_ils/modules/acquisition/acq_orders/models.py
+++ b/rero_ils/modules/acquisition/acq_orders/models.py
@@ -42,6 +42,17 @@ class AcqOrderMetadata(db.Model, RecordMetadataBase):
     __tablename__ = 'acq_order_metadata'
 
 
+class AcqOrderType:
+    """Type of acquisition order."""
+
+    MONOGRAPH = 'monograph'
+    MONOGRAPHIC_SET = 'monographic_set'
+    SERIAL = 'serial'
+    STANDING_ORDER = 'standing_order'
+    PLANNED_ORDER = 'planned_order'
+    MULTI_VOLUME = 'multi_volume'
+
+
 class AcqOrderStatus:
     """Available statuses for an acquisition order."""
 

--- a/rero_ils/modules/acquisition/acq_receipt_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/api.py
@@ -23,7 +23,8 @@ from functools import partial
 
 from werkzeug.utils import cached_property
 
-from rero_ils.modules.api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
+from rero_ils.modules.acquisition.api import AcquisitionIlsRecord
+from rero_ils.modules.api import IlsRecordsIndexer, IlsRecordsSearch
 from rero_ils.modules.fetchers import id_fetcher
 from rero_ils.modules.minters import id_minter
 from rero_ils.modules.providers import Provider
@@ -61,7 +62,7 @@ class AcqReceiptLinesSearch(IlsRecordsSearch):
         default_filter = None
 
 
-class AcqReceiptLine(IlsRecord):
+class AcqReceiptLine(AcquisitionIlsRecord):
     """AcqReceiptLine class."""
 
     minter = acq_receipt_line_id_minter

--- a/rero_ils/modules/acquisition/acq_receipts/api.py
+++ b/rero_ils/modules/acquisition/acq_receipts/api.py
@@ -23,7 +23,8 @@ from functools import partial
 
 from rero_ils.modules.acquisition.acq_receipt_lines.api import \
     AcqReceiptLine, AcqReceiptLinesSearch
-from rero_ils.modules.api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
+from rero_ils.modules.acquisition.api import AcquisitionIlsRecord
+from rero_ils.modules.api import IlsRecordsIndexer, IlsRecordsSearch
 from rero_ils.modules.extensions import DecimalAmountExtension
 from rero_ils.modules.fetchers import id_fetcher
 from rero_ils.modules.minters import id_minter
@@ -62,7 +63,7 @@ class AcqReceiptsSearch(IlsRecordsSearch):
         default_filter = None
 
 
-class AcqReceipt(IlsRecord):
+class AcqReceipt(AcquisitionIlsRecord):
     """AcqReceipt class."""
 
     minter = acq_receipt_id_minter

--- a/rero_ils/modules/acquisition/api.py
+++ b/rero_ils/modules/acquisition/api.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2022 RERO
+# Copyright (C) 2022 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -15,14 +16,23 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Acquisition Order resolver."""
+"""Acquisition api record."""
 
-import jsonresolver
+from abc import ABC
 
-from rero_ils.modules.jsonresolver import resolve_json_refs
+from rero_ils.modules.api import IlsRecord
 
 
-@jsonresolver.route('/api/acq_orders/<pid>', host='bib.rero.ch')
-def acq_order_resolver(pid):
-    """Resolver for acquisition order record."""
-    return resolve_json_refs('acor', pid)
+class AcquisitionIlsRecord(IlsRecord, ABC):
+    """Abstract acquisition resource record."""
+
+    def __str__(self):
+        """Human-readable record string representation."""
+        output = f'[{self.provider.pid_type}#{self.pid}]'
+        if 'name' in self:
+            output += f" {self['name']}"
+        return output
+
+    def __repr__(self):
+        """Full representation of the record."""
+        return super().__repr__()

--- a/rero_ils/modules/acquisition/cli.py
+++ b/rero_ils/modules/acquisition/cli.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Click command-line utilities about acquisition."""
+
+import click
+from click import UsageError
+from flask.cli import with_appcontext
+
+from rero_ils.modules.acquisition.budgets.api import Budget
+from rero_ils.modules.acquisition.exceptions import BudgetDoesNotExist
+from rero_ils.modules.acquisition.rollover import AcqRollover
+from rero_ils.modules.utils import get_ref_for_pid
+
+
+@click.group()
+def acquisition():
+    """Acquisition management commands."""
+
+
+@acquisition.command('rollover')
+@click.argument('origin_budget_pid',
+                type=str)
+@click.option('-d', '--destination',
+              'dest_budget_pid',
+              type=str,
+              help='Destination budget pid')
+@click.option('-i', '--interactive',
+              'interactive',
+              is_flag=True,
+              default=False,
+              help='interactive mode')
+@click.option('--new-budget',
+              is_flag=True,
+              default=False,
+              help='Create a new destination budget resource')
+@click.option('--budget-name',
+              'budget_name',
+              help='The new budget name')
+@click.option('--budget-start-date',
+              'budget_start_date',
+              help='The new budget start-date')
+@click.option('--budget-end-date',
+              'budget_end_date',
+              help='The new budget end-date')
+@with_appcontext
+def rollover(
+    origin_budget_pid, dest_budget_pid,
+    interactive,
+    new_budget, budget_name, budget_start_date, budget_end_date
+):
+    """CLI to run rollover process between two acquisition budgets."""
+    # Check parameters
+    if not dest_budget_pid and not new_budget:
+        raise UsageError('destination budget OR new budget is required')
+
+    original_budget = Budget.get_record_by_pid(origin_budget_pid)
+    # Try to create the destination budget if required
+    if new_budget:
+        if not all([budget_name, budget_start_date, budget_end_date]):
+            raise UsageError('budget name, start-date, end-date are required')
+        org_ref = get_ref_for_pid('org', original_budget.organisation_pid)
+        data = {
+            'organisation': {'$ref': org_ref},
+            'is_active': False,
+            'name': budget_name,
+            'start_date': budget_start_date,
+            'end_date': budget_end_date
+        }
+        destination_budget = Budget.create(data, dbcommit=True, reindex=True)
+        if not destination_budget:
+            raise BudgetDoesNotExist('Unable to create new budget')
+        dest_budget_pid = destination_budget.pid
+
+    destination_budget = Budget.get_record_by_pid(dest_budget_pid)
+    rollover_runner = AcqRollover(
+        original_budget, destination_budget, is_interactive=interactive)
+    rollover_runner.run()

--- a/rero_ils/modules/acquisition/exceptions.py
+++ b/rero_ils/modules/acquisition/exceptions.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Exception about acquisition resources."""
+
+from invenio_records.errors import RecordsError
+
+
+class BudgetDoesNotExist(RecordsError):
+    """Error raised when acquisition budget record doest not exist."""
+
+
+class RolloverError(Exception):
+    """Generic error for rollover process."""
+
+
+class InactiveBudgetError(RolloverError):
+    """Inactive budget exception."""
+
+    def __init__(self, pid_value, *args, **kwargs):
+        """Initialize exception."""
+        self.pid_value = pid_value
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        """Exception as string."""
+        return f'Budget#{self.pid_value} is inactive'
+
+
+class IncompatibleBudgetError(RolloverError):
+    """When two budget aren't compatible with each other."""
+
+    def __init__(self, pid1_value, pid2_value, *args, **kwargs):
+        """Initialize exception."""
+        self.pid1 = pid1_value
+        self.pid2 = pid2_value
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        """Exception as string."""
+        return f'Budget#{self.pid1} isn\' compatible with Budget#{self.pid2}'
+
+
+class BudgetNotEmptyError(RolloverError):
+    """When a budget are linked children resources."""
+
+    def __init__(self, pid, *args, **kwargs):
+        """Initialize exception."""
+        self.pid = pid
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        """Exception as string."""
+        return f'Budget#{self.pid} are some linked children resources.'

--- a/rero_ils/modules/acquisition/rollover.py
+++ b/rero_ils/modules/acquisition/rollover.py
@@ -1,0 +1,681 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Rollover on acquisition resource."""
+
+import logging.config
+import random
+import string
+from copy import deepcopy
+
+from elasticsearch_dsl import Q
+from flask import current_app
+
+from rero_ils.modules.acquisition.acq_accounts.api import AcqAccount, \
+    AcqAccountsSearch
+from rero_ils.modules.acquisition.acq_accounts.utils import \
+    sort_accounts_as_tree
+from rero_ils.modules.acquisition.acq_order_lines.api import AcqOrderLine, \
+    AcqOrderLinesSearch
+from rero_ils.modules.acquisition.acq_order_lines.models import \
+    AcqOrderLineStatus
+from rero_ils.modules.acquisition.acq_orders.api import AcqOrder, \
+    AcqOrdersSearch
+from rero_ils.modules.acquisition.acq_orders.models import AcqOrderStatus, \
+    AcqOrderType
+from rero_ils.modules.acquisition.budgets.api import Budget
+from rero_ils.modules.acquisition.exceptions import BudgetDoesNotExist, \
+    BudgetNotEmptyError, InactiveBudgetError, IncompatibleBudgetError, \
+    RolloverError
+from rero_ils.modules.libraries.api import Library
+from rero_ils.modules.libraries.models import AccountTransferOption
+from rero_ils.modules.organisations.api import Organisation
+from rero_ils.modules.utils import draw_data_table, get_ref_for_pid
+from rero_ils.modules.utils import truncate_string as truncate
+
+
+class AcqRollover:
+    """Acquisition rollover class.
+
+    The aim of this class is to proceed to rollover process. A rollover process
+    consist of migration of resources related to an acquisition budget to
+    another budget. Migrated resources will be acquisition accounts, orders
+    and order lines ; acquisition reception and reception lines are NEVER
+    migrate by rollover process.
+
+    USAGE :
+    -------
+       >> rollover_cli = AcqRollover(original_budget, destination_budget)
+       >> rollover_cli.run()
+    OR
+       >> rollover_cli = AcqRollover(original_budget, name='', start_date='',
+       ...                           end_date='')
+       >> rollover_cli.run()
+
+    During the rollover object creation, some checks will be done to validate
+    arguments. If the destination budget doesn't exist, you could omit this
+    argument, but it will then be necessary to specify required arguments to
+    create the budget (name, start_date and end_date).
+
+    A rollover process could only be operated with some resources related to
+    an original budget, and if the destination budget is empty (related to none
+    resources).
+
+
+    ERROR MANAGEMENT :
+    ------------------
+    Some errors can occurred during the rollover process. If any errors are
+    raised during the rollover process, then all possibly created object will
+    be deleted ; so the database situation should be restored at the same point
+    that before rollover start.
+
+    INTERACTIVE MODE :
+    ------------------
+    By default, the rollover process will ask user to confirm choices at
+    different step of the process. This interactive mode could be skipped using
+    the init argument `is_interactive=False` ; In this case, the script will
+    not prompt any questions and operations will be chained until end of the
+    process or any errors.
+
+    LOGGING:
+    --------
+    The rollover process has option to log operations to some output streams.
+    This configuration is based on Python logging package. If no configuration
+    is specified, the default configuration will be used. This configuration
+    could be found into ``ROLLOVER_LOGGING_CONFIG`` variable.
+
+    If you want to specify another configuration, you could use this variable
+    as default template.
+
+    >> custom_logging_config = deepcopy(ROLLOVER_LOGGING_CONFIG)
+    >> custom_logging_config['handlers'] = ...
+    >> custom_logging_config['formatters']['my_format'] = {...}
+    >> rollover_cli = AcqRollover(..., logging_config=custom_logging_config)
+    >> rollover_cli.run()
+
+
+    """
+
+    def __init__(self, original_budget, destination_budget=None,
+                 logging_config=None, is_interactive=True,
+                 propagate_errors=False, **kwargs):
+        """Initialization.
+
+        :param original_budget: the `Budget` resource related to resources to
+            migrate.
+        :param destination_budget: the `Budget` resource where the rollovered
+            resources will be migrated.
+        :param logging_config: (optional) a dictionary containing all necessary
+            configuration to log the rollover process result. If not specified
+            the configuration comes from `ROLLOVER_LOGGING_CONFIG` setting.
+        :param is_interactive: boolean to determine if user confirmation is
+            required. True by default.
+        :param propagate_errors: Boolean to determine if error will be
+            propagated to caller. Default is false
+        :param **kwargs: all others named argument useful for rollover process.
+        :raises InactiveBudgetException: if ....
+        """
+        # A dictionary where will be stored some redundant resources
+        self._cache = {}
+        # The list of resource created by the rollover script. Must be unstack
+        # if the process is aborted.
+        self._stack = []
+        # Dictionary where will be store the mapping between original resource
+        # pid's and new created resources pid's.
+        self._mapping_table = {}
+        self.propagate_errors = propagate_errors
+
+        # Set special logging configuration for rollover process
+        default_config = current_app.config.get('ROLLOVER_LOGGING_CONFIG')
+        logging.config.dictConfig(logging_config or default_config)
+        self.logger = logging.getLogger(__name__)
+        self.logger.info('ROLLOVER PROCESS ==================================')
+
+        self.original_budget = original_budget
+        if destination_budget is None:
+            destination_budget = self._create_new_budget(**kwargs)
+
+        self.destination_budget = destination_budget
+        self.is_interactive = is_interactive
+        # Why `_validate` is into a try...except.
+        #   It's possible that the stack already contains an object if the
+        #   destination budget didn't exist and has been created. In this case
+        #   this destination budget must be destroyed.
+        try:
+            self._validate()
+        except Exception as e:
+            self._abort_rollover(str(e))
+            if self.propagate_errors:
+                raise
+
+    def run(self):
+        """Run the rollover process."""
+        log = self.logger
+        try:
+            log.info('start running....')
+            log.info("parameters ::")
+            log.info(f"\torigin      : {self.original_budget}")
+            log.info(f"\tdestination : {self.destination_budget}")
+
+            # STEP#1 :: Get account related to original budget
+            #   Load acquisition accounts related to the original budget and
+            #   sort them to get a hierarchical tree structure (parent -> child
+            #   -> grandchild -> ...).
+            #   When loaded, log these accounts into a table to visualize which
+            #   resources will be migrated according to related library
+            #   rollover setting.
+            orig_accounts = AcqRollover._get_accounts(self.original_budget.pid)
+            if not orig_accounts:
+                raise RolloverError('Unable to find any account to rollovered')
+            log.info("original accounts ::")
+            columns = [
+                ('ACCOUNT', 60),  # title, max_length, alignment
+                ('AMOUNT', 16, 'right'),
+                ('ENCUMBRANCE', 16, 'right'),
+                ('MIGRATION_SETTING', 30)
+            ]
+            rows = []
+            for account in orig_accounts:
+                padding = '  ' * account.depth
+                label = f"[#{account.pid}] {account.name}"
+                rows.append((
+                    padding + label,
+                    str(account.get('allocated_amount')),
+                    str(account.encumbrance_amount[0]),
+                    self._get_rollover_migration_setting(account)
+                ))
+            self._draw_data_table(columns, rows, padding='  ')
+
+            # STEP#2 :: Get user confirmation
+            #   If interactive mode is activated, ask user for a confirmation
+            #   to determine if previous table seems correct for it. If user
+            #   confirm this table, a random password key will be asked to
+            #   avoid bad/quick confirmation click
+            if self.is_interactive:
+                if not self._confirm('Are you agree ?', default="no"):
+                    raise RolloverError("User doesn\'t agree")
+                key_confirm = ''.join(random.choices(string.ascii_letters,
+                                                     k=10))
+                log.info("To continue, please enter the confirmation "
+                         f"key [{key_confirm}] :: ")
+                key = input()
+                if key != key_confirm:
+                    raise RolloverError("Confirmation key mismatch")
+
+            # STEP#3 :: Get resources to rollover
+            #   * Filter account to keep only account to migrate.
+            #   * Get orders to migrate.
+            #   * Get orders lines to migrate.
+            accounts = {
+                account.pid: account for account in orig_accounts
+                if self._get_rollover_migration_setting(account) !=
+                AccountTransferOption.NO_TRANSFER
+            }
+            account_pids = list(accounts.keys())
+            orders = {
+                order.pid: order
+                for order in AcqRollover._get_orders_to_migrate(account_pids)
+            }
+            order_pids = list(orders.keys())
+            to_migrate = {
+                'accounts': accounts.values(),
+                'orders': orders.values(),
+                'order_lines': AcqRollover._get_opened_order_lines(
+                    order_pids, account_pids)
+            }
+            log.info('Resources to migrate (according rollover settings) :')
+            log.info(f"\t#AcqAccount   : {len(to_migrate['accounts'])}")
+            log.info(f"\t#AcqOrder     : {len(to_migrate['orders'])}")
+            log.info(f"\t#AcqOrderLine : {len(to_migrate['order_lines'])}")
+
+            # STEP#4 :: Validate the rollover data
+            #   Try to validate acquisition object that will be rollovered.
+            #   This check should prevent any problem during rollover process
+            #   that could cause a huge and slow rollover aborting process
+            log.info('Starting data validation process ...')
+            self._validate_data_to_migrate(to_migrate)
+
+            # STEP#5 :: Proceed to rollover
+            log.info('Starting resources migrations ...')
+            self._migrate_accounts(to_migrate['accounts'])
+            self._migrate_orders(to_migrate['orders'])
+            self._migrate_order_lines(to_migrate['order_lines'])
+
+            # STEP#6 :: compare new budget account table with previous version.
+            log.info("Completed process comparison table ::")
+            columns = [
+                ('ACCOUNT', 60),  # title, max_length
+                ('AMOUNT', 16, 'right'),
+                ('ENCUMBRANCE', 16, 'right'),
+                ('SUCCESS ?', 11, 'center'),
+                ('NEW AMOUNT', 20, 'right'),
+                ('NEW ENCUMBRANCE', 20, 'right'),
+            ]
+            rows = []
+            errors = 0
+            for account in accounts.values():
+                padding = '  ' * account.depth
+                label = f"[#{account.pid}] {account.name}"
+                n_acc_pid = self._mapping_table['accounts'][account.pid]
+                new_acc = AcqAccount.get_record_by_pid(n_acc_pid)
+
+                rollover_status = 'OK'
+                if account.encumbrance_amount[0] != \
+                   new_acc.encumbrance_amount[0]:
+                    rollover_status = '!! ERR !!'
+                    errors += 1
+                rows.append((
+                    padding + label,
+                    str(account.get('allocated_amount')),
+                    str(account.encumbrance_amount[0]),
+                    rollover_status,
+                    str(new_acc.get('allocated_amount')),
+                    str(new_acc.encumbrance_amount[0]),
+                ))
+            self._draw_data_table(columns, rows, padding='  ')
+            if errors:
+                raise RolloverError(f"{errors} detected on completion table.")
+
+            # STEP#7 :: user confirmation that all seems correct for it
+            if self.is_interactive:
+                if not self._confirm('Are you agree ?', default="no"):
+                    raise RolloverError("User doesn\'t agree")
+            self._update_budgets(False, True)
+            self._update_organisation()
+            log.info("Rollover complete.... it's time for 🍺🍺🍺🍹 party !")
+            # raise RolloverError("All works as expected !")
+
+        except RolloverError as re:
+            self._abort_rollover(str(re))
+            if self.propagate_errors:
+                raise
+
+    # RESOURCE MIGRATION METHODS ==============================================
+
+    def _validate_data_to_migrate(self, data):
+        """Validate data that should be migrated by rollover process.
+
+        :param data: the dictionary containing all data to analyze.
+        :raise RolloverError: if error was found on data.
+        """
+        log = self.logger
+        error_count = 0
+        # Testing acquisition order lines
+        #   - the unreceived_quantity for each order line should be > 0
+        log.info("  Testing order lines ...")
+        for line in data.get('order_lines', []):
+            if line.unreceived_quantity == 0:
+                log.warning(f"\t* Unreceived quantity for {str(line)} is 0 !")
+                error_count += 1
+            if line.document.harvested:
+                log.warning(f"\t* {str(line)} related to harvested document !")
+                error_count += 1
+        if error_count:
+            raise RolloverError(f"Data validation failed : {error_count} "
+                                f"error(s) found")
+
+    def _migrate_accounts(self, accounts):
+        """Migrate a list of account to the destination budget.
+
+        :params account (AcqAccount[]): the list of account to migrate.
+        :raises RolloverError: If an account migration failed.
+        """
+        log = self.logger
+        log.info("  Migrating accounts ...")
+        self._mapping_table['accounts'] = {}
+        new_budget_ref = get_ref_for_pid('budg', self.destination_budget.pid)
+        for idx, acc in enumerate(accounts, 1):
+            data = deepcopy(acc)
+            data['budget']['$ref'] = new_budget_ref
+            # Try to find the new parent account (checking the temporary
+            # mapping table). This is possible because we sorted the accounts
+            # in hierarchical tree, so root/parent account should be migrated
+            # before children accounts.
+            if old_parent_pid := acc.parent_pid:
+                p_pid = self._mapping_table.get('accounts').get(old_parent_pid)
+                if not p_pid:
+                    raise RolloverError(
+                        f'Unable to find new parent account for {str(acc)}'
+                        f' : parent pid was {old_parent_pid}'
+                    )
+                data['parent']['$ref'] = get_ref_for_pid('acac', p_pid)
+            # Create the new account.
+            #   If create failed :: raise an error.
+            #   If success :: fill the mapping table AND the stack of new obj.
+            try:
+                new_account = AcqAccount.create(
+                    data, dbcommit=True, reindex=True, delete_pid=True)
+                self._stack.append(new_account)
+                self._mapping_table['accounts'][acc.pid] = new_account.pid
+                old_label = truncate(str(acc), 55).ljust(57)
+                new_label = truncate(str(new_account), 55)
+                log.info(f"\t* (#{idx}) migrate {old_label} --> {new_label}")
+            except Exception as e:
+                raise RolloverError(f'Account creation failed on '
+                                    f'[acac#{acc.pid}] :: {str(e)}') from e
+
+    def _migrate_orders(self, orders):
+        """Migrate a list of orders.
+
+        :params orders (AcqOrder[]): the list of orders to migrate.
+        :raises RolloverError: If an order migration failed.
+        """
+        log = self.logger
+        log.info("  Migrating orders ...")
+        self._mapping_table['orders'] = {}
+        for idx, order in enumerate(orders, 1):
+            data = deepcopy(order)
+            # Add a relation between the new order and the previous one.
+            # This is useful to navigate in order history.
+            data['previousVersion'] = {
+                '$ref': get_ref_for_pid('acor', order.pid)
+            }
+            # Create the new order.
+            #   If create failed :: raise an error.
+            #   If success :: fill the mapping table AND the stack of new obj.
+            try:
+                new_order = AcqOrder.create(
+                    data, dbcommit=True, reindex=True, delete_pid=True)
+                self._stack.append(new_order)
+                self._mapping_table['orders'][order.pid] = new_order.pid
+                old_label = truncate(str(order), 55).ljust(57)
+                new_label = truncate(str(new_order), 55)
+                log.info(f"\t* (#{idx}) migrate {old_label} --> {new_label}")
+            except Exception as e:
+                raise RolloverError(f'Order creation failed on '
+                                    f'[acor#{order.pid}] :: {str(e)}') from e
+
+    def _migrate_order_lines(self, order_lines):
+        """Migrate a list of order lines.
+
+        :params order_lines (AcqOrderLine[]): the order lines list to migrate.
+        :raises RolloverError: If an order line migration failed.
+        """
+        log = self.logger
+        log.info("  Migrating order lines ...")
+        self._mapping_table['order_lines'] = {}
+        for idx, line in enumerate(order_lines, 1):
+            data = deepcopy(line)
+            # Try to find the new parent pids (checking the temporary
+            # mapping table).
+            o_order_pid = line.order_pid
+            p_order_pid = self._mapping_table.get('orders').get(o_order_pid)
+            if not p_order_pid:
+                raise RolloverError(
+                    f'Unable to find new parent order for {str(line)}'
+                    f' : parent pid was {p_order_pid}'
+                )
+            o_acc_pid = line.account_pid
+            p_acc_pid = self._mapping_table.get('accounts').get(o_acc_pid)
+            if not p_acc_pid:
+                raise RolloverError(
+                    f'Unable to find new parent account for {str(line)}'
+                    f' : parent pid was {p_acc_pid}'
+                )
+            data['acq_order']['$ref'] = get_ref_for_pid('acor', p_order_pid)
+            data['acq_account']['$ref'] = get_ref_for_pid('acac', p_acc_pid)
+            # Update specific order line fields
+            data['quantity'] = line.unreceived_quantity
+            del data['total_amount']
+
+            # Create the new order line.
+            #   If create failed :: raise an error.
+            #   If success :: fill the mapping table AND the stack of new obj.
+            try:
+                new_line = AcqOrderLine.create(
+                    data, dbcommit=True, reindex=True, delete_pid=True)
+                self._stack.append(new_line)
+                self._mapping_table['order_lines'][line.pid] = new_line.pid
+                old_label = truncate(str(line), 55).ljust(57)
+                new_label = truncate(str(new_line), 55)
+                log.info(f"\t* (#{idx}) migrate {old_label} --> {new_label}")
+            except Exception as e:
+                raise RolloverError(f'Order line creation failed on '
+                                    f'[acol#{line.pid}] :: {str(e)}') from e
+
+    def _update_budgets(self, orig_state=False, dest_state=False):
+        """Update rollover budgets to activate/deactivate them.
+
+        :param orig_state (boolean): the new state for original budget.
+        :param dest_state (boolean): the new state for destination budget.
+        """
+        self.logger.info("\tUpdating budget resources...")
+        orig_data = deepcopy(self.original_budget)
+        orig_data['is_active'] = orig_state
+        self.original_budget.update(orig_data, dbcommit=True, reindex=True)
+        state_str = 'activated' if orig_state else 'deactivated'
+        self.logger.info(f"\t  * Original budget is now {state_str}")
+
+        dest_data = deepcopy(self.destination_budget)
+        dest_data['is_active'] = dest_state
+        self.destination_budget.update(dest_data, dbcommit=True, reindex=True)
+        state_str = 'activated' if dest_state else 'deactivated'
+        self.logger.info(f"\t  * Destination budget is now {state_str}")
+
+    def _update_organisation(self):
+        """Update the organisation current active budget."""
+        self.logger.info("\tUpdating organisation current budget...")
+        org_pid = self.destination_budget.organisation_pid
+        org = Organisation.get_record_by_pid(org_pid)
+        org['current_budget_pid'] = self.destination_budget.pid
+        org = org.update(org, dbcommit=True, reindex=True)
+        self.logger.info(f"\t  * Current organisation budget is now "
+                         f"{org['current_budget_pid']}")
+
+    # PRIVATE METHODS =========================================================
+    #  These methods are used during the rollover process. They shouldn't be
+    #  use outside this class
+
+    def _abort_rollover(self, message=None):
+        """Aborting the rollover process.
+
+        This will delete all acquisition resources created on the destination
+        `Budget` resource in the reverse order of their creation.
+
+        :param message: the message to log.
+        """
+        if message:
+            self.logger.warning(message)
+        self.logger.warning('Aborting rollover process !')
+        self._update_budgets(True, False)
+        if not self._stack:
+            return
+        self.logger.info('Purging created resources...')
+        for obj in reversed(self._stack):
+            obj.delete(force=True, dbcommit=True, delindex=True)
+            self.logger.info(f"\t* object {str(obj)} deleted")
+
+    def _confirm(self, question, default="yes"):
+        """Ask a yes/no question via raw_input() and return their answer.
+
+        :param question: is a string that is presented to the user.
+        :param default: is the presumed answer if the user just hits <Enter>.
+            It must be "yes" (the default), "no" or None (meaning an answer
+            is required of the user).
+        :return: The "answer" return value is True for "yes" or False for "no".
+        """
+        valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
+        if default is None:
+            prompt = " [y/n] "
+        elif default == "yes":
+            prompt = " [Y/n] "
+        elif default == "no":
+            prompt = " [y/N] "
+        else:
+            raise ValueError("invalid default answer: '%s'" % default)
+
+        while True:
+            self.logger.info(question + prompt)
+            choice = input().lower()
+            if default is not None and choice == "":
+                return valid[default]
+            elif choice in valid:
+                return valid[choice]
+            else:
+                self.logger.warning("Please respond with 'yes' or 'no'.")
+
+    def _create_new_budget(self, **kwargs):
+        """Create a new budget to use for rollover setting.
+
+        :param **kwargs: all necessary information to create the new budget.
+        :return: the new `Budget` resource.
+        :raises ValueError: If some required budget parameters are missing.
+        """
+        org_pid = self.original_budget.organisation_pid
+        data = {
+            'organisation': {'$ref': get_ref_for_pid('org', org_pid)},
+            'is_active': False
+        }
+        for required_param in ['name', 'start_date', 'end_date']:
+            assert required_param in kwargs, f'{required_param} param required'
+            data[required_param] = kwargs[required_param]
+        if budget := Budget.create(data, dbcommit=True, reindex=True):
+            self._stack.append(budget)
+        return budget
+
+    def _draw_data_table(self, columns, rows=None, padding=''):
+        """Draw data as a table using ASCII characters.
+
+        :param columns: the column headers. Each column is a tuple that must
+            define column name, column max length and optionally data alignment
+            in this column.
+        :param rows: a list of tuple. Each tuple representing a data row and
+            must define at most as much data as the number of columns.
+        :param padding: the left padding to apply to each table line.
+        """
+        rows = rows or []
+        for line in draw_data_table(columns, rows, padding).splitlines():
+            self.logger.info(line)
+
+    def _get_rollover_migration_setting(self, account):
+        """Get the rollover migration setting from library related to account.
+
+        :param account: the account to analyze.
+        :return: the migration setting ; 'ALLOCATED_AMOUNT' by default.
+        """
+        return self._get_library(account.library_pid) \
+            .get('rollover_settings', {}) \
+            .get('account_transfer', AccountTransferOption.ALLOCATED_AMOUNT)
+
+    def _get_library(self, library_pid):
+        """Get a `Library` resources from cache or load it.
+
+        :param library_pid (string): the library_pid to get/load.
+        """
+        if library_pid not in self._cache.get('library', {}):
+            library = Library.get_record_by_pid(library_pid)
+            self._cache.setdefault('library', {})[library_pid] = library
+        return self._cache['library'][library_pid]
+
+    def _validate(self):
+        """Validate the rollover parameters.
+
+        To be valid, we need to check parameters of a rollover process :
+          - origin and destination budget exists
+          - both budgets must be related to the same organisation
+          - origin budget is an active budget
+          - destination budget must be empty (no acquisition account children
+            doesn't exist)
+
+        :raises BudgetDoesNotExist: A desired resource doesn't exist.
+        :raises IncompatibleBudgetError: If budgets doesn't belong to the same
+            organisation
+        :raises InactiveBudgetError: If origin budget is inactive.
+        :raises NotEmptyBudgetError: If destination budget doesn't empty
+        """
+        if not self.original_budget or not self.destination_budget:
+            raise BudgetDoesNotExist()
+        o_org_pid = self.original_budget.organisation_pid
+        d_org_pid = self.destination_budget.organisation_pid
+        if o_org_pid != d_org_pid:
+            raise IncompatibleBudgetError(o_org_pid, d_org_pid)
+        elif not self.original_budget.is_active:
+            raise InactiveBudgetError(self.original_budget.pid)
+        elif self.destination_budget.get_links_to_me():
+            raise BudgetNotEmptyError(self.destination_budget.pid)
+
+    # PRIVATE STATIC METHODS ==================================================
+
+    @staticmethod
+    def _get_accounts(budget_pid):
+        """Get accounts related to a budget sorted as hierarchical tree.
+
+        :param budget_pid (string): the budget pid to filter.
+        :return: the sorted list of `AcqAccount`.
+        """
+        query = AcqAccountsSearch() \
+            .filter('term', budget__pid=budget_pid) \
+            .params(preserve_order=True) \
+            .sort({'depth': {'order': 'asc'}}) \
+            .source(False).scan()
+        return sort_accounts_as_tree(
+            [AcqAccount.get_record(hit.meta.id) for hit in query]
+        )
+
+    @staticmethod
+    def _get_orders_to_migrate(account_pids):
+        """Get orders to migrate related to a list of accounts.
+
+        * An opened order is an order for which the status is still PENDING,
+          ORDERED or PARTIALLY_RECEIVED. If an order is CANCELLED or totally
+          RECEIVED, it's not necessary to migrate it.
+        * STANDING_ORDER type orders :: These orders (even if all order lines
+          are closed) must migrate because there is a huge possibility that new
+          items will be received for the new budget.
+
+        :param account_pids (string[]): the list of account pids to filter.
+        :return: a list of `AcqOrder` related to account pids.
+        """
+        open_status = [
+            AcqOrderStatus.ORDERED,
+            AcqOrderStatus.PENDING,
+            AcqOrderStatus.PARTIALLY_RECEIVED
+        ]
+        filters = Q('terms', status=open_status)
+        filters |= Q('term', type=AcqOrderType.STANDING_ORDER)
+
+        query = AcqOrdersSearch() \
+            .filter('terms', order_lines__account__pid=account_pids) \
+            .filter(filters) \
+            .source(False)
+        return [AcqOrder.get_record(hit.meta.id) for hit in query.scan()]
+
+    @staticmethod
+    def _get_opened_order_lines(order_pids, account_pids):
+        """Get opened order lines related to some orders and some accounts.
+
+        Valid states for opened order lines are APPROVED, ORDERED and PARTIALLY
+        RECEIVED. We need to check accounts AND orders, because an order
+        contains multiple order lines and these order lines are linked to
+        an account (not necessary always the same).
+
+        :param order_pids (string[]): the list of order pids.
+        :param account_pids (string[]): the list of account pids.
+        :return: a list open `AcqOrderLine` matching criteria.
+        """
+        open_status = [
+            AcqOrderLineStatus.APPROVED,
+            AcqOrderLineStatus.ORDERED,
+            AcqOrderLineStatus.PARTIALLY_RECEIVED
+        ]
+        query = AcqOrderLinesSearch() \
+            .filter('terms', acq_account__pid=account_pids) \
+            .filter('terms', acq_order__pid=order_pids) \
+            .filter('terms', status=open_status) \
+            .source(False).scan()
+        return [AcqOrderLine.get_record(hit.meta.id) for hit in query]

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -399,7 +399,7 @@ class IlsRecord(Record):
     def delete(self, force=False, dbcommit=False, delindex=False):
         """Delete record and persistent identifier."""
         can, _ = self.can_delete
-        if can:
+        if can or force:
             if delindex:
                 self.delete_from_index()
             persistent_identifier = self.get_persistent_identifier(self.id)

--- a/rero_ils/modules/cli/reroils.py
+++ b/rero_ils/modules/cli/reroils.py
@@ -22,17 +22,19 @@ from __future__ import absolute_import, print_function
 
 import click
 
+from rero_ils.modules.acquisition.cli import acquisition
+from rero_ils.modules.apiharvester.cli import apiharvester
+from rero_ils.modules.contributions.cli import contribution
+from rero_ils.modules.ebooks.cli import oaiharvester
+from rero_ils.modules.monitoring.cli import monitoring
+from rero_ils.modules.notifications.cli import notifications
+from rero_ils.modules.stats.cli import stats
+from rero_ils.schedulers import scheduler
+
 from .fixtures import fixtures
 from .index import index
 from .users import users
 from .utils import utils
-from ..apiharvester.cli import apiharvester
-from ..contributions.cli import contribution
-from ..ebooks.cli import oaiharvester
-from ..monitoring.cli import monitoring
-from ..notifications.cli import notifications
-from ..stats.cli import stats
-from ...schedulers import scheduler
 
 
 @click.group()
@@ -40,6 +42,7 @@ def reroils():
     """Reroils management commands."""
 
 
+reroils.add_command(acquisition)
 reroils.add_command(apiharvester)
 reroils.add_command(contribution)
 reroils.add_command(fixtures)

--- a/rero_ils/modules/libraries/models.py
+++ b/rero_ils/modules/libraries/models.py
@@ -48,3 +48,10 @@ class LibraryAddressType:
     MAIN_ADDRESS = 'main'
     SHIPPING_ADDRESS = 'shipping'
     BILLING_ADDRESS = 'billing'
+
+
+class AccountTransferOption:
+    """Allowed account transfer option for rollover setting."""
+
+    NO_TRANSFER = 'rollover_no_transfer'
+    ALLOCATED_AMOUNT = 'rollover_allocated_amount'

--- a/rero_ils/modules/stats/permissions.py
+++ b/rero_ils/modules/stats/permissions.py
@@ -112,8 +112,10 @@ def filter_stat_by_librarian(record):
     :return: statistics filtered by libraries.
     """
     library_pids = StatsForLibrarian.get_librarian_library_pids()
-    record['values'] = list(filter(lambda lib: lib['library']['pid'] in
-                            library_pids, record['values']))
+    record['values'] = list(filter(
+        lambda lib: lib['library']['pid'] in library_pids,
+        record['values']
+    ))
     return record
 
 

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -276,6 +276,16 @@ def extracted_data_from_ref(input, data='pid'):
         if len(parts) > abs(idx):
             return input_string.split('/')[idx]
 
+    def get_acronym():
+        """Get resource acronym for a $ref URI."""
+        resource_list = extracted_data_from_ref(input, data='resource')
+        endpoints = {
+            endpoint.get('search_index'): acronym
+            for acronym, endpoint
+            in current_app.config.get('RECORDS_REST_ENDPOINTS', {}).items()
+        }
+        return endpoints.get(resource_list)
+
     def get_record_class():
         """Search about a record_class name for a $ref URI."""
         resource_list = extracted_data_from_ref(input, data='resource')
@@ -312,6 +322,7 @@ def extracted_data_from_ref(input, data='pid'):
         'es_record': get_data_from_es,
         'pid': lambda: extract_part(input.get('$ref'), -1),
         'resource': lambda: extract_part(input.get('$ref'), -2),
+        'acronym': get_acronym,
         'record_class': get_record_class,
         'record': get_record
     }
@@ -1117,3 +1128,66 @@ def strip_chars(string, extra=u''):
     remove_re = re.compile(u'[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F%s]' % extra)
     new_string, _ = remove_re.subn('', string)
     return new_string
+
+
+def truncate_string(str_input, max_length, ellipsis='...'):
+    """Truncate a string if too long and add an ellipsis."""
+    if len(str_input) > max_length:
+        return str_input[:max_length - len(ellipsis)] + ellipsis
+    return str_input
+
+
+def draw_data_table(columns, rows=[], padding=''):
+    """Draw data as a table using ASCII characters.
+
+    :param columns: the column headers. Each column is a tuple that must
+        define column name, column max length and optionally data alignment
+        in this column.
+    :param rows: a list of tuple. Each tuple representing a data row and
+        must define at most as much data as the number of columns.
+    :param padding: the left padding to apply to each table line.
+    """
+
+    def table_header():
+        column_lengths = [column[1] for column in columns]
+
+        def draw_line(col_lengths, sep='┼'):
+            return sep.join(['─' * length for length in col_lengths])
+
+        def draw_column_name(cols, sep='│', pad=' '):
+            return sep.join([
+                f'{pad}{truncate_string(col[0], col[1] - len(pad * 2))}{pad}'
+                .ljust(col[1])
+                for col in cols
+            ])
+
+        return f"{padding}┌{draw_line(column_lengths, sep='┬')}┐\n" + \
+               f"{padding}│{draw_column_name(columns)}│\n" + \
+               f"{padding}├{draw_line(column_lengths)}┤\n"
+
+    def table_footer():
+        return f"{padding}└{'┴'.join(['─' * col[1] for col in columns])}┘\n"
+
+    def table_rows(sep='│'):
+        def draw_row_content(row, pad=' '):
+            parts = []
+            for idx, col_content in enumerate(row, 0):
+                column = columns[idx]
+                col_length = columns[idx][1]
+                align = column[2] if len(column) >= 3 else 'left'
+                data = truncate_string(col_content, col_length - len(pad * 2))
+                if align == 'right':
+                    data = f'{pad}{data}{pad}'.rjust(col_length)
+                elif align == 'center':
+                    data = f'{pad}{data}{pad}'.center(col_length)
+                else:
+                    data = f'{pad}{data}{pad}'.ljust(col_length)
+                parts.append(data)
+            return sep.join(parts)
+
+        return "\n".join([
+            f"{padding}{sep}{draw_row_content(row)}{sep}"
+            for row in rows
+        ])+"\n"
+
+    return table_header() + table_rows() + table_footer()

--- a/tests/api/acquisition/acq_utils.py
+++ b/tests/api/acquisition/acq_utils.py
@@ -17,13 +17,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Utils for acquisitions."""
-
+import mock
 from flask import url_for
-from utils import postdata
+from utils import VerifyRecordPermissionPatch, postdata
 
 from rero_ils.modules.utils import get_record_class_from_schema_or_pid_type
 
 
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def _make_resource(client, pid_type, input_data):
     """Dynamic creation of resource using REST_API.
 
@@ -40,6 +42,8 @@ def _make_resource(client, pid_type, input_data):
         raise Exception(data['message'])
 
 
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def _del_resource(client, pid_type, pid):
     """Delete a resource using the REST API.
 

--- a/tests/api/acquisition/test_acquisition_rollover.py
+++ b/tests/api/acquisition/test_acquisition_rollover.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests acquisition rollover process."""
+import os
+from copy import deepcopy
+
+import mock
+import pytest
+from api.acquisition.acq_utils import _make_resource
+from click.testing import CliRunner
+
+from rero_ils.config import ROLLOVER_LOGGING_CONFIG
+from rero_ils.modules.acquisition.budgets.api import Budget
+from rero_ils.modules.acquisition.cli import rollover
+from rero_ils.modules.acquisition.exceptions import BudgetDoesNotExist, \
+    BudgetNotEmptyError, InactiveBudgetError, IncompatibleBudgetError
+from rero_ils.modules.acquisition.rollover import AcqRollover
+from rero_ils.modules.utils import get_ref_for_pid
+
+
+def test_rollover_cli(client, acq_full_structure_a, org_martigny, script_info):
+    """Test rollover script using the CLI command."""
+
+    origin_budget = acq_full_structure_a
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.mkdir('logs')
+
+        # Missing destination budget argument
+        res = runner.invoke(rollover, [origin_budget.pid])
+        assert res != 0
+        # Missing parameters to create destination budget
+        res = runner.invoke(rollover, [origin_budget.pid, '-n'])
+        assert res != 0
+
+        result = runner.invoke(
+            rollover, [
+                origin_budget.pid,
+                '--new-budget',
+                '--budget-name', 'Budget destination',
+                '--budget-start-date', '2022-01-01',
+                '--budget-end-date', '2022-12-31'
+            ], obj=script_info
+        )
+        assert result.exit_code == 0  # all works fine !
+
+
+def test_rollover_exceptions(
+    client, acq_full_structure_a, org_martigny, org_sion, lib_martigny
+):
+    """Test rollover process exceptions."""
+    origin_budget = acq_full_structure_a
+    # budget data
+    ref_org_sion = get_ref_for_pid('org', org_sion.pid)
+    ref_org_martigny = get_ref_for_pid('org', org_martigny.pid)
+
+    destination_budget = {
+        'name': 'Budget destination',
+        'start_date': '2022-01-01',
+        'end_date': '2022-12-31',
+        'is_active': False,
+        'organisation': {'$ref': ref_org_martigny}
+    }
+
+    # Use special logging configuration to disable any logs
+    logging_config = deepcopy(ROLLOVER_LOGGING_CONFIG)
+    logging_config['handlers']['console'] = {'class': 'logging.NullHandler'}
+    logging_config['handlers']['file'] = {'class': 'logging.NullHandler'}
+
+    # TEST#1 :: Run rollover process without destination budget
+    #    In this case, the rollover script will try to create a new budget
+    #    using additional keyword arguments. If not present, it will raise
+    #    AssertionError
+    with pytest.raises(AssertionError) as err:
+        AcqRollover(origin_budget, logging_config=logging_config)
+    assert 'param required' in str(err)
+
+    # TEST#2 :: Rollover arguments validation
+    #   * testing budget record existence.
+    #   * testing budget in same organisation
+    #   * testing original budget is active
+    #   * testing destination budget is empty
+    with pytest.raises(BudgetDoesNotExist):
+        AcqRollover(origin_budget, {}, logging_config=logging_config,
+                    propagate_errors=True)
+
+    destination_budget['organisation']['$ref'] = ref_org_sion
+    sion_budget = _make_resource(client, 'budg', destination_budget)
+    with pytest.raises(IncompatibleBudgetError):
+        AcqRollover(origin_budget, sion_budget, logging_config=logging_config,
+                    propagate_errors=True)
+
+    destination_budget['organisation']['$ref'] = ref_org_martigny
+    dest_budget = _make_resource(client, 'budg', destination_budget)
+    origin_budget['is_active'] = False
+    origin_budget.update(origin_budget, dbcommit=True, reindex=True)
+    with pytest.raises(InactiveBudgetError):
+        AcqRollover(origin_budget, dest_budget, logging_config=logging_config,
+                    propagate_errors=True)
+
+    origin_budget['is_active'] = True
+    origin_budget.update(origin_budget, dbcommit=True, reindex=True)
+    _make_resource(client, 'acac', {
+        'name': 'account_1',
+        'number': '000.0000.01',
+        'allocated_amount': 1000,
+        'budget': {'$ref': get_ref_for_pid('budg', dest_budget.pid)},
+        'library': {'$ref': get_ref_for_pid('lib', lib_martigny.pid)}
+    })
+    with pytest.raises(BudgetNotEmptyError):
+        AcqRollover(origin_budget, dest_budget, logging_config=logging_config,
+                    propagate_errors=True)
+
+
+def test_rollover_misc_functions(client, acq_full_structure_a, org_martigny):
+    """Test miscellaneous methods of rollover process.
+
+    Test of these methods are difficult into a classic rollover process ; test
+    them into this function to increase code coverage and ensure all works as
+    expected.
+    """
+    original_budget = acq_full_structure_a
+    destination_budget = _make_resource(client, 'budg', {
+        'name': 'Budget destination',
+        'start_date': '2022-01-01',
+        'end_date': '2022-12-31',
+        'is_active': False,
+        'organisation': {'$ref': get_ref_for_pid('org', org_martigny.pid)}
+    })
+    # Use special logging configuration to disable any logs
+    logging_config = deepcopy(ROLLOVER_LOGGING_CONFIG)
+    logging_config['handlers']['console'] = {'class': 'logging.NullHandler'}
+    logging_config['handlers']['file'] = {'class': 'logging.NullHandler'}
+    process = AcqRollover(
+        original_budget,
+        destination_budget,
+        logging_config=logging_config
+    )
+
+    # TEST#1 :: budget creation by rollover process
+    new_budget = process._create_new_budget(
+        name='test_budget',
+        start_date='2000-01-01',
+        end_date='2000-12-31'
+    )
+    assert new_budget
+    assert new_budget.name == 'test_budget'
+
+    # TEST#2 :: confirmation message
+    with mock.patch('builtins.input', side_effect=['Y', 'No', 'inv', 'y', '']):
+        confirmation = process._confirm('user will enter "Y"', default=None)
+        assert confirmation
+        confirmation = process._confirm('user will enter "n"')
+        assert not confirmation
+        confirmation = process._confirm('user will enter "inv", next "y"')
+        assert confirmation
+        confirmation = process._confirm('user just push ENTER', default='no')
+        assert not confirmation
+
+    with pytest.raises(ValueError):
+        process._confirm('invalid default', default='dummy')
+
+    # TEST#3 :: aborting ; this will delete the new created budget
+    assert len(process._stack) == 1
+    process._abort_rollover('dummy errors')
+    control_budget = Budget.get_record_by_pid(new_budget.pid)
+    assert not control_budget

--- a/tests/api/holdings/test_provisional_items.py
+++ b/tests/api/holdings/test_provisional_items.py
@@ -241,7 +241,7 @@ def test_holding_requests(client, patron_martigny, loc_public_martigny,
     assert item_2.get('enumerationAndChronology') == description
     assert item_2.pid != item.pid
 
-    all_item_pids = [pid for pid in Item.get_all_pids()]
+    all_item_pids = list(Item.get_all_pids())
     assert all_item_pids
 
     # test delete provisional items with no active fees/loans
@@ -250,7 +250,7 @@ def test_holding_requests(client, patron_martigny, loc_public_martigny,
     assert report.get('number_of_candidate_items_to_delete')
     # assert that not deleted items are either having loans/fees or not
     # provisional items
-    left_item_pids = [pid for pid in Item.get_all_pids()]
+    left_item_pids = list(Item.get_all_pids())
     assert left_item_pids
     for pid in left_item_pids:
         record = Item.get_record_by_pid(pid)

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -202,7 +202,7 @@
       }
     ],
     "rollover_settings": {
-      "account_transfer": "rollover_no_transfer"
+      "account_transfer": "rollover_allocated_amount"
     }
   },
   "lib2": {

--- a/tests/fixtures/acquisition.py
+++ b/tests/fixtures/acquisition.py
@@ -21,6 +21,7 @@
 from copy import deepcopy
 
 import pytest
+from api.acquisition.acq_utils import _make_resource
 from utils import flush_index
 
 from rero_ils.modules.acquisition.acq_accounts.api import AcqAccount, \
@@ -36,6 +37,7 @@ from rero_ils.modules.acquisition.acq_receipt_lines.api import \
 from rero_ils.modules.acquisition.acq_receipts.api import AcqReceipt, \
     AcqReceiptsSearch
 from rero_ils.modules.acquisition.budgets.api import Budget, BudgetsSearch
+from rero_ils.modules.utils import get_ref_for_pid as get_ref
 from rero_ils.modules.vendors.api import Vendor, VendorsSearch
 
 
@@ -469,7 +471,7 @@ def acq_order_fiction_saxon_data(acquisition):
 
 @pytest.fixture(scope="module")
 def acq_order_fiction_saxon(
-        app, lib_saxon, vendor_martigny, acq_order_fiction_saxon_data):
+        app, lib_saxon, vendor2_martigny, acq_order_fiction_saxon_data):
     """Load acq_order lib saxon fiction record."""
     acor = AcqOrder.create(
         data=acq_order_fiction_saxon_data,
@@ -744,3 +746,141 @@ def acq_invoice_fiction_sion(
         reindex=True)
     flush_index(AcquisitionInvoicesSearch.Meta.index)
     return acin
+
+
+@pytest.fixture(scope="function")
+def acq_full_structure_a(client, lib_martigny, vendor_martigny, document,
+                         org_martigny):
+    """Create a full acquisition structure.
+
+    Budget_A
+      +--> Account_1
+      |    +--> Order_10
+      |         +--> OrderLine_10_1
+      |         +--> OrderLine_10_2
+      |         +--> Reception_10_1
+      |              +--> ReceptionLine_10_1_1 (ref to OrderLine_10_1)
+      +--> Account_2
+      |    +--> Order_20
+      +--> Account_3
+           +--> Account_3.1
+                +--> Order_30
+                     +--> OrderLine_30_1
+                     +--> Reception_30_1
+                          + ReceptionLine_30_1_1 (ref to OrderLine_30_1)
+    """
+    org_ref = get_ref('org', org_martigny.pid)
+    lib_ref = get_ref('lib', lib_martigny.pid)
+    vendor_ref = get_ref('vndr', vendor_martigny.pid)
+    # Budget ==============================================
+    budget = _make_resource(client, 'budg', {
+        'name': 'Budget A',
+        'start_date': '2022-01-01',
+        'end_date': '2022-12-31',
+        'is_active': True,
+        'organisation': {'$ref': org_ref}
+    })
+    budget_ref = get_ref('budg', budget.pid)
+    # Accounts ============================================
+    acac1 = _make_resource(client, 'acac', {
+        'name': 'account_1',
+        'number': '000.0000.01',
+        'allocated_amount': 1000,
+        'budget': {'$ref': budget_ref},
+        'library': {'$ref': lib_ref}
+    })
+    acac2 = _make_resource(client, 'acac', {
+        'name': 'account_2',
+        'number': '000.0000.02',
+        'allocated_amount': 2000,
+        'budget': {'$ref': budget_ref},
+        'library': {'$ref': lib_ref}
+    })
+    acac3 = _make_resource(client, 'acac', {
+        'name': 'account_3',
+        'number': '000.0000.03',
+        'allocated_amount': 3000,
+        'budget': {'$ref': budget_ref},
+        'library': {'$ref': lib_ref}
+    })
+    acac31 = _make_resource(client, 'acac', {
+        'name': 'account_3.1',
+        'number': '000.0000.03',
+        'allocated_amount': 300,
+        'budget': {'$ref': budget_ref},
+        'library': {'$ref': lib_ref},
+        'parent': {'$ref': get_ref('acac', acac3.pid)},
+    })
+    # Orders ==============================================
+    order_10 = _make_resource(client, 'acor', {
+        'vendor': {'$ref': vendor_ref},
+        'library': {'$ref': lib_ref},
+        'type': 'monograph',
+    })
+    order_20 = _make_resource(client, 'acor', {
+        'vendor': {'$ref': vendor_ref},
+        'library': {'$ref': lib_ref},
+        'type': 'monograph',
+    })
+    order_30 = _make_resource(client, 'acor', {
+        'vendor': {'$ref': vendor_ref},
+        'library': {'$ref': lib_ref},
+        'type': 'monograph',
+    })
+    # OrderLines ==========================================
+    orderline_10_1 = _make_resource(client, 'acol', {
+        'acq_account': {'$ref': get_ref('acac', acac1.pid)},
+        'acq_order': {'$ref': get_ref('acor', order_10.pid)},
+        'document': {'$ref': get_ref('doc', document.pid)},
+        'quantity': 4,
+        'amount': 25
+    })
+    orderline_10_2 = _make_resource(client, 'acol', {
+        'acq_account': {'$ref': get_ref('acac', acac1.pid)},
+        'acq_order': {'$ref': get_ref('acor', order_10.pid)},
+        'document': {'$ref': get_ref('doc', document.pid)},
+        'quantity': 2,
+        'amount': 15
+    })
+    orderline_30_1 = _make_resource(client, 'acol', {
+        'acq_account': {'$ref': get_ref('acac', acac31.pid)},
+        'acq_order': {'$ref': get_ref('acor', order_30.pid)},
+        'document': {'$ref': get_ref('doc', document.pid)},
+        'quantity': 3,
+        'amount': 33
+    })
+    # Reception ===========================================
+    reception_10_1 = _make_resource(client, 'acre', {
+        'acq_order': {'$ref': get_ref('acor', order_10.pid)},
+        'exchange_rate': 1,
+        'amount_adjustments': [{
+            'label': 'handling fees',
+            'amount': 2.0,
+            'acq_account': {'$ref':  get_ref('acac', acac1.pid)}
+        }],
+        'library': {'$ref': lib_ref}
+    })
+    reception_30_1 = _make_resource(client, 'acre', {
+        'acq_order': {'$ref': get_ref('acor', order_30.pid)},
+        'exchange_rate': 1,
+        'library': {'$ref': lib_ref}
+    })
+    # ReceptionLine =======================================
+    receptionLine_10_1_1 = _make_resource(client, 'acrl', {
+        'acq_receipt': {'$ref': get_ref('acre', reception_10_1.pid)},
+        'acq_order_line': {'$ref': get_ref('acol', orderline_10_1.pid)},
+        'quantity': 2,
+        'amount': 25,
+        'receipt_date': '2022-06-01',
+        'library': {'$ref': lib_ref}
+    })
+    receptionLine_30_1_1 = _make_resource(client, 'acrl', {
+        'acq_receipt': {'$ref': get_ref('acre', reception_30_1.pid)},
+        'acq_order_line': {'$ref': get_ref('acol', orderline_30_1.pid)},
+        'quantity': 1,
+        'amount': 30,
+        'receipt_date': '2022-07-01',
+        'library': {'$ref': lib_ref}
+    })
+
+    return budget

--- a/tests/ui/budgets/test_budgets_api.py
+++ b/tests/ui/budgets/test_budgets_api.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Budget API tests."""
+from utils import flush_index
+
+from rero_ils.modules.acquisition.acq_accounts.api import AcqAccountsSearch
+from rero_ils.modules.acquisition.budgets.api import BudgetsSearch
+
+
+def test_budget_properties(budget_2017_martigny):
+    """Test budget properties."""
+    assert budget_2017_martigny.name == budget_2017_martigny.get('name')
+
+
+def test_budget_cascade_reindex(
+    acq_account_fiction_martigny,
+    budget_2020_martigny
+):
+    """Test budget cascading reindex."""
+    budg = budget_2020_martigny
+    acac = acq_account_fiction_martigny
+    flush_index(BudgetsSearch.Meta.index)
+    flush_index(AcqAccountsSearch.Meta.index)
+
+    # when the `is_active` budget field change, the related account must be
+    # reindex too.
+    es_budg = BudgetsSearch().get_record_by_pid(budg.pid)
+    es_acac = AcqAccountsSearch().get_record_by_pid(acac.pid)
+    assert es_budg['is_active'] and es_acac['is_active']
+
+    budg['is_active'] = False
+    budg.update(budg, dbcommit=True, reindex=True)
+    flush_index(BudgetsSearch.Meta.index)
+    flush_index(AcqAccountsSearch.Meta.index)
+
+    es_budg = BudgetsSearch().get_record_by_pid(budg.pid)
+    es_acac = AcqAccountsSearch().get_record_by_pid(acac.pid)
+    assert not es_budg['is_active'] and not es_acac['is_active']

--- a/tests/ui/test_utils_app.py
+++ b/tests/ui/test_utils_app.py
@@ -20,8 +20,16 @@
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.utils import get_record_class_from_schema_or_pid_type, \
-    get_ref_for_pid, pids_exists_in_data
+    get_ref_for_pid, pids_exists_in_data, truncate_string
 from rero_ils.utils import get_current_language, remove_empties_from_dict
+
+
+def test_truncate_string():
+    """Test truncate string."""
+    assert truncate_string('this is a long string', 10, '…') \
+           == 'this is a…'
+    assert truncate_string('not truncated string', 100, '…') \
+           == 'not truncated string'
 
 
 def test_get_ref_for_pid(app):


### PR DESCRIPTION
* Creates the rollover script between two acquisition budgets.
* Removes restrictions on acquisition order reference field.
* Adds relations between acquisition order resources.
* Add acquisition CLI command to perform a rollover between two
  acquisition budgets.
* Creates uni-tests about the rollover process.
* Fixes `Budget` resource cascade indexing process.
* Fixes ElasticSearch floating sum calculation for acquisition account.
* Updates some fixtures unitest data.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

