### PR TITLE
fix: reinforce search/export of patron transaction 

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -292,7 +292,8 @@ class IlsRecord(Record):
         """
         assert type(pids) is list
         for pid in pids:
-            yield cls.get_record_by_pid(pid)
+            if resource := cls.get_record_by_pid(pid):
+                yield resource
 
     @classmethod
     def record_pid_exists(cls, pid):

--- a/rero_ils/modules/patron_transaction_events/serializers/csv.py
+++ b/rero_ils/modules/patron_transaction_events/serializers/csv.py
@@ -18,6 +18,7 @@
 
 """Patron transaction event CSV serializer."""
 import csv
+from functools import wraps
 
 from babel.numbers import format_decimal
 from ciso8601 import parse_datetime
@@ -114,6 +115,15 @@ class PatronTransactionEventCSVSerializer(CSVSerializer,
         return stream_with_context(generate_csv())
 
 
+def _skip_if_no_record(func):
+    """Decorator used to skip extract function if record doesn't exist."""
+    @wraps(func)
+    def decorated_view(record, *args, **kwargs):
+        return func(record, *args, **kwargs) if record else {}
+    return decorated_view
+
+
+@_skip_if_no_record
 def _extract_patron_data(record):
     """Extract data from patron to include into the csv export file.
 
@@ -131,6 +141,7 @@ def _extract_patron_data(record):
     }
 
 
+@_skip_if_no_record
 def _extract_document_data(record):
     """Extract document from loan to include into the csv export file.
 
@@ -144,6 +155,7 @@ def _extract_document_data(record):
     }
 
 
+@_skip_if_no_record
 def _extract_item_data(record, collector):
     """Extract item from loan to include into the csv export file.
 
@@ -159,6 +171,7 @@ def _extract_item_data(record, collector):
     }
 
 
+@_skip_if_no_record
 def _extract_operator_data(record):
     """Extract data from operator to include into the csv export file.
 
@@ -170,6 +183,7 @@ def _extract_operator_data(record):
     }
 
 
+@_skip_if_no_record
 def _extract_patron_type_data(record):
     """Extract data from patron type to include into the csv export file.
 
@@ -181,6 +195,7 @@ def _extract_patron_type_data(record):
     }
 
 
+@_skip_if_no_record
 def _extract_transaction_library_data(record):
     """Extract data from library to include into the csv export file.
 

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -283,24 +283,6 @@ def test_loans_serializers(
             assert data.get('transaction_library_name')
 
 
-def test_patron_transactions_serializers(
-    client,
-    rero_json_header,
-    librarian_saxon,
-    patron_transaction_overdue_saxon
-):
-    """Test serializers for patron transactions."""
-    login_user(client, librarian_saxon)
-    list_url = url_for('invenio_records_rest.pttr_list')
-    response = client.get(list_url, headers=rero_json_header)
-    assert response.status_code == 200
-    data = get_json(response)
-    record = data.get('hits', {}).get('hits', [])[0]
-    assert record.get('metadata', {}).get('document')
-    assert record.get('metadata', {}).get('loan')
-    assert record.get('metadata', {}).get('loan', {}).get('item')
-
-
 def test_patron_transaction_events_serializers(
     client,
     rero_json_header,


### PR DESCRIPTION
If patron transaction related resources are delete, the search and export caused error. This PR fix all these problems.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>


