### PR TITLE
document: fix contribution error

### DIFF
--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -303,11 +303,16 @@ class Document(IlsRecord):
     def replace_refs(self):
         """Replace $ref with real data."""
         from ..contributions.api import Contribution
-        for contribution in self.get('contribution', []):
+        contributions = self.get('contribution', [])
+        # we need to iterate over a copy of the list if we want to remove an
+        # element on the original list
+        for contribution in list(contributions):
             if ref := contribution['agent'].get('$ref'):
                 agent, _ = Contribution.get_record_by_ref(ref)
                 if agent:
                     contribution['agent'] = agent
+                else:
+                    contributions.remove(contribution)
         for subjects in ['subjects', 'subjects_imported']:
             for subject in self.get(subjects, []):
                 subject_ref = subject.get('$ref')

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -221,3 +221,36 @@ def test_document_indexing(document, export_document):
     document['title'].pop(-1)
     document['title'][0]['mainTitle'][1]['value'] = orig_title
     document.update(document, dbcommit=True, reindex=True)
+
+
+def test_document_replace_refs(document):
+    """Test document replace refs."""
+    data = document.replace_refs()
+    assert len(data.get('contribution')) == 1
+
+    # add wrong referenced contribution agent
+    contributions = document.get('contribution', [])
+    contributions.append({
+        'agent': {
+          'type': 'bf:Person',
+          '$ref': 'https://mef.rero.ch/api/agents/iderf/WRONGIDREF'
+        },
+        'role': [
+          'aut'
+        ]
+      })
+    data = document.replace_refs()
+    assert len(data.get('contribution')) == 1
+
+    # add MEF contribution agent
+    contributions.append({
+        'agent': {
+            'type': 'bf:Person',
+            '$ref': 'https://mef.rero.ch/api/agents/rero/A017671081'
+        },
+        'role': [
+            'aut'
+        ]
+    })
+    data = document.replace_refs()
+    assert len(data.get('contribution')) == 2


### PR DESCRIPTION
We need to prevent internal server error when MEF resolver returns no metadata for the linked agent.

* Updates `replace_refs` method.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
