### PR TITLE
translations: fix unicode characters in jsonschema

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: M\u00fcller, Hans",
+        "placeholder": "Example: Miller, John",
         "templateOptions": {
           "itemCssClass": "col-lg-6"
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: M\u00fcller, Hans",
+        "placeholder": "Example: Miller, John",
         "templateOptions": {
           "itemCssClass": "col-lg-6"
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_copyright_date-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_copyright_date-v0.0.1.json
@@ -8,7 +8,7 @@
       "title": "Copyright date",
       "minLength": 4,
       "form": {
-        "placeholder": "Example: \u00a9 2010",
+        "placeholder": "Example: cop. 2010",
         "templateOptions": {
           "cssClass": "w-md-50"
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_dimensions-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_dimensions-v0.0.1.json
@@ -1,7 +1,7 @@
 {
   "dimensions": {
     "title": "Dimensions",
-    "description": "Dimensions include measurements of height, width, depth, length, gauge, and diameter. For oblong volumes, record the height \u00d7 width.",
+    "description": "Dimensions include measurements of height, width, depth, length, gauge, and diameter. For oblong volumes, record the height x width.",
     "type": "array",
     "minItems": 1,
     "items": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_table_of_contents-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_table_of_contents-v0.0.1.json
@@ -8,7 +8,7 @@
       "title": "Content",
       "type": "string",
       "form": {
-        "placeholder": "Example: Volume 1: Fondements / \u00e9dit\u00e9 par A. M\u00fcller"
+        "placeholder": "Example: 1. Fundamentals / ed. by A. Miller"
       }
     },
     "form": {


### PR DESCRIPTION
* Removed unicodes from jsonschemas as they cause translations extraction problems.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>