### PR TITLE
item: avoid deletion when a collection use it

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -228,7 +228,7 @@
     {% endif %}
 
     <!-- LINKED DOCUMENTS -->
-    {% if linked_documents_count > 0 %}
+    {% if linked_documents_count and linked_documents_count > 0 %}
       <a
         class="btn btn-sm btn-outline-primary mt-3"
         href="{{ url_for('rero_ils.search', viewcode=viewcode, recordType='documents', q='partOf.document.pid:' ~ record.pid, simple=0) }}"

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -267,6 +267,19 @@ def test_get_links_to_me_with_fees(patron_transaction_overdue_saxon):
     assert item.get_links_to_me(get_pids=True) == {'loans': ['1']}
 
 
+def test_get_links_to_me_with_collection(coll_martigny_1, item_lib_martigny):
+    """Test item deletion used by a collection."""
+    assert item_lib_martigny.get_links_to_me() == {
+        'collections': 1
+    }
+    assert item_lib_martigny.get_links_to_me(get_pids=True) == {
+        'collections': [coll_martigny_1.pid]
+    }
+    can_delete, links = item_lib_martigny.can_delete
+    assert not can_delete
+    assert links == {'links': {'collections': 1}}
+
+
 def test_items_properties(item_lib_martigny):
     """Test some properties about item class."""
     item = item_lib_martigny


### PR DESCRIPTION
Related to RERO-ILS-2ER sentry id.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
