### PR TITLE
document: fix EAN identifier indexing

### DIFF
--- a/rero_ils/modules/commons/identifiers.py
+++ b/rero_ils/modules/commons/identifiers.py
@@ -241,11 +241,15 @@ class EANIdentifier(Identifier):
 
     def normalize(self) -> str:
         """Get the normalized value for this EAN."""
-        return canonical(self.value)
+        return canonical(self.value) or self.value
     __str__ = normalize
 
+    def is_valid(self) -> bool:
+        """Check if the identifier is valid."""
+        return bool(canonical(self.value))
+
     def get_alternatives(self) -> list[Identifier]:
-        """Get a list of alternative for this identifiers."""
+        """Get a list of alternative for this identifier."""
         alternatives = []
         for identifier in (to_isbn10(self.value), to_isbn13(self.value)):
             if identifier:


### PR DESCRIPTION
Invalid EAN identifiers were not dumped into ES during indexing process. Now, even invalid EAN are indexed and could be searched. 
Closes rero/rero-ils#3220.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

### migration ###

execute the script :
```python
from rero_ils.modules.documents.api import DocumentsSearch, DocumentsIndexer
from elasticsearch_dsl.query import Q

query = DocumentsSearch().filter('nested',
    path='nested_identifiers',
    query=Q('bool', must=[
        Q('term', nested_identifiers__type='bf:Ean'),
        ~Q('exists', field='nested_identifiers.value')
    ])).source(False)
uuids = [hit.meta.id for hit in query.scan()]

indexer = DocumentsIndexer()
indexer.bulk_index(uuids)
_, (indexer_count, error_count) = indexer.process_bulk_queue()
print(f'{indexer_count} documents indexed, {error_count} errors')
```
