### PR TITLE
documents: simplify `work_access_point` structure

### DIFF
--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -598,11 +598,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Bach, Johann Sebastian"
-        },
-        "title": "Jauchzet Gott in allen Landen"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Bach, Johann Sebastian. Jauchzet Gott in allen Landen."
+        }
       }
     ],
     "partOf": [
@@ -3115,14 +3114,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Marguerite",
-          "date_of_birth": "1492",
-          "date_of_death": "1549",
-          "qualifier": "d'Angoul\u00eame, reine de Navarre"
-        },
-        "title": "L'heptam\u00e9ron"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Marguerite, 1492-1549, d'Angoul\u00eame, reine de Navarre. L'heptam\u00e9ron."
+        }
       }
     ],
     "partOf": [
@@ -3328,11 +3323,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Plas, Alain"
-        },
-        "title": "Chasseurs de temps"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Plas, Alain. Chasseurs de temps."
+        }
       }
     ],
     "partOf": [
@@ -3864,8 +3858,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Travelling",
-        "miscellaneous_information": "Lausanne"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Travelling. Lausanne."
+        }
       }
     ],
     "title": [
@@ -4506,7 +4502,10 @@
     ],
     "work_access_point": [
       {
-        "title": "La norme SIA 118 et l'actualit\u00e9 juridique en mati\u00e8re de construction"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "La norme SIA 118 et l'actualit\u00e9 juridique en mati\u00e8re de construction."
+        }
       }
     ],
     "classification": [
@@ -6374,8 +6373,8 @@
           "authorized_access_point": "Binet, Christian"
         },
         "role": [
-          "aut",
-          "ill"
+          "ill",
+          "aut"
         ]
       }
     ],
@@ -6482,11 +6481,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Binet, Christian"
-        },
-        "title": "Les Bidochons"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Binet, Christian. Les Bidochons."
+        }
       }
     ]
   },
@@ -7237,11 +7235,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Mozart, Wolfgang Amadeus"
-        },
-        "title": "Neue Ausgabe s\u00e4mtlicher Werke"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Mozart, Wolfgang Amadeus. Neue Ausgabe s\u00e4mtlicher Werke."
+        }
       }
     ],
     "seriesStatement": [
@@ -7588,11 +7585,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Glanzmann, Arthur"
-        },
-        "title": "Bibliographie des schweizerischen Steuerrechts"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Glanzmann, Arthur. Bibliographie des schweizerischen Steuerrechts."
+        }
       }
     ],
     "partOf": [
@@ -7898,11 +7894,11 @@
       },
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos10"
+        "value": "target_school_harmos9"
       },
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos9"
+        "value": "target_school_harmos10"
       },
       {
         "audienceType": "school_level",
@@ -8355,11 +8351,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Cantin, Marc"
-        },
-        "title": "Les mal\u00e9fices d'Halequin"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Cantin, Marc. Les mal\u00e9fices d'Halequin."
+        }
       }
     ],
     "partOf": [
@@ -8743,12 +8738,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Urlaub, Farin",
-          "date_of_birth": "1963"
-        },
-        "title": "Unterwegs"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Urlaub, Farin, 1963. Unterwegs."
+        }
       }
     ],
     "electronicLocator": [
@@ -8858,8 +8851,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Tempi e figure",
-        "date_of_work": "1953-1968"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Tempi e figure. 1953-1968."
+        }
       }
     ],
     "title": [
@@ -10058,12 +10053,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "King, Stephen",
-          "date_of_birth": "1947"
-        },
-        "title": "La tour sombre"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "King, Stephen, 1947. La tour sombre."
+        }
       }
     ],
     "partOf": [
@@ -10230,12 +10223,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "King, Stephen",
-          "date_of_birth": "1947"
-        },
-        "title": "La tour sombre"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "King, Stephen, 1947. La tour sombre."
+        }
       }
     ],
     "partOf": [
@@ -10615,12 +10606,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Collection histoire de l'art",
-        "part": [
-          {
-            "partName": "Carr\u00e9 multim\u00e9dia"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Collection histoire de l'art. Carr\u00e9 multim\u00e9dia."
+        }
       }
     ],
     "title": [
@@ -10866,14 +10855,12 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/082686335",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/082686335"
         }
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026699656",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026699656"
         }
       },
       {
@@ -11825,13 +11812,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Haydn, Joseph",
-          "date_of_birth": "1732",
-          "date_of_death": "1809"
-        },
-        "title": "Werke"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Haydn, Joseph, 1732-1809. Werke."
+        }
       }
     ],
     "seriesStatement": [
@@ -14708,8 +14692,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/204515998",
-          "type": "bf:Organisation"
+          "$ref": "https://mef.rero.ch/api/agents/idref/204515998"
         }
       },
       {
@@ -14873,19 +14856,19 @@
     "intendedAudience": [
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos1"
-      },
-      {
-        "audienceType": "school_level",
         "value": "target_school_harmos2"
       },
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos3"
+        "value": "target_school_harmos1"
       },
       {
         "audienceType": "school_level",
         "value": "target_school_harmos4"
+      },
+      {
+        "audienceType": "school_level",
+        "value": "target_school_harmos3"
       }
     ]
   },
@@ -15254,8 +15237,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027408183",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027408183"
         }
       },
       {
@@ -19241,15 +19223,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux",
-        "date_of_work": "2011-.",
-        "miscellaneous_information": "Lausanne",
-        "part": [
-          {
-            "partNumber": "2,",
-            "partName": "Droit civil, poursuite pour dettes et faillites et proc\u00e9dure civile : jurisprudence f\u00e9d\u00e9rale"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux. 2,. Droit civil, poursuite pour dettes et faillites et proc\u00e9dure civile : jurisprudence f\u00e9d\u00e9rale. Lausanne. 2011-.."
+        }
       }
     ],
     "title": [
@@ -19550,12 +19527,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Organisation",
-          "conference": false,
-          "preferred_name": "Italia"
-        },
-        "title": "Code p\u00e9nal"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Italia. Code p\u00e9nal."
+        }
       }
     ],
     "partOf": [
@@ -20279,11 +20254,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Knoepfel, Peter"
-        },
-        "title": "Luftreinhaltepolitik (station\u00e4re Quellen) im internationalen Vergleich"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Knoepfel, Peter. Luftreinhaltepolitik (station\u00e4re Quellen) im internationalen Vergleich."
+        }
       }
     ],
     "partOf": [
@@ -22817,11 +22791,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Mauriac, Claude"
-        },
-        "title": "Le temps immobile"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Mauriac, Claude. Le temps immobile."
+        }
       }
     ]
   },
@@ -23689,36 +23662,28 @@
     ],
     "work_access_point": [
       {
-        "title": "Babel",
-        "part": [
-          {
-            "partName": "Actes sud"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Babel. Actes sud."
+        }
       },
       {
-        "title": "Babel",
-        "part": [
-          {
-            "partName": "Labor"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Babel. Labor."
+        }
       },
       {
-        "title": "Babel",
-        "part": [
-          {
-            "partName": "Lem\u00e9ac"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Babel. Lem\u00e9ac."
+        }
       },
       {
-        "title": "Babel",
-        "part": [
-          {
-            "partName": "L'Aire"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Babel. L'Aire."
+        }
       }
     ],
     "title": [
@@ -24252,8 +24217,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/139843418",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/139843418"
         }
       }
     ],
@@ -26131,17 +26095,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Shelley, Mary Wollstonecraft Godwin",
-          "date_of_birth": "1797",
-          "date_of_death": "1851",
-          "identifiedBy": {
-            "value": "026671131",
-            "type": "IdRef"
-          }
-        },
-        "title": "Frankenstein"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Shelley, Mary Wollstonecraft Godwin, 1797-1851. Frankenstein."
+        }
       }
     ]
   },
@@ -26898,8 +26855,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026667673",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026667673"
         }
       },
       {
@@ -27832,11 +27788,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "PoiPoi"
-        },
-        "title": "Ange le Terrible"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "PoiPoi. Ange le Terrible."
+        }
       }
     ],
     "partOf": [
@@ -29641,10 +29596,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Go down Moses",
-        "medium_of_performance_for_music": [
-          "Orchestre \u00e0 cordes"
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Go down Moses. Orchestre \u00e0 cordes."
+        }
       }
     ]
   },
@@ -30038,12 +29993,12 @@
     "sequence_numbering": "No 1(2005)-",
     "intendedAudience": [
       {
-        "audienceType": "understanding_level",
-        "value": "target_understanding_tertiary"
-      },
-      {
         "audienceType": "school_level",
         "value": "target_school_tertiary"
+      },
+      {
+        "audienceType": "understanding_level",
+        "value": "target_understanding_tertiary"
       },
       {
         "audienceType": "understanding_level",
@@ -30302,12 +30257,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Bertholet, Alfred",
-          "qualifier": "Musicien"
-        },
-        "title": "A vous la musique, 2\u00e8me ann\u00e9e"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Bertholet, Alfred, Musicien. A vous la musique, 2\u00e8me ann\u00e9e."
+        }
       }
     ],
     "partOf": [
@@ -33542,8 +33495,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027525457",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027525457"
         }
       },
       {
@@ -33562,8 +33514,7 @@
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027930408",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027930408"
         }
       }
     ],
@@ -35179,11 +35130,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Nix, Garth"
-        },
-        "title": "Les sept clefs du pouvoir"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Nix, Garth. Les sept clefs du pouvoir."
+        }
       }
     ],
     "partOf": [
@@ -37720,14 +37670,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Marek, Robert"
-        },
-        "title": "Trios",
-        "medium_of_performance_for_music": [
-          "Trompette, cor, trombone"
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Marek, Robert. Trios. Trompette, cor, trombone."
+        }
       }
     ],
     "partOf": [
@@ -39955,9 +39901,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Conf\u00e9rence",
-        "date_of_work": "1995-2019",
-        "miscellaneous_information": "Meaux"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Conf\u00e9rence. Meaux. 1995-2019."
+        }
       }
     ],
     "title": [
@@ -40829,25 +40776,16 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Schumann, Robert",
-          "date_of_birth": "1810",
-          "date_of_death": "1856"
-        },
-        "title": "Romances",
-        "medium_of_performance_for_music": [
-          "Piano"
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Schumann, Robert, 1810-1856. Romances. Piano."
+        }
       },
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Schumann, Robert",
-          "date_of_birth": "1810",
-          "date_of_death": "1856"
-        },
-        "title": "Waldszenen"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Schumann, Robert, 1810-1856. Waldszenen."
+        }
       }
     ],
     "classification": [
@@ -41144,43 +41082,22 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Haydn, Joseph",
-          "date_of_birth": "1732",
-          "date_of_death": "1809"
-        },
-        "title": "Symphonies",
-        "medium_of_performance_for_music": [
-          "Orchestre."
-        ],
-        "key_for_music": "Hob. 1:7, do majeur"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Haydn, Joseph, 1732-1809. Symphonies. Orchestre.. Hob. 1:7, do majeur."
+        }
       },
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Haydn, Joseph",
-          "date_of_birth": "1732",
-          "date_of_death": "1809"
-        },
-        "title": "Symphonies",
-        "medium_of_performance_for_music": [
-          "Orchestre."
-        ],
-        "key_for_music": "Hob. 1:8, sol majeur"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Haydn, Joseph, 1732-1809. Symphonies. Orchestre.. Hob. 1:8, sol majeur."
+        }
       },
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Haydn, Joseph",
-          "date_of_birth": "1732",
-          "date_of_death": "1809"
-        },
-        "title": "Symphonies",
-        "medium_of_performance_for_music": [
-          "Orchestre."
-        ],
-        "key_for_music": "Hob. 1:6, r\u00e9 majeur"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Haydn, Joseph, 1732-1809. Symphonies. Orchestre.. Hob. 1:6, r\u00e9 majeur."
+        }
       }
     ]
   },
@@ -41693,8 +41610,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027437469",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027437469"
         }
       },
       {
@@ -43513,8 +43429,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026745151",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026745151"
         }
       },
       {
@@ -44329,12 +44244,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Mendelssohn-Bartholdy, Felix"
-        },
-        "title": "Motets",
-        "key_for_music": "Op. 23 no 1"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Mendelssohn-Bartholdy, Felix. Motets. Op. 23 no 1."
+        }
       }
     ],
     "classification": [
@@ -44574,8 +44487,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026934612",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026934612"
         }
       },
       {
@@ -45101,13 +45013,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Plato",
-          "date_of_birth": "ca. 427",
-          "date_of_death": "ca. 348 av. J"
-        },
-        "title": "Criton"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Plato, ca. 427-ca. 348 av. J. Criton."
+        }
       }
     ],
     "partOf": [
@@ -45465,8 +45374,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Poema del Cid",
-        "miscellaneous_information": "language: Espagnol"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Poema del Cid. language: Espagnol."
+        }
       }
     ]
   },
@@ -46888,8 +46799,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/035000457",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/035000457"
         }
       }
     ]
@@ -47883,12 +47793,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Travelling",
-        "part": [
-          {
-            "partName": "Cin\u00e9math\u00e8que suisse"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Travelling. Cin\u00e9math\u00e8que suisse."
+        }
       }
     ],
     "title": [
@@ -48605,12 +48513,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Po\u00e9sie",
-        "part": [
-          {
-            "partName": "Gallimard"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Po\u00e9sie. Gallimard."
+        }
       }
     ],
     "title": [
@@ -49182,11 +49088,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Bubnoff, Serge von"
-        },
-        "title": "Geologie von Europa"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Bubnoff, Serge von. Geologie von Europa."
+        }
       }
     ],
     "partOf": [
@@ -49846,8 +49751,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026576988",
-          "type": "bf:Organisation"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026576988"
         }
       },
       {
@@ -50426,11 +50330,10 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Glanzmann, Arthur"
-        },
-        "title": "Bibliographie des schweizerischen Steuerrechts"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Glanzmann, Arthur. Bibliographie des schweizerischen Steuerrechts."
+        }
       }
     ],
     "classification": [
@@ -51286,13 +51189,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux (Lausanne : 1930)",
-        "part": [
-          {
-            "partNumber": "2,",
-            "partName": "Poursuite pour dettes"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux (Lausanne : 1930). 2,. Poursuite pour dettes."
+        }
       }
     ],
     "title": [
@@ -51780,8 +51680,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/067025501",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/067025501"
         }
       },
       {
@@ -51844,22 +51743,16 @@
     ],
     "work_access_point": [
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Darbellay, Etienne",
-          "identifiedBy": {
-            "value": "055056911",
-            "type": "IdRef"
-          }
-        },
-        "title": "Luigi Ferdinando Tagliavini: le musicologue"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Darbellay, Etienne. Luigi Ferdinando Tagliavini: le musicologue."
+        }
       },
       {
-        "agent": {
-          "type": "bf:Person",
-          "preferred_name": "Darbellay, Etienne"
-        },
-        "title": "Stile fantastico, passi, affetti: des imprese musicali? : le temps comme interpr\u00e8te de l'espace et la forme comme histoire"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Darbellay, Etienne. Stile fantastico, passi, affetti: des imprese musicali? : le temps comme interpr\u00e8te de l'espace et la forme comme histoire."
+        }
       }
     ]
   },
@@ -51901,12 +51794,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Etudes fran\u00e7aises",
-        "part": [
-          {
-            "partName": "Presses de l'Universit\u00e9 de Montr\u00e9al"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Etudes fran\u00e7aises. Presses de l'Universit\u00e9 de Montr\u00e9al."
+        }
       }
     ],
     "title": [
@@ -52643,12 +52534,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Romans",
-        "part": [
-          {
-            "partName": "Presses de la Cit\u00e9"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Romans. Presses de la Cit\u00e9."
+        }
       }
     ],
     "title": [
@@ -56194,15 +56083,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Critique",
-        "part": [
-          {
-            "partName": "Ed. de Minuit."
-          },
-          {
-            "partName": "Revue"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Critique. Ed. de Minuit.. Revue."
+        }
       }
     ],
     "title": [
@@ -56727,15 +56611,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Science et vie",
-        "part": [
-          {
-            "partName": "Excelsior Publications"
-          },
-          {
-            "partName": "Hors s\u00e9rie"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Science et vie. Excelsior Publications. Hors s\u00e9rie."
+        }
       }
     ],
     "title": [
@@ -56925,12 +56804,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Documenti",
-        "part": [
-          {
-            "partName": "Allemandi"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Documenti. Allemandi."
+        }
       }
     ],
     "title": [
@@ -57101,8 +56978,7 @@
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/031023169",
-          "type": "bf:Organisation"
+          "$ref": "https://mef.rero.ch/api/agents/idref/031023169"
         }
       },
       {
@@ -61025,12 +60901,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Pubblicazioni degli Archivi di Stato",
-        "part": [
-          {
-            "partName": "Ministero per i beni culturali e ambientali Ufficio centrale per i beni archivistici"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Pubblicazioni degli Archivi di Stato. Ministero per i beni culturali e ambientali Ufficio centrale per i beni archivistici."
+        }
       }
     ],
     "title": [
@@ -62386,7 +62260,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Studienheft / Kirchliches Aussenamt der Evangelischen Kirche in Deutschland"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Studienheft / Kirchliches Aussenamt der Evangelischen Kirche in Deutschland."
+        }
       }
     ],
     "responsibilityStatement": [
@@ -64959,13 +64836,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Documentation",
-        "miscellaneous_information": "Minneapolis",
-        "part": [
-          {
-            "partName": "Lutheran University Press"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Documentation. Lutheran University Press. Minneapolis."
+        }
       }
     ],
     "responsibilityStatement": [
@@ -65772,7 +65646,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux (Lausanne : 1877)"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux (Lausanne : 1877)."
+        }
       }
     ],
     "title": [
@@ -66872,13 +66749,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux (Lausanne : 1930)",
-        "part": [
-          {
-            "partNumber": "3,",
-            "partName": "Droit cantonal"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux (Lausanne : 1930). 3,. Droit cantonal."
+        }
       }
     ],
     "title": [
@@ -67064,13 +66938,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux (Lausanne : 1930)",
-        "part": [
-          {
-            "partNumber": "1,",
-            "partName": "Droit f\u00e9d\u00e9ral"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux (Lausanne : 1930). 1,. Droit f\u00e9d\u00e9ral."
+        }
       }
     ],
     "title": [
@@ -67590,15 +67461,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux",
-        "date_of_work": "2011-.",
-        "miscellaneous_information": "Lausanne",
-        "part": [
-          {
-            "partNumber": "3,",
-            "partName": "Jurisprudence et pratique des autorit\u00e9s vaudoises"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux. 3,. Jurisprudence et pratique des autorit\u00e9s vaudoises. Lausanne. 2011-.."
+        }
       }
     ],
     "title": [
@@ -67932,15 +67798,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux",
-        "date_of_work": "2011-.",
-        "miscellaneous_information": "Lausanne",
-        "part": [
-          {
-            "partNumber": "1,",
-            "partName": "Droit public, droit constitutionnel et administratif : jurisprudence f\u00e9d\u00e9rale"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux. 1,. Droit public, droit constitutionnel et administratif : jurisprudence f\u00e9d\u00e9rale. Lausanne. 2011-.."
+        }
       }
     ],
     "title": [
@@ -68117,13 +67978,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux (Lausanne : 1930)",
-        "part": [
-          {
-            "partNumber": "4,",
-            "partName": "Droit p\u00e9nal"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux (Lausanne : 1930). 4,. Droit p\u00e9nal."
+        }
       }
     ],
     "title": [
@@ -68311,7 +68169,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux (Lausanne : 1846)"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux (Lausanne : 1846)."
+        }
       }
     ],
     "title": [
@@ -68482,15 +68343,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Journal des tribunaux",
-        "date_of_work": "2011-.",
-        "miscellaneous_information": "Lausanne",
-        "part": [
-          {
-            "partNumber": "4,",
-            "partName": "Droit p\u00e9nal et proc\u00e9dure p\u00e9nale : jurisprudence f\u00e9d\u00e9rale"
-          }
-        ]
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Journal des tribunaux. 4,. Droit p\u00e9nal et proc\u00e9dure p\u00e9nale : jurisprudence f\u00e9d\u00e9rale. Lausanne. 2011-.."
+        }
       }
     ],
     "title": [
@@ -68917,8 +68773,10 @@
     ],
     "work_access_point": [
       {
-        "title": "Droit",
-        "miscellaneous_information": "Lausanne"
+        "entity": {
+          "type": "bf:Work",
+          "authorized_access_point": "Droit. Lausanne."
+        }
       }
     ],
     "title": [

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -617,8 +617,7 @@ def marc21_to_subjects_6XX(self, key, value):
                 marc21.bib_id, marc21.bib_id, cont_id, key)
             if ref:
                 subject = {
-                    '$ref': ref,
-                    'type': data_type,
+                    '$ref': ref
                 }
         if not subject.get('$ref'):
             identifier = build_identifier(value)

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
@@ -126,10 +126,6 @@ def marc21_to_contribution(self, key, value):
         if ref := get_contribution_link(
                 marc21.bib_id, marc21.rero_id, subfields_0[0], key):
             agent['$ref'] = ref
-            if key[:3] in ['100', '700']:
-                agent['type'] = 'bf:Person'
-            elif key[:3] in ['710', '711']:
-                agent['type'] = 'bf:Organisation'
 
     # we do not have a $ref
     agent_data = {}
@@ -574,16 +570,13 @@ def marc21_to_subjects(self, key, value):
         field_key = 'genreForm' if tag_key == '655' else 'subjects'
         subfields_0 = utils.force_list(value.get('0'))
         if data_type in ['bf:Person', 'bf:Organisation'] and subfields_0:
-            ref = get_contribution_link(marc21.bib_id, marc21.rero_id,
-                                        subfields_0[0], key)
-            if ref:
+            if ref := get_contribution_link(marc21.bib_id, marc21.rero_id,
+                                            subfields_0[0], key):
                 subject = {
-                    '$ref': ref,
-                    'type': data_type,
+                    '$ref': ref
                 }
         if not subject.get('$ref'):
-            identifier = build_identifier(value)
-            if identifier:
+            if identifier := build_identifier(value):
                 subject['identifiedBy'] = identifier
             if field_key != 'genreForm':
                 perform_subdivisions(subject, value)
@@ -594,9 +587,8 @@ def marc21_to_subjects(self, key, value):
             self[field_key] = subjects
 
     elif subfield_2 == 'rerovoc' or indicator_2 in ['0', '2']:
-        term_string = build_string_from_subfields(
-            value, 'abcdefghijklmnopqrstuw', ' - ')
-        if term_string:
+        if term_string := build_string_from_subfields(
+           value, 'abcdefghijklmnopqrstuw', ' - '):
             source = 'rerovoc' if subfield_2 == 'rerovoc' \
                 else source_per_indicator_2[indicator_2]
             subject_imported = {
@@ -628,7 +620,7 @@ def marc21_to_subjects_imported(self, key, value):
     field_key = 'subjects_imported'
     if subfields_2:
         subfield_2 = subfields_2[0]
-        if match := contains_specific_voc_regexp.search(subfield_2):
+        if contains_specific_voc_regexp.search(subfield_2):
             add_data_imported = False
             if subfield_2 == 'chrero':
                 subfields_9 = utils.force_list(value.get('9'))

--- a/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
@@ -6,150 +6,23 @@
     "minItems": 1,
     "items": {
       "type": "object",
-      "title": "Title",
-      "oneOf": [
-        {
-          "title": "Link to work",
-          "type": "object",
-          "additionalProperties": false,
-          "propertiesOrder": [
-            "$ref"
-          ],
-          "required": [
-            "$ref"
-          ],
-          "properties": {
-            "$ref": {
-              "title": "Title",
-              "type": "string",
-              "pattern": "^https://mef.rero.ch/api/work/rero/.*?$",
-              "form": {
-                "remoteTypeahead": {
-                  "type": "mef-work",
-                  "enableGroupField": true
-                },
-                "templateOptions": {
-                  "itemCssClass": "col-lg-12"
-                }
-              }
+      "title": "Work",
+      "additionalProperties": false,
+      "propertiesOrder": [
+        "entity"
+      ],
+      "required": [
+        "entity"
+      ],
+      "properties": {
+        "entity": {
+          "oneOf": [
+            {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_work_access_point_local-v0.0.1.json"
             }
-          }
-        },
-        {
-          "title": "Work (local)",
-          "type": "object",
-          "additionalProperties": false,
-          "propertiesOrder": [
-            "agent",
-            "title",
-            "date_of_work",
-            "miscellaneous_information",
-            "language",
-            "part",
-            "form_subdivision",
-            "medium_of_performance_for_music",
-            "arranged_statement_for_music",
-            "key_for_music",
-            "identifiedBy"
-          ],
-          "required": [
-            "title"
-          ],
-          "properties": {
-            "agent": {
-              "title": "Agent",
-              "type": "object",
-              "oneOf": [
-                {
-                  "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_person-v0.0.1.json"
-                },
-                {
-                  "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_organisation-v0.0.1.json"
-                }
-              ]
-            },
-            "title": {
-              "title": "Title",
-              "type": "string",
-              "minLength": 1
-            },
-            "date_of_work": {
-              "title": "Date of work",
-              "type": "string",
-              "minLength": 1
-            },
-            "miscellaneous_information": {
-              "title": "Miscellaneous information",
-              "type": "string",
-              "minLength": 1
-            },
-            "language": {
-              "$ref": "https://bib.rero.ch/schemas/common/languages-v0.0.1.json#/language"
-            },
-            "part": {
-              "title": "Parts",
-              "description": "Part, Section, or Supplement",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "title": "Part",
-                "type": "object",
-                "propertiesOrder": [
-                  "partNumber",
-                  "partName"
-                ],
-                "properties": {
-                  "partNumber": {
-                    "title": "Designation",
-                    "description": "Numeric designation of the part, section or supplement",
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "partName": {
-                    "title": "Title",
-                    "description": "Title of the part, section, or supplement",
-                    "type": "string",
-                    "minLength": 1
-                  }
-                }
-              }
-            },
-            "form_subdivision": {
-              "title": "Form subdivisions",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "title": "Form subdivision",
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "medium_of_performance_for_music": {
-              "title": "Mediums of performance (music)",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "title": "Medium of performance (music)",
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "arranged_statement_for_music": {
-              "title": "Arranged statement (music)",
-              "type": "string",
-              "minLength": 1
-            },
-            "key_for_music": {
-              "title": "Key (music)",
-              "type": "string",
-              "minLength": 1
-            },
-            "identifiedBy": {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
-            }
-          }
+          ]
         }
-      ]
+      }
     },
     "form": {
       "hide": true

--- a/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point_local-v0.0.1.json
@@ -1,0 +1,41 @@
+{
+  "title": "Local Entity",
+  "type": "object",
+  "additionalProperties": false,
+  "propertiesOrder": [
+    "type",
+    "authorized_access_point",
+    "identifiedBy"
+  ],
+  "required": [
+    "type",
+    "authorized_access_point"
+  ],
+  "properties": {
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "const": "bf:Work",
+      "default": "bf:Work",
+      "form": {
+        "hide": true
+      }
+    },
+    "authorized_access_point": {
+      "title": "Access Point",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "placeholder": "Example: Musset, Alfred de, 1810-1857. Work title (2008)"
+      }
+    },
+    "identifiedBy": {
+      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+    }
+  },
+  "form": {
+    "templateOptions": {
+      "containerCssClass": "row"
+    }
+  }
+}

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -329,6 +329,7 @@
               },
               "authorized_access_point_en": {
                 "type": "text",
+                "analyzer": "english",
                 "copy_to": [
                   "authorized_access_point",
                   "facet_contribution_en"
@@ -336,6 +337,7 @@
               },
               "authorized_access_point_fr": {
                 "type": "text",
+                "analyzer": "french",
                 "copy_to": [
                   "authorized_access_point",
                   "facet_contribution_fr"
@@ -343,6 +345,7 @@
               },
               "authorized_access_point_de": {
                 "type": "text",
+                "analyzer": "german",
                 "copy_to": [
                   "authorized_access_point",
                   "facet_contribution_de"
@@ -350,6 +353,7 @@
               },
               "authorized_access_point_it": {
                 "type": "text",
+                "analyzer": "italian",
                 "copy_to": [
                   "authorized_access_point",
                   "facet_contribution_it"
@@ -1932,52 +1936,67 @@
       "work_access_point": {
         "type": "object",
         "properties": {
-          "title": {
-            "type": "text"
-          },
-          "date_of_work": {
-            "type": "text"
-          },
-          "miscellaneous_information": {
-            "type": "text"
-          },
-          "language": {
-            "type": "keyword"
-          },
-          "part": {
-            "type": "object",
-            "properties": {
-              "partNumber": {
-                "type": "text"
-              },
-              "partName": {
-                "type": "text"
-              }
-            }
-          },
-          "form_subdivision": {
-            "type": "text"
-          },
-          "medium_of_performance_for_music": {
-            "type": "text"
-          },
-          "arranged_statement_for_music": {
-            "type": "text"
-          },
-          "key_for_music": {
-            "type": "text"
-          },
-          "identifiedBy": {
+          "entity": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "keyword"
               },
-              "value": {
+              "primary_source": {
                 "type": "keyword"
+              },
+              "pid": {
+                "type": "keyword"
+              },
+              "id_gnd": {
+                "type": "keyword"
+              },
+              "id_idref": {
+                "type": "keyword"
+              },
+              "id_rero": {
+                "type": "keyword"
+              },
+              "authorized_access_point_en": {
+                "type": "text",
+                "analyzer": "english",
+                "copy_to": "facet_genre_form"
+              },
+              "authorized_access_point_fr": {
+                "type": "text",
+                "analyzer": "french",
+                "copy_to": "facet_genre_form"
+              },
+              "authorized_access_point_de": {
+                "type": "text",
+                "analyzer": "german",
+                "copy_to": "facet_genre_form"
+              },
+              "authorized_access_point_it": {
+                "type": "text",
+                "analyzer": "italian",
+                "copy_to": "facet_genre_form"
               },
               "source": {
                 "type": "keyword"
+              },
+              "authorized_access_point": {
+                "type": "text",
+                "copy_to": "facet_genre_form"
+              },
+              "identifiedBy": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "keyword"
+                  },
+                  "value": {
+                    "type": "keyword"
+                  },
+                  "source": {
+                    "type": "keyword"
+                  }
+                }
               }
             }
           }

--- a/rero_ils/modules/documents/utils.py
+++ b/rero_ils/modules/documents/utils.py
@@ -242,16 +242,13 @@ def create_authorized_access_point(agent):
     :param agent: Agent to create the authorized_access_point for.
     :returns: authorized access point.
     """
+    from rero_ils.modules.entities.models import EntityType
     if not agent:
         return None
     authorized_access_point = agent.get('preferred_name')
-    from ..entities.models import EntityType
     if agent.get('type') == EntityType.PERSON:
-        date_of_birth = agent.get('date_of_birth')
-        date_of_death = agent.get('date_of_death')
-        date = date_of_birth or ''
-        if date_of_death:
-            date += f'-{date_of_death}'
+        date_parts = [agent.get('date_of_birth'), agent.get('date_of_death')]
+        date = '-'.join(filter(None, date_parts))
         numeration = agent.get('numeration')
         fuller_form_of_name = agent.get('fuller_form_of_name')
         qualifier = agent.get('qualifier')
@@ -270,18 +267,14 @@ def create_authorized_access_point(agent):
             if qualifier:
                 authorized_access_point += f', {qualifier}'
     elif agent.get('type') == EntityType.ORGANISATION:
-        subordinate_unit = agent.get('subordinate_unit')
-        if subordinate_unit:
+        if subordinate_unit := agent.get('subordinate_unit'):
             authorized_access_point += f'''. {'. '.join(subordinate_unit)}'''
         conference_data = []
-        numbering = agent.get('numbering')
-        if numbering:
+        if numbering := agent.get('numbering'):
             conference_data.append(numbering)
-        conference_date = agent.get('conference_date')
-        if conference_date:
+        if conference_date := agent.get('conference_date'):
             conference_data.append(conference_date)
-        place = agent.get('place')
-        if place:
+        if place := agent.get('place'):
             conference_data.append(place)
         if conference_data:
             authorized_access_point += ' ({conference})'.format(

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -375,71 +375,16 @@ def record_library_pickup_locations(record):
 
 
 @blueprint.app_template_filter()
-def work_access_point(work_access_point):
-    """Process work access point data."""
-    wap = []
-    for work in work_access_point:
-        agent_formatted = ''
-        if 'agent' in work:
-            agent = work['agent']
-            if agent['type'] == 'bf:Person':
-                # Person
-                name = []
-                if 'preferred_name' in agent:
-                    name.append(agent['preferred_name'])
-                if 'numeration' in agent:
-                    name.append(agent['numeration'])
-                elif 'fuller_form_of_name' in agent:
-                    name.append(f"({agent['fuller_form_of_name']})")
-                if len(name):
-                    agent_formatted += f"{', '.join(name)}, "
-                if 'numeration' in agent and 'qualifier' in agent:
-                    agent_formatted += f"{agent['qualifier']}, "
-                dates = [
-                    agent[key]
-                    for key in ['date_of_birth', 'date_of_death']
-                    if key in agent
-                ]
-                if len(dates):
-                    agent_formatted += f"{'-'.join(dates)}. "
-                if 'numeration' not in agent and 'qualifier' in agent:
-                    agent_formatted += f"{agent['qualifier']}. "
-            else:
-                # Organisation
-                if 'preferred_name' in agent:
-                    agent_formatted += agent['preferred_name'] + '. '
-                if 'subordinate_unit' in agent:
-                    for unit in agent['subordinate_unit']:
-                        agent_formatted += unit + '. '
-                if 'numbering' in agent or 'conference_date' in agent or \
-                   'place' in agent:
-                    conf = [
-                        agent[key]
-                        for key in ['numbering', 'conference_date', 'place']
-                    ]
-                    if len(conf):
-                        agent_formatted += f"({' : '.join(conf)}) "
-        agent_formatted += f"{work['title']}. "
-        if 'part' in work:
-            for part in work['part']:
-                for key in ['partNumber', 'partName']:
-                    if key in part:
-                        agent_formatted += f"{part[key]}. "
-        if 'miscellaneous_information' in work:
-            agent_formatted += f"{work['miscellaneous_information']}. "
-        if 'language' in work:
-            agent_formatted += f"{_('lang_'+work['language'])}. "
-        if 'medium_of_performance_for_music' in work:
-            agent_formatted += \
-                f"{'. '.join(work['medium_of_performance_for_music'])}. "
-        if 'key_for_music' in work:
-            agent_formatted += f"{work['key_for_music']}. "
-        if 'arranged_statement_for_music' in work:
-            agent_formatted += f"{work['arranged_statement_for_music']}. "
-        if 'date_of_work' in work:
-            agent_formatted += f"{work['date_of_work']}. "
-        wap.append(agent_formatted.strip())
-    return wap
+def work_access_point(access_points):
+    """Process work access point data.
+
+    :param access_points: a list of work access points data as a dictionary.
+    :returns a list of formatted work access points.
+    """
+    return list(filter(None, [
+        work.get('entity', {}).get('authorized_access_point')
+        for work in access_points
+    ]))
 
 
 @api_blueprint.route('/availabilty/<document_pid>', methods=['GET'])

--- a/tests/ui/documents/test_documents_filter.py
+++ b/tests/ui/documents/test_documents_filter.py
@@ -303,95 +303,17 @@ def test_title_variants():
 
 def test_work_access_point():
     """Test work access point process."""
-    wap = [
-        {
-            'part': [
-                {
-                    'partName': 'part section title',
-                    'partNumber': 'part section designation'
-                }
-            ],
-            'agent': {
-                'type': 'bf:Person',
-                'qualifier': 'physicien',
-                'numeration': 'XX',
-                'date_of_birth': '1955',
-                'date_of_death': '2012',
-                'preferred_name':
-                'Müller, Hans',
-                'fuller_form_of_name':
-                'Müller, Hans Peter'
-            },
-            'title': 'Müller, Hans (Title)',
-            'language': 'fre',
-            'date_of_work': '2000',
-            'key_for_music': 'key music',
-            'form_subdivision': ['Form sub.'],
-            'miscellaneous_information': 'Miscellaneous info',
-            'arranged_statement_for_music': 'arranged stat',
-            'medium_of_performance_for_music': ['medium perf']
-        },
-        {
-            'part': [
-                {
-                    'partName': 'Title',
-                    'partNumber': 'part designation'
-                }],
-            'agent': {
-                'type': 'bf:Organisation',
-                'place': 'Lausanne',
-                'numbering': '4',
-                'conference': False,
-                'preferred_name': 'Corp body Name',
-                'conference_date': '1990',
-                'subordinate_unit': ['Office 1', 'Office 2']
-            },
-            'title': 'Corp Title',
-            'language': 'fre',
-            'date_of_work': '1980',
-            'key_for_music': 'Corp Key music',
-            'form_subdivision': ['Form sub 1', 'Form sub 2'],
-            'miscellaneous_information': 'miscellaneous info',
-            'arranged_statement_for_music': 'Copr Arranged stat',
-            'medium_of_performance_for_music': [
-                'Corp Medium perf  1',
-                'Corp Medium perf  2'
-            ]
-        },
-        {
-            'agent': {
-                'type': 'bf:Person',
-                'qualifier': 'pianiste',
-                'date_of_birth': '1980',
-                'preferred_name': 'Hans, Peter'
-            },
-            'title': 'Work title'
-        },
-        {
-            'part': [
-                {
-                    'partNumber': 'part number'
-                }
-            ],
-            'agent': {
-                'type': 'bf:Person',
-                'qualifier': 'pianiste'
-            },
-            'title': 'title with part'
+    assert work_access_point([{
+        'entity': {
+            'type': 'bf:Work',
+            'authorized_access_point':
+                'Müller, Hans, XX, physicien, 1955-2012. Müller, Hans (Title).'
+                ' part section designation. part section title. Miscellaneous '
+                'info. medium perf. key music. arranged stat. 2000.'
         }
-    ]
-    results = [
-        'Müller, Hans, XX, physicien, 1955-2012. Müller, Hans (Title). '
-        'part section designation. part section title. Miscellaneous info. '
-        'lang_fre. medium perf. key music. arranged stat. 2000.',
-        'Corp body Name. Office 1. Office 2. (4 : 1990 : Lausanne) '
-        'Corp Title. part designation. Title. miscellaneous info. '
-        'lang_fre. Corp Medium perf  1. Corp Medium perf  2. '
-        'Corp Key music. Copr Arranged stat. 1980.',
-        'Hans, Peter, 1980. pianiste. Work title.',
-        'pianiste. title with part. part number.'
-    ]
-    assert results == work_access_point(wap)
+    }]) == ['Müller, Hans, XX, physicien, 1955-2012. Müller, Hans (Title). '
+            'part section designation. part section title. Miscellaneous '
+            'info. medium perf. key music. arranged stat. 2000.']
 
 
 def test_contribution_format(db, document, entity_organisation):

--- a/tests/unit/documents/test_documents_dojson.py
+++ b/tests/unit/documents/test_documents_dojson.py
@@ -1421,7 +1421,6 @@ def test_marc21_to_contribution(mock_get, mef_agents_url):
     contribution = data.get('contribution')
     assert contribution == [{
         'entity': {
-            'type': 'bf:Person',
             '$ref': f'{mef_agents_url}/idref/XXXXXXXX'
         },
         'role': ['cre']
@@ -4161,11 +4160,10 @@ def test_marc21_to_part_of_without_link():
         }
     ]
     assert data.get('work_access_point') == [{
-        'agent': {
-            'preferred_name': 'Jacq, Christian',
-            'type': 'bf:Person'
-        },
-        'title': 'Ramsès'
+        'entity': {
+            'authorized_access_point': 'Jacq, Christian. Ramsès.',
+            'type': 'bf:Work'
+        }
     }]
 
     marc21xml = """
@@ -4185,7 +4183,10 @@ def test_marc21_to_part_of_without_link():
         }
     ]
     assert data.get('work_access_point') == [{
-         'title': 'Stuart Hall : critical dialogues'
+        'entity': {
+            'authorized_access_point': 'Stuart Hall : critical dialogues.',
+            'type': 'bf:Work'
+        }
     }]
 
     marc21xml = """
@@ -4323,17 +4324,18 @@ def test_marc21_to_part_of_with_multiple_800():
       }
     ]
     assert data.get('work_access_point') == [{
-        'agent': {
-            'preferred_name': 'Mirallés, Ana',
-            'type': 'bf:Person'
-        },
-        'title': 'A la recherche de la Licorne'
+        'entity': {
+            'authorized_access_point':
+                'Mirallés, Ana. A la recherche de la Licorne.',
+            'type': 'bf:Work'
+        }
+
     }, {
-        'agent': {
-            'preferred_name': 'Ruiz, Emilio',
-            'type': 'bf:Person'
-        },
-        'title': 'A la recherche de la Licorne'
+        'entity': {
+            'authorized_access_point':
+                'Ruiz, Emilio. A la recherche de la Licorne.',
+            'type': 'bf:Work'
+        }
     }]
 
 
@@ -4763,7 +4765,6 @@ def test_marc21_to_subjects(mock_get, mef_agents_url):
     data = marc21.do(marc21json)
     assert data.get('subjects') == [{
         'entity': {
-            'type': 'bf:Person',
             '$ref': f'{mef_agents_url}/idref/XXXXXXXX'
         }
     }]

--- a/tests/unit/documents/test_documents_dojson_slsp.py
+++ b/tests/unit/documents/test_documents_dojson_slsp.py
@@ -97,28 +97,22 @@ def test_marc21_to_contribution(mock_get):
         'role': ['aut']
     }]
     assert data.get('work_access_point') == [{
-        'agent': {
-            'date_of_birth': '1954',
-            'numeration': 'II',
-            'preferred_name': 'Jean-Paul',
-            'qualifier': 'Pape',
-            'type': 'bf:Person'
-        },
-        'title': 'Treaties, etc.'
+        'entity': {
+            'authorized_access_point':
+                'Jean-Paul II, Pape, 1954. Treaties, etc..',
+            'type': 'bf:Work'
+        }
     }, {
-        'agent': {
-            'preferred_name': 'Santamaría, Germán',
-            'type': 'bf:Person'
-        },
-        'language': 'fre',
-        'title': 'No morirás'
+        'entity': {
+            'authorized_access_point': 'Santamaría, Germán. No morirás. fre.',
+            'type': 'bf:Work'
+        }
     }, {
-        'miscellaneous_information': 'language: Coréen',
-        'part': [{
-            'partName': 'A.T. et N.T.',
-            'partNumber': '000'
-        }],
-        'title': 'Bible'
+        'entity': {
+            'authorized_access_point':
+                'Bible. 000. A.T. et N.T.. language: Coréen.',
+            'type': 'bf:Work'
+        }
     }]
 
     marc21xml = """
@@ -138,18 +132,15 @@ def test_marc21_to_contribution(mock_get):
     marc21json = create_record(marc21xml)
     data = marc21.do(marc21json)
     assert data.get('work_access_point') == [{
-        'agent': {
-            'date_of_birth': '1919',
-            'date_of_death': '1990',
-            'preferred_name': 'Santamaría, Germán',
-            'type': 'bf:Person'
-        },
-        'title': 'No morirás'
+        'entity': {
+            'type': 'bf:Work',
+            'authorized_access_point':
+                'Santamaría, Germán, 1919-1990. No morirás.',
+        }
     }, {
-        'agent': {
-            'date_of_birth': '1919',
-            'preferred_name': 'Santamaría, Germán',
-            'type': 'bf:Person'
-        },
-        'title': 'No morirás'
+        'entity': {
+            'type': 'bf:Work',
+            'authorized_access_point':
+                'Santamaría, Germán, 1919. No morirás.',
+        }
     }]


### PR DESCRIPTION
* Uses entity for `work_access_point` document.
* Adapts Jinja filter to reflect changes.
* Adapts `dojson` methods.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>