### PR TITLE
documents: fix contribution duplicates

### DIFF
--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -414,10 +414,12 @@ class Document(IlsRecord):
         for electronic_locator in electronic_locators:
             e_content = electronic_locator.get('content')
             e_type = electronic_locator.get('type')
-            if e_content == 'coverImage' and e_type == 'relatedResource':
-                # don't add the same url
-                if electronic_locator.get('url') == url:
-                    return self, False
+            if (
+                e_content == 'coverImage'
+                and e_type == 'relatedResource'
+                and electronic_locator.get('url') == url
+            ):
+                return self, False
         electronic_locators.append({
             'content': 'coverImage',
             'type': 'relatedResource',


### PR DESCRIPTION
* Uses post create and post commit (update) to create the contribution
  to avoid orphan contribution in elasticsearch.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
