### PR TITLE
import: customize subjects mapping by instance

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -3207,6 +3207,11 @@ RERO_IMPORT_REST_ENDPOINTS = dict(
     )
 )
 
+# RERO_ILS_IMPORT_6XX_TARGET_ATTRIBUTE
+# Use attribute 'subjects' or 'subjects_imported'
+# =============================================================================
+RERO_ILS_IMPORT_6XX_TARGET_ATTRIBUTE = 'subjects_imported'
+
 # STREAMED EXPORT RECORDS
 # =============================================================================
 RERO_INVENIO_BASE_EXPORT_REST_ENDPOINTS = dict(

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -23,6 +23,7 @@ import contextlib
 import re
 
 from dojson import utils
+from flask import current_app
 
 from rero_ils.dojson.utils import ReroIlsMarc21Overdo, TitlePartList, \
     build_identifier, build_string_from_subfields, get_contribution_link, \
@@ -575,7 +576,6 @@ def marc21_to_subjects_6XX(self, key, value):
         '651': 'a',
         '655': 'a'
     }
-
     conference_per_tag = {
         '610': False,
         '611': True
@@ -590,6 +590,11 @@ def marc21_to_subjects_6XX(self, key, value):
     subfields_2 = utils.force_list(value.get('2'))
     subfield_2 = subfields_2[0] if subfields_2 else None
     subfields_a = utils.force_list(value.get('a', []))
+    config_field_key = \
+        current_app.config.get(
+            'RERO_ILS_IMPORT_6XX_TARGET_ATTRIBUTE',
+            'subjects_imported'
+        )
 
     if subfield_2 in ['rero', 'gnd', 'idref']:
         if tag_key in ['600', '610', '611'] and value.get('t'):
@@ -622,7 +627,7 @@ def marc21_to_subjects_6XX(self, key, value):
             subject['creator'] = remove_trailing_punctuation(
                 build_string_from_subfields(
                     value, subfield_code_per_tag[creator_tag_key]), '.', '.')
-        field_key = 'genreForm' if tag_key == '655' else 'subjects'
+        field_key = 'genreForm' if tag_key == '655' else config_field_key
         subfields_0 = utils.force_list(value.get('0'))
         if data_type in [DocumentSubjectType.PERSON,
                          DocumentSubjectType.ORGANISATION] and subfields_0:
@@ -640,25 +645,21 @@ def marc21_to_subjects_6XX(self, key, value):
             perform_subdivisions(subject)
 
         if subject.get('$ref') or subject.get(field_data_per_tag[tag_key]):
-            subjects = self.get(field_key, [])
-            subjects.append(subject)
-            self[field_key] = subjects
+            self.setdefault(field_key, []).append(subject)
     elif indicator_2 in ['0', '2']:
         term_string = build_string_from_subfields(
             value, 'abcdefghijklmnopqrstuw', ' - ')
         if term_string:
-            subject_imported = {
+            data = {
                 'type': type_per_tag[tag_key],
                 'source': source_per_indicator_2[indicator_2],
                 field_data_per_tag[tag_key]: term_string.rstrip('.')
             }
-            perform_subdivisions(subject_imported)
+            perform_subdivisions(data)
             if tag_key in ['610', '611']:
-                subject_imported['conference'] = conference_per_tag[tag_key]
-            subjects_imported = self.get('subjects_imported', [])
-            if subject_imported:
-                subjects_imported.append(subject_imported)
-                self['subjects_imported'] = subjects_imported
+                data['conference'] = conference_per_tag[tag_key]
+            if data:
+                self.setdefault(config_field_key, []).append(data)
 
 
 @marc21.over('sequence_numbering', '^362..')

--- a/tests/unit/documents/test_documents_dojson_unimarc.py
+++ b/tests/unit/documents/test_documents_dojson_unimarc.py
@@ -1549,6 +1549,7 @@ def test_unimarc_subjects():
         <subfield code="c">Jr.</subfield>
         <subfield code="d">III</subfield>
         <subfield code="f">1700-1780</subfield>
+        <subfield code="y">France</subfield>
       </datafield>
     </record>
     """
@@ -1559,7 +1560,7 @@ def test_unimarc_subjects():
         'type': 'bf:Topic',
         'source': 'rameau'
     }, {
-        'term': 'Capet, Louis III, Jr., 1700-1780',
+        'term': 'Capet, Louis III, Jr., 1700-1780 -- France',
         'type': 'bf:Topic'
     }]
 


### PR DESCRIPTION
* Adds a new parameter in config.py in order to map subjects to "subject_imported" or "subjects"
* Adapts the code for each source.
* Closes https://github.com/rero/rero-ils/issues/3079

Co-Authored-by: Benoit Erken <erken.benoit@gmail.com>

## Why are you opening this PR?

- This PR addresses the issue https://github.com/rero/rero-ils/issues/3079
- It allows the set the way an instance of RERO-ILS maps/stores subjects from MARC21 to JSON.

## Dependencies

- None

## How to test?

- Edit config.py and set variable RERO_ILS_IMPORT_6XX_TARGET_ATTRIBUTE to 'subjects' or 'subjects_imported' 
- Try to import document from BnF, LoC, SLSP,.... It should set the content of tags 6XX in the JSON attribute you define in config.py.
