### PR TITLE
SRU: fix illegal characters

### DIFF
--- a/rero_ils/modules/documents/serializers/marc.py
+++ b/rero_ils/modules/documents/serializers/marc.py
@@ -32,6 +32,7 @@ from rero_ils.modules.documents.dojson.contrib.jsontomarc21 import to_marc21
 from rero_ils.modules.documents.dojson.contrib.jsontomarc21.model import \
     replace_contribution_sources
 from rero_ils.modules.serializers import JSONSerializer
+from rero_ils.modules.utils import strip_chars
 
 DEFAULT_LANGUAGE = LocalProxy(
     lambda: current_app.config.get('BABEL_DEFAULT_LANGUAGE'))
@@ -256,11 +257,14 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
                             for code, value in items:
                                 if isinstance(value, string_types):
                                     datafield.append(element.subfield(
-                                        value, code=code))
+                                        strip_chars(value), code=code)
+                                    )
                                 else:
                                     for v in value:
                                         datafield.append(
-                                            element.subfield(v, code=code))
+                                            element.subfield(
+                                                strip_chars(v), code=code)
+                                        )
                             rec_data.append(datafield)
                 rec_record_data.append(rec_data)
                 rec.append(rec_record_data)

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -20,6 +20,7 @@
 import cProfile
 import os
 import pstats
+import re
 import unicodedata
 from datetime import date, datetime, time
 from functools import wraps
@@ -1093,3 +1094,10 @@ def get_objects(record_class, query):
     """
     for hit in query.source().scan():
         yield record_class.get_record_by_id(hit.meta.id)
+
+
+def strip_chars(string, extra=u''):
+    """Remove control characters from string."""
+    remove_re = re.compile(u'[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F%s]' % extra)
+    new_string, _ = remove_re.subn('', string)
+    return new_string


### PR DESCRIPTION
* Removes control characters from SRU export.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
