### PR TITLE
dojson: use MEF latest api for contribution link

### DIFF
--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -447,14 +447,17 @@ def get_contribution_link(bibid, reroid, id, key):
                             match_type = source
                             break
         if match_type in ['idref', 'gnd']:
-            url = f'{mef_url}/mef/?q={match_type}.pid:"{match_value}"'
+            url = f'{mef_url}/mef/latest/{match_type}:{match_value}'
             response = requests_retry_session().get(url)
             status_code = response.status_code
             total = 0
             if status_code == requests.codes.ok:
-                total = response.json().get('hits', {}).get('total', 0)
-                if total > 0:
-                    return f'{mef_url}/{match_type}/{match_value}'
+                if value := response.json().get(match_type, {}).get('pid'):
+                    if match_value != value:
+                        error_print('INFO GET MEF CONTRIBUTION:',
+                                    bibid, reroid, key, id, 'NEW',
+                                    f'({match_type.upper()}){value}')
+                    return f'{mef_url}/{match_type}/{value}'
             error_print('WARNING GET MEF CONTRIBUTION:',
                         bibid, reroid, key, id, url, status_code, total)
     else:

--- a/tests/unit/documents/test_documents_dojson.py
+++ b/tests/unit/documents/test_documents_dojson.py
@@ -1420,15 +1420,9 @@ def test_marc21_to_contribution(mock_get):
     </record>
     """
     mock_get.return_value = mock_response(json_data={
-        'hits': {
-            'hits': [{
-                'metadata': {
-                    'type': 'bf:Person',
-                    'rero': {'pid': 'XXXXXXXX'}
-                }
-            }],
-            'total': 1
-        }
+        'pid': 'test',
+        'type': 'bf:Person',
+        'idref': {'pid': 'XXXXXXXX'}
     })
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
@@ -4763,15 +4757,9 @@ def test_marc21_to_subjects(mock_get):
     </record>
     """
     mock_get.return_value = mock_response(json_data={
-        'hits': {
-            'hits': [{
-                'metadata': {
-                    'type': 'bf:Person',
-                    'rero': {'pid': 'XXXXXXXX'}
-                }
-            }],
-            'total': 1
-        }
+        'pid': 'tets',
+        'type': 'bf:Person',
+        'idref': {'pid': 'XXXXXXXX'}
     })
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
@@ -5393,15 +5381,8 @@ def test_get_contribution_link(mock_get, capsys):
     os.environ['RERO_ILS_MEF_HOST'] = 'mef.xxx.rero.ch'
 
     mock_get.return_value = mock_response(json_data={
-        'hits': {
-            'hits': [{
-                'metadata': {
-                    'type': 'bf:Person',
-                    'idref': {'pid': '003945843'}
-                }
-            }],
-            'total': 1
-        }
+        'pid': 'test',
+        'idref': {'pid': '003945843'}
     })
     mef_url = get_contribution_link(
         bibid='1',
@@ -5422,8 +5403,8 @@ def test_get_contribution_link(mock_get, capsys):
     out, err = capsys.readouterr()
     assert out == (
         'WARNING GET MEF CONTRIBUTION:\t1\t1\t100..\t(IdRef)123456789\t'
-        'https://mef.xxx.rero.ch/api/agents/mef/'
-        '?q=idref.pid:"123456789"\t404\t0\t\n'
+        'https://mef.xxx.rero.ch/api/agents/mef/latest/'
+        'idref:123456789\t404\t0\t\n'
     )
 
     mock_get.return_value = mock_response(status=400)


### PR DESCRIPTION
* Uses Mef latest api in the function `get_contribution_link`.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
