### PR TITLE
loans: clean `can_anonymize` method

### DIFF
--- a/rero_ils/modules/items/decorators.py
+++ b/rero_ils/modules/items/decorators.py
@@ -60,7 +60,7 @@ def add_action_parameters_and_flush_indexes(function):
 
         loan, kwargs = item.complete_action_missing_params(
                 item=item, checkin_loan=checkin_loan, **kwargs)
-        Loan.check_required_params(loan, function.__name__, **kwargs)
+        Loan.check_required_params(function.__name__, **kwargs)
         item, action_applied = function(item, loan, *args, **kwargs)
         item.change_status_commit_and_reindex()
         return item, action_applied

--- a/rero_ils/modules/loans/listener.py
+++ b/rero_ils/modules/loans/listener.py
@@ -42,7 +42,7 @@ def enrich_loan_data(sender, json=None, record=None, index=None,
 
     # Update the patron type related to this loan only for "alive" loan to
     # try preserving performance during circulation process.
-    if not record.concluded(record):
+    if not record.is_concluded():
         if patron_type_pid := record.patron.patron_type_pid:
             json['patron_type_pid'] = patron_type_pid
         if record.transaction_location_pid:

--- a/tests/api/patron_transactions/test_patron_transactions_rest.py
+++ b/tests/api/patron_transactions/test_patron_transactions_rest.py
@@ -32,7 +32,8 @@ from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.patron_transactions.api import PatronTransaction
 from rero_ils.modules.patron_transactions.utils import \
     create_subscription_for_patron, get_transactions_pids_for_patron
-from rero_ils.modules.utils import add_years, get_ref_for_pid
+from rero_ils.modules.utils import add_years, extracted_data_from_ref, \
+    get_ref_for_pid
 
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',
@@ -321,8 +322,9 @@ def test_transactions_add_manual_fee(client, librarian_sion, org_sion,
     record = PatronTransaction.get_record_by_pid(metadata['pid'])
     assert record.get('library') == librarian_sion.get('libraries')[0]
     event = next(record.events)
-    event.get('operator') == librarian_sion.get('pid')
-    event.get('library') == librarian_sion.get('libraries')[0]
+    assert extracted_data_from_ref(event.get('operator')) \
+        == librarian_sion.get('pid')
+    assert event.get('library') == librarian_sion.get('libraries')[0]
 
     # Delete the record created above
     clear_patron_transaction_data(metadata['pid'])


### PR DESCRIPTION
* Transforms some class methods to instance methods for `Loan` objects.
* Implements best open transactions detection (skipping Notification step).
* Closes rero/rero-ils#3121.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
