### PR TITLE
documents: inject MEF pid in for subjects

### DIFF
--- a/rero_ils/modules/contributions/tasks.py
+++ b/rero_ils/modules/contributions/tasks.py
@@ -71,20 +71,6 @@ def delete_records(records, verbose=False):
 
 
 @shared_task(ignore_result=True)
-def create_mef_record_online(ref):
-    """Get a record from DB.
-
-    If the record dos not exist get it from MEF and create it.
-
-    :param ref: referer to contribution record on MEF
-    :return: contribution pid, online = True if contribution was loaded
-    """
-    contribution, online = Contribution.get_record_by_ref(ref)
-    pid = contribution.get('pid') if contribution else None
-    return pid, online
-
-
-@shared_task(ignore_result=True)
 def update_contributions(pids=None, dbcommit=True, reindex=True, verbose=False,
                          debug=False, timestamp=True):
     """Update contributions.

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -345,12 +345,12 @@ class Document(IlsRecord):
             for subject in data.get(subjects, []):
                 subject_ref = subject.get('$ref')
                 subject_type = subject.get('type')
+                mef_pid = subject.get('pid')
                 if subject_ref and subject_type in [
                     DocumentSubjectType.PERSON,
                     DocumentSubjectType.ORGANISATION
                 ]:
-                    contrib_data, _ = Contribution.get_record_by_ref(
-                        subject_ref)
+                    contrib_data = Contribution.get_record_by_pid(mef_pid)
                     del subject['$ref']
                     subject.update(contrib_data)
         return data

--- a/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
@@ -22,6 +22,7 @@ from dojson import utils
 from dojson.contrib.to_marc21.model import Underdo
 from flask import current_app
 from flask_babelex import gettext as translate
+from invenio_db import db
 
 from rero_ils.modules.contributions.api import Contribution
 from rero_ils.modules.documents.utils import display_alternate_graphic_first
@@ -258,6 +259,7 @@ class ToMarc21Overdo(Underdo):
             if ref := contribution['agent'].get('$ref'):
                 agent, _ = Contribution.get_record_by_ref(ref)
                 if agent:
+                    db.session.commit()
                     contribution['agent'] = agent
                     replace_contribution_sources(
                         contribution=contribution,

--- a/rero_ils/modules/selfcheck/cli.py
+++ b/rero_ils/modules/selfcheck/cli.py
@@ -147,5 +147,4 @@ def update_terminal(name, enable, disable, location_pid, access_token,
         if comments:
             terminal.comments = comments
         db.session.merge(terminal)
-        db.session.commit()
         click.secho(f'{name} updated', fg='green')

--- a/rero_ils/modules/selfcheck/utils.py
+++ b/rero_ils/modules/selfcheck/utils.py
@@ -56,7 +56,6 @@ def authorize_selfckeck_terminal(terminal, access_token, **kwargs):
             terminal.last_login_at = datetime.utcnow()
             terminal.last_login_ip = kwargs.get('terminal_ip', None)
             db.session.merge(terminal)
-            db.session.commit()
             return token.user
 
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -354,9 +354,9 @@ then
     if [ ${INDEX_PARALLEL} -gt 0 ]; then
         eval ${PREFIX} invenio reroils index reindex_missing -t cont -v
     fi
-else
-    info_msg "- Contributions from MEF: ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE}"
-    eval ${PREFIX} invenio reroils fixtures get_all_mef_records ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE} -v
+# else
+#     info_msg "- Contributions from MEF: ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE}"
+#     eval ${PREFIX} invenio reroils fixtures get_all_mef_records ${DOCUMENTS} ${CREATE_LAZY} ${ENQUEUE} -v
 fi
 
 info_msg "- Documents: ${DOCUMENTS} ${CREATE_LAZY} ${DONT_STOP}"

--- a/tests/unit/test_cli_fixtures.py
+++ b/tests/unit/test_cli_fixtures.py
@@ -23,8 +23,7 @@ import mock
 from click.testing import CliRunner
 from utils import mock_response
 
-from rero_ils.modules.cli.fixtures import count_cli, create, \
-    get_all_mef_records
+from rero_ils.modules.cli.fixtures import count_cli, create
 
 
 def test_count(app, script_info):
@@ -48,32 +47,6 @@ def test_count(app, script_info):
     )
     assert result.exit_code == 0
     assert result.output.strip().split('\n')[1] == 'Count: 2'
-
-
-@mock.patch('requests.get')
-def test_get_all_mef_records(mock_contributions_mef_get, app, script_info,
-                             contribution_person_response_data):
-    """Test get_all_mef_records cli."""
-    json_file_name = join(dirname(__file__), '../data/documents.json')
-    mock_contributions_mef_get.return_value = mock_response(
-        json_data=contribution_person_response_data
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(
-        get_all_mef_records,
-        [json_file_name, '-v'],
-        obj=script_info
-    )
-    assert result.exit_code == 0
-
-    assert result.output.strip().split('\n')[1:] == [
-        '1         ref: https://mef.rero.ch/api/agents/idref/223977268\t'
-        'contribution pid: cont_pers True',
-        '1         ref: https://mef.rero.ch/api/agents/rero/A017671081\t'
-        'contribution pid: cont_pers False',
-        'Count refs: 2',
-    ]
 
 
 @mock.patch('requests.get')


### PR DESCRIPTION
* Adds MEF pid in the document database for subjects.
* Uses `pre_create` instead of `post_init` to inject pid.
* Resolves subject from the database for indexing.
* Removes pre loading contributions during the setup.
* Removes unused code.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
