### PR TITLE
documents: better facets fiction

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1833,31 +1833,40 @@ RECORDS_REST_FACETS = dict(
                 )
             ),
             subject_fiction=dict(
-                terms=dict(
-                    field='facet_subjects',
-                    size=DOCUMENTS_AGGREGATION_SIZE,
-
-                ),
-                filter={
-                    'bool': {
-                        'must': [
-                            {'terms': {
-                                'genreForm.identifiedBy.value': [
-                                    'A027757308',
-                                    'A021097366'
-                                ]}}]}}
+                terms=dict(field='facet_subjects',
+                           size=DOCUMENTS_AGGREGATION_SIZE),
+                filter=dict(
+                    bool=dict(
+                        must=[
+                            dict(
+                                terms=dict(
+                                    facet_genre_form=[
+                                        'Fictions',
+                                        'Films de fiction'
+                                    ]
+                                )
+                            )
+                        ]
+                    )
+                )
             ),
             subject_no_fiction=dict(
                 terms=dict(field='facet_subjects',
                            size=DOCUMENTS_AGGREGATION_SIZE),
-                filter={
-                    'bool': {
-                        'must_not': [
-                            {'terms': {
-                                'genreForm.identifiedBy.value': [
-                                    'A027757308',
-                                    'A021097366'
-                                ]}}]}}
+                filter=dict(
+                    bool=dict(
+                        must_not=[
+                            dict(
+                                terms=dict(
+                                    facet_genre_form=[
+                                        'Fictions',
+                                        'Films de fiction'
+                                    ]
+                                )
+                            )
+                        ]
+                    )
+                )
             ),
             status=dict(
                 terms=dict(field='holdings.items.status',
@@ -1872,9 +1881,9 @@ RECORDS_REST_FACETS = dict(
                            size=DOCUMENTS_AGGREGATION_SIZE)
             ),
             year=dict(date_histogram=dict(
-                           field='provisionActivity.startDate',
-                           interval='year',
-                           format='yyyy')
+                field='provisionActivity.startDate',
+                interval='year',
+                format='yyyy')
             )
         ),
         filters={


### PR DESCRIPTION
* Uses 'Fictions' and 'Films de fiction' for the `subject_fiction` and `subject_no_fiction` facets.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
