### PR TITLE
contribution: fixes PIDDoesNotExistError

### DIFF
--- a/rero_ils/modules/contributions/views.py
+++ b/rero_ils/modules/contributions/views.py
@@ -23,7 +23,6 @@ import requests
 from flask import Blueprint, Response, abort, current_app, render_template, \
     request
 from flask_babelex import gettext as translate
-from invenio_pidstore.models import PersistentIdentifier
 from invenio_records_ui.signals import record_viewed
 
 from .api import Contribution
@@ -55,11 +54,10 @@ def contribution_proxy(viewcode, pid, contribution_type):
     :returns: contribution template
     """
     contribution = Contribution.get_record_by_pid(pid)
-    if contribution and contribution['type'] != contribution_type:
+    if not contribution or contribution.get('type') != contribution_type:
         abort(404, 'Record not found')
-    persistent_id = PersistentIdentifier.get('cont', pid)
     return contribution_view_method(
-        pid=persistent_id,
+        pid=contribution.persistent_identifier,
         record=contribution,
         template='rero_ils/detailed_view_contribution.html',
         viewcode=viewcode


### PR DESCRIPTION
* Returns `abort(404, 'Record not found')` for non existing records.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
