### PR TITLE
items: issue sorting & late issue schedule task

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2638,6 +2638,10 @@ RECORDS_REST_SORT_OPTIONS['items']['issue_expected_date'] = dict(
     fields=['issue.expected_date'], title='Issue expected date',
     default_order='asc'
 )
+RECORDS_REST_SORT_OPTIONS['items']['issue_sort_date'] = dict(
+    fields=['issue.sort_date'], title='Issue chronology date',
+    default_order='asc'
+)
 RECORDS_REST_SORT_OPTIONS['items']['enumeration_chronology'] = dict(
     fields=['-enumerationAndChronology'], title='Enumeration and Chronology',
     default_order='desc'

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -397,6 +397,17 @@ class IlsRecord(Record):
         """Get record count."""
         return cls._get_all(with_deleted=with_deleted).count()
 
+    def db_record(self):
+        """Get record stored into DB for this record (aka original_record).
+
+        :returns: the record stored into database corresponding to the record
+                  id. If the record ID doesn't yet exist, return None.
+        """
+        try:
+            return self.__class__.get_record(self.id)
+        except NoResultFound:
+            pass
+
     def delete(self, force=False, dbcommit=False, delindex=False):
         """Delete record and persistent identifier."""
         can, _ = self.can_delete

--- a/rero_ils/modules/holdings/cli.py
+++ b/rero_ils/modules/holdings/cli.py
@@ -26,15 +26,15 @@ from datetime import datetime, timedelta, timezone
 import click
 from flask.cli import with_appcontext
 
-from ..documents.api import Document, DocumentsSearch
-from ..holdings.api import Holding, create_holding
-from ..item_types.api import ItemTypesSearch
-from ..items.api import Item
-from ..items.models import ItemIssueStatus
-from ..items.tasks import process_late_issues
-from ..locations.api import LocationsSearch
-from ..organisations.api import Organisation
-from ..utils import read_json_record
+from rero_ils.modules.documents.api import Document, DocumentsSearch
+from rero_ils.modules.holdings.api import Holding, create_holding
+from rero_ils.modules.item_types.api import ItemTypesSearch
+from rero_ils.modules.items.api import ItemIssue
+from rero_ils.modules.items.models import ItemIssueStatus
+from rero_ils.modules.items.tasks import process_late_issues
+from rero_ils.modules.locations.api import LocationsSearch
+from rero_ils.modules.organisations.api import Organisation
+from rero_ils.modules.utils import read_json_record
 
 
 def get_document_pid_by_rero_number(rero_control_number):
@@ -198,8 +198,7 @@ def create_patterns(infile, verbose, debug, lazy):
     # create some late issues.
     process_late_issues(dbcommit=True, reindex=True)
     # make late issues ready for a claim
-    for item in Item.get_issues_by_status(issue_status=ItemIssueStatus.LATE):
-        holding = Holding.get_record_by_pid(item.holding_pid)
-        item['issue']['status_date'] = \
+    for issue in ItemIssue.get_issues_by_status(status=ItemIssueStatus.LATE):
+        issue['issue']['status_date'] = \
             (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
-        item.update(item, dbcommit=True, reindex=True)
+        issue.update(issue, dbcommit=True, reindex=True)

--- a/rero_ils/modules/holdings/utils.py
+++ b/rero_ils/modules/holdings/utils.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities functions about `Holdings` resource."""
+
+from datetime import datetime, timedelta, timezone
+
+from flask import current_app
+
+from rero_ils.modules.errors import RegularReceiveNotAllowed
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
+from rero_ils.modules.items.models import ItemIssueStatus
+
+
+def get_late_serial_holdings():
+    """Return serial holdings with late issues.
+
+    Holdings are considered late if :
+      * holding type is `serial`
+      * it's a `regular` serial holding (exclude irregular type)
+      * it's considered as alive (acq_status='currently_received')
+      * next expected date has passed (greater than current datetime).
+
+    :return: A `Holding` resource generator
+    """
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    yesterday = yesterday.strftime('%Y-%m-%d')
+    query = HoldingsSearch() \
+        .filter('term', holdings_type='serial') \
+        .filter('term', acquisition_status='currently_received') \
+        .filter('range', patterns__next_expected_date={'lte': yesterday}) \
+        .exclude('term', patterns__frequency='rdafr:1016') \
+        .source(False)
+    for hit in query.scan():
+        yield Holding.get_record(hit.meta.id)
+
+
+def receive_next_late_expected_issues(dbcommit=False, reindex=False):
+    """Receive the next late expected issue for all holdings.
+
+    :param reindex: reindex record by record.
+    :param dbcommit: commit record to database.
+    :return: the number of created issues.
+    """
+    counter = 0
+    for holding in get_late_serial_holdings():
+        try:
+            issue = holding.receive_regular_issue(
+                dbcommit=dbcommit, reindex=reindex)
+            issue.issue_status = ItemIssueStatus.LATE
+            issue.update(issue, dbcommit=dbcommit, reindex=reindex)
+            counter += 1
+        except RegularReceiveNotAllowed as err:
+            pid = holding.pid
+            msg = f'Cannot receive next expected issue for Holding#{pid}'
+            current_app.logger.error(f'{msg}::{str(err)}')
+    return counter

--- a/rero_ils/modules/items/api/issue.py
+++ b/rero_ils/modules/items/api/issue.py
@@ -21,7 +21,6 @@ from datetime import datetime, timezone
 
 import ciso8601
 from flask import current_app
-from future.backports.datetime import timedelta
 
 from .record import ItemRecord
 from ..models import ItemIssueStatus, TypeOfItem
@@ -40,15 +39,35 @@ class ItemIssue(ItemRecord):
         """Shortcut for issue expected date."""
         return self.get('issue', {}).get('expected_date')
 
+    @expected_date.setter
+    def expected_date(self, value):
+        """Setter for the issue expected date."""
+        self.setdefault('issue', {})['expected_date'] = value
+
     @property
     def received_date(self):
         """Shortcut for issue received date."""
         return self.get('issue', {}).get('received_date')
 
     @property
+    def sort_date(self):
+        """Shortcut for issue sort date."""
+        return self.get('issue', {}).get('sort_date')
+
+    @sort_date.setter
+    def sort_date(self, value):
+        """Setter for the issue sort date."""
+        self.setdefault('issue', {})['sort_date'] = value
+
+    @property
     def issue_status(self):
         """Shortcut for issue status."""
         return self.get('issue', {}).get('status')
+
+    @issue_status.setter
+    def issue_status(self, value):
+        """Setter for issue status."""
+        self.setdefault('issue', {})['status'] = value
 
     @property
     def issue_is_regular(self):
@@ -66,9 +85,9 @@ class ItemIssue(ItemRecord):
         return self.get('issue', {}).get('claims_count', 0)
 
     @claims_count.setter
-    def claims_count(self, claims_count):
-        self.setdefault('issue', {}).setdefault('claims_count', 0)
-        self['issue']['claims_count'] = claims_count
+    def claims_count(self, value):
+        """Setter for issue claims counter."""
+        self.setdefault('issue', {})['claims_count'] = value
 
     @property
     def vendor_pid(self):
@@ -76,9 +95,20 @@ class ItemIssue(ItemRecord):
         from ...holdings.api import Holding
         if self.holding_pid:
             holding = Holding.get_record_by_pid(self.holding_pid)
-            vendor = holding.vendor
-            if vendor:
+            if vendor := holding.vendor:
                 return vendor.pid
+
+    @property
+    def issue_inherited_first_call_number(self):
+        """Get issue inherited first call number.
+
+        When the issue first call number is missing,
+        it returns the parent holdings first call number if exists.
+        """
+        from rero_ils.modules.holdings.api import Holding
+        if self.is_issue and not self.get('call_number'):
+            holding = Holding.get_record_by_pid(self.holding_pid)
+            return holding.get('call_number')
 
     @classmethod
     def get_issues_pids_by_status(cls, issue_status, holdings_pid=None):
@@ -88,7 +118,7 @@ class ItemIssue(ItemRecord):
         :param issue_status: the issue status.
         :return a generator of issues pid.
         """
-        from . import ItemsSearch
+        from .api import ItemsSearch
         query = ItemsSearch() \
             .filter('term', issue__status=issue_status) \
             .filter('term', type='issue')
@@ -99,97 +129,36 @@ class ItemIssue(ItemRecord):
             .sort({'_created': {'order': 'asc'}}) \
             .source(['pid'])
 
-        for hit in [hit for hit in query.scan()]:
-            yield hit.pid
+        return [hit.pid for hit in query.scan()]
 
     @classmethod
-    def get_issues_by_status(cls, issue_status, holdings_pid=None):
+    def get_issues_by_status(cls, status, holdings_pid=None):
         """Return all issues by status optionally filtered for a holdings pid.
 
-        :param issue_status: the status of the issue.
+        :param status: the status of the issue.
         :param holdings_pid: the holdings pid. If none, return all late issues.
         :return a generator of Item.
         """
-        from . import Item
-        for pid in cls.get_issues_pids_by_status(
-                issue_status, holdings_pid=holdings_pid):
+        from .api import Item
+        for pid in cls.get_issues_pids_by_status(status, holdings_pid):
             yield Item.get_record_by_pid(pid)
 
     @classmethod
-    def get_late_serial_holdings_pids(cls):
-        """Return pids for all late holdings.
-
-        The holdings is considered late if :
-          * it is of type serial
-          * it is considered as alive (acq_status='currently_received')
-          * next expected date has passed (greater than current datetime).
-
-        :return a generator of holdings pid.
-        """
-        from ...holdings.api import HoldingsSearch
-        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
-        yesterday = yesterday.strftime('%Y-%m-%d')
-        query = HoldingsSearch() \
-            .filter('term', holdings_type='serial') \
-            .filter('term', acquisition_status='currently_received') \
-            .filter('range', patterns__next_expected_date={'lte': yesterday}) \
-            .exclude('term', patterns__frequency='rdafr:1016') \
-            .params(preserve_order=True) \
-            .sort({'_created': {'order': 'asc'}}) \
-            .source(['pid'])
-
-        for hit in [hit for hit in query.scan()]:
-            yield hit.pid
-
-    @classmethod
-    def receive_next_late_expected_issues(cls, dbcommit=False, reindex=False):
-        """Receive the next late expected issue for all holdings.
-
-        :param reindex: reindex record by record.
-        :param dbcommit: commit record to database.
-
-        :return a count of created issues.
-        """
-        from ...holdings.api import Holding
-        created_issues = 0
-        pids = cls.get_late_serial_holdings_pids()
-        for pid in pids:
-            try:
-                holding = Holding.get_record_by_pid(pid)
-                issue = holding.receive_regular_issue(
-                    dbcommit=dbcommit, reindex=reindex)
-                issue['issue']['status'] = ItemIssueStatus.LATE
-                issue.update(issue, dbcommit=dbcommit, reindex=reindex)
-                created_issues += 1
-            except Exception:
-                current_app.logger.error(
-                    'Can not receive next late expected issue for serial '
-                    f'holding: {pid}'
-                )
-        return created_issues
-
-    @classmethod
-    def _process_issue_claim(
-            cls, issue, claims_count, claims_days, modified_issues,
-            dbcommit=False, reindex=False):
+    def _process_issue_claim(cls, issue, claims_days, dbcommit=False,
+                             reindex=False):
         """Process issue for a new claim.
 
         :param issue: the issue item record.
-        :param claims_days: claims days parameter to compare with issue age.
-        :param modified_issues: counter to count modified issues.
         :param reindex: reindex the records.
         :param dbcommit: commit record to database.
-        :param claims_count: current claim count for this issue.
-
         :return a count of modified issues.
         """
-        days = cls._get_issue_status_age(issue)
-        if days >= claims_days:
+        update_counts = 0
+        if cls._get_issue_status_age(issue) >= claims_days:
             cls._update_issue_status_claims_count(
-                issue, claims_count,
-                dbcommit=dbcommit, reindex=reindex)
-            modified_issues += 1
-        return modified_issues
+                issue, dbcommit=dbcommit, reindex=reindex)
+            update_counts += 1
+        return update_counts
 
     @classmethod
     def _get_issue_status_age(cls, issue):
@@ -206,73 +175,78 @@ class ItemIssue(ItemRecord):
 
     @classmethod
     def _update_issue_status_claims_count(
-            cls, issue, claims_count, dbcommit=False,
-            reindex=False):
+            cls, issue, dbcommit=False, reindex=False):
         """Update issue status and claims count.
 
         It compares the issue status date with the current timestamp
 
         :param issue: the issue item record.
-        :param claims_count: the current claims_count from the issue.
         :param reindex: reindex the records.
         :param dbcommit: commit record to database.
         """
         issue['issue']['status'] = ItemIssueStatus.CLAIMED
         issue.claims_count += 1
-        issue = issue.update(
-            issue, dbcommit=dbcommit, reindex=reindex)
+        issue.update(issue, dbcommit=dbcommit, reindex=reindex)
 
     @classmethod
-    def create_first_and_next_claims(
-            cls, claim_type=None, dbcommit=False, reindex=False):
+    def create_first_and_next_claims(cls, claim_type=None, dbcommit=False,
+                                     reindex=False):
         """Claim the late and claimed issues for all holdings.
 
-        :param claim_type: if first, it creates the first claim for the late
-        issues. if value is next, it creates the next claim for the claimed
-        issues.
-        :param reindex: reindex the records.
-        :param dbcommit: commit record to database.
-
-        :return a count of modified issues.
+        :param claim_type: if "first", it creates the first claim for late
+            issues. if "next", it creates the next claim for claimed issues.
+        :param reindex: is the issues should be reindex.
+        :param dbcommit: is the issues should be committed into database.
+        :return: a count of modified issues.
         """
-        from ...holdings.api import Holding
+        from rero_ils.modules.holdings.api import Holding
 
-        modified_issues = 0
-        issues = []
-
+        assert claim_type in ['first', 'next'], 'Invalid claim type'
+        issue_status = ItemIssueStatus.CLAIMED  # default for 'next' claim type
         if claim_type == 'first':
             issue_status = ItemIssueStatus.LATE
-        elif claim_type == 'next':
-            issue_status = ItemIssueStatus.CLAIMED
-        if issue_status:
-            issues = cls.get_issues_by_status(issue_status=issue_status)
+
+        issues = cls.get_issues_by_status(issue_status) if issue_status else []
+        modified_issues = 0
+        holdings_cache = {}
 
         for issue in issues:
             try:
-                email = None
-                holding = Holding.get_record_by_pid(issue.holding_pid)
-                vendor = holding.vendor
-                if vendor:
-                    email = vendor.order_email
-                max_number_of_claims = holding.max_number_of_claims
-                if email and max_number_of_claims and \
-                        max_number_of_claims > issue.claims_count:
-                    if issue.claims_count == 0 and \
-                            holding.days_before_first_claim:
-                        claims_days = holding.days_before_first_claim
-                    elif issue.claims_count and holding.days_before_next_claim:
-                        claims_days = holding.days_before_next_claim
-                    modified_issues = cls._process_issue_claim(
-                        issue=issue,
-                        claims_count=issue.claims_count,
-                        claims_days=claims_days,
-                        modified_issues=modified_issues,
-                        dbcommit=dbcommit,
-                        reindex=reindex
-                    )
+                # Load the holding if not already loaded. If related holding
+                # doesn't exist, raise an error.
+                holding_pid = issue.holding_pid
+                if holding_pid not in holdings_cache:
+                    holding = Holding.get_record_by_pid(issue.holding_pid)
+                    if not holding:
+                        raise KeyError(f'Unable to load holding#{holding_pid}')
+                    holdings_cache[holding.pid] = holding
+
+                # Determine if the maximum of claims is already done. If yes,
+                # skip this issue.
+                holding = holdings_cache.get(holding_pid)
+                if issue.claims_count >= holding.max_number_of_claims:
+                    raise ValueError('Maximum claim reached')
+
+                # Try to get the related vendor email. If not found, raise an
+                # error and skip the claim creation process.
+                if not (vendor := holding.vendor) or not vendor.order_email:
+                    raise ValueError(f'holding#{holding_pid} : Unable to find '
+                                     f'an related vendor email')
+
+                # run the claim process for this issue
+                if issue.claims_count == 0:
+                    claims_days = holding.days_before_first_claim
+                else:
+                    claims_days = holding.days_before_next_claim
+                modified_issues += cls._process_issue_claim(
+                    issue=issue,
+                    claims_days=claims_days,
+                    dbcommit=dbcommit,
+                    reindex=reindex
+                )
             except Exception as err:
                 current_app.logger.error(
                     f'Can not create {claim_type} '
-                    f'claim for issue: {issue.pid} error: {err}'
+                    f'claim for issue: {issue.pid} error: {str(err)}'
                 )
         return modified_issues

--- a/rero_ils/modules/items/extensions.py
+++ b/rero_ils/modules/items/extensions.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Item record extensions."""
+from datetime import datetime
+
+import ciso8601
+from invenio_records.extensions import RecordExtension
+
+from rero_ils.modules.items.models import ItemIssueStatus
+
+
+class IssueSortDateExtension(RecordExtension):
+    """Extension to control the `sort_date` field for an `issue` Item.
+
+    If the item is an issue, the `sort_date` field is used as default sort
+    filter. This `sort_date` is an optional field ; so in ElasticSearch, if
+    no `sort_date` value is present, we use the `expected_date` as sort key.
+    But, when an issue comes to 'LATE' status, a manager could update this
+    `expected_date` for a new one without filling the `sort_date` (to keep the
+    best possible order). In this case, this extension will fill the
+    `sort_date` field with the original `expected_date` value.
+    """
+
+    def pre_commit(self, record, **kwargs):
+        """Called before a record is committed.
+
+        :param record: the record metadata.
+        :param kwargs: any additional named arguments.
+        """
+        # If record isn't an issue or `sort_date` is already set. No more
+        # operations must be done.
+        if not record.is_issue or record.sort_date:
+            return
+
+        # Compare `expected_date` value from current record and db_record. If
+        # value changes then use the `db_record.expected_date` as `sort_date`
+        db_record = record.db_record()
+        if db_record.expected_date != record.expected_date:
+            record.sort_date = db_record.expected_date or record.expected_date
+
+
+class IssueStatusExtension(RecordExtension):
+    """Extension to manage the issue status depending on expected date.
+
+    Manager could manually update the `expected_date` of an issue. If the
+    expected date is in the future, then the issue status must always be set
+    to `expected` regardless current status.
+    """
+
+    @staticmethod
+    def _control_status(record):
+        """Control and update issue status if necessary.
+
+        :param record: the record metadata.
+        """
+        # It could happen that manager would change the `expected_date`
+        # when the issue status is late/claimed (because editor give a new
+        # date) BUT this manager could forget to update the issue status to
+        # 'expected' in this case, this extension will automatically change
+        # the issue status.
+        invalid_statuses = [ItemIssueStatus.LATE, ItemIssueStatus.CLAIMED]
+        if record.is_issue and record.issue_status in invalid_statuses:
+            expected_date = ciso8601.parse_datetime(record.expected_date)
+            if expected_date >= datetime.now():
+                record.issue_status = ItemIssueStatus.EXPECTED
+
+    def pre_commit(self, record, **kwargs):
+        """Called before a record is committed.
+
+        :param record: the record metadata.
+        :param kwargs: any additional named arguments.
+        """
+        IssueStatusExtension._control_status(record)
+
+    def pre_create(self, record, **kwargs):
+        """Called before a record is created.
+
+        :param record: the record metadata.
+        :param kwargs: any additional named arguments.
+        """
+        IssueStatusExtension._control_status(record)
+        if record.model:
+            record.model.data = record

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -306,6 +306,7 @@
       "propertiesOrder": [
         "received_date",
         "expected_date",
+        "sort_date",
         "regular",
         "status"
       ],
@@ -380,6 +381,22 @@
         "expected_date": {
           "format": "date",
           "title": "Expected date",
+          "type": "string",
+          "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
+          "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
+          "form": {
+            "type": "datepicker",
+            "validation": {
+              "messages": {
+                "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
+              }
+            }
+          }
+        },
+        "sort_date": {
+          "format": "date",
+          "title": "Sorting date",
+          "description": "Date used to sort the issue from the holdings item list. If empty, the issue expected date will be used as sort key.",
           "type": "string",
           "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
           "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -184,6 +184,9 @@
           "expected_date": {
             "type": "date"
           },
+          "sort_date": {
+            "type": "date"
+          },
           "regular": {
             "type": "boolean"
           },

--- a/rero_ils/modules/items/models.py
+++ b/rero_ils/modules/items/models.py
@@ -65,10 +65,11 @@ class ItemStatus:
 class ItemIssueStatus:
     """Enum class to list all possible status of an issue item."""
 
-    RECEIVED = 'received'
     CLAIMED = 'claimed'
     DELETED = 'deleted'
+    EXPECTED = 'expected'
     LATE = 'late'
+    RECEIVED = 'received'
 
 
 class ItemCirculationAction:

--- a/rero_ils/modules/items/utils.py
+++ b/rero_ils/modules/items/utils.py
@@ -16,9 +16,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Item utils."""
+from datetime import datetime, timedelta, timezone
 
-
-from rero_ils.modules.items.models import ItemStatus, TypeOfItem
+from rero_ils.modules.items.models import ItemIssueStatus, ItemStatus, \
+    TypeOfItem
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.patron_transactions.api import PatronTransactionsSearch
 
@@ -71,7 +72,7 @@ def same_location_validator(item_pid, input_location_pid):
     return lib_from_loc == lib_from_item
 
 
-def exists_available_item(items=[]):
+def exists_available_item(items=None):
     """Check if at least one item of the list are available.
 
     Caution: `items` param couldn't be a generator otherwise the
@@ -80,6 +81,7 @@ def exists_available_item(items=[]):
     :return True if one item is available; false otherwise.
     """
     from rero_ils.modules.items.api import Item
+    items = items or []
     for item in items:
         if isinstance(item, str):  # `item` seems to be an item pid
             item = Item.get_record_by_pid(item)
@@ -90,7 +92,7 @@ def exists_available_item(items=[]):
     return False
 
 
-def get_provisional_items_pids_candidate_to_delete():
+def get_provisional_items_candidate_to_delete():
     """Returns checked-in provisional items pids.
 
     Returns list of candidate provisional items pids to delete, based on the
@@ -98,7 +100,7 @@ def get_provisional_items_pids_candidate_to_delete():
     items with active loans. in addition, remove items with active fees.
     :return an item pid generator.
     """
-    from rero_ils.modules.items.api import ItemsSearch
+    from rero_ils.modules.items.api import Item, ItemsSearch
 
     # query ES index for open fees
     query_fees = PatronTransactionsSearch()\
@@ -112,6 +114,30 @@ def get_provisional_items_pids_candidate_to_delete():
         .filter('term', type=TypeOfItem.PROVISIONAL) \
         .filter('terms', status=[ItemStatus.ON_SHELF]) \
         .exclude('terms', pid=item_pids_with_fees)\
-        .source('pid')
+        .source(False)
     for hit in query.scan():
-        yield hit.pid
+        yield Item.get_record(hit.meta.id)
+
+
+def update_late_expected_issue(dbcommit=False, reindex=False):
+    """Update status of issues with a passed `expected_date` to late status.
+
+    :param reindex: reindex record by record.
+    :param dbcommit: commit record to database.
+    :return: the number of updated issues.
+    """
+    from rero_ils.modules.items.api import Item, ItemsSearch
+
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    yesterday = yesterday.strftime('%Y-%m-%d')
+    query = ItemsSearch() \
+        .filter('term', type=TypeOfItem.ISSUE) \
+        .filter('term', issue__status=ItemIssueStatus.EXPECTED) \
+        .filter('range', issue__expected_date={'lte': yesterday}) \
+        .source(False)
+    counter = 0
+    for counter, hit in enumerate(query.scan(), 1):
+        item = Item.get_record(hit.meta.id)
+        item.issue_status = ItemIssueStatus.LATE
+        item.update(item, dbcommit=dbcommit, reindex=reindex)
+    return counter

--- a/tests/api/holdings/test_provisional_items.py
+++ b/tests/api/holdings/test_provisional_items.py
@@ -30,7 +30,7 @@ from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus, TypeOfItem
 from rero_ils.modules.items.tasks import delete_provisional_items
 from rero_ils.modules.items.utils import \
-    get_provisional_items_pids_candidate_to_delete
+    get_provisional_items_candidate_to_delete
 from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.patron_transactions.api import PatronTransaction
@@ -246,7 +246,7 @@ def test_holding_requests(client, patron_martigny, loc_public_martigny,
 
     # test delete provisional items with no active fees/loans
     report = delete_provisional_items()
-    assert report.get('numner_of_deleted_items')
+    assert report.get('number_of_deleted_items')
     assert report.get('number_of_candidate_items_to_delete')
     # assert that not deleted items are either having loans/fees or not
     # provisional items
@@ -258,7 +258,7 @@ def test_holding_requests(client, patron_martigny, loc_public_martigny,
         assert not can or record.get('type') != TypeOfItem.PROVISIONAL
     # item_2 has pending loans then it should not be removed
     assert item_2.pid in left_item_pids
-    assert item_2.pid in get_provisional_items_pids_candidate_to_delete()
+    assert item_2 in get_provisional_items_candidate_to_delete()
     # add fee to item_2 and make sure it will not be candidate at the deletion.
     data = {
         'loan': {'$ref': get_ref_for_pid('loanid', loan_2.pid)},
@@ -270,4 +270,4 @@ def test_holding_requests(client, patron_martigny, loc_public_martigny,
         'creation_date': datetime.now(timezone.utc).isoformat()
     }
     PatronTransaction.create(data, dbcommit=True, reindex=True)
-    assert item_2.pid not in get_provisional_items_pids_candidate_to_delete()
+    assert item_2 not in get_provisional_items_candidate_to_delete()

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -65,7 +65,7 @@ def test_patterns_quarterly_one_level(holding_lib_martigny_w_patterns):
     assert holding.next_issue_display_text == 'no 61 mars 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'no 62 juin 2020'
-    for r in range(11):
+    for _ in range(11):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'no 73 mars 2023'
     # test preview
@@ -78,7 +78,7 @@ def test_patterns_quarterly_one_level(holding_lib_martigny_w_patterns):
     assert new_holding.next_issue_display_text == '1 3'
 
 
-def test_receive_regular_issue(holding_lib_martigny_w_patterns):
+def test_receive_regular_issue(holding_lib_martigny_w_patterns, tomorrow):
     """Test holdings receive regular issues."""
     holding = holding_lib_martigny_w_patterns
     assert holding.is_serial
@@ -104,9 +104,12 @@ def test_receive_regular_issue(holding_lib_martigny_w_patterns):
     assert issue_status_date.strftime('%Y-%m-%d') == \
         datetime.now().strftime('%Y-%m-%d')
     # test change status_date with status changes
-    issue['issue']['status'] = ItemIssueStatus.CLAIMED
+    issue.expected_date = tomorrow.strftime('%Y-%m-%d')
+    issue.issue_status = ItemIssueStatus.CLAIMED
     new_issues = issue.update(issue, dbcommit=True, reindex=True)
-    assert new_issues.issue_status == ItemIssueStatus.CLAIMED
+    # As we choose a future expected date, the issue status should be
+    # automatically changed to `expected`
+    assert new_issues.issue_status == ItemIssueStatus.EXPECTED
     new_issue_status_date = ciso8601.parse_datetime(
         new_issues.issue_status_date)
     assert new_issue_status_date > issue_status_date
@@ -150,7 +153,7 @@ def test_patterns_yearly_one_level(
     assert holding.next_issue_display_text == '82 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == '83 2021'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == '108 2046'
     # test preview
@@ -169,7 +172,7 @@ def test_patterns_yearly_one_level_with_label(
     assert holding.next_issue_display_text == '29 Edition 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == '30 Edition 2021'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == '55 Edition 2046'
     # test preview
@@ -188,7 +191,7 @@ def test_patterns_yearly_two_times(
     assert holding.next_issue_display_text == 'Jg. 8 Nov. 2019'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Jg. 9 März 2020'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Jg. 21 Nov. 2032'
     # test preview
@@ -207,7 +210,7 @@ def test_patterns_quarterly_two_levels(
     assert holding.next_issue_display_text == 'Jg. 20 Heft 1 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Jg. 20 Heft 2 2020'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Jg. 26 Heft 3 2026'
     # test preview
@@ -228,7 +231,7 @@ def test_patterns_quarterly_two_levels_with_season(
         'année 2019 no 277 printemps 2018'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'année 2019 no 278 été 2018'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == \
         'année 2025 no 303 automne 2024'
@@ -251,7 +254,7 @@ def test_patterns_half_yearly_one_level(
     assert holding.next_issue_display_text == 'N˚ 48 printemps 2019'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'N˚ 49 automne 2019'
-    for r in range(13):
+    for _ in range(13):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'N˚ 62 printemps 2026'
     # test preview
@@ -271,7 +274,7 @@ def test_patterns_bimonthly_every_two_months_one_level(
     assert holding.next_issue_display_text == '47 jan./fév. 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == '48 mars/avril 2020'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == '73 mai/juin 2024'
     # test preview
@@ -291,7 +294,7 @@ def test_patterns_half_yearly_two_levels(
     assert holding.next_issue_display_text == 'Année 30 no 84 June 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Année 30 no 85 Dec. 2020'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Année 43 no 110 June 2033'
     # test preview
@@ -311,7 +314,7 @@ def test_bimonthly_every_two_months_two_levels(
     assert holding.next_issue_display_text == 'Jg 51 Nr 1 Jan. 2020'
     holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Jg 51 Nr 2 März 2020'
-    for r in range(25):
+    for _ in range(25):
         holding.increment_next_prediction()
     assert holding.next_issue_display_text == 'Jg 55 Nr 3 Mai 2024'
     # test preview


### PR DESCRIPTION
* Adds new `sort_date` for issue item. Used to sort issue regardless expected date.
* Adds extensions on `Item` resource to control/manage issue status and issue sort_date.
* Updates `late_issue_process` to include already created issue if expected_date has been manually changed by manager.
* Item/Holding code refactoring.
* Closes rero/rero-ils#2921.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

### Migration script ###

🚨 Update mapping for `item` resource 🚨

```python
from rero_ils.modules.items.api import ItemsIndexer, ItemsSearch

query = ItemsSearch().filter('term', type='issue').source(False)
uuids = [hit.meta.id for hit in query.scan()]

indexer = ItemsIndexer()
indexer.bulk_index(uuids)
_, (indexer_count, error_count) = indexer.process_bulk_queue()
print(f'{indexer_count} items indexed, {error_count} errors')
```
