### PR TITLE
indexing: fix wildcard queries

### DIFF
--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -955,9 +955,6 @@
           "pid": {
             "type": "keyword"
           },
-          "available": {
-            "type": "boolean"
-          },
           "location": {
             "type": "object",
             "properties": {
@@ -1065,9 +1062,6 @@
               },
               "status": {
                 "type": "keyword"
-              },
-              "available": {
-                "type": "boolean"
               },
               "acquisition": {
                 "type": "nested",
@@ -1828,9 +1822,6 @@
             "type": "text"
           }
         }
-      },
-      "available": {
-        "type": "boolean"
       },
       "organisation": {
         "properties": {

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -21,7 +21,7 @@ from flask import url_for
 from utils import get_json, login_user_via_session
 
 
-def test_document_search(
+def test_documents_search(
         client,
         doc_title_travailleurs,
         doc_title_travailleuses
@@ -316,6 +316,17 @@ def test_document_search(
     res = client.get(list_url)
     hits = get_json(res)['hits']
     assert hits['total']['value'] == 1
+
+    # test wildcard query with boolean sub property
+    # See: elasticsearch query_string lenient property
+    #      for more details
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q=r'subjects.\*:test'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits
 
 
 def test_patrons_search(


### PR DESCRIPTION
* Fixes wildcard queries for field containing boolean sub fields. For example: `q=subject.%5C*:test`

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
