### PR TITLE
security: uniformize failed login message

### DIFF
--- a/rero_ils/accounts_views.py
+++ b/rero_ils/accounts_views.py
@@ -43,7 +43,7 @@ def user_exists(email):
     """Validate that a user exists."""
     user = User.get_by_username_or_email(email)
     if not user:
-        raise ValidationError(_('USER_DOES_NOT_EXIST'))
+        raise ValidationError(_('INVALID_USER_OR_PASSWORD'))
 
 
 class LoginView(CoreLoginView):
@@ -66,7 +66,7 @@ class LoginView(CoreLoginView):
         """Verify and login a user."""
         user = self.get_user(**kwargs)
         if not user:
-            _abort(_('USER_DOES_NOT_EXIST'))
+            _abort(_('INVALID_USER_OR_PASSWORD'))
         self.verify_login(user, **kwargs)
         self.login_user(user)
         return self.success_response(user)

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2882,6 +2882,10 @@ RERO_ILS_COMMUNICATION_DISPATCHER_FUNCTIONS = {
 
 # Login Configuration
 # ===================
+#: Supercharge flask_security invalid password or user message.
+SECURITY_MSG_INVALID_PASSWORD = (_('INVALID_USER_OR_PASSWORD'), 'error')
+SECURITY_MSG_USER_DOES_NOT_EXIST = (_('INVALID_USER_OR_PASSWORD'), 'error')
+
 #: Allow password change by users.
 SECURITY_CHANGEABLE = True
 

--- a/tests/api/test_user_authentication.py
+++ b/tests/api/test_user_authentication.py
@@ -40,7 +40,7 @@ def test_login(client, patron_sion):
     assert res.status_code == 400
     data = get_json(res)
     assert data['errors'][0] == dict(
-        field='email', message=gettext('USER_DOES_NOT_EXIST'))
+        field='email', message=gettext('INVALID_USER_OR_PASSWORD'))
 
     # wrong password
     res, _ = postdata(
@@ -54,7 +54,7 @@ def test_login(client, patron_sion):
     assert res.status_code == 400
     data = get_json(res)
     assert data['errors'][0] == dict(
-        field='password', message='Invalid password')
+        field='password', message=gettext('INVALID_USER_OR_PASSWORD'))
 
     # login by email
     res, _ = postdata(


### PR DESCRIPTION
* Provides same message to the user on login attempt if the password or username is invalid, to prevent security exploits.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
