### PR TITLE
notification: enrich availability context

### DIFF
--- a/rero_ils/modules/notifications/templates/email/availability/eng.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/eng.txt
@@ -7,6 +7,10 @@ The document you requested is now available. You can pick it up at the loan desk
 
 Title: {{ loan.document.title_text }}
 Pick up location: {{ loan.pickup_name }}
+Barcode: {{ loan.document.barcode }}
+{%- if loan.document.call_numbers %}
+Call number: {{ loan.document.call_numbers | join(' / ') }}
+{%- endif %}
 {%- if loan.pickup_until %}
 To pick up until: {{ loan.pickup_until.strftime('%d/%m/%Y') }}
 {%- endif %}

--- a/rero_ils/modules/notifications/templates/email/availability/fre.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/fre.txt
@@ -5,10 +5,14 @@ Chère lectrice, cher lecteur,
 Le document que vous avez demandé est maintenant disponible. Vous pouvez venir le retirer au bureau de prêt de la bibliothèque mentionnée ci-dessous.
 {%- for loan in loans %}
 
-Titre : {{ loan.document.title_text  }}
-Lieu de retrait : {{ loan.pickup_name }}
+Titre: {{ loan.document.title_text  }}
+Code-barres: {{ loan.document.barcode }}
+{%- if loan.document.call_numbers %}
+Cote: {{ loan.document.call_numbers | join(' / ') }}
+{%- endif %}
+Lieu de retrait: {{ loan.pickup_name }}
 {%- if loan.pickup_until %}
-A retirer jusqu'au : {{ loan.pickup_until.strftime('%d/%m/%Y') }}
+A retirer jusqu'au: {{ loan.pickup_until.strftime('%d/%m/%Y') }}
 {%- endif %}
 {%- endfor %}
 

--- a/rero_ils/modules/notifications/templates/email/availability/ger.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/ger.txt
@@ -5,7 +5,11 @@ Sehr geehrte Kundin, sehr geehrter Kunde,
 Das von Ihnen bestellte Dokument ist nun verfügbar und kann an der Ausleihtheke der nachstehend genannten Bibliothek abgeholt werden.
 {%- for loan in loans %}
 
-Titel : {{ loan.document.title_text }}
+Titel: {{ loan.document.title_text }}
+Strichcode: {{ loan.document.barcode }}
+{%- if loan.document.call_numbers %}
+Signatur: {{ loan.document.call_numbers | join(' / ') }}
+{%- endif %}
 Abholort: {{ loan.pickup_name }}
 {%- if loan.pickup_until %}
 Abholen bis: {{ loan.pickup_until.strftime('%d.%m.%Y') }}

--- a/rero_ils/modules/notifications/templates/email/availability/ita.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/ita.txt
@@ -6,6 +6,10 @@ Il documento che Lei ha domandato è ora disponibile. Lei può ritirarlo al serv
 {%- for loan in loans %}
 
 Titolo: {{ loan.document.title_text }}
+Codice a barre: {{ loan.document.barcode }}
+{%- if loan.document.call_numbers %}
+Segnatura: {{ loan.document.call_numbers | join(' / ') }}
+{%- endif %}
 Punto di ritiro: {{ loan.pickup_name }}
 {%- if loan.pickup_until %}
 Ritirare entro: {{ loan.pickup_until.strftime('%d/%m/%Y') }}


### PR DESCRIPTION
* Adds item's informations in context for availability notification.
* Adapts availability notification templates.
* Closes rero#2693.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
