### PR TITLE
patron transaction: add manuel fee

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2685,6 +2685,15 @@ RECORDS_REST_SORT_OPTIONS['patrons']['full_name'] = dict(
 RECORDS_REST_DEFAULT_SORT['patrons'] = dict(
     query='bestmatch', noquery='full_name')
 
+# ------ PATRON TRANSACTIONS SORT
+RECORDS_REST_SORT_OPTIONS['patron_transactions']['creation_date'] = dict(
+    fields=['creation_date'], title='Patron transaction creation date',
+    default_order='asc'
+)
+
+RECORDS_REST_DEFAULT_SORT['patrons'] = dict(
+    query='mostrecent', noquery='creation_date')
+
 # ------ PATRON TYPES SORT
 RECORDS_REST_SORT_OPTIONS['patron_types']['name'] = dict(
     fields=['patron_type_name'], title='Patron type name',

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -225,9 +225,9 @@ class Notification(IlsRecord, ABC):
         """Returns patron transactions attached of a notification."""
         results = PatronTransactionsSearch()\
             .filter('term', notification__pid=self.pid)\
-            .source(['pid']).scan()
+            .source(False).scan()
         for result in results:
-            yield PatronTransaction.get_record_by_pid(result.pid)
+            yield PatronTransaction.get_record_by_id(result.meta.id)
 
     # CLASS METHODS ===========================================================
     def update_process_date(self, sent=False, status=NotificationStatus.DONE):

--- a/rero_ils/modules/patron_transactions/extensions.py
+++ b/rero_ils/modules/patron_transactions/extensions.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2022 RERO
+# Copyright (C) 2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transactions record extensions."""
+
+from flask_babelex import gettext as _
+from invenio_records.extensions import RecordExtension
+
+from rero_ils.modules.patron_transaction_events.api import \
+    PatronTransactionEvent
+from rero_ils.modules.utils import get_ref_for_pid
+
+
+class PatronTransactionExtension(RecordExtension):
+    """Patron transactions extension."""
+
+    @staticmethod
+    def _base_data_patron_event(record, steps=None):
+        """Create a initial data for Patron Transaction Event."""
+        data = {
+            'creation_date': record.get('creation_date'),
+            'type': 'fee',
+            'subtype': 'other',
+            'amount': record.get('total_amount'),
+            'parent': {
+                '$ref': get_ref_for_pid('pttr', record.pid)
+            },
+            'note': _('Initial charge')
+        }
+        if library := record.get('library'):
+            data['library'] = {
+                '$ref': library.get('$ref')
+            }
+        if steps:
+            data['steps'] = steps
+        return data
+
+    @staticmethod
+    def _data_operator_event(data, event=None):
+        """Add event on Patron Transaction Event.
+
+        If the library is defined at the event level,
+        it overrides the library of the patron transaction.
+        """
+        if event:
+            if operator := event.get('operator'):
+                data['operator'] = {
+                    '$ref': operator.get('$ref')
+                }
+            if library := event.get('library'):
+                data['library'] = {
+                    '$ref': library.get('$ref')
+                }
+        return data
+
+    @staticmethod
+    def _data_overdue(data, record):
+        """Add overdue informations on Patron Transaction Event."""
+        if record.get('type') == 'overdue':
+            data['subtype'] = 'overdue'
+            library_pid = record.loan.library_pid if record.loan_pid else \
+                record.notification_transaction_library_pid
+            if library_pid:
+                data['library'] = {
+                    '$ref': get_ref_for_pid('lib', library_pid)
+                }
+        return data
+
+    def pre_create(self, record):
+        """Called before a patron transaction event record is created."""
+        # Extract steps and event if exists.
+        steps = record.pop('steps', None)
+        event = record.pop('event', None)
+        # Update the model with the new data of the record.
+        record.model.data = dict(record)
+        # Creation of data for the event
+        data = PatronTransactionExtension._base_data_patron_event(
+            record, steps)
+        data = PatronTransactionExtension._data_operator_event(data, event)
+        data = PatronTransactionExtension._data_overdue(data, record)
+        rec = PatronTransactionEvent.create(data, update_parent=False)
+        # Add the event pid for indexing
+        record.event_pids.append(rec.pid)

--- a/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
@@ -97,6 +97,10 @@
     "patron": {
       "title": "Patron",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Patron URI",
@@ -105,9 +109,28 @@
         }
       }
     },
+    "library": {
+      "title": "Library",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "title": "Library URI",
+          "type": "string",
+          "pattern": "^https://bib.rero.ch/api/libraries/.*?$"
+        }
+      }
+    },
     "notification": {
       "title": "Notification",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Notification URI",
@@ -119,6 +142,10 @@
     "loan": {
       "title": "Loan",
       "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
       "properties": {
         "$ref": {
           "title": "Loan URI",

--- a/rero_ils/modules/patron_transactions/utils.py
+++ b/rero_ils/modules/patron_transactions/utils.py
@@ -126,17 +126,16 @@ def create_patron_transaction_from_overdue_loan(
             'note': _('incremental overdue fees'),
             'total_amount': total_amount,
             'creation_date': datetime.now(timezone.utc).isoformat(),
+            'steps': [
+                {'timestamp': fee[1].isoformat(), 'amount': fee[0]}
+                for fee in fees
+            ]
         }
-        steps = [
-            {'timestamp': fee[1].isoformat(), 'amount': fee[0]}
-            for fee in fees
-        ]
         return PatronTransaction.create(
             data,
             dbcommit=dbcommit,
             reindex=reindex,
-            delete_pid=delete_pid,
-            steps=steps
+            delete_pid=delete_pid
         )
 
 


### PR DESCRIPTION
* Adds library field on patron_transactions schema.
* Adds a sort option for patron transaction.
* Adds extensions for patron transactions.
* Transfer of event creation to the extension.
* Fixes some tests.
* Closes #3143.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
