### PR TITLE
devel: add keep alive dev server support

### DIFF
--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -186,6 +186,12 @@ class REROILSAPP(object):
         for k in dir(app.config):
             if k.startswith('RERO_ILS_APP_'):
                 app.config.setdefault(k, getattr(app.config, k))
+        # add keep alive support for angular application
+        # NOTE: this will not work for werkzeug> 2.1.2
+        # https://werkzeug.palletsprojects.com/en/2.2.x/changes/#version-2-1-2
+        if app.config.get('DEBUG'):
+            from werkzeug.serving import WSGIRequestHandler
+            WSGIRequestHandler.protocol_version = "HTTP/1.1"
 
     def register_signals(self, app):
         """Register signals."""


### PR DESCRIPTION
Since new version of webpack the dev server should support Keep-Alive.
This is not enabled by default in werkzeug.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
