### PR TITLE
templates: use marshmallow for API control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,7 @@ patron_transaction_event_id = "rero_ils.modules.patron_transaction_events.api:pa
 patron_transaction_id = "rero_ils.modules.patron_transactions.api:patron_transaction_id_fetcher"
 patron_type_id = "rero_ils.modules.patron_types.api:patron_type_id_fetcher"
 stat_id = "rero_ils.modules.stats.api:stat_id_fetcher"
-template_id = "rero_ils.modules.templates.api:template_id_minter"
+template_id = "rero_ils.modules.templates.api:template_id_fetcher"
 vendor_id = "rero_ils.modules.vendors.api:vendor_id_fetcher"
 
 [tool.poetry.plugins."invenio_pidstore.minters"]

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -124,7 +124,6 @@ from .modules.patrons.permissions import PatronPermissionPolicy
 from .modules.selfcheck.permissions import seflcheck_permission_factory
 from .modules.stats.api import Stat
 from .modules.stats.permissions import StatisticsPermissionPolicy
-from .modules.templates.api import Template
 from .modules.templates.permissions import TemplatePermissionPolicy
 from .modules.users.api import get_profile_countries, \
     get_readonly_profile_fields
@@ -1532,7 +1531,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': 'rero_ils.modules.serializers:json_v1_search'
         },
         record_loaders={
-            'application/json': lambda: Template(request.get_json()),
+            'application/json': 'rero_ils.modules.templates.loaders:json_v1'
         },
         list_route='/templates/',
         record_class='rero_ils.modules.templates.api:Template',

--- a/rero_ils/modules/commons/schemas.py
+++ b/rero_ils/modules/commons/schemas.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Common marshmallow schema for RERO-ILS project."""
+
+from functools import wraps
+
+from flask import request
+from invenio_records_rest.schemas.fields import SanitizedUnicode
+from marshmallow import Schema
+from marshmallow.validate import Length
+
+
+def http_applicable_method(*http_methods):
+    """Skip the decorated function if HTTP request method isn't applicable.
+
+    :param http_methods: the list of HTTP method for which the decorated
+        function will be applicable. If request method isn't in this list, the
+        decorated function will be skipped/uncalled.
+    """
+    def inner(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if request.method in http_methods:
+                return func(*args, **kwargs)
+        return wrapper
+    return inner
+
+
+class RefSchema(Schema):
+    """Schema to describe a reference to another resources."""
+
+    # TODO : find a way to validate the `$ref` using a variable pattern.
+    ref = SanitizedUnicode(data_key='$ref', attribute='$ref')
+
+
+class NoteSchema(Schema):
+    """Schema to describe a note."""
+
+    type = SanitizedUnicode()
+    content = SanitizedUnicode(validate=Length(1, 2000))

--- a/rero_ils/modules/documents/loaders/marcxml.py
+++ b/rero_ils/modules/documents/loaders/marcxml.py
@@ -32,13 +32,13 @@ def marcxml_marshmallow_loader():
     """
     marcxml_records = split_stream(BytesIO(request.data))
     number_of_xml_records = 0
-    josn_record = {}
+    json_record = {}
     for marcxml_record in marcxml_records:
         marc21json_record = create_record(marcxml_record)
-        josn_record = marc21.do(marc21json_record)
+        json_record = marc21.do(marc21json_record)
         # converted records are considered as draft
-        josn_record['_draft'] = True
+        json_record['_draft'] = True
         if number_of_xml_records > 0:
             abort(400)
         number_of_xml_records += 1
-    return josn_record
+    return json_record

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -155,8 +155,8 @@ def logged_user():
         patron['organisation'] = patron.organisation.dumps(
             dumper=OrganisationLoggedUserDumper())
         patron['libraries'] = [
-            {'pid': extracted_data_from_ref(library)}
-            for library in patron.get('libraries', [])
+            {'pid': pid}
+            for pid in patron.manageable_library_pids
         ]
         data['patrons'].append(patron)
 

--- a/rero_ils/modules/serializers/base.py
+++ b/rero_ils/modules/serializers/base.py
@@ -19,10 +19,17 @@
 """RERO ILS record serialization."""
 
 from flask import json, request
+from invenio_jsonschemas import current_jsonschemas
 from invenio_records_rest.serializers.json import \
     JSONSerializer as _JSONSerializer
 
 from .mixins import PostprocessorMixin
+
+
+def schema_from_context(_, context, data, schema):
+    """Get the record's schema from context."""
+    record = (context or {}).get('record', {})
+    return record.get('$schema', current_jsonschemas.path_to_url(schema))
 
 
 class JSONSerializer(_JSONSerializer, PostprocessorMixin):

--- a/rero_ils/modules/templates/api.py
+++ b/rero_ils/modules/templates/api.py
@@ -25,8 +25,7 @@ from rero_ils.modules.minters import id_minter
 from rero_ils.modules.providers import Provider
 from rero_ils.modules.utils import extracted_data_from_ref
 
-from .extensions import CleanDataDictExtension, \
-    TemplateVisibilityChangesExtension
+from .extensions import CleanDataDictExtension
 from .models import TemplateIdentifier, TemplateMetadata, TemplateVisibility
 
 # provider
@@ -59,14 +58,14 @@ class Template(IlsRecord):
     """Templates class."""
 
     _extensions = [
-        CleanDataDictExtension(),
-        TemplateVisibilityChangesExtension()
+        CleanDataDictExtension()
     ]
 
     minter = template_id_minter
     fetcher = template_id_fetcher
     provider = TemplateProvider
     model_cls = TemplateMetadata
+    schema = 'templates/template-v0.0.1.json'
     pids_exist_check = {
         'required': {
             'org': 'organisation',

--- a/rero_ils/modules/templates/loaders/__init__.py
+++ b/rero_ils/modules/templates/loaders/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Loaders for `Template` resources."""
+from invenio_records_rest.loaders.marshmallow import marshmallow_loader
+
+from ..schemas.json import TemplateMetadataSchemaV1
+
+json_v1 = marshmallow_loader(TemplateMetadataSchemaV1)
+
+__all__ = (
+    'json_v1',
+)

--- a/rero_ils/modules/templates/schemas/__init__.py
+++ b/rero_ils/modules/templates/schemas/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Templates schemas."""

--- a/rero_ils/modules/templates/schemas/json.py
+++ b/rero_ils/modules/templates/schemas/json.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Schema for JSON representation of `Template` resources."""
+from functools import partial
+
+from flask_babelex import gettext as _
+from invenio_records_rest.schemas import StrictKeysMixin
+from invenio_records_rest.schemas.fields import GenFunction, SanitizedUnicode
+from marshmallow import ValidationError, fields, validates, validates_schema
+from marshmallow.validate import OneOf
+
+from rero_ils.modules.commons.schemas import RefSchema, http_applicable_method
+from rero_ils.modules.patrons.api import current_librarian
+from rero_ils.modules.serializers.base import schema_from_context
+from rero_ils.modules.users.models import UserRole
+
+from ..api import Template
+from ..models import TemplateVisibility
+
+schema_from_template = partial(schema_from_context, schema=Template.schema)
+
+
+class TemplateMetadataSchemaV1(StrictKeysMixin):
+    """Marshmallow schema for the `Template` metadata."""
+
+    pid = SanitizedUnicode()
+    template_type = SanitizedUnicode(required=True)
+    name = SanitizedUnicode(required=True)
+    description = SanitizedUnicode()
+    visibility = SanitizedUnicode(
+        required=True,
+        validate=OneOf([TemplateVisibility.PUBLIC, TemplateVisibility.PRIVATE])
+    )
+    data = fields.Dict()
+    creator = fields.Nested(RefSchema)
+    organisation = fields.Nested(RefSchema)
+    schema = GenFunction(
+        load_only=True,
+        attribute="$schema",
+        data_key="$schema",
+        deserialize=schema_from_template
+    )
+
+    # DEV NOTES : Why using marshmallow validation process
+    #   We use marshmallow validation decorators to restrict some changes on
+    #   record fields instead of using permissions workflow. We use this
+    #   procedure to allow custom error message transmission ; permissions
+    #   procedure only send an HTTP 403 status, without any message, this isn't
+    #   enough relevant for end user.
+
+    @validates('visibility')
+    @http_applicable_method('POST')
+    def validate_visibility(self, data, **kwargs):
+        """Validate the visibility field through REST API request.
+
+        Through the API, a template could only be created with `private`
+        visibility. To set a template in `public` visibility, an authorized
+        user must update an existing template.
+
+        :param data: the visibility field value.
+        :param kwargs: any additional named arguments.
+        :raises ValidationError: if error has detected on visibility attribute
+        """
+        if data == TemplateVisibility.PUBLIC:
+            raise ValidationError(
+                _('Template can be created only with `private` visibility')
+            )
+
+    @validates_schema()
+    @http_applicable_method('PUT')
+    def validate_visibility_changes(self, data, **kwargs):
+        """Validate `visibility` changes through REST API request.
+
+        Updates on `visibility` attribute is subject to restriction depending
+        on current connected user ; only FULL_PERMISSIONS and
+        LIBRARY_ADMINISTRATOR users could change `visibility` attribute.
+
+        :param data: the json data to validate.
+        :param kwargs: additional named arguments.
+        :raises ValidationError: if error has detected on visibility attribute
+        """
+        # Load DB record
+        db_record = Template.get_record_by_pid(data.get('pid'))
+        if not db_record:
+            raise ValidationError(f'Unable to load Template#{data.get("pid")}')
+
+        # Check if visibility of the template changed. If not, we can stop
+        # the validation process.
+        if db_record.get('visibility') == data.get('visibility'):
+            return
+
+        # Only lib_admin and full_permission roles can change visibility field
+        allowed_roles = [
+            UserRole.FULL_PERMISSIONS,
+            UserRole.LIBRARY_ADMINISTRATOR
+        ]
+        user_roles = set()
+        if current_librarian:
+            user_roles = set(current_librarian.get('roles', []))
+        if not user_roles.intersection(allowed_roles):
+            raise ValidationError(
+                _('You are not allowed to change template visibility')
+            )

--- a/tests/api/templates/test_templates_marshmallow.py
+++ b/tests/api/templates/test_templates_marshmallow.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2022 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests Marshmallow schema through REST API for templates."""
+import json
+from copy import deepcopy
+
+import mock
+from flask import url_for
+from utils import VerifyRecordPermissionPatch, login_user_via_session, postdata
+
+from rero_ils.modules.templates.api import Template
+from rero_ils.modules.templates.models import TemplateVisibility
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_templates_marshmallow_loaders(
+    client, system_librarian_martigny, templ_doc_public_martigny_data_tmp,
+    json_header
+):
+    """Test template marshmallow loaders"""
+    login_user_via_session(client, system_librarian_martigny.user)
+    data = templ_doc_public_martigny_data_tmp
+    del data['pid']
+
+    # TEST#1 :: API vs Console mode
+    #   Through the API, a public template creation aren't allowed.
+    #   Public template must be created as `private` and updated later by
+    #   an authorized staff member. But using console mode, such restriction
+    #   aren't applicable.
+    assert data['visibility'] == TemplateVisibility.PUBLIC
+    res, res_data = postdata(client, 'invenio_records_rest.tmpl_list', data)
+    assert res.status_code == 400
+
+    template = Template.create(deepcopy(data), dbcommit=True, reindex=False)
+    assert template.pid
+    template.delete()
+
+    # TEST#2 :: API workflow
+    #   Create a private template using API, then update it to set visibility
+    #   as 'public'.
+    data['visibility'] = TemplateVisibility.PRIVATE
+    res, res_data = postdata(client, 'invenio_records_rest.tmpl_list', data)
+    assert res.status_code == 201
+
+    data['pid'] = res_data['metadata']['pid']
+    data['visibility'] = TemplateVisibility.PUBLIC
+    res = client.put(
+        url_for('invenio_records_rest.tmpl_item', pid_value=data['pid']),
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    template = Template.get_record_by_pid(data['pid'])
+    assert template.is_public
+
+    # RESET FIXTURES
+    template.delete()

--- a/tests/api/templates/test_templates_rest.py
+++ b/tests/api/templates/test_templates_rest.py
@@ -36,33 +36,32 @@ from rero_ils.modules.utils import get_ref_for_pid
 def test_templates_get(client, templ_doc_public_martigny):
     """Test template retrieval."""
     template = templ_doc_public_martigny
-    item_url = url_for('invenio_records_rest.tmpl_item', pid_value='tmpl1')
 
-    res = client.get(item_url)
+    url = url_for('invenio_records_rest.tmpl_item', pid_value=template.pid)
+    res = client.get(url)
     assert res.status_code == 200
-    assert res.headers['ETag'] == '"{}"'.format(template.revision_id)
+    assert res.headers['ETag'] == f'"{template.revision_id}"'
     data = get_json(res)
     assert template.dumps() == data['metadata']
 
     # Check metadata
     for k in ['created', 'updated', 'metadata', 'links']:
         assert k in data
-
     # Check self links
     res = client.get(to_relative_url(data['links']['self']))
     assert res.status_code == 200
-    json = get_json(res)
-    assert data == json
+    assert data == res.json
     assert template.dumps() == data['metadata']
 
-    list_url = url_for('invenio_records_rest.tmpl_list', q='pid:tmpl1')
-    res = client.get(list_url)
-    assert res.status_code == 200
-    data = get_json(res)
+    url = url_for('invenio_records_rest.tmpl_list', q='pid:tmpl1')
+    res = client.get(url)
 
-    tmpl_data = template.replace_refs()
-    tmpl_data.pop('data', None)
-    assert data['hits']['hits'][0]['metadata'] == tmpl_data
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+
+    data = template.replace_refs()
+    data.pop('data', None)
+    assert res.json['hits']['hits'][0]['metadata'] == data
 
 
 def test_filtered_templates_get(
@@ -121,33 +120,33 @@ def test_filtered_templates_get(
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
-def test_templates_post_put_delete(client, org_martigny,
-                                   system_librarian_martigny,
-                                   templ_doc_public_martigny_data,
-                                   json_header):
+def test_templates_post_put_delete(
+    client, org_martigny, system_librarian_martigny, json_header,
+    templ_doc_private_martigny_data_tmp
+):
     """Test template post."""
     # Create policy / POST
     item_url = url_for('invenio_records_rest.tmpl_item', pid_value='foo1')
     list_url = url_for('invenio_records_rest.tmpl_list', q='pid:foo1')
-    templ_doc_public_martigny_data['pid'] = 'foo1'
+    templ_doc_private_martigny_data_tmp['pid'] = 'foo1'
     res, data = postdata(
         client,
         'invenio_records_rest.tmpl_list',
-        templ_doc_public_martigny_data
+        templ_doc_private_martigny_data_tmp
     )
     assert res.status_code == 201
 
     # Check that the returned template matches the given data
-    templ_doc_public_martigny_data['pid'] = 'foo1'
-    assert data['metadata'] == templ_doc_public_martigny_data
+    templ_doc_private_martigny_data_tmp['pid'] = 'foo1'
+    assert data['metadata'] == templ_doc_private_martigny_data_tmp
 
     res = client.get(item_url)
     assert res.status_code == 200
     data = get_json(res)
-    assert templ_doc_public_martigny_data == data['metadata']
+    assert templ_doc_private_martigny_data_tmp == data['metadata']
 
     # Update template/PUT
-    data = templ_doc_public_martigny_data
+    data = templ_doc_private_martigny_data_tmp
     data['name'] = 'Test Name'
     res = client.put(
         item_url,
@@ -155,127 +154,104 @@ def test_templates_post_put_delete(client, org_martigny,
         headers=json_header
     )
     assert res.status_code == 200
-
-    # Check that the returned template matches the given data
-    data = get_json(res)
-    assert data['metadata']['name'] == 'Test Name'
-
-    res = client.get(item_url)
-    assert res.status_code == 200
-
     data = get_json(res)
     assert data['metadata']['name'] == 'Test Name'
 
     res = client.get(list_url)
     assert res.status_code == 200
-
     data = get_json(res)['hits']['hits'][0]
     assert data['metadata']['name'] == 'Test Name'
 
-    # Delete tempalte/DELETE
+    # Delete template/DELETE
     res = client.delete(item_url)
     assert res.status_code == 204
-
     res = client.get(item_url)
     assert res.status_code == 410
 
 
-def test_template_secure_api_create(client, json_header,
-                                    system_librarian_martigny,
-                                    system_librarian_sion,
-                                    templ_doc_public_martigny_data,
-                                    templ_item_public_martigny,
-                                    templ_hold_public_martigny,
-                                    templ_patron_public_martigny):
+def test_template_secure_api_create(
+    client, json_header, system_librarian_martigny,
+    templ_doc_public_martigny, templ_item_public_martigny,
+    templ_hold_public_martigny, templ_patron_public_martigny
+):
     """Test templates secure api create."""
-    # Martigny
-    login_user_via_session(client, system_librarian_martigny.user)
     post_entrypoint = 'invenio_records_rest.tmpl_list'
+    login_user_via_session(client, system_librarian_martigny.user)
 
     # test template creation for documents
-    del templ_doc_public_martigny_data['pid']
-    # add a pid to the record data
-    templ_doc_public_martigny_data['data']['pid'] = 'toto'
-    res, _ = postdata(
-        client,
-        post_entrypoint,
-        templ_doc_public_martigny_data
-    )
+    doc_tmpl = templ_doc_public_martigny
+    del doc_tmpl['pid']
+    doc_tmpl['visibility'] = TemplateVisibility.PRIVATE
+    doc_tmpl['data']['pid'] = 'toto'
+    res, _ = postdata(client, post_entrypoint, doc_tmpl)
     assert res.status_code == 201
-    # ensure that pid is removed from recordds
+    # ensure that pid is removed from record
     assert 'pid' not in res.json['metadata']['data']
+    # ensure that DB stored data is cleaned too
+    record = Template.get_record_by_pid(res.json['metadata']['pid'])
+    assert 'pid' not in record.get('data', {})
 
     # test template creation for items
-    del templ_item_public_martigny['pid']
-    # add fields that will be removed at the creation of the template.
-    templ_item_public_martigny['data']['pid'] = 'toto'
-    templ_item_public_martigny['data']['barcode'] = 'toto'
-    templ_item_public_martigny['data']['status'] = 'on_loan'
-    templ_item_public_martigny['data']['library'] = \
-        {'$ref': get_ref_for_pid('lib', 'toto')}
-    templ_item_public_martigny['data']['document'] = \
-        {'$ref': get_ref_for_pid('doc', 'toto')}
-    templ_item_public_martigny['data']['holding'] = \
-        {'$ref': get_ref_for_pid('hold', 'toto')}
-    templ_item_public_martigny['data']['organisation'] = \
-        {'$ref': get_ref_for_pid('org', 'toto')}
-
-    res, _ = postdata(
-        client,
-        post_entrypoint,
-        templ_item_public_martigny
-    )
+    #   add fields that will be removed at the creation of the template.
+    item_tmpl = templ_item_public_martigny
+    del item_tmpl['pid']
+    item_tmpl['visibility'] = TemplateVisibility.PRIVATE
+    item_tmpl['data'].update({
+        'pid': 'dummy',
+        'barcode': 'dummy',
+        'status': 'on_loan',
+        'library': {'$ref': get_ref_for_pid('lib', 'x')},
+        'document': {'$ref': get_ref_for_pid('doc', 'x')},
+        'holding': {'$ref': get_ref_for_pid('hold', 'x')},
+        'organisation': {'$ref': get_ref_for_pid('org', 'x')}
+    })
+    res, _ = postdata(client, post_entrypoint, item_tmpl)
     assert res.status_code == 201
     # ensure that added fields are removed from record.
-    fields = [
-        'barcode', 'pid', 'status', 'document', 'holding', 'organisation',
-        'library']
-    for field in fields:
-        assert field not in res.json['metadata']['data']
+    record = Template.get_record_by_pid(res.json['metadata']['pid'])
+    for field in ['barcode', 'pid', 'status', 'document', 'holding',
+                  'organisation', 'library']:
+        assert field not in record['data']
 
     # templates now prevent the deletion of its owner
     assert system_librarian_martigny.get_links_to_me().get('templates')
 
     # test template creation for holdings
-    del templ_hold_public_martigny['pid']
-    # add fields that will be removed at the creation of the template.
-    templ_hold_public_martigny['data']['pid'] = 'toto'
-    templ_hold_public_martigny['data']['organisation'] = \
-        {'$ref': get_ref_for_pid('org', 'toto')}
-    templ_hold_public_martigny['data']['library'] = \
-        {'$ref': get_ref_for_pid('lib', 'toto')}
-    templ_hold_public_martigny['data']['document'] = \
-        {'$ref': get_ref_for_pid('doc', 'toto')}
+    #   add fields that will be removed at the creation of the template.
+    hold_tmpl = templ_hold_public_martigny
+    del hold_tmpl['pid']
+    hold_tmpl['visibility'] = TemplateVisibility.PRIVATE
+    hold_tmpl['data'].update({
+        'pid': 'dummy',
+        'organisation': {'$ref': get_ref_for_pid('org', 'x')},
+        'library': {'$ref': get_ref_for_pid('lib', 'x')},
+        'document': {'$ref': get_ref_for_pid('doc', 'x')}
+    })
 
-    res, _ = postdata(
-        client,
-        post_entrypoint,
-        templ_hold_public_martigny
-    )
+    res, _ = postdata(client, post_entrypoint, hold_tmpl)
     assert res.status_code == 201
     # ensure that added fields are removed from record.
-    fields = ['organisation', 'library', 'document', 'pid']
-    for field in fields:
+    for field in ['organisation', 'library', 'document', 'pid']:
         assert field not in res.json['metadata']['data']
 
     # test template creation for patrons
-    del templ_patron_public_martigny['pid']
-    # add fields that will be removed at the creation of the template.
-    templ_patron_public_martigny['data']['pid'] = 'toto'
-    templ_patron_public_martigny['data']['user_id'] = 'toto'
-    templ_patron_public_martigny['data']['patron']['subscriptions'] = 'toto'
-    templ_patron_public_martigny['data']['patron']['barcode'] = ['toto']
-
-    res, _ = postdata(
-        client,
-        post_entrypoint,
-        templ_patron_public_martigny
-    )
+    #   add fields that will be removed at the creation of the template.
+    ptrn_tmpl = templ_patron_public_martigny
+    del ptrn_tmpl['pid']
+    ptrn_tmpl['visibility'] = TemplateVisibility.PRIVATE
+    ptrn_tmpl['data'].update({
+        'pid': 'toto',
+        'user_id': 'toto'
+    })
+    ptrn_tmpl['data']['patron'].update({
+        'subscriptions': 'toto',
+        'barcode': ['toto']
+    })
+    res, _ = postdata(client, post_entrypoint, ptrn_tmpl)
     assert res.status_code == 201
     # ensure that added fields are removed from record.
-    fields = ['user_id', 'patron.subscriptions', 'patron.barcode', 'pid']
     json_data = res.json['metadata']['data']
-    for field in fields:
+    for field in ['user_id', 'patron.subscriptions', 'patron.barcode', 'pid']:
         if '.' in field:
             level_1, level_2 = field.split('.')
             assert level_2 not in json_data.get(level_1)
@@ -294,24 +270,18 @@ def test_template_secure_api_update(
     record_url = url_for('invenio_records_rest.tmpl_item',
                          pid_value=templ_doc_private_martigny.pid)
 
+    original_data = deepcopy(templ_doc_private_martigny_data)
     data = templ_doc_private_martigny_data
     data['name'] = 'Test Name'
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
+    res = client.put(record_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 403
 
     login_user_via_session(client, librarian_martigny.user)
     data = templ_doc_private_martigny_data
     data['name'] = 'Test Name'
     data['data']['pid'] = 'toto'
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
+
+    res = client.put(record_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 200
     # ensure that pid is removed from records
     assert 'pid' not in res.json['metadata']['data']
@@ -319,45 +289,33 @@ def test_template_secure_api_update(
     login_user_via_session(client, librarian2_martigny.user)
     data = templ_doc_private_martigny_data
     data['visibility'] = 'public'
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
+    res = client.put(record_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 403
 
     login_user_via_session(client, system_librarian_martigny.user)
     data = templ_doc_private_martigny_data
-    data['visibility'] = 'public'
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
+    data['visibility'] = TemplateVisibility.PUBLIC
+    res = client.put(record_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 403
 
     login_user_via_session(client, librarian_saxon.user)
     data = templ_doc_private_martigny_data
     data['name'] = 'Test Name'
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
+    res = client.put(record_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 403
 
     # Sion
     login_user_via_session(client, system_librarian_sion.user)
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
+    res = client.put(record_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 403
+
+    # Reset data
+    templ_doc_private_martigny.update(
+        original_data, dbcommit=True, reindex=True)
 
 
 def test_template_update_visibility(
-    client, templ_doc_private_martigny, templ_doc_private_martigny_data,
+    client, templ_doc_private_martigny, templ_doc_private_martigny_data_tmp,
     librarian2_martigny, system_librarian_martigny, json_header
 ):
     """Test template visibility attribute update thought API."""
@@ -408,7 +366,7 @@ def test_template_update_visibility(
     #   visibility attribute as 'public'. After all test, delete this new
     #   template
     login_user_via_session(client, system_librarian_martigny.user)
-    tmpl_data = deepcopy(templ_doc_private_martigny_data)
+    tmpl_data = deepcopy(templ_doc_private_martigny_data_tmp)
     del tmpl_data['pid']
     tmpl_data['creator']['$ref'] = \
         get_ref_for_pid('ptrn', system_librarian_martigny.pid)

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -1003,6 +1003,12 @@ def templ_doc_private_martigny_data(data):
     return deepcopy(data.get('tmpl2'))
 
 
+@pytest.fixture(scope="function")
+def templ_doc_private_martigny_data_tmp(data):
+    """Load template for a private document martigny data."""
+    return deepcopy(data.get('tmpl2'))
+
+
 @pytest.fixture(scope="module")
 def templ_doc_private_martigny(
         app, org_martigny, templ_doc_private_martigny_data,


### PR DESCRIPTION
* Creates marshmallow schema for template resources.
* Controls "public" template creation through REST API.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

