### PR TITLE
serializers: fix error when no `bf:Publication`

### DIFF
--- a/rero_ils/modules/items/serializers/collector.py
+++ b/rero_ils/modules/items/serializers/collector.py
@@ -143,22 +143,25 @@ class Collecter():
                 for edition in edition_statement.get('_text', [])
             )
             # process provision activity
-            provision_activity = next(
-                filter(lambda x: x.get('type')
-                       == 'bf:Publication', data.get('provisionActivity'))
-            )
-            start_date = provision_activity.get('startDate', '')
-            end_date = provision_activity.get('endDate')
-            document_data['document_publication_year'] = \
-                f'{start_date} - {end_date}' \
-                if end_date else start_date
 
-            document_data['document_publisher'] = cls.separator.join(
-                data['value']
-                for stmt in provision_activity.get('statement', [])
-                for data in stmt.get('label', [])
-                if stmt['type'] == 'bf:Agent'
-            )
+            # we only use the first provision activity of type
+            # bf:publication
+            if any(
+                (provision_activity := prov).get('type' == 'bf:Publication')
+                for prov in data.get('provisionActivity', [])
+            ):
+                start_date = provision_activity.get('startDate', '')
+                end_date = provision_activity.get('endDate')
+                document_data['document_publication_year'] = \
+                    f'{start_date} - {end_date}' \
+                    if end_date else start_date
+
+                document_data['document_publisher'] = cls.separator.join(
+                    data['value']
+                    for stmt in provision_activity.get('statement', [])
+                    for data in stmt.get('label', [])
+                    if stmt['type'] == 'bf:Agent'
+                )
             return document_data
 
         doc_search = DocumentsSearch() \

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -124,6 +124,7 @@ def test_document_and_holdings_serializers(
 def test_items_serializers(
     client,
     item_lib_martigny,  # on shelf
+    document,
     item_lib_fully,  # on loan
     csv_header,
     json_header,
@@ -207,6 +208,19 @@ def test_items_serializers(
     ]
     for field in fields:
         assert field in data
+
+    # test provisionActivity without type bf:Publication
+    document['provisionActivity'][0]['type'] = 'bf:Manufacture'
+    document.update(document, True, True, True)
+
+    list_url = url_for('api_item.inventory_search')
+    response = client.get(list_url, headers=csv_header)
+    assert response.status_code == 200
+    data = get_csv(response)
+    assert data
+
+    document['provisionActivity'][0]['type'] = 'bf:Publication'
+    document.update(document, True, True, True)
 
 
 def test_loans_serializers(


### PR DESCRIPTION
* When no `provisionActivity` of type `bf:publication` is present, the collector returns None rather than an empty generator.
* Fixes RT 412.
* Fixes Sentry RERO-ILS-2D1.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
