### PR TITLE
user: change the type for the password field

### DIFF
--- a/rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json
+++ b/rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json
@@ -253,8 +253,8 @@
       "minLength": 6,
       "maxLength": 255,
       "widget": {
-        "templateOptions": {
-          "type": "password"
+        "formlyConfig": {
+          "type": "passwordGenerator"
         }
       }
     }


### PR DESCRIPTION
The field is now disabled and has a button for generating the password.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Dependencies

My PR depends on the following `ng-core`'s PR(s):

* [rero/ng-core#531](https://github.com/rero/ng-core/pull/531)

## How to test?

- Edit a patron and modify the user datas
- Check password field
