### PR TITLE
utils: timestamps

### DIFF
--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -126,8 +126,10 @@ def create_notifications(types=None, tstamp=None, verbose=True):
                     )
         process_notifications(NotificationType.OVERDUE)
     notification_sum = sum(notification_counter.values())
-    counters = {k: v for k, v in notification_counter.items() if v > 0}
+    # in timestamp we need also 0 values
+    set_timestamp('notification-creation', **notification_counter)
 
+    counters = {k: v for k, v in notification_counter.items() if v > 0}
     if verbose:
         logger = current_app.logger
         logger.info("NOTIFICATIONS CREATION TASK")
@@ -135,5 +137,4 @@ def create_notifications(types=None, tstamp=None, verbose=True):
         for notif_type, cpt in counters.items():
             logger.info(f'  +--> {cpt} `{notif_type}` notification(s) created')
 
-    set_timestamp('notification-creation', **counters)
     return counters

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -569,6 +569,7 @@ def set_timestamp(name, **kwargs):
     time_stamps[name]['time'] = utc_now
     for key, value in kwargs.items():
         time_stamps[name][key] = value
+    time_stamps[name]['name'] = name
     if not current_cache.set(key='timestamps', value=time_stamps, timeout=0):
         current_app.logger.warning(
             f'Can not set time stamp for: {name}')

--- a/tests/api/test_monitoring_rest.py
+++ b/tests/api/test_monitoring_rest.py
@@ -137,7 +137,11 @@ def test_monitoring_check_es_db_counts(app, client, contribution_person_data,
 def test_timestamps(app, client):
     """Test timestamps."""
     time_stamp = set_timestamp('test', msg='test msg')
-    assert get_timestamp('test') == {'time': time_stamp, 'msg': 'test msg'}
+    assert get_timestamp('test') == {
+        'time': time_stamp,
+        'name': 'test',
+        'msg': 'test msg'
+    }
     res = client.get(url_for('api_monitoring.timestamps'))
     assert res.status_code == 401
 
@@ -158,6 +162,7 @@ def test_timestamps(app, client):
         'data': {
             'test': {
                 'msg': 'test msg',
+                'name': 'test',
                 'unixtime': time.mktime(time_stamp.timetuple()),
                 'utctime': time_stamp.strftime("%Y-%m-%d %H:%M:%S")
             }


### PR DESCRIPTION
* Adds `name` to timestamps for better json parsing in monitoring software.
* Saves also 0 values for `notification-creation` timestamp.

