### PR TITLE
tests: avoid changes in the database and the indices

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -81,6 +81,7 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "discovery.type=single-node"
       - "indices.query.bool.max_clause_count=3000"
+      - path.repo="snaps"
     ulimits:
       memlock:
         soft: -1

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,9 @@
 live_server_scope = module
 addopts = --color=yes --pycodestyle --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=rero_ils --cov-report=term-missing --ignore=setup.py --ignore=docs/conf.py --ignore=rero_ils/config.py -m "not external"
 testpaths = docs tests rero_ils
+usefixtures =
+    db_rollback
+    es_snapshot
 
 # custom markers
 markers =


### PR DESCRIPTION
* When a test modify the database and the elasticsearch indices, we want
  to restore the original data.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
