### PR TITLE
indexer: add missing mapping configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ tests/e2e/cypress/cypress/integration/test
 
 # Dependencies
 /node_modules
+
+# Macosx
+.DS_Store

--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -16383,7 +16383,7 @@
           {
             "country": "sz",
             "type": "bf:Place",
-            "identifyBy": {
+            "identifiedBy": {
               "value": "027418545",
               "type": "IdRef"
             }

--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -649,7 +649,7 @@ class ReroIlsOverdo(Overdo):
         if place:
             place['type'] = 'bf:Place'
         if self.links_from_752:
-            place['identifyBy'] = self.links_from_752[0]
+            place['identifiedBy'] = self.links_from_752[0]
         return place
 
     def default_provision_activity(self, result):
@@ -665,7 +665,7 @@ class ReroIlsOverdo(Overdo):
             place = {
                 'country': 'xx',
                 'type': 'bf:Place',
-                'identifyBy': self.links_from_752[i]
+                'identifiedBy': self.links_from_752[i]
             }
             places.append(place)
 
@@ -1186,7 +1186,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
                     self.admin_meta_data['descriptionConventions'] = \
                         description_conventions
 
-            # build the list of links from filed 752
+            # build the list of links from field 752
             self.links_from_752 = []
             fields_752 = self.get_fields(tag='752')
             for field_752 in fields_752:
@@ -1985,7 +1985,7 @@ def build_responsibility_data(responsibility_data):
 
 
 def build_identifier(data):
-    """Build identifyBy for document_identifier-v0.0.1.json from $0.
+    """Build identifiedBy for document_identifier-v0.0.1.json from $0.
 
     :param data: data to build the identifiedBy from.
     :returns: identifiedBy from $0 or None.

--- a/rero_ils/es_templates/v7/record.json
+++ b/rero_ils/es_templates/v7/record.json
@@ -1,5 +1,35 @@
 {
-  "index_patterns": "*",
+  "index_patterns": [
+    "acq_accounts-*",
+    "acq_invoices-*",
+    "acq_order_lines-*",
+    "acq_orders-*",
+    "acq_receipt_lines-*",
+    "acq_receipts-*",
+    "budgets-*",
+    "circ_policies-*",
+    "collections-*",
+    "contributions-*",
+    "documents-*",
+    "holdings-*",
+    "ill_requests-*",
+    "item_types-*",
+    "items-*",
+    "libraries-*",
+    "loans-*",
+    "loans-*",
+    "local_fields-*",
+    "locations-*",
+    "notifications-*",
+    "organisations-*",
+    "patron_transaction_events-*",
+    "patron_transactions-*",
+    "patron_types-*",
+    "patrons-*",
+    "stats-*",
+    "templates-*",
+    "vendors-*"
+  ],
   "settings": {
     "number_of_shards": "8",
     "number_of_replicas": "1",
@@ -141,5 +171,18 @@
         }
       }
     }
+  },
+  "mappings": {
+    "dynamic": "false",
+    "dynamic_templates": [
+      {
+        "objects": {
+          "match_mapping_type": "object",
+          "mapping": {
+            "dynamic": "false"
+          }
+        }
+      }
+    ]
   }
 }

--- a/rero_ils/modules/acquisition/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_orders/mappings/v7/acq_orders/acq_order-v0.0.1.json
@@ -102,10 +102,16 @@
           "reference": {
             "type": "keyword"
           },
+          "pid": {
+            "type": "keyword"
+          },
           "receipt_date": {
             "type": "date"
           }
         }
+      },
+      "order_date": {
+        "type": "date"
       },
       "order_lines": {
         "properties": {

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
@@ -818,19 +818,18 @@ def do_provision_activity(data, marc21, key, value):
             place = {
                 'country': 'xx',
                 'type': 'bf:Place',
-                'identifyBy': marc21.links_from_752[i]
             }
+            if marc21.links_from_752:
+                place['identifiedBy'] = marc21.links_from_752[i]
             places.append(place)
         if places:
             publication['place'] = places
     subfield_3 = not_repetitive(
         marc21.bib_id, marc21.rero_id, key, value, '3')
     if subfield_3:
-        notes = publication.get('note')
-        if notes:
-            notes = [notes]
-        else:
-            notes = []
+        notes = []
+        if pub_notes := publication.get('note'):
+            notes = [pub_notes]
         notes.append(subfield_3)
         publication['note'] = ', '.join(notes)
 

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -1063,6 +1063,9 @@
               "call_number": {
                 "type": "text"
               },
+              "second_call_number": {
+                "type": "text"
+              },
               "status": {
                 "type": "keyword"
               },
@@ -1195,6 +1198,12 @@
       "supplement": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1226,6 +1235,12 @@
       "supplementTo": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1257,6 +1272,12 @@
       "otherEdition": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1288,6 +1309,12 @@
       "otherPhysicalFormat": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1319,6 +1346,12 @@
       "issuedWith": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1350,6 +1383,12 @@
       "precededBy": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1381,6 +1420,12 @@
       "succeededBy": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },
@@ -1412,6 +1457,12 @@
       "relatedTo": {
         "type": "object",
         "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
           "label": {
             "type": "text"
           },

--- a/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/mappings/v7/patrons/patron-v0.0.1.json
@@ -160,6 +160,15 @@
           "communication_channel": {
             "type": "keyword"
           },
+          "additional_communication_email": {
+            "type": "keyword",
+            "fields": {
+              "analyzed": {
+                "type": "text",
+                "analyzer": "custom_keyword"
+              }
+            }
+          },
           "communication_language": {
             "type": "keyword"
           },

--- a/tests/unit/documents/test_documents_dojson.py
+++ b/tests/unit/documents/test_documents_dojson.py
@@ -1578,7 +1578,7 @@ def test_marc21_provisionActivity_without_264_with_752():
         'place': [{
             'country': 'sz',
             'type': 'bf:Place',
-            'identifyBy': {
+            'identifiedBy': {
                     'type': 'IdRef',
                     'value': '027401421'
                 }
@@ -1815,7 +1815,7 @@ def test_marc21_to_provision_activity_1_place_2_agents_with_one_752():
             'place': [{
                 'country': 'fr',
                 'type': 'bf:Place',
-                'identifyBy': {
+                'identifiedBy': {
                     'type': 'IdRef',
                     'value': '027401421'
                 }
@@ -1879,14 +1879,14 @@ def test_marc21_to_provision_activity_1_place_2_agents_with_two_752():
             'place': [{
                     'country': 'fr',
                     'type': 'bf:Place',
-                    'identifyBy': {
+                    'identifiedBy': {
                         'type': 'IdRef',
                         'value': '027401421'
                     }
                 }, {
                     'country': 'xx',
                     'type': 'bf:Place',
-                    'identifyBy': {
+                    'identifiedBy': {
                         'type': 'RERO',
                         'value': 'A000000001'
                     }


### PR DESCRIPTION
- Fixes spelling: identifyBy to identifiedBy.
- Applies elasticsearch templates for all the resources excepts the
  operation logs.
- Adds missing mapping configurations for documents, patrons and
  acquisition order.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
