### PR TITLE
user: improve register and forgot password

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -143,6 +143,21 @@ docs = ["Sphinx (>=1.4.2)"]
 tests = ["check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "pydocstyle (>=1.0)", "pytest (>=3.6.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest-runner (>=2.7.0)"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "dev"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "billiard"
 version = "3.6.4.0"
 description = "Python multiprocessing fork with improvements and bugfixes"
@@ -2913,6 +2928,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "speaklater"
 version = "1.3"
 description = "implements a lazy string for python useful for use with gettext"
@@ -3376,7 +3399,7 @@ sip2 = ["invenio-sip2"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">= 3.9, <3.10"
-content-hash = "340e00f9589e0f1cd5d2c8ea66c52694b66e05ff84ce1b0d4056e0b2a01ccb07"
+content-hash = "6d0b9352763e12ce3582bb683c9cf9841aef2e1643b27e8c37a599b8e27b9f92"
 
 [metadata.files]
 alabaster = [
@@ -3429,6 +3452,10 @@ backcall = [
 base32-lib = [
     {file = "base32-lib-1.0.2.tar.gz", hash = "sha256:09663df621bbc454079a54c92fa25d3bc33ea4a191053a09dd1e05ea4c0fe47c"},
     {file = "base32_lib-1.0.2-py2.py3-none-any.whl", hash = "sha256:f3cbc1c4b3df7af844c9b7ffc1638a688423db2b1e51082b2c014b3959b756ae"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 billiard = [
     {file = "billiard-3.6.4.0-py3-none-any.whl", hash = "sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b"},
@@ -4745,6 +4772,10 @@ six = [
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+soupsieve = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
 speaklater = [
     {file = "speaklater-1.3.tar.gz", hash = "sha256:59fea336d0eed38c1f0bf3181ee1222d0ef45f3a9dd34ebe65e6bfffdd6a65a9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -410,6 +410,10 @@ vendors = "rero_ils.modules.vendors.mappings"
 operation_logs = "rero_ils.modules.operation_logs.es_templates:list_es_templates"
 rero_ils = "rero_ils.es_templates:list_es_templates"
 
+
+[tool.poetry.group.dev.dependencies]
+beautifulsoup4 = "^4.11.1"
+
 [tool.poe.tasks]
 bootstrap = {cmd = "./scripts/bootstrap", help = "Runs bootstrap"}
 console = {cmd = "./scripts/console", help = "Opens invenio shell"}

--- a/rero_ils/accounts_views.py
+++ b/rero_ils/accounts_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2019-2023 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -17,20 +17,25 @@
 
 """Invenio Account custom views."""
 
-from flask import after_this_request, current_app
+from flask import abort, after_this_request, current_app
 from flask import request as flask_request
+from flask.views import MethodView
 from flask_babelex import gettext as _
+from flask_security.confirmable import requires_confirmation
+from flask_security.utils import get_message, verify_and_update_password
 from invenio_accounts.utils import change_user_password
 from invenio_accounts.views.rest import \
     ChangePasswordView as BaseChangePasswordView
 from invenio_accounts.views.rest import LoginView as CoreLoginView
 from invenio_accounts.views.rest import _abort, _commit, use_args, use_kwargs
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validates, validates_schema
 from webargs import ValidationError, validate
 from werkzeug.local import LocalProxy
 
-from .modules.patrons.api import Patron, current_librarian
-from .modules.users.api import User
+from rero_ils.modules.patrons.api import Patron, current_librarian
+from rero_ils.modules.users.api import User
+from rero_ils.modules.utils import PasswordValidatorException, \
+    password_validator
 
 current_datastore = LocalProxy(
     lambda: current_app.extensions['security'].datastore)
@@ -46,6 +51,22 @@ def user_exists(email):
         raise ValidationError(_('INVALID_USER_OR_PASSWORD'))
 
 
+def validate_password(password):
+    """Validate the password."""
+    length = current_app.config.get('RERO_ILS_PASSWORD_MIN_LENGTH', 8)
+    special_char = current_app.config.get('RERO_ILS_PASSWORD_SPECIAL_CHAR')
+    try:
+        password_validator(password, length=length, special_char=special_char)
+    except PasswordValidatorException as pve:
+        raise ValidationError(str(pve)) from pve
+
+
+def validate_passwords(password, confirm_password):
+    """Validate that the 2 passwords are identical."""
+    if password != confirm_password:
+        raise ValidationError(_('The 2 passwords are not identical.'))
+
+
 class LoginView(CoreLoginView):
     """invenio-accounts Login REST View."""
 
@@ -57,8 +78,7 @@ class LoginView(CoreLoginView):
     @classmethod
     def get_user(cls, email=None, **kwargs):
         """Retrieve a user by the provided arguments."""
-        user = User.get_by_username_or_email(email)
-        if user:
+        if user := User.get_by_username_or_email(email):
             return user.user
 
     @use_kwargs(post_args)
@@ -71,23 +91,51 @@ class LoginView(CoreLoginView):
         self.login_user(user)
         return self.success_response(user)
 
+    def verify_login(self, user, password=None, **kwargs):
+        """Verify the login via password."""
+        if not user.password or not verify_and_update_password(password, user):
+            _abort(_('INVALID_USER_OR_PASSWORD'))
+        if requires_confirmation(user):
+            _abort(get_message('CONFIRMATION_REQUIRED')[0])
+        if not user.is_active:
+            _abort(get_message('DISABLED_ACCOUNT')[0])
+
 
 class PasswordPassword(Schema):
     """Args validation when a user want to change his password."""
 
-    password = fields.String(
-        validate=[validate.Length(min=6, max=128)])
-    new_password = fields.String(
-        required=True, validate=[validate.Length(min=6, max=128)])
+    password = fields.String(required=True)
+    new_password = fields.String(required=True)
+    new_password_confirm = fields.String(required=True)
+
+    @validates("new_password")
+    def validate_password(self, value):
+        """Validate password."""
+        validate_password(value)
+
+    @validates_schema
+    def validate_passwords(self, data, **kwargs):
+        """Validate that the 2 passwords are identical."""
+        validate_passwords(data['new_password'], data['new_password_confirm'])
 
 
 class UsernamePassword(Schema):
     """Args validation when a professional change a password for a user."""
 
-    username = fields.String(
-        validate=[validate.Length(min=1, max=128)])
-    new_password = fields.String(
-        required=True, validate=[validate.Length(min=6, max=128)])
+    username = fields.String(required=True,
+                             validate=[validate.Length(min=1, max=128)])
+    new_password = fields.String(required=True)
+    new_password_confirm = fields.String(required=True)
+
+    @validates("new_password")
+    def validate_password(self, value):
+        """Validate password."""
+        validate_password(value)
+
+    @validates_schema
+    def validate_passwords(self, data, **kwargs):
+        """Validate that the 2 passwords are identical."""
+        validate_passwords(data['new_password'], data['new_password_confirm'])
 
 
 def make_password_schema(request):
@@ -100,7 +148,6 @@ def make_password_schema(request):
     if request.json.get('username'):
         return UsernamePassword(only=only,
                                 partial=partial, context={"request": request})
-
     # Add current request to the schema's context
     return PasswordPassword(only=only,
                             partial=partial, context={"request": request})
@@ -139,3 +186,15 @@ class ChangePasswordView(BaseChangePasswordView):
             self.verify_password(**args)
             self.change_password(**args)
         return self.success_response()
+
+
+class DisabledAuthApiView(MethodView):
+    """Disabled Account rest auth api."""
+
+    def post(self, **kwargs):
+        """Post Data."""
+        abort(404)
+
+    def get(self, **kwargs):
+        """Get Data."""
+        abort(404)

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -287,17 +287,16 @@ USERPROFILES_READONLY_FIELDS = get_readonly_profile_fields
 # Custom login view
 ACCOUNTS_REST_AUTH_VIEWS = {
     "login": "rero_ils.accounts_views:LoginView",
-    "logout": "invenio_accounts.views.rest:LogoutView",
-    "user_info": "invenio_accounts.views.rest:UserInfoView",
-    "register": "invenio_accounts.views.rest:RegisterView",
-    "forgot_password": "invenio_accounts.views.rest:ForgotPasswordView",
-    "reset_password": "invenio_accounts.views.rest:ResetPasswordView",
+    "logout": "rero_ils.accounts_views:DisabledAuthApiView",
+    "user_info": "rero_ils.accounts_views:DisabledAuthApiView",
+    "register": "rero_ils.accounts_views:DisabledAuthApiView",
+    "forgot_password": "rero_ils.accounts_views:DisabledAuthApiView",
+    "reset_password": "rero_ils.accounts_views:DisabledAuthApiView",
     "change_password": "rero_ils.accounts_views:ChangePasswordView",
-    "send_confirmation":
-        "invenio_accounts.views.rest:SendConfirmationEmailView",
-    "confirm_email": "invenio_accounts.views.rest:ConfirmEmailView",
-    "sessions_list": "invenio_accounts.views.rest:SessionsListView",
-    "sessions_item": "invenio_accounts.views.rest:SessionsItemView"
+    "send_confirmation": "rero_ils.accounts_views:DisabledAuthApiView",
+    "confirm_email": "rero_ils.accounts_views:DisabledAuthApiView",
+    "sessions_list": "rero_ils.accounts_views:DisabledAuthApiView",
+    "sessions_item": "rero_ils.accounts_views:DisabledAuthApiView"
 }
 
 ACCOUNTS_REGISTER_BLUEPRINT = True

--- a/rero_ils/filter.py
+++ b/rero_ils/filter.py
@@ -29,6 +29,7 @@ from invenio_i18n.ext import current_i18n
 from jinja2 import TemplateNotFound
 from markupsafe import Markup
 
+from .modules.message import Message
 from .modules.utils import extracted_data_from_ref
 
 
@@ -172,5 +173,14 @@ def address_block(metadata, language=None):
         tpl_file = f'rero_ils/address_block/{language}.tpl.txt'
         return render_template(tpl_file, data=metadata)
     except TemplateNotFound:
-        tpl_file = f'rero_ils/address_block/eng.tpl.txt'
+        tpl_file = 'rero_ils/address_block/eng.tpl.txt'
         return render_template(tpl_file, data=metadata)
+
+
+def message_filter(key):
+    """Message filter.
+
+    :param key: key of the message.
+    :return: none or a json (check structure into the class Message).
+    """
+    return Message.get(key)

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2019-2023 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -25,6 +25,7 @@ from flask_bootstrap import Bootstrap4
 from flask_login.signals import user_loaded_from_cookie, user_logged_in, \
     user_logged_out
 from flask_wiki import Wiki
+from invenio_base.signals import app_loaded
 from invenio_circulation.signals import loan_state_changed
 from invenio_indexer.signals import before_record_index
 from invenio_oaiharvester.signals import oaiharvest_finished
@@ -35,7 +36,8 @@ from invenio_userprofiles.signals import after_profile_update
 from jsonschema.exceptions import ValidationError
 
 from rero_ils.filter import address_block, empty_data, format_date_filter, \
-    get_record_by_ref, jsondumps, node_assets, text_to_id, to_pretty_json
+    get_record_by_ref, jsondumps, message_filter, node_assets, text_to_id, \
+    to_pretty_json
 from rero_ils.modules.acquisition.acq_accounts.listener import \
     enrich_acq_account_data
 from rero_ils.modules.acquisition.acq_order_lines.listener import \
@@ -76,6 +78,8 @@ from rero_ils.modules.patrons.listener import \
     update_from_profile
 from rero_ils.modules.sru.views import SRUDocumentsSearch
 from rero_ils.modules.templates.listener import prepare_template_data
+from rero_ils.modules.users.listener import user_register_forms, \
+    user_reset_password_forms
 from rero_ils.modules.users.views import UsersCreateResource, UsersResource
 from rero_ils.modules.utils import remove_user_name, set_user_name
 from rero_ils.version import __version__
@@ -107,6 +111,7 @@ class REROILSAPP(object):
             app.add_template_filter(jsondumps, name='jsondumps')
             app.add_template_filter(empty_data, name='empty_data')
             app.add_template_filter(address_block, name='address_block')
+            app.add_template_filter(message_filter, name='message')
             app.jinja_env.add_extension('jinja2.ext.do')
             app.jinja_env.globals['version'] = __version__
             self.register_signals(app)
@@ -249,3 +254,7 @@ class REROILSAPP(object):
         user_logged_in.connect(set_user_name)
         user_logged_out.connect(remove_user_name)
         user_loaded_from_cookie.connect(set_user_name)
+
+        # invenio-base signal: after application loaded
+        app_loaded.connect(user_register_forms, weak=False)
+        app_loaded.connect(user_reset_password_forms, weak=False)

--- a/rero_ils/modules/message.py
+++ b/rero_ils/modules/message.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Message interface."""
+
+from invenio_cache.proxies import current_cache
+from markupsafe import Markup
+
+
+class Message():
+    """Message for the user."""
+
+    prefix = 'message_'
+
+    @classmethod
+    def set(cls, key, type, value):
+        """Set value.
+
+        :param key: the cache key.
+        :param type: the type of message.
+        :param value: the value of message.
+        :return: True if the insertion went well.
+        """
+        data = {'type': type or 'primary', 'message': Markup(value)}
+        return current_cache.set(f'{cls.prefix}{key}', data)
+
+    @classmethod
+    def get(cls, key):
+        """Get value.
+
+        :param key: the cache key.
+        :return: empty or the json.
+        """
+        return current_cache.get(f'{cls.prefix}{key}')
+
+    @classmethod
+    def delete(cls, key):
+        """Delete value.
+
+        :param key: the cache key.
+        :return: True if the removal went well.
+        """
+        return current_cache.delete(f'{cls.prefix}{key}')

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -236,7 +236,8 @@ class Patron(IlsRecord):
     def removeUserData(cls, data):
         """Remove the user data."""
         data = deepcopy(data)
-        profile_fields = User.profile_fields + ['username', 'email']
+        profile_fields = User.profile_fields + \
+            ['username', 'email', 'password']
         for field in profile_fields:
             try:
                 del data[field]

--- a/rero_ils/modules/users/api_views.py
+++ b/rero_ils/modules/users/api_views.py
@@ -40,7 +40,8 @@ def password_generate():
     special_char = current_app.config.get('RERO_ILS_PASSWORD_SPECIAL_CHAR')
     length = int(request.args.get('length', min_length))
     if length < min_length:
-        abort(400, f'Minimal length: {min_length}')
+        abort(400,
+              f'The password must be at least {min_length} characters long.')
     generator = obj_or_import_string(
         current_app.config.get('RERO_ILS_PASSWORD_GENERATOR'))
     try:

--- a/rero_ils/modules/users/forms.py
+++ b/rero_ils/modules/users/forms.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""User forms."""
+
+from flask import current_app
+from flask_security.forms import RegisterForm as SecurityRegisterForm
+from flask_security.forms import ResetPasswordForm as SecurityResetPasswordForm
+from flask_security.forms import password_required
+
+from .validators import PasswordValidator
+
+
+class RegisterForm(SecurityRegisterForm):
+    """Register form."""
+
+    def __init__(self, *args, **kwargs):
+        """Register form class initializer."""
+        super().__init__(*args, **kwargs)
+        self.password.validators = [
+            password_required,
+            PasswordValidator(
+                length=current_app.config['RERO_ILS_PASSWORD_MIN_LENGTH'],
+                special_char=current_app.config[
+                    'RERO_ILS_PASSWORD_SPECIAL_CHAR'])
+        ]
+
+
+class ResetPasswordForm(SecurityResetPasswordForm):
+    """Change password form."""
+
+    def __init__(self, *args, **kwargs):
+        """Reset password form class initializer."""
+        super().__init__(*args, **kwargs)
+        self.password.validators = [
+            password_required,
+            PasswordValidator(
+                length=current_app.config['RERO_ILS_PASSWORD_MIN_LENGTH'],
+                special_char=current_app.config[
+                    'RERO_ILS_PASSWORD_SPECIAL_CHAR'])
+        ]

--- a/rero_ils/modules/users/listener.py
+++ b/rero_ils/modules/users/listener.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Listener user auth forms."""
+
+from .forms import RegisterForm, ResetPasswordForm
+
+
+def user_register_forms(sender, app=None, **kwargs):
+    """Register form (personalized).
+
+    :param sender: the application factory function.
+    :param app: the Flask application instance.
+    :param kwargs: additional arguments.
+    """
+    if security := app.extensions.get('security'):
+        # Override Register form
+        security.register_form = RegisterForm
+
+
+def user_reset_password_forms(sender, app=None, **kwargs):
+    """Change password form (personalized).
+
+    :param sender: the application factory function.
+    :param app: the Flask application instance.
+    :param kwargs: additional arguments.
+    """
+    if security := app.extensions.get('security'):
+        # Override Reset password form
+        security.reset_password_form = ResetPasswordForm

--- a/rero_ils/modules/users/validators.py
+++ b/rero_ils/modules/users/validators.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Password validator."""
+
+from wtforms import ValidationError
+
+from rero_ils.modules.utils import PasswordValidatorException, \
+    password_validator
+
+
+class PasswordValidator:
+    """Password Validator."""
+
+    def __init__(self, length=8, special_char=False):
+        """Password validator class initializer."""
+        self.length = length
+        self.special_char = special_char
+
+    def __call__(self, form, field):
+        """Call.
+
+        :param form: the current form.
+        :param field: the password field.
+        :raise ValidationError: If the password is invalid.
+        """
+        try:
+            password_validator(field.data, length=self.length,
+                               special_char=self.special_char)
+        except PasswordValidatorException as e:
+            raise ValidationError(str(e)) from e

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -26,6 +26,7 @@ import string
 import unicodedata
 from datetime import date, datetime, time
 from functools import wraps
+from gettext import ngettext
 from io import StringIO
 from json import JSONDecodeError, JSONDecoder, dumps
 from time import sleep
@@ -1209,7 +1210,11 @@ def password_validator(pw, length=8, special_char=False):
     :return True or raise PasswordValidatorException
     """
     if len(pw) < length:
-        raise PasswordValidatorException(f'Minimal size {length}')
+        raise PasswordValidatorException(ngettext(
+            'Field must be at least %(min)d character long.',
+            'Field must be at least %(min)d characters long.',
+            length
+        ) % {"min": length})
     if not set(string.ascii_lowercase).intersection(pw):
         raise PasswordValidatorException('The password must contain a lower '
                                          'case character.')

--- a/rero_ils/theme/templates/rero_ils/_info_test.html
+++ b/rero_ils/theme/templates/rero_ils/_info_test.html
@@ -20,31 +20,31 @@
   <h3>Test RERO ILS</h3>
   <p>As an anonymous user</p>
   <p>As a patron, login with:</br>
-  reroilstest+giulia@gmail.com / 123456</p>
+  reroilstest+giulia@gmail.com / Pw123456</p>
   <p>As a system librarian:</br>
-  reroilstest@gmail.com / 123456</p>
+  reroilstest@gmail.com / Pw123456</p>
 {% endif %}
 {% if current_i18n.language == 'fr' %}
   <h3>Testez RERO ILS</h3>
   <p>En tant qu'utilisateur anonyme</p>
   <p>En tant que lecteur, connectez-vous avec:</br>
-  reroilstest+giulia@gmail.com / 123456</p>
+  reroilstest+giulia@gmail.com / Pw123456</p>
   <p>En tant que bibliothécaire système:</br>
-  reroilstest@gmail.com / 123456</p>
+  reroilstest@gmail.com / Pw123456</p>
 {% endif %}
 {% if current_i18n.language == 'de' %}
   <h3>Testen Sie RERO ILS</h3>
   <p>Als anonymer Benutzer</p>
   <p>Melden Sie sich als Benutzer an mit:</br>
-  reroilstest+giulia@gmail.com / 123456</p>
+  reroilstest+giulia@gmail.com / Pw123456</p>
   <p>Als Systembibliothekar: </br>
-  reroilstest@gmail.com / 123456</p>
+  reroilstest@gmail.com / Pw123456</p>
 {% endif %}
 {% if current_i18n.language == 'it' %}
   <h3>Testare il progetto</h3>
   <p>Come utente anonimo</p>
   <p>Come utente, accedi con:</br>
-  reroilstest+giulia@gmail.com / 123456</p>
+  reroilstest+giulia@gmail.com / Pw123456</p>
   <p>Come bibliotecario di sistema:</br>
-  reroilstest@gmail.com / 123456</p>
+  reroilstest@gmail.com / Pw123456</p>
 {% endif %}

--- a/rero_ils/theme/templates/rero_ils/login_user.html
+++ b/rero_ils/theme/templates/rero_ils/login_user.html
@@ -1,7 +1,7 @@
 {# -*- coding: utf-8 -*-
 
   RERO ILS
-  Copyright (C) 2019 RERO
+  Copyright (C) 2019-2023 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -18,6 +18,15 @@
 #}
 {%- extends 'rero_ils/page_cover.html' %}
 {% from "rero_ils/macros/macro.html" import render_field, form_errors %}
+
+{% block message %}
+{% set msg = ('login_' ~ current_i18n.locale.language|safe|lower)|message %}
+{% if msg %}
+  <div class="w-25 mt-2 alert alert-{{ msg.type }}" role="{{ msg.type }}">
+    {{ msg.message }}
+  </div>
+{% endif %}
+{% endblock %}
 
 {% block panel %}
 <div class="card text-center m-4">

--- a/rero_ils/theme/templates/rero_ils/page_cover.html
+++ b/rero_ils/theme/templates/rero_ils/page_cover.html
@@ -1,7 +1,7 @@
 {# -*- coding: utf-8 -*-
 
   RERO ILS
-  Copyright (C) 2019 RERO
+  Copyright (C) 2019-2023 RERO
   Copyright (C) 2015-2018 CERN
 
   This program is free software: you can redistribute it and/or modify
@@ -49,6 +49,7 @@
     </header>
   {% endblock page_header%}
   {% block page_body%}
+    {% block message %}{% endblock %}
     <section class="text-center">
       {% block panel %}
       {% endblock panel %}

--- a/rero_ils/theme/templates/rero_ils/register_user.html
+++ b/rero_ils/theme/templates/rero_ils/register_user.html
@@ -54,37 +54,3 @@
 </div>
 {%- endwith %}
 {% endblock panel %}
-{#
-{% block panel %}
-  <div class="card text-center mb-4">
-   {%- block form_header %}
-    <h3 class="card-title my-4">{{_('Log in to account') }}</h3>
-  {%- endblock form_header %}
-  {%- block form_outer %}
-    <div class="card-body">
-    {%- with form = login_user_form %}
-      <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
-        {{form.hidden_tag()}}
-        {{form_errors(form)}}
-        {{ render_field(form.email, icon="fa fa-user", autofocus=True, errormsg=False) }}
-        {{ render_field(form.password, icon="fa fa-lock", errormsg=False) }}
-      <button type="submit" class="btn btn-primary btn-lg btn-block mb-2"><i class="fa fa-sign-in"></i> {{_('Log In')}}</button>
-      </form>
-    {%- endwith %}
-    {%- endblock form_outer %}
- </div>
-  {%- block registerable %}
-  {%- if security.registerable %}
-  <div class="card-footer">
-      <h4 class="text-muted my-2">{% trans sitename=config.ACCOUNTS_SITENAME %}New to {{sitename}}?{% endtrans %} <a href="{{ url_for('security.register')}}">{{_('Sign Up')}}</a></h4>
-  </div>
-  {%- endif %}
-  {%- endblock registerable %}
-  </div>
-  {%- block recoverable %}
-  {%- if security.recoverable %}
-    <a href="{{url_for('security.forgot_password')}}" class="text-white">{{_('Forgot password?')}}</a>
-  {%- endif %}
-  {%- endblock recoverable %}
-{% endblock panel %}
- #}

--- a/tests/api/patrons/test_patrons_views.py
+++ b/tests/api/patrons/test_patrons_views.py
@@ -95,13 +95,13 @@ def test_patron_utils(client, librarian_martigny,
 
 
 def test_patron_authenticate(client, patron_martigny, patron_martigny_data,
-                             system_librarian_martigny):
+                             system_librarian_martigny, default_user_password):
     """Test for patron authenticate."""
     # parameters
     token = 'Or7DTg1WT34cLKuSMcS7WzhdhxtKklpTizb1Hn2H0aaV5Vig6nden63VEqBE'
     token_url_data = {'access_token': token}
     username = patron_martigny_data['username']
-    password = patron_martigny_data['birth_date']
+    password = default_user_password
 
     create_personal(
         name='token_test',

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -71,7 +71,7 @@ def test_selfcheck_login(librarian_martigny, selfcheck_librarian_martigny):
     assert response.get('authenticated')
 
 
-def test_authorize_patron(selfcheck_patron_martigny):
+def test_authorize_patron(selfcheck_patron_martigny, default_user_password):
     """Test authorize patron."""
 
     # try to authorize with wrong password
@@ -86,7 +86,7 @@ def test_authorize_patron(selfcheck_patron_martigny):
     # authorize patron with email
     response = authorize_patron(
         selfcheck_patron_martigny.get('patron', {}).get('barcode')[0],
-        selfcheck_patron_martigny.dumps().get('birth_date'))
+        default_user_password)
     assert response
 
     # authorize patron without email (using username for authentication)
@@ -98,7 +98,7 @@ def test_authorize_patron(selfcheck_patron_martigny):
         selfcheck_patron_martigny.pid)
     response = authorize_patron(
         selfcheck_patron_martigny.get('patron', {}).get('barcode')[0],
-        selfcheck_patron_martigny.dumps().get('birth_date'))
+        default_user_password)
     assert response
 
     # reset user data

--- a/tests/api/test_accounts_rest_auth.py
+++ b/tests/api/test_accounts_rest_auth.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests account rest auth api."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_disabled_endpoint(client, app, patron_martigny):
+    """Test disabled endpoint."""
+
+    ext = app.extensions['security']
+    ext.registerable = ext.changeable = ext.recoverable = ext.confirmable = \
+        True
+
+    app.config['SECURITY_CONFIRMABLE'] = True
+    app.config['SECURITY_SEND_PASSWORD_CHANGE_EMAIL'] = True
+    app.config['ACCOUNTS_SESSION_ACTIVITY_ENABLED'] = True
+
+    def get(url_endpoint):
+        res = client.get(url_endpoint)
+        assert res.status_code == 404
+
+    def post(url_endpoint):
+        res = client.post(url_endpoint)
+        assert res.status_code == 404
+
+    post(url_for('invenio_accounts_rest_auth.register'))
+    post(url_for('invenio_accounts_rest_auth.forgot_password'))
+    post(url_for('invenio_accounts_rest_auth.reset_password'))
+
+    post('invenio_accounts_rest_auth.send_confirmation')
+    post('invenio_accounts_rest_auth.confirm_email')
+
+    # Logged as user
+    login_user_via_session(client, patron_martigny.user)
+
+    post(url_for('invenio_accounts_rest_auth.logout'))
+    get(url_for('invenio_accounts_rest_auth.user_info'))
+    get(url_for('invenio_accounts_rest_auth.sessions_list'))
+    get(url_for('invenio_accounts_rest_auth.sessions_item', sid_s='1'))

--- a/tests/api/test_user_authentication.py
+++ b/tests/api/test_user_authentication.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2019-2023 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -25,7 +25,7 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
 
-def test_login(client, patron_sion):
+def test_login(client, patron_sion, default_user_password):
     """Test login with several scenarios."""
     patron_sion = patron_sion.dumps()
     # user does not exists
@@ -39,8 +39,7 @@ def test_login(client, patron_sion):
     )
     assert res.status_code == 400
     data = get_json(res)
-    assert data['errors'][0] == dict(
-        field='email', message=gettext('INVALID_USER_OR_PASSWORD'))
+    assert data['message'] == 'Validation error.'
 
     # wrong password
     res, _ = postdata(
@@ -53,8 +52,7 @@ def test_login(client, patron_sion):
     )
     assert res.status_code == 400
     data = get_json(res)
-    assert data['errors'][0] == dict(
-        field='password', message=gettext('INVALID_USER_OR_PASSWORD'))
+    assert data['message'] == gettext('INVALID_USER_OR_PASSWORD')
 
     # login by email
     res, _ = postdata(
@@ -62,7 +60,7 @@ def test_login(client, patron_sion):
         'invenio_accounts_rest_auth.login',
         {
             'email': patron_sion.get('email'),
-            'password': patron_sion.get('birth_date')
+            'password': default_user_password
         }
     )
     data = get_json(res)
@@ -77,7 +75,7 @@ def test_login(client, patron_sion):
         'invenio_accounts_rest_auth.login',
         {
             'email': patron_sion.get('username'),
-            'password': patron_sion.get('birth_date')
+            'password': default_user_password
         }
     )
     data = get_json(res)
@@ -87,7 +85,8 @@ def test_login(client, patron_sion):
     client.post(url_for('invenio_accounts_rest_auth.logout'))
 
 
-def test_login_without_email(client, patron_sion_without_email1):
+def test_login_without_email(client, patron_sion_without_email1,
+                             default_user_password):
     """Test login with several scenarios."""
     patron_sion_without_email1 = patron_sion_without_email1.dumps()
     # login by username without email
@@ -96,7 +95,7 @@ def test_login_without_email(client, patron_sion_without_email1):
         'invenio_accounts_rest_auth.login',
         {
             'email': patron_sion_without_email1.get('username'),
-            'password': patron_sion_without_email1.get('birth_date')
+            'password': default_user_password
         }
     )
     assert res.status_code == 200
@@ -106,23 +105,25 @@ def test_login_without_email(client, patron_sion_without_email1):
     client.post(url_for('invenio_accounts_rest_auth.logout'))
 
 
-def test_change_password(client, patron_martigny,
+def test_change_password(client, app, patron_martigny,
                          librarian_sion,
-                         librarian_martigny):
+                         librarian_martigny,
+                         default_user_password):
     """Test login with several scenarios."""
+    # Fix the size of password
+    app.config['RERO_ILS_PASSWORD_MIN_LENGTH'] = 8
     p_martigny = patron_martigny
     patron_martigny = patron_martigny.dumps()
     l_sion = librarian_sion
-    librarian_sion = librarian_sion.dumps()
     l_martigny = librarian_martigny
-    librarian_martigny = librarian_martigny.dumps()
     # try to change password with an anonymous user
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'password': patron_martigny.get('birth_date'),
-            'new_password': 'new'
+            'password': default_user_password,
+            'new_password': default_user_password,
+            'new_password_confirm': default_user_password
         }
     )
     data = get_json(res)
@@ -134,21 +135,40 @@ def test_change_password(client, patron_martigny,
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'password': patron_martigny.get('birth_date'),
-            'new_password': 'new'
+            'password': default_user_password,
+            'new_password': '123456',
+            'new_password_confirm': '123456'
         }
     )
     data = get_json(res)
     assert res.status_code == 400
     assert data.get('message') == 'Validation error.'
+    assert data.get('errors')[0].get('message') == \
+        'Field must be at least 8 characters long.'
 
     # with a logged user
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.change_password',
         {
-            'password': patron_martigny.get('birth_date'),
-            'new_password': 'new_passwd'
+            'password': default_user_password,
+            'new_password': 'Pw123458',
+            'new_password_confirm': 'Pw123455'
+        }
+    )
+    data = get_json(res)
+    assert res.status_code == 400
+    assert data.get('message') == 'Validation error.'
+    assert data.get('errors')[0].get('message') == \
+        'The 2 passwords are not identical.'
+
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.change_password',
+        {
+            'password': default_user_password,
+            'new_password': 'Pw123458',
+            'new_password_confirm': 'Pw123458'
         }
     )
     data = get_json(res)
@@ -162,7 +182,8 @@ def test_change_password(client, patron_martigny,
         'invenio_accounts_rest_auth.change_password',
         {
             'username': patron_martigny.get('username'),
-            'new_password': 'new_passwd2'
+            'new_password': 'Pw123458',
+            'new_password_confirm': 'Pw123458'
         }
     )
     data = get_json(res)
@@ -170,12 +191,29 @@ def test_change_password(client, patron_martigny,
 
     # with a librarian of the same organisation
     login_user_via_session(client, l_martigny.user)
+
     res, _ = postdata(
         client,
         'invenio_accounts_rest_auth.change_password',
         {
             'username': patron_martigny.get('username'),
-            'new_password': 'new_passwd2'
+            'new_password': 'Pw123458',
+            'new_password_confirm': 'Pw123455'
+        }
+    )
+    data = get_json(res)
+    assert res.status_code == 400
+    assert data.get('message') == 'Validation error.'
+    assert data.get('errors')[0].get('message') == \
+        'The 2 passwords are not identical.'
+
+    res, _ = postdata(
+        client,
+        'invenio_accounts_rest_auth.change_password',
+        {
+            'username': patron_martigny.get('username'),
+            'new_password': 'Pw123458',
+            'new_password_confirm': 'Pw123458'
         }
     )
     data = get_json(res)

--- a/tests/api/users/test_user_api.py
+++ b/tests/api/users/test_user_api.py
@@ -37,7 +37,8 @@ def test_generate_password(client, app, librarian_martigny):
     login_user_via_session(client, librarian_martigny.user)
     res = client.get(url_for('api_user.password_generate', length=6))
     assert res.status_code == 400
-    assert get_json(res)['message'].find('Minimal length') != -1
+    assert get_json(res)['message'] \
+        .find('The password must be at least 8 characters long.') != -1
 
     res = client.get(url_for('api_user.password_generate'))
     assert res.status_code == 200
@@ -68,7 +69,8 @@ def test_validate_password(client, app):
 
     res = client.post(
         url_for('api_user.password_validate'), json={'password': 'foo'})
-    assert get_json(res)['message'].find('Minimal size 8') != -1
+    assert get_json(res)['message'] \
+        .find('Field must be at least 8 characters long.') != -1
     assert res.status_code == 400
 
     res = client.post(

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3823,7 +3823,8 @@
     "home_phone": "+41324993585",
     "roles": [
       "system_librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn2": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -3844,7 +3845,8 @@
     "home_phone": "+41324993578",
     "roles": [
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn3": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -3865,7 +3867,8 @@
     "home_phone": "+41324993541",
     "roles": [
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn4": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -3886,7 +3889,8 @@
     "home_phone": "+41324993515",
     "roles": [
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn5": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -3907,7 +3911,8 @@
     "home_phone": "+41324111515",
     "roles": [
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn6": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -3956,7 +3961,8 @@
         "type": "staff_note",
         "content": "A kind person."
       }
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn7": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -3983,7 +3989,8 @@
       },
       "communication_channel": "email",
       "communication_language": "eng"
-    }
+    },
+    "password": "Pw123456"
   },
   "ptrn8": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4004,7 +4011,8 @@
     "roles": [
       "system_librarian",
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn9": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4024,7 +4032,8 @@
     ],
     "roles": [
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn10": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4051,7 +4060,8 @@
       },
       "communication_channel": "email",
       "communication_language": "eng"
-    }
+    },
+    "password": "Pw123456"
   },
   "ptrn11": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4088,7 +4098,8 @@
       },
       "communication_channel": "email",
       "communication_language": "eng"
-    }
+    },
+    "password": "Pw123456"
   },
   "ptrn12": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4115,7 +4126,8 @@
       },
       "communication_channel": "email",
       "communication_language": "fre"
-    }
+    },
+    "password": "Pw123456"
   },
   "ptrn13": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4136,7 +4148,8 @@
     "home_phone": "+41324993599",
     "roles": [
       "librarian"
-    ]
+    ],
+    "password": "Pw123456"
   },
   "ptrn14": {
     "$schema": "https://bib.rero.ch/schemas/patrons/patron-v0.0.1.json",
@@ -4180,7 +4193,8 @@
       {
         "$ref": "https://bib.rero.ch/api/libraries/lib1"
       }
-    ]
+    ],
+    "password": "Pw123456"
   },
   "dummy_notif": {
     "$schema": "https://bib.rero.ch/schemas/notifications/notification-v0.0.1.json",

--- a/tests/ui/ill_requests/test_ill_requests_ui.py
+++ b/tests/ui/ill_requests/test_ill_requests_ui.py
@@ -27,7 +27,8 @@ from utils import login_user_for_view
 def test_ill_request_create_request_form(client, app,
                                          ill_request_martigny_data_tmp,
                                          loc_public_martigny,
-                                         patron_martigny):
+                                         patron_martigny,
+                                         default_user_password):
     """ test ill request create form."""
     request_form_url = url_for(
         'ill_requests.ill_request_form', viewcode='global')
@@ -38,7 +39,7 @@ def test_ill_request_create_request_form(client, app,
     assert res.status_code == 302
 
     # logged as user
-    login_user_for_view(client, patron_martigny)
+    login_user_for_view(client, patron_martigny, default_user_password)
     res = client.get(request_form_url)
     assert res.status_code == 200
 
@@ -64,7 +65,8 @@ def test_ill_request_create_request_form(client, app,
     assert res.status_code == 302
 
 
-def test_ill_request_with_document(client, app, document, patron_martigny):
+def test_ill_request_with_document(client, app, document, patron_martigny,
+                                   default_user_password):
     """Test ills request form with document data."""
     app.config['RERO_ILS_ILL_REQUEST_ON_GLOBAL_VIEW'] = True
     app.config['RERO_ILS_ILL_DEFAULT_SOURCE'] = 'RERO +'
@@ -75,7 +77,7 @@ def test_ill_request_with_document(client, app, document, patron_martigny):
         record_pid=document.pid)
 
     # logged as user
-    login_user_for_view(client, patron_martigny)
+    login_user_for_view(client, patron_martigny, default_user_password)
     res = client.get(request_form_url)
     assert res.status_code == 200
 

--- a/tests/ui/loans/test_loans_operation_logs.py
+++ b/tests/ui/loans/test_loans_operation_logs.py
@@ -28,9 +28,10 @@ from rero_ils.modules.patrons.api import Patron
 
 
 def test_loan_operation_log(client, operation_log_data,
-                            loan_validated_martigny, librarian_martigny):
+                            loan_validated_martigny, librarian_martigny,
+                            default_user_password):
     """Test operation logs creation."""
-    login_user_for_view(client, librarian_martigny)
+    login_user_for_view(client, librarian_martigny, default_user_password)
 
     operation_log = LoanOperationLog.create(deepcopy(loan_validated_martigny),
                                             index_refresh='wait_for')

--- a/tests/ui/test_message.py
+++ b/tests/ui/test_message.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Message."""
+
+from rero_ils.filter import message_filter
+from rero_ils.modules.message import Message
+
+
+def test_message(app):
+    """Test message."""
+    key = 'test_fr'
+    message = 'Foo bar'
+    result = {'type': 'success', 'message': message}
+
+    assert Message.set(key=key, type='success', value=message)
+    assert Message.get(key) == result
+    assert Message.delete(key)
+    assert Message.get(key) is None
+
+
+def test_message_filter(app):
+    """Test message filter."""
+    key = 'test_en'
+    message = 'Filter'
+    result = {'type': 'success', 'message': message}
+
+    assert Message.set(key=key, type='success', value=message)
+    assert message_filter(key) == result

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -30,8 +30,9 @@ def test_has_superuser_access(app):
 
 
 def test_librarian_update_permission_factory(client, document, ebook_1,
-                                             librarian_martigny):
+                                             librarian_martigny,
+                                             default_user_password):
     """Test librarian_update_permission_factory function."""
     assert not librarian_update_permission_factory(ebook_1).can()
-    login_user_for_view(client, librarian_martigny)
+    login_user_for_view(client, librarian_martigny, default_user_password)
     assert librarian_update_permission_factory(document).can()

--- a/tests/ui/users/test_forms.py
+++ b/tests/ui/users/test_forms.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests Form for users."""
+
+import mock
+from bs4 import BeautifulSoup
+from flask import url_for
+
+
+def test_register_form(client, app):
+    """Test register form."""
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': '123',
+        'password_confirm': '123'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "alert-danger"}).find('p')
+    assert 'Field must be at least 8 characters long.' == el.text
+
+    app.config['RERO_ILS_PASSWORD_MIN_LENGTH'] = 10
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': '123',
+        'password_confirm': '123'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "alert-danger"}).find('p')
+    assert 'Field must be at least 10 characters long.' == el.text
+
+    app.config['RERO_ILS_PASSWORD_MIN_LENGTH'] = 8
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': '12345678',
+        'password_confirm': '12345678'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "alert-danger"}).find('p')
+    assert el.text == 'The password must contain a lower case character.'
+
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': 'a12345678',
+        'password_confirm': 'a12345678'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "alert-danger"}).find('p')
+    assert el.text == 'The password must contain a upper case character.'
+
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': 'NewHouse',
+        'password_confirm': 'NewHouse'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "alert-danger"}).find('p')
+    assert el.text == 'The password must contain a number.'
+
+    # Check special char
+    app.config['RERO_ILS_PASSWORD_SPECIAL_CHAR'] = True
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': 'House1234',
+        'password_confirm': 'House1234'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "alert-danger"}).find('p')
+    assert el.text == 'The password must contain a special character.'
+
+    # Valid password
+    app.config['RERO_ILS_PASSWORD_SPECIAL_CHAR'] = False
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': 'Pw123456',
+        'password_confirm': 'Pw123456'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    assert res.status_code == 302
+    assert res.location == 'http://localhost/'
+
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': 'Eléphant$07_',
+        'password_confirm': 'Eléphant$07_'
+    }
+    res = client.post(url_for('security.register'), data=form_data)
+    assert res.status_code == 302
+    assert res.location == 'http://localhost/'
+
+
+@mock.patch('flask_security.views.reset_password_token_status',
+            mock.MagicMock(return_value=[False, False, {}]))
+@mock.patch('flask_security.views.update_password',
+            mock.MagicMock())
+def test_reset_password_form(client, app):
+    """Test reset password form.
+
+    All validator tests are performed by the test_register_form (above).
+    Here we only test that the validator is active on the field.
+    """
+
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': '123',
+        'password_confirm': '123'
+    }
+    res = client.post(url_for('security.reset_password', token='123ab'),
+                      data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "text-danger"}).find('p')
+    assert 'Field must be at least 8 characters long.' == el.text
+
+    form_data = {
+        'email': 'foo@bar.com',
+        'password': '12345678',
+        'password_confirm': '12345678'
+    }
+    res = client.post(url_for('security.reset_password', token='123ab'),
+                      data=form_data)
+    soup = BeautifulSoup(res.data, 'html.parser')
+    el = soup.find('div', {"class": "text-danger"}).find('p')
+    assert el.text == 'The password must contain a lower case character.'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,10 +65,10 @@ def login_user(client, user):
     login_user_via_session(client, user=user.user)
 
 
-def login_user_for_view(client, user):
+def login_user_for_view(client, user, default_user_password):
     """Sign in user for view."""
     invenio_user = user.user
-    invenio_user.password_plaintext = user.dumps().get('birth_date')
+    invenio_user.password_plaintext = default_user_password
     login_user_via_view(client, user=invenio_user)
 
 


### PR DESCRIPTION
* Adds beautifulsoup4 package for test.
* Disables account rest api endpoint.
* Adds validations on the change password api.
* Updates password on the interface test information.
* Adds the possibility to put a message in the cache
  and display it on the html page.
* Changes of the API response on invalid login.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
