### PR TITLE
document: add filter on the remoteTypeahead

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json
@@ -226,7 +226,8 @@
           "pattern": "^https://bib.rero.ch/api/documents/.*?$",
           "form": {
             "remoteTypeahead": {
-              "type": "documents"
+              "type": "documents",
+              "filter": "NOT harvested:true"
             },
             "validation": {
               "messages": {


### PR DESCRIPTION
Adds a filter on the relations supplement, supplementTo, otherEdition, otherPhysicalFormat, issuedWith, precededBy, succeededBy, relatedTo, hasReproduction, reproductionOf in order not to present anymore the "harvested" documents.

* Closes #3018.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

### Linked to
[document: filter on the remote typeahead](https://github.com/rero/rero-ils-ui/pull/898)