### PR TITLE
export: fix zotero plugin error

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2703,7 +2703,7 @@ RECORDS_UI_ENDPOINTS = {
 
 RECORDS_UI_EXPORT_FORMATS = {
     'doc': {
-        'raw': dict(
+        'json': dict(
             title='JSON',
             serializer='invenio_records_rest.serializers:json_v1',
             order=1,

--- a/tests/ui/documents/test_documents_ui.py
+++ b/tests/ui/documents/test_documents_ui.py
@@ -39,7 +39,7 @@ def tests_document_item_filter_detailed_view(
 
 def tests_document_export_formats(client, document):
     """Test document export view format."""
-    for format in ['raw', 'ris']:
+    for format in ['json', 'ris']:
         url = url_for(
             'invenio_records_ui.doc_export',
             viewcode='global',


### PR DESCRIPTION
The Zotero plugin use `export/json` as endpoint to retrieve document data. With previous works on export, we have changed endpoint format to `raw`. This commit revert changes.

* Uses `json` instead `raw`in RECORDS_UI_EXPORT_FORMATS config.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
