### PR TITLE
documents: delete `$ref` possibility on `provisionActivity.places`

### DIFF
--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -47,8 +47,7 @@
         "startDate": 1946,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -384,8 +383,7 @@
         "endDate": 2004,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -532,8 +530,7 @@
         "startDate": 1920,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -726,8 +723,7 @@
         "startDate": 2017,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -987,8 +983,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -1108,8 +1103,7 @@
         "startDate": 2014,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -1200,8 +1194,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -1566,8 +1559,7 @@
         "startDate": 1982,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -1709,8 +1701,7 @@
         "startDate": 1993,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -1836,8 +1827,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -1986,8 +1976,7 @@
         "startDate": 1967,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -2161,8 +2150,7 @@
         "startDate": 1978,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -2340,8 +2328,7 @@
         "startDate": 1936,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -2473,8 +2460,7 @@
         "startDate": 2006,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -2590,8 +2576,7 @@
         "endDate": 2002,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -2731,8 +2716,7 @@
         "note": "Date(s) uncertain or unknown",
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -2919,8 +2903,7 @@
         "startDate": 1957,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -3057,8 +3040,7 @@
         "startDate": 1991,
         "place": [
           {
-            "country": "fi",
-            "type": "bf:Place"
+            "country": "fi"
           }
         ],
         "statement": [
@@ -3212,8 +3194,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -3439,8 +3420,7 @@
         "startDate": 2017,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -3630,8 +3610,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "cc",
-            "type": "bf:Place"
+            "country": "cc"
           }
         ],
         "statement": [
@@ -3777,8 +3756,7 @@
         "note": "Date(s) uncertain or unknown",
         "place": [
           {
-            "country": "is",
-            "type": "bf:Place"
+            "country": "is"
           }
         ],
         "statement": [
@@ -3891,8 +3869,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -4090,8 +4067,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -4259,8 +4235,7 @@
         "startDate": 1968,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -4410,8 +4385,7 @@
         "startDate": 1987,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -4602,8 +4576,7 @@
         "startDate": 1986,
         "place": [
           {
-            "country": "pl",
-            "type": "bf:Place"
+            "country": "pl"
           }
         ],
         "statement": [
@@ -5110,8 +5083,7 @@
         "startDate": 2007,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -5306,8 +5278,7 @@
         "startDate": 1985,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -5515,8 +5486,7 @@
         "place": [
           {
             "canton": "be",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -5808,8 +5778,7 @@
         "startDate": 1975,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -6051,8 +6020,7 @@
         "startDate": 1984,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -6191,8 +6159,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -6402,8 +6369,7 @@
         "startDate": 1983,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -6552,8 +6518,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -6710,8 +6675,7 @@
         "startDate": 1975,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -6822,8 +6786,7 @@
         "startDate": 1977,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -6942,8 +6905,7 @@
         "place": [
           {
             "canton": "ne",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -7175,8 +7137,7 @@
         "endDate": 2003,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -7491,8 +7452,7 @@
         "startDate": 1987,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -7688,8 +7648,7 @@
         "startDate": 2003,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -7822,8 +7781,7 @@
         "startDate": 2010,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -7898,15 +7856,15 @@
       },
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos10"
-      },
-      {
-        "audienceType": "school_level",
         "value": "target_school_harmos9"
       },
       {
         "audienceType": "school_level",
         "value": "target_school_harmos11"
+      },
+      {
+        "audienceType": "school_level",
+        "value": "target_school_harmos10"
       }
     ],
     "partOf": [
@@ -8148,8 +8106,7 @@
         "startDate": 2008,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -8285,8 +8242,7 @@
         "startDate": 2008,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -8463,8 +8419,7 @@
         "startDate": 1998,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -8653,8 +8608,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -8879,8 +8833,7 @@
         "endDate": 1968,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -9032,8 +8985,7 @@
         "endDate": 2016,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -9225,8 +9177,7 @@
         "endDate": 1758,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -9396,8 +9347,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "at",
-            "type": "bf:Place"
+            "country": "at"
           }
         ],
         "statement": [
@@ -9537,8 +9487,7 @@
         "startDate": 1911,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -9674,8 +9623,7 @@
         "startDate": 1974,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -9822,8 +9770,7 @@
         "startDate": 1964,
         "place": [
           {
-            "country": "sp",
-            "type": "bf:Place"
+            "country": "sp"
           }
         ],
         "statement": [
@@ -9979,8 +9926,7 @@
         "startDate": 1994,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -10151,8 +10097,7 @@
         "startDate": 1993,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -10315,8 +10260,7 @@
         "startDate": 1981,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -10483,8 +10427,7 @@
         "startDate": 1982,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -10798,8 +10741,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -10866,14 +10808,12 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/082686335",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/082686335"
         }
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026699656",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026699656"
         }
       },
       {
@@ -10994,8 +10934,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -11233,8 +11172,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -11397,8 +11335,7 @@
         "endDate": 1908,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -11581,8 +11518,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -11766,8 +11702,7 @@
         "endDate": 2018,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -12045,8 +11980,7 @@
         "startDate": 1986,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -12170,8 +12104,7 @@
         "startDate": 1992,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -12305,8 +12238,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -12397,8 +12329,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -12496,8 +12427,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -12628,8 +12558,7 @@
         "startDate": 1904,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -12748,8 +12677,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "bl",
-            "type": "bf:Place"
+            "country": "bl"
           }
         ],
         "statement": [
@@ -12937,8 +12865,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -13100,8 +13027,7 @@
         "place": [
           {
             "canton": "vs",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -13265,8 +13191,7 @@
         "startDate": 1984,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -13526,8 +13451,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -13658,8 +13582,7 @@
         "startDate": 1779,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -13851,8 +13774,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -13989,8 +13911,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -14147,8 +14068,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -14295,8 +14215,7 @@
         "startDate": 1981,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -14475,8 +14394,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "bl",
-            "type": "bf:Place"
+            "country": "bl"
           }
         ],
         "statement": [
@@ -14639,8 +14557,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -14708,8 +14625,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/204515998",
-          "type": "bf:Organisation"
+          "$ref": "https://mef.rero.ch/api/agents/idref/204515998"
         }
       },
       {
@@ -14822,8 +14738,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -14881,11 +14796,11 @@
       },
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos3"
+        "value": "target_school_harmos4"
       },
       {
         "audienceType": "school_level",
-        "value": "target_school_harmos4"
+        "value": "target_school_harmos3"
       }
     ]
   },
@@ -14963,8 +14878,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -15182,8 +15096,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "ru",
-            "type": "bf:Place"
+            "country": "ru"
           }
         ],
         "statement": [
@@ -15254,8 +15167,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027408183",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027408183"
         }
       },
       {
@@ -15371,8 +15283,7 @@
         "place": [
           {
             "canton": "be",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -15846,8 +15757,7 @@
         "startDate": 1959,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -15972,8 +15882,7 @@
         "startDate": 1996,
         "place": [
           {
-            "country": "sa",
-            "type": "bf:Place"
+            "country": "sa"
           }
         ],
         "statement": [
@@ -16141,8 +16050,7 @@
         "startDate": 1985,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -16382,8 +16290,7 @@
         "startDate": 2006,
         "place": [
           {
-            "country": "ja",
-            "type": "bf:Place"
+            "country": "ja"
           }
         ],
         "statement": [
@@ -16684,8 +16591,7 @@
         "startDate": 1976,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -16839,8 +16745,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -17032,7 +16937,6 @@
         "place": [
           {
             "country": "sz",
-            "type": "bf:Place",
             "identifiedBy": {
               "value": "027418545",
               "type": "IdRef"
@@ -17182,8 +17086,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -17358,8 +17261,7 @@
         "startDate": 1991,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -17514,8 +17416,7 @@
         "endDate": 1977,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -17653,8 +17554,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -17837,8 +17737,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -18080,8 +17979,7 @@
         "place": [
           {
             "canton": "ne",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -18307,8 +18205,7 @@
         "startDate": 1982,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -18476,8 +18373,7 @@
         "startDate": 1980,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -18594,8 +18490,7 @@
         "startDate": 2014,
         "place": [
           {
-            "country": "ua",
-            "type": "bf:Place"
+            "country": "ua"
           }
         ],
         "statement": [
@@ -18863,8 +18758,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -19016,8 +18910,7 @@
         "startDate": 1965,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -19296,8 +19189,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -19451,8 +19343,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -19636,8 +19527,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "xxc",
-            "type": "bf:Place"
+            "country": "xxc"
           }
         ],
         "statement": [
@@ -19823,8 +19713,7 @@
         "startDate": 1985,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -19992,8 +19881,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -20177,8 +20065,7 @@
         "startDate": 1985,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -20377,8 +20264,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -20615,8 +20501,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -20761,8 +20646,7 @@
         "startDate": 1976,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -20921,8 +20805,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -21138,8 +21021,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -21295,8 +21177,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -21553,8 +21434,7 @@
         "type": "bf:Publication",
         "place": [
           {
-            "country": "stk",
-            "type": "bf:Place"
+            "country": "stk"
           }
         ],
         "startDate": 1818
@@ -21652,8 +21532,7 @@
         "startDate": 1991,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -21838,8 +21717,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -21959,8 +21837,7 @@
         "startDate": 1860,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -22161,8 +22038,7 @@
         "startDate": 2017,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -22349,8 +22225,7 @@
         "startDate": 1963,
         "place": [
           {
-            "country": "ru",
-            "type": "bf:Place"
+            "country": "ru"
           }
         ],
         "statement": [
@@ -22527,8 +22402,7 @@
         "startDate": 2016,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -22759,8 +22633,7 @@
         "startDate": 1986,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -22882,8 +22755,7 @@
         "place": [
           {
             "canton": "vs",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -23278,8 +23150,7 @@
         "startDate": 1994,
         "place": [
           {
-            "country": "ne",
-            "type": "bf:Place"
+            "country": "ne"
           }
         ],
         "statement": [
@@ -23527,8 +23398,7 @@
         "startDate": 1988,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -23936,8 +23806,7 @@
         "startDate": 1968,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -24176,8 +24045,7 @@
         "startDate": 2002,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -24252,8 +24120,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/139843418",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/139843418"
         }
       }
     ],
@@ -24356,8 +24223,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -24500,8 +24366,7 @@
         "startDate": 1839,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -24645,8 +24510,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -24814,8 +24678,7 @@
         "startDate": 1992,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -25037,8 +24900,7 @@
         "startDate": 2017,
         "place": [
           {
-            "country": "cc",
-            "type": "bf:Place"
+            "country": "cc"
           }
         ],
         "statement": [
@@ -25213,8 +25075,7 @@
         "endDate": 1970,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -25367,8 +25228,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -25509,8 +25369,7 @@
         "startDate": 1987,
         "place": [
           {
-            "country": "ru",
-            "type": "bf:Place"
+            "country": "ru"
           }
         ],
         "statement": [
@@ -25633,8 +25492,7 @@
         "startDate": 1952,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -25783,8 +25641,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -25973,8 +25830,7 @@
         "startDate": 1998,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -26331,8 +26187,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -26551,8 +26406,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -26669,8 +26523,7 @@
         "place": [
           {
             "canton": "lu",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -26839,8 +26692,7 @@
         "startDate": 1988,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -26898,8 +26750,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026667673",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026667673"
         }
       },
       {
@@ -27066,8 +26917,7 @@
         "startDate": 2017,
         "place": [
           {
-            "country": "ru",
-            "type": "bf:Place"
+            "country": "ru"
           }
         ],
         "statement": [
@@ -27335,8 +27185,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -27601,8 +27450,7 @@
         "endDate": 1871,
         "place": [
           {
-            "country": "ru",
-            "type": "bf:Place"
+            "country": "ru"
           }
         ],
         "statement": [
@@ -27752,8 +27600,7 @@
         "startDate": 2011,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -27920,8 +27767,7 @@
         "startDate": 1981,
         "place": [
           {
-            "country": "bl",
-            "type": "bf:Place"
+            "country": "bl"
           }
         ],
         "statement": [
@@ -28100,8 +27946,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -28276,8 +28121,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -28402,8 +28246,7 @@
         "startDate": 1983,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -28520,8 +28363,7 @@
         "endDate": 1954,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -28686,8 +28528,7 @@
         "startDate": 2008,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -28831,8 +28672,7 @@
         "startDate": 1993,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -29002,8 +28842,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -29101,8 +28940,7 @@
         "startDate": 1942,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -29236,8 +29074,7 @@
         "startDate": 1974,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -29429,8 +29266,7 @@
         "startDate": 1886,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -29577,8 +29413,7 @@
         "place": [
           {
             "canton": "fr",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -29735,8 +29570,7 @@
         "place": [
           {
             "canton": "be",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -29969,8 +29803,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -30038,12 +29871,12 @@
     "sequence_numbering": "No 1(2005)-",
     "intendedAudience": [
       {
-        "audienceType": "understanding_level",
-        "value": "target_understanding_tertiary"
-      },
-      {
         "audienceType": "school_level",
         "value": "target_school_tertiary"
+      },
+      {
+        "audienceType": "understanding_level",
+        "value": "target_understanding_tertiary"
       },
       {
         "audienceType": "understanding_level",
@@ -30203,8 +30036,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -30478,8 +30310,7 @@
         "startDate": 1966,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -30780,8 +30611,7 @@
         "startDate": 1991,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -30953,8 +30783,7 @@
         "startDate": 1969,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -31125,8 +30954,7 @@
         "startDate": 1970,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -31269,8 +31097,7 @@
         "startDate": 1992,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -31416,8 +31243,7 @@
         "startDate": 2016,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -31703,8 +31529,7 @@
         "endDate": 1975,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -31898,8 +31723,7 @@
         "startDate": 1992,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -32039,8 +31863,7 @@
         "place": [
           {
             "canton": "zh",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -32221,8 +32044,7 @@
         "startDate": 1947,
         "place": [
           {
-            "country": "sa",
-            "type": "bf:Place"
+            "country": "sa"
           }
         ],
         "statement": [
@@ -32339,8 +32161,7 @@
         "startDate": 1983,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -32534,8 +32355,7 @@
         "startDate": 1992,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -32709,8 +32529,7 @@
         "startDate": 2008,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -32974,8 +32793,7 @@
         "startDate": 2004,
         "place": [
           {
-            "country": "sp",
-            "type": "bf:Place"
+            "country": "sp"
           }
         ],
         "statement": [
@@ -33287,8 +33105,7 @@
         "startDate": 2016,
         "place": [
           {
-            "country": "is",
-            "type": "bf:Place"
+            "country": "is"
           }
         ],
         "statement": [
@@ -33542,8 +33359,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027525457",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027525457"
         }
       },
       {
@@ -33562,8 +33378,7 @@
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027930408",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027930408"
         }
       }
     ],
@@ -33713,8 +33528,7 @@
         "startDate": 2013,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -33989,8 +33803,7 @@
         "startDate": 2003,
         "place": [
           {
-            "country": "lu",
-            "type": "bf:Place"
+            "country": "lu"
           }
         ],
         "statement": [
@@ -34175,8 +33988,7 @@
         "startDate": 2007,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -34322,8 +34134,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -34447,8 +34258,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -34590,8 +34400,7 @@
         "startDate": 2016,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -34715,8 +34524,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -34847,8 +34655,7 @@
         "startDate": 1985,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -34983,8 +34790,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -35106,8 +34912,7 @@
         "startDate": 2009,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -35276,8 +35081,7 @@
         "startDate": 2010,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -35433,8 +35237,7 @@
         "startDate": 1745,
         "place": [
           {
-            "country": "ne",
-            "type": "bf:Place"
+            "country": "ne"
           }
         ],
         "statement": [
@@ -35569,8 +35372,7 @@
         "startDate": 1993,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -35734,8 +35536,7 @@
         "startDate": 1989,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -35970,8 +35771,7 @@
         "startDate": 1997,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -36239,8 +36039,7 @@
         "startDate": 1997,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -36394,8 +36193,7 @@
         "startDate": 1997,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -36523,8 +36321,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -36640,8 +36437,7 @@
         "startDate": 2010,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -36805,8 +36601,7 @@
         "startDate": 2010,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -36955,8 +36750,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "bl",
-            "type": "bf:Place"
+            "country": "bl"
           }
         ],
         "statement": [
@@ -37072,8 +36866,7 @@
         "startDate": 1989,
         "place": [
           {
-            "country": "sp",
-            "type": "bf:Place"
+            "country": "sp"
           }
         ],
         "statement": [
@@ -37179,8 +36972,7 @@
         "endDate": 1893,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -37355,8 +37147,7 @@
         "startDate": 2004,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -37532,8 +37323,7 @@
         "place": [
           {
             "canton": "ju",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -37653,8 +37443,7 @@
         "startDate": 1959,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -37826,8 +37615,7 @@
         "startDate": 1950,
         "place": [
           {
-            "country": "ja",
-            "type": "bf:Place"
+            "country": "ja"
           }
         ],
         "statement": [
@@ -37975,8 +37763,7 @@
         "place": [
           {
             "canton": "vs",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -38255,8 +38042,7 @@
         "startDate": 2010,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -38411,8 +38197,7 @@
         "startDate": 1988,
         "place": [
           {
-            "country": "ne",
-            "type": "bf:Place"
+            "country": "ne"
           }
         ],
         "statement": [
@@ -38612,8 +38397,7 @@
         "startDate": 2005,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -38764,8 +38548,7 @@
         "startDate": 1975,
         "place": [
           {
-            "country": "gr",
-            "type": "bf:Place"
+            "country": "gr"
           }
         ],
         "statement": [
@@ -38974,8 +38757,7 @@
         "place": [
           {
             "canton": "lu",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -39159,8 +38941,7 @@
         "startDate": 1984,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -39336,8 +39117,7 @@
         "startDate": 1986,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -39561,8 +39341,7 @@
         "startDate": 2005,
         "place": [
           {
-            "country": "mr",
-            "type": "bf:Place"
+            "country": "mr"
           }
         ],
         "statement": [
@@ -39862,8 +39641,7 @@
         "startDate": 1966,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -39990,8 +39768,7 @@
         "endDate": 2019,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -40110,8 +39887,7 @@
         "startDate": 1974,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -40317,8 +40093,7 @@
         "place": [
           {
             "canton": "zh",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -40455,8 +40230,7 @@
         "startDate": 2006,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -40573,8 +40347,7 @@
         "startDate": 1986,
         "place": [
           {
-            "country": "au",
-            "type": "bf:Place"
+            "country": "au"
           }
         ],
         "statement": [
@@ -40785,8 +40558,7 @@
         "startDate": 1899,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -40948,8 +40720,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "is",
-            "type": "bf:Place"
+            "country": "is"
           }
         ],
         "statement": [
@@ -41276,8 +41047,7 @@
         "startDate": 1968,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -41488,8 +41258,7 @@
         "startDate": 2012,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -41628,8 +41397,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -41693,8 +41461,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/027437469",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/027437469"
         }
       },
       {
@@ -41784,8 +41551,7 @@
         "startDate": 1998,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -41912,8 +41678,7 @@
         "startDate": 1992,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -42147,8 +41912,7 @@
         "startDate": 1936,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -42313,8 +42077,7 @@
         "place": [
           {
             "canton": "ne",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -42478,8 +42241,7 @@
         "startDate": 1884,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -42604,8 +42366,7 @@
         "startDate": 1982,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -42747,8 +42508,7 @@
         "endDate": 1956,
         "place": [
           {
-            "country": "ne",
-            "type": "bf:Place"
+            "country": "ne"
           }
         ],
         "statement": [
@@ -42866,8 +42626,7 @@
         "startDate": 1977,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -43019,8 +42778,7 @@
         "startDate": 2005,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -43132,8 +42890,7 @@
         "startDate": 2004,
         "place": [
           {
-            "country": "cc",
-            "type": "bf:Place"
+            "country": "cc"
           }
         ],
         "statement": [
@@ -43279,8 +43036,7 @@
         "place": [
           {
             "canton": "bs",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -43460,8 +43216,7 @@
         "startDate": 1996,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -43513,8 +43268,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026745151",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026745151"
         }
       },
       {
@@ -43600,8 +43354,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -43751,8 +43504,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -43893,8 +43645,7 @@
         "startDate": 1984,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -44098,8 +43849,7 @@
         "startDate": 1979,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -44267,8 +44017,7 @@
         "startDate": 1977,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -44518,8 +44267,7 @@
         "startDate": 1986,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -44574,8 +44322,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026934612",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026934612"
         }
       },
       {
@@ -44655,8 +44402,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -44896,8 +44642,7 @@
         "startDate": 2014,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -45037,8 +44782,7 @@
         "startDate": 2003,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -45292,8 +45036,7 @@
         "startDate": 2017,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -45412,8 +45155,7 @@
         "startDate": 1988,
         "place": [
           {
-            "country": "sp",
-            "type": "bf:Place"
+            "country": "sp"
           }
         ],
         "statement": [
@@ -45535,8 +45277,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -45885,8 +45626,7 @@
         "startDate": 1854,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -45996,8 +45736,7 @@
         "endDate": 1885,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -46370,8 +46109,7 @@
         "startDate": 1877,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -46642,8 +46380,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -46834,8 +46571,7 @@
         "startDate": 1911,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -46888,8 +46624,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/035000457",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/035000457"
         }
       }
     ]
@@ -46960,8 +46695,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -47148,8 +46882,7 @@
         "endDate": 1992,
         "place": [
           {
-            "country": "ja",
-            "type": "bf:Place"
+            "country": "ja"
           }
         ],
         "statement": [
@@ -47402,8 +47135,7 @@
         "startDate": 1864,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -47540,8 +47272,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -47796,8 +47527,7 @@
         "startDate": 1964,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -47914,8 +47644,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -48082,8 +47811,7 @@
         "endDate": 2000,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -48224,8 +47952,7 @@
         "endDate": 1908,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -48506,8 +48233,7 @@
         "startDate": 1909,
         "place": [
           {
-            "country": "fi",
-            "type": "bf:Place"
+            "country": "fi"
           }
         ],
         "statement": [
@@ -48813,8 +48539,7 @@
         "endDate": 1986,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -48996,8 +48721,7 @@
         "startDate": 2008,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -49115,8 +48839,7 @@
         "endDate": 1936,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -49266,8 +48989,7 @@
         "startDate": 1982,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -49417,8 +49139,7 @@
         "startDate": 1965,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -49545,8 +49266,7 @@
         "endDate": 1990,
         "place": [
           {
-            "country": "au",
-            "type": "bf:Place"
+            "country": "au"
           }
         ],
         "statement": [
@@ -49683,8 +49403,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -49791,8 +49510,7 @@
         "endDate": 1977,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -49846,8 +49564,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/026576988",
-          "type": "bf:Organisation"
+          "$ref": "https://mef.rero.ch/api/agents/idref/026576988"
         }
       },
       {
@@ -49969,8 +49686,7 @@
         "startDate": 2006,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -50205,8 +49921,7 @@
         "endDate": 1939,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -50336,8 +50051,7 @@
         "startDate": 1987,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -50707,8 +50421,7 @@
         "endDate": 1954,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -50877,8 +50590,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -51050,8 +50762,7 @@
         "startDate": 1941,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -51335,8 +51046,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -51482,8 +51192,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -51717,8 +51426,7 @@
         "startDate": 2001,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -51780,8 +51488,7 @@
     "subjects": [
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/067025501",
-          "type": "bf:Person"
+          "$ref": "https://mef.rero.ch/api/agents/idref/067025501"
         }
       },
       {
@@ -51930,8 +51637,7 @@
         "startDate": 1965,
         "place": [
           {
-            "country": "xxc",
-            "type": "bf:Place"
+            "country": "xxc"
           }
         ],
         "statement": [
@@ -52100,8 +51806,7 @@
         "endDate": 1939,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -52206,8 +51911,7 @@
         "endDate": 1950,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -52340,8 +52044,7 @@
         "startDate": 1966,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [
@@ -52550,8 +52253,7 @@
         "startDate": 2004,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -53248,8 +52950,7 @@
         "endDate": 1937,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -53392,8 +53093,7 @@
         "startDate": 1969,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -53504,8 +53204,7 @@
         "startDate": 1988,
         "place": [
           {
-            "country": "ne",
-            "type": "bf:Place"
+            "country": "ne"
           }
         ],
         "statement": [
@@ -53601,8 +53300,7 @@
         "place": [
           {
             "canton": "vs",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -53891,8 +53589,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -55196,8 +54893,7 @@
         "startDate": 1957,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -55387,8 +55083,7 @@
         "endDate": 2011,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -55591,8 +55286,7 @@
         "startDate": 1981,
         "place": [
           {
-            "country": "ja",
-            "type": "bf:Place"
+            "country": "ja"
           }
         ],
         "statement": [
@@ -55727,8 +55421,7 @@
         "endDate": 1964,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -55839,8 +55532,7 @@
         "startDate": 1946,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -55985,8 +55677,7 @@
         "startDate": 1955,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -56111,8 +55802,7 @@
         "endDate": 2001,
         "place": [
           {
-            "country": "xxk",
-            "type": "bf:Place"
+            "country": "xxk"
           }
         ],
         "statement": [
@@ -56226,8 +55916,7 @@
         "startDate": 1946,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -56346,8 +56035,7 @@
         "endDate": 1995,
         "place": [
           {
-            "country": "sa",
-            "type": "bf:Place"
+            "country": "sa"
           }
         ],
         "statement": [
@@ -56659,8 +56347,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -56780,8 +56467,7 @@
         "startDate": 1945,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -56860,8 +56546,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -57041,8 +56726,7 @@
         "startDate": 1989,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -57101,8 +56785,7 @@
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/agents/idref/031023169",
-          "type": "bf:Organisation"
+          "$ref": "https://mef.rero.ch/api/agents/idref/031023169"
         }
       },
       {
@@ -57220,8 +56903,7 @@
         "startDate": 1954,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -57849,8 +57531,7 @@
         "endDate": 1899,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -58009,8 +57690,7 @@
         "endDate": 2007,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -58393,8 +58073,7 @@
         "startDate": 1945,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -58493,8 +58172,7 @@
         "startDate": 1993,
         "place": [
           {
-            "country": "ja",
-            "type": "bf:Place"
+            "country": "ja"
           }
         ],
         "statement": [
@@ -58617,8 +58295,7 @@
         "endDate": 1986,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -58739,8 +58416,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -58902,8 +58578,7 @@
         "endDate": 1983,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -59011,8 +58686,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -59150,8 +58824,7 @@
         "endDate": 1990,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -59323,8 +58996,7 @@
         "endDate": 1952,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -59516,8 +59188,7 @@
         "endDate": 1992,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -59629,8 +59300,7 @@
         "endDate": 1983,
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -59877,8 +59547,7 @@
         "startDate": 1987,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -60064,8 +59733,7 @@
         "startDate": 2000,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -60229,8 +59897,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -60393,8 +60060,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "fr",
-            "type": "bf:Place"
+            "country": "fr"
           }
         ],
         "statement": [
@@ -60615,8 +60281,7 @@
         "endDate": 1867,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -60745,8 +60410,7 @@
         "endDate": 1877,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -60878,8 +60542,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -61049,8 +60712,7 @@
         "startDate": 1950,
         "place": [
           {
-            "country": "it",
-            "type": "bf:Place"
+            "country": "it"
           }
         ],
         "statement": [
@@ -61148,8 +60810,7 @@
         "endDate": 1967,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -61231,8 +60892,7 @@
         "endDate": 1950,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -61366,8 +61026,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -61483,8 +61142,7 @@
         "endDate": 1936,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -61628,8 +61286,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -61808,8 +61465,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -61946,8 +61602,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -62104,8 +61759,7 @@
         "endDate": 1968,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -62249,8 +61903,7 @@
         "endDate": 1950,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -62551,8 +62204,7 @@
         "endDate": 1990,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -62718,8 +62370,7 @@
         "endDate": 1950,
         "place": [
           {
-            "country": "xxu",
-            "type": "bf:Place"
+            "country": "xxu"
           }
         ],
         "statement": [
@@ -62852,8 +62503,7 @@
         "note": "Date not available and automatically set to 2050",
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -62980,8 +62630,7 @@
         "endDate": 2000,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -63086,8 +62735,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -63213,8 +62861,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -63394,8 +63041,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -63520,8 +63166,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -63726,8 +63371,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -63861,8 +63505,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -64093,8 +63736,7 @@
         "place": [
           {
             "canton": "ne",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -64255,8 +63897,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -64379,8 +64020,7 @@
         "endDate": 2000,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -64532,8 +64172,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -64681,8 +64320,7 @@
         "endDate": 1987,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -64853,8 +64491,7 @@
         "endDate": 1998,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ],
         "statement": [
@@ -64993,8 +64630,7 @@
         "place": [
           {
             "canton": "ge",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -65193,8 +64829,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -65453,8 +65088,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -65633,8 +65267,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -65811,8 +65444,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -65983,8 +65615,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -66144,8 +65775,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -66312,8 +65942,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -66469,8 +66098,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -66603,8 +66231,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -66744,8 +66371,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -66921,8 +66547,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -67113,8 +66738,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -67281,8 +66905,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -67441,8 +67064,7 @@
         "endDate": 1969,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -67640,8 +67262,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -67788,8 +67409,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -67987,8 +67607,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -68166,8 +67785,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -68340,8 +67958,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -68537,8 +68154,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -68646,8 +68262,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -68802,8 +68417,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [
@@ -68944,8 +68558,7 @@
         "place": [
           {
             "canton": "vd",
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ],
         "statement": [

--- a/rero_ils/alembic/a710021979fe_migrate_contribution_to_entity.py
+++ b/rero_ils/alembic/a710021979fe_migrate_contribution_to_entity.py
@@ -22,7 +22,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'a710021979fe'
-down_revision = '5f0b086e4b82'
+down_revision = '8145a7cdef99'
 branch_labels = ()
 depends_on = None
 

--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -646,8 +646,6 @@ class ReroIlsOverdo(Overdo):
             place['canton'] = self.cantons[0]
         if self.country:
             place['country'] = self.country
-        if place:
-            place['type'] = 'bf:Place'
         if self.links_from_752:
             place['identifiedBy'] = self.links_from_752[0]
         return place
@@ -664,7 +662,6 @@ class ReroIlsOverdo(Overdo):
         for i in range(1, len(self.links_from_752)):
             place = {
                 'country': 'xx',
-                'type': 'bf:Place',
                 'identifiedBy': self.links_from_752[i]
             }
             places.append(place)

--- a/rero_ils/modules/documents/dojson/contrib/jsontodc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontodc/model.py
@@ -21,6 +21,7 @@ from dojson import Overdo, utils
 from flask_babelex import gettext as _
 
 from rero_ils.modules.documents.extensions import TitleExtension
+from rero_ils.modules.entities.models import EntityType
 from rero_ils.modules.entities.utils import get_entity_localized_value
 
 
@@ -210,8 +211,8 @@ def json_to_relations(self, key, value):
 def json_to_subject(self, key, value):
     """Get subject data."""
     result = ''
-    subject_type = value.get('type')
-    if subject_type in ['bf:Person', 'bf:Organisation', 'bf:Place']:
+    _type = value.get('type')
+    if _type in [EntityType.PERSON, EntityType.ORGANISATION, EntityType.PLACE]:
         # TODO: set the language
         authorized_access_point = get_entity_localized_value(
             entity=value,
@@ -222,13 +223,13 @@ def json_to_subject(self, key, value):
             result = authorized_access_point
         else:
             result = value.get('preferred_name')
-    elif subject_type == 'bf:Work':
+    elif _type == EntityType.WORK:
         work = []
         creator = value.get('creator')
         if creator:
             work.append(creator)
         work.append(value.get('title'))
         result = '. - '.join(work)
-    elif subject_type in ['bf:Topic', 'bf:Temporal']:
+    elif _type in [EntityType.TOPIC, EntityType.TEMPORAL]:
         result = value.get('term')
     return result or None

--- a/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
@@ -27,6 +27,7 @@ from invenio_db import db
 from rero_ils.modules.documents.utils import display_alternate_graphic_first
 from rero_ils.modules.documents.views import create_title_responsibilites
 from rero_ils.modules.entities.api import Entity
+from rero_ils.modules.entities.models import EntityType
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.items.api import Item, ItemsSearch
 from rero_ils.modules.libraries.api import Library
@@ -596,7 +597,7 @@ def reverse_contribution(self, key, value):
             break
         result = {}
         result = add_value(result, 'a', preferred_name)
-        if agent_type == 'bf:Person':
+        if agent_type == EntityType.PERSON:
             tag = '7000_'
             if ',' in preferred_name:
                 tag = '7001_'
@@ -611,7 +612,7 @@ def reverse_contribution(self, key, value):
             date = f'{date_of_birth} - {date_of_death}'
             if date != ' - ':
                 result = add_value(result, 'd', date)
-        elif agent_type == 'bf:Organisation':
+        elif agent_type == EntityType.ORGANISATION:
             tag = '710__'
             if agent.get('conference'):
                 tag = '711__'

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -168,7 +168,7 @@ def marc21_to_work_access_point(self, key, value):
         if field_100 := marc21.get_fields('100'):
             agent = {}
             for blob_key, blob_value in field_100[0].get('subfields').items():
-                agent['type'] = 'bf:Person'
+                agent['type'] = EntityType.PERSON
                 if blob_key == 'a':
                     # numeration = not_repetitive(
                     # marc21.bib_id, marc21.bib_id, blob_key, blob_value, 'b')
@@ -616,10 +616,7 @@ def marc21_to_subjects_6XX(self, key, value):
             ref = get_contribution_link(
                 marc21.bib_id, marc21.bib_id, cont_id, key)
             if ref:
-                subject = {
-                    '$ref': ref,
-                    'type': data_type,
-                }
+                subject = {'$ref': ref}
         if not subject.get('$ref'):
             identifier = build_identifier(value)
             if identifier:

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
@@ -25,6 +25,7 @@ from flask import current_app
 from rero_ils.dojson.utils import ReroIlsMarc21Overdo, build_identifier, \
     build_string_from_subfields, get_contribution_link, \
     remove_trailing_punctuation
+from rero_ils.modules.entities.models import EntityType
 
 from ..utils import do_abbreviated_title, \
     do_acquisition_terms_from_field_037, do_classification, do_contribution, \
@@ -320,16 +321,16 @@ def marc21_to_subjects_6XX(self, key, value):
         subjects_imported : for 6xx having indicator 2 '0' or '2'
     """
     type_per_tag = {
-        '600': 'bf:Person',
-        '610': 'bf:Organisation',
-        '611': 'bf:Organisation',
-        '600t': 'bf:Work',
-        '610t': 'bf:Work',
-        '611t': 'bf:Work',
-        '630': 'bf:Work',
-        '650': 'bf:Topic',  # or bf:Temporal, changed by code
-        '651': 'bf:Place',
-        '655': 'bf:Topic'
+        '600': EntityType.PERSON,
+        '610': EntityType.ORGANISATION,
+        '611': EntityType.ORGANISATION,
+        '600t': EntityType.WORK,
+        '610t': EntityType.WORK,
+        '611t': EntityType.WORK,
+        '630': EntityType.WORK,
+        '650': EntityType.TOPIC,  # or bf:Temporal, changed by code
+        '651': EntityType.PLACE,
+        '655': EntityType.TOPIC
     }
 
     conference_per_tag = {
@@ -362,7 +363,7 @@ def marc21_to_subjects_6XX(self, key, value):
         if tag_key == '650':
             for subfield_a in subfields_a:
                 if subfield_a[0].isdigit():
-                    data_type = 'bf:Temporal'
+                    data_type = EntityType.TEMPORAL
                     break
 
         subject = {
@@ -398,7 +399,8 @@ def marc21_to_subjects_6XX(self, key, value):
                     value, subfield_code_per_tag[creator_tag_key]), '.', '.')
         field_key = 'genreForm' if tag_key == '655' else config_field_key
         subfields_0 = utils.force_list(value.get('0'))
-        if data_type in ['bf:Person', 'bf:Organisation'] and subfields_0:
+        if data_type in [EntityType.PERSON, EntityType.ORGANISATION] \
+           and subfields_0:
             ref = get_contribution_link(
                 marc21.bib_id, marc21.bib_id, subfields_0[0], key)
             if ref:
@@ -413,7 +415,7 @@ def marc21_to_subjects_6XX(self, key, value):
             subfields_2 = utils.force_list(value.get('2'))
 
             if identifier \
-                    and data_type == 'bf:Topic' \
+                    and data_type == EntityType.TOPIC \
                     and len(subfields_2) > 0 \
                     and subfields_2[0].lower() == 'rero':
                 identifier['type'] = 'RERO-RAMEAU'

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/ugent/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/ugent/model.py
@@ -23,6 +23,7 @@ from flask import current_app
 
 from rero_ils.dojson.utils import ReroIlsMarc21Overdo, \
     build_string_from_subfields
+from rero_ils.modules.entities.models import EntityType
 
 from ..utils import do_abbreviated_title, \
     do_acquisition_terms_from_field_037, do_classification, do_contribution, \
@@ -305,16 +306,16 @@ def marc21_to_subjects_6XX(self, key, value):
         subjects_imported : for 6xx having indicator 2 '0' or '2'
     """
     type_per_tag = {
-        '600': 'bf:Person',
-        '610': 'bf:Organisation',
-        '611': 'bf:Organisation',
-        '600t': 'bf:Work',
-        '610t': 'bf:Work',
-        '611t': 'bf:Work',
-        '630': 'bf:Work',
-        '650': 'bf:Topic',  # or bf:Temporal, changed by code
-        '651': 'bf:Place',
-        '655': 'bf:Topic'
+        '600': EntityType.PERSON,
+        '610': EntityType.ORGANISATION,
+        '611': EntityType.ORGANISATION,
+        '600t': EntityType.WORK,
+        '610t': EntityType.WORK,
+        '611t': EntityType.WORK,
+        '630': EntityType.WORK,
+        '650': EntityType.TOPIC,  # or bf:Temporal, changed by code
+        '651': EntityType.PLACE,
+        '655': EntityType.TOPIC
     }
 
     conference_per_tag = {

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
@@ -33,6 +33,7 @@ from rero_ils.dojson.utils import _LANGUAGES, TitlePartList, add_note, \
     get_contribution_link, get_field_items, get_field_link_data, \
     not_repetitive, re_identified, remove_trailing_punctuation
 from rero_ils.modules.documents.utils import create_authorized_access_point
+from rero_ils.modules.entities.models import EntityType
 
 _DOCUMENT_RELATION_PER_TAG = {
     '770': 'supplement',
@@ -518,16 +519,11 @@ def build_agent(marc21, key, value):
     """Build agent."""
     agent_data = {}
     if value.get('a'):
-        name = not_repetitive(
-            marc21.bib_id, marc21.bib_id, key, value, 'a')
-        agent_data['preferred_name'] = remove_trailing_punctuation(name)
+        agent_data['preferred_name'] = remove_trailing_punctuation(
+            not_repetitive(marc21.bib_id, marc21.bib_id, key, value, 'a'))
     # 100|700|240 Person
     if key[:3] in ['100', '700']:
-        agent_data['type'] = 'bf:Person'
-        if value.get('a'):
-            name = not_repetitive(
-                marc21.bib_id, marc21.bib_id, key, value, 'a')
-            agent_data['preferred_name'] = remove_trailing_punctuation(name)
+        agent_data['type'] = EntityType.PERSON
         if value.get('b'):
             numeration = not_repetitive(
                 marc21.bib_id, marc21.bib_id, key, value, 'b')
@@ -559,7 +555,7 @@ def build_agent(marc21, key, value):
 
     # 710|711 Organisation
     if key[:3] in ['710', '711']:
-        agent_data['type'] = 'bf:Organisation'
+        agent_data['type'] = EntityType.ORGANISATION
         agent_data['conference'] = key[:3] == '711'
         if value.get('b'):
             subordinate_units = [
@@ -604,15 +600,10 @@ def do_contribution(data, marc21, key, value):
         return None
 
     agent = {}
-
     if value.get('0'):
         if ref := get_contribution_link(marc21.bib_id, marc21.rero_id,
                                         value.get('0'), key):
             agent['$ref'] = ref
-            if key[:3] in ['100', '700']:
-                agent['type'] = 'bf:Person'
-            elif key[:3] in ['710', '711']:
-                agent['type'] = 'bf:Organisation'
 
     # we do not have a $ref
     if not agent.get('$ref') and value.get('a'):
@@ -744,10 +735,10 @@ def do_provision_activity(data, marc21, key, value):
 
         def build_agent_data(code, label, index, link):
             type_per_code = {
-                'a': 'bf:Place',
-                'b': 'bf:Agent',
-                'e': 'bf:Place',
-                'f': 'bf:Agent'
+                'a': EntityType.PLACE,
+                'b': EntityType.AGENT,
+                'e': EntityType.PLACE,
+                'f': EntityType.AGENT
             }
             label = remove_trailing_punctuation(label)
             if label and code == 'e':
@@ -821,8 +812,7 @@ def do_provision_activity(data, marc21, key, value):
         # parce the link skipping the fist (already used by build_place)
         for i in range(1, len(marc21.links_from_752)):
             place = {
-                'country': 'xx',
-                'type': 'bf:Place',
+                'country': 'xx'
             }
             if marc21.links_from_752:
                 place['identifiedBy'] = marc21.links_from_752[i]
@@ -1634,7 +1624,7 @@ def do_work_access_point(marc21, key, value):
     work_access_point = {}
     if tag in ['700', '800'] and value.get('t'):
         title_tag = 't'
-        agent['type'] = 'bf:Person'
+        agent['type'] = EntityType.PERSON
         if value.get('a'):
             preferred_name = not_repetitive(
                 marc21.bib_id, marc21.bib_id, key, value, 'a')
@@ -1660,7 +1650,7 @@ def do_work_access_point(marc21, key, value):
             ).rstrip('.')
     elif tag == '710':
         title_tag = 't'
-        agent['type'] = 'bf:Organisation'
+        agent['type'] = EntityType.ORGANISATION
         agent['conference'] = False
         if value.get('a'):
             preferred_name = not_repetitive(
@@ -2009,10 +1999,10 @@ def do_temporal_coverage(marc21, key, value):
 def perform_subdivisions(field, value):
     """Perform subject subdivisions from MARC field."""
     subdivisions = {
-        'v': 'bf:Concept',
-        'x': 'bf:Topic',
-        'y': 'bf:Temporal',
-        'z': 'bf:Place'
+        'v': EntityType.CONCEPT,
+        'x': EntityType.TOPIC,
+        'y': EntityType.TEMPORAL,
+        'z': EntityType.PLACE
     }
     for tag, val in value.items():
         if tag in subdivisions:

--- a/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
@@ -32,6 +32,7 @@ from rero_ils.dojson.utils import ReroIlsUnimarcOverdo, TitlePartList, \
     remove_trailing_punctuation
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.utils import create_authorized_access_point
+from rero_ils.modules.entities.models import EntityType
 
 _ISSUANCE_MAIN_TYPE_PER_BIB_LEVEL = {
     'a': 'rdami:1001',
@@ -561,7 +562,7 @@ def unimarc_to_contribution(self, key, value):
     """
     agent = {
         'preferred_name': ', '.join(utils.force_list(value.get('a', ''))),
-        'type': 'bf:Person',
+        'type': EntityType.PERSON
     }
 
     if key[:3] in ['700', '701', '702', '703']:
@@ -685,10 +686,10 @@ def unimarc_publishers_provision_activity_publication(self, key, value):
     """Get provision activity dates."""
     def build_place_or_agent_data(code, label, index):
         type_per_code = {
-            'a': 'bf:Place',
-            'c': 'bf:Agent',
-            'e': 'bf:Place',
-            'g': 'bf:Agent'
+            'a': EntityType.PLACE,
+            'c': EntityType.AGENT,
+            'e': EntityType.PLACE,
+            'g': EntityType.AGENT
         }
         place_or_agent_data = {
             'type': type_per_code[code],
@@ -707,7 +708,7 @@ def unimarc_publishers_provision_activity_publication(self, key, value):
                 country = _COUNTRY_UNIMARC_MARC21.get(country_codes[0])
                 if country:
                     place['country'] = country
-                    place['type'] = 'bf:Place'
+                    place['type'] = EntityType.PLACE
         return place
 
     # only take 214 if exists
@@ -1156,7 +1157,7 @@ def unimarc_subjects(self, key, value):
         to_return += ' -- ' + ' -- '.join(utils.force_list(value.get('y')))
     if to_return:
         data = dict(entity={
-            'type': "bf:Topic",
+            'type': EntityType.TOPIC,
             'authorized_access_point': to_return
         })
         if source := value.get('2', None):

--- a/rero_ils/modules/documents/extensions/provision_activities.py
+++ b/rero_ils/modules/documents/extensions/provision_activities.py
@@ -24,6 +24,7 @@ from invenio_records.extensions import RecordExtension
 from rero_ils.dojson.utils import remove_trailing_punctuation
 
 from ..utils import display_alternate_graphic_first
+from ...entities.models import EntityType
 
 
 class ProvisionActivitiesExtension(RecordExtension):
@@ -38,8 +39,8 @@ class ProvisionActivitiesExtension(RecordExtension):
         :rtype: string
         """
         punctuation = {
-            'bf:Place': ' ; ',
-            'bf:Agent': ' ; ',
+            EntityType.PLACE: ' ; ',
+            EntityType.AGENT: ' ; ',
             'Date': ', '
         }
         statement_with_language = {'default': ''}
@@ -54,7 +55,7 @@ class ProvisionActivitiesExtension(RecordExtension):
                         statement_with_language[language] += punctuation[
                             last_statement_type
                         ]
-                    elif statement['type'] == 'bf:Place':
+                    elif statement['type'] == EntityType.PLACE:
                         statement_with_language[language] += ' ; '
                     elif statement['type'] == 'Date':
                         statement_with_language[language] += ', '

--- a/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
@@ -68,31 +68,14 @@
             "type": "object",
             "title": "Place",
             "required": [
-              "country",
-              "type"
+              "country"
             ],
             "propertiesOrder": [
-              "type",
               "country",
               "canton",
-              "$ref",
               "identifiedBy"
             ],
             "properties": {
-              "type": {
-                "title": "Type",
-                "type": "string",
-                "const": "bf:Place",
-                "default": "bf:Place",
-                "readOnly": true,
-                "form": {
-                  "templateOptions": {
-                    "wrappers": [
-                      "hide"
-                    ]
-                  }
-                }
-              },
               "country": {
                 "allOf": [
                   {
@@ -109,21 +92,6 @@
               },
               "canton": {
                 "$ref": "https://bib.rero.ch/schemas/common/cantons-v0.0.1.json#/canton"
-              },
-              "$ref": {
-                "title": "Place",
-                "type": "string",
-                "pattern": "^https://mef.rero.ch/api/places/gnd|idref|rero/.*?$",
-                "form": {
-                  "hide": true,
-                  "remoteTypeahead": {
-                    "type": "mef-places",
-                    "enableGroupField": true
-                  },
-                  "templateOptions": {
-                    "itemCssClass": "col-lg-12"
-                  }
-                }
               },
               "identifiedBy": {
                 "allOf": [

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -502,9 +502,6 @@
           "place": {
             "type": "object",
             "properties": {
-              "type": {
-                "type": "text"
-              },
               "canton": {
                 "type": "text"
               },

--- a/rero_ils/modules/documents/serializers/base.py
+++ b/rero_ils/modules/documents/serializers/base.py
@@ -27,6 +27,7 @@ from rero_ils.modules.commons.identifiers import IdentifierFactory, \
 from rero_ils.modules.utils import get_base_url
 
 from ..api import DocumentsSearch
+from ...entities.models import EntityType
 
 CREATOR_ROLES = [
     'aut', 'cmp', 'cre', 'dub', 'pht', 'ape', 'aqt', 'arc', 'art', 'aus',
@@ -188,7 +189,7 @@ class BaseDocumentFormatterMixin(ABC):
             for statement in provision.get('statement', [])
             for data in statement.get('label', [])
             if provision['type'] == 'bf:Publication'
-            and statement['type'] == 'bf:Place'
+            and statement['type'] == EntityType.PLACE
         ]
 
     def _get_languages(self):
@@ -203,7 +204,7 @@ class BaseDocumentFormatterMixin(ABC):
             for statement in provision.get('statement', [])
             for data in statement.get('label', [])
             if provision['type'] == 'bf:Publication'
-            and statement['type'] == 'bf:Agent'
+            and statement['type'] == EntityType.AGENT
         ]
 
     def _get_identifiers(self, types, states=None):

--- a/rero_ils/modules/documents/utils.py
+++ b/rero_ils/modules/documents/utils.py
@@ -247,11 +247,8 @@ def create_authorized_access_point(agent):
     authorized_access_point = agent.get('preferred_name')
     from ..entities.models import EntityType
     if agent.get('type') == EntityType.PERSON:
-        date_of_birth = agent.get('date_of_birth')
-        date_of_death = agent.get('date_of_death')
-        date = date_of_birth or ''
-        if date_of_death:
-            date += f'-{date_of_death}'
+        date_parts = [agent.get('date_of_birth'), agent.get('date_of_death')]
+        date = '-'.join(filter(None, date_parts))
         numeration = agent.get('numeration')
         fuller_form_of_name = agent.get('fuller_form_of_name')
         qualifier = agent.get('qualifier')
@@ -270,18 +267,14 @@ def create_authorized_access_point(agent):
             if qualifier:
                 authorized_access_point += f', {qualifier}'
     elif agent.get('type') == EntityType.ORGANISATION:
-        subordinate_unit = agent.get('subordinate_unit')
-        if subordinate_unit:
+        if subordinate_unit := agent.get('subordinate_unit'):
             authorized_access_point += f'''. {'. '.join(subordinate_unit)}'''
         conference_data = []
-        numbering = agent.get('numbering')
-        if numbering:
+        if numbering := agent.get('numbering'):
             conference_data.append(numbering)
-        conference_date = agent.get('conference_date')
-        if conference_date:
+        if conference_date := agent.get('conference_date'):
             conference_data.append(conference_date)
-        place = agent.get('place')
-        if place:
+        if place := agent.get('place'):
             conference_data.append(place)
         if conference_data:
             authorized_access_point += ' ({conference})'.format(
@@ -307,14 +300,10 @@ def process_literal_contributions(contributions):
             for language in get_i18n_supported_languages():
                 agent[f'authorized_access_point_{language}'] = \
                     authorized_access_point
-            variant_access_point = contribution['entity'].get(
-                'variant_access_point')
-            if variant_access_point:
-                agent['variant_access_point'] = variant_access_point
-            parallel_access_point = contribution['entity'].get(
-                'parallel_access_point')
-            if parallel_access_point:
-                agent['parallel_access_point'] = parallel_access_point
+            if variant := contribution['entity'].get('variant_access_point'):
+                agent['variant_access_point'] = variant
+            if parallel := contribution['entity'].get('parallel_access_point'):
+                agent['parallel_access_point'] = parallel
             if contribution['entity'].get('identifiedBy'):
                 agent['identifiedBy'] = contribution['entity']['identifiedBy']
             contribution['entity'] = agent

--- a/rero_ils/modules/ebooks/dojson/contrib/marc21/model.py
+++ b/rero_ils/modules/ebooks/dojson/contrib/marc21/model.py
@@ -31,6 +31,7 @@ from rero_ils.dojson.utils import ReroIlsMarc21Overdo, TitlePartList, \
 from rero_ils.modules.documents.dojson.contrib.marc21tojson.utils import \
     do_language
 from rero_ils.modules.documents.utils import create_authorized_access_point
+from rero_ils.modules.entities.models import EntityType
 
 marc21 = ReroIlsMarc21Overdo()
 
@@ -346,8 +347,8 @@ def marc21_to_provision_activity(self, key, value):
 
         def build_place_or_agent_data(code, label):
             type_per_code = {
-                'a': 'bf:Place',
-                'b': 'bf:Agent'
+                'a': EntityType.PLACE,
+                'b': EntityType.AGENT
             }
             return {'type': type_per_code[code], 'label': [{'value': value}]} \
                 if (value := remove_trailing_punctuation(label)) else None
@@ -368,7 +369,7 @@ def marc21_to_provision_activity(self, key, value):
         if marc21.country:
             place['country'] = marc21.country
         if place:
-            place['type'] = 'bf:Place'
+            place['type'] = EntityType.PLACE
         return place
 
     # the function marc21_to_provision_activity start here
@@ -493,7 +494,7 @@ def marc21_to_subjects(self, key, value):
     seen = {}
     for subject in utils.force_list(value.get('a')):
         subject = {
-            'type': "bf:Topic",
+            'type': EntityType.TOPIC,
             'authorized_access_point': subject
         }
         str_subject = str(subject)

--- a/rero_ils/modules/entities/models.py
+++ b/rero_ils/modules/entities/models.py
@@ -47,6 +47,8 @@ class EntityMetadata(db.Model, RecordMetadataBase):
 class EntityType:
     """Class holding all available entity types."""
 
+    AGENT = 'bf:Agent'
+    CONCEPT = 'bf:Concept'
     ORGANISATION = 'bf:Organisation'
     PERSON = 'bf:Person'
     PLACE = 'bf:Place'

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2356,8 +2356,7 @@
         "startDate": 2015,
         "place": [
           {
-            "country": "cc",
-            "type": "bf:Place"
+            "country": "cc"
           }
         ]
       }
@@ -2475,8 +2474,7 @@
         "startDate": 1950,
         "place": [
           {
-            "country": "xx",
-            "type": "bf:Place"
+            "country": "xx"
           }
         ]
       }
@@ -2578,8 +2576,7 @@
         "startDate": 1950,
         "place": [
           {
-            "country": "xx",
-            "type": "bf:Place"
+            "country": "xx"
           }
         ]
       }
@@ -2702,8 +2699,7 @@
         "startDate": 1979,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ]
       }
@@ -2851,8 +2847,7 @@
         "endDate": 1944,
         "place": [
           {
-            "country": "be",
-            "type": "bf:Place"
+            "country": "be"
           }
         ],
         "statement": [

--- a/tests/data/documents.json
+++ b/tests/data/documents.json
@@ -101,8 +101,7 @@
         "startDate": 1987,
         "place": [
           {
-            "country": "sz",
-            "type": "bf:Place"
+            "country": "sz"
           }
         ]
       }
@@ -235,8 +234,7 @@
         "startDate": 1999,
         "place": [
           {
-            "country": "gw",
-            "type": "bf:Place"
+            "country": "gw"
           }
         ]
       }

--- a/tests/unit/documents/test_documents_dojson.py
+++ b/tests/unit/documents/test_documents_dojson.py
@@ -1421,7 +1421,6 @@ def test_marc21_to_contribution(mock_get, mef_agents_url):
     contribution = data.get('contribution')
     assert contribution == [{
         'entity': {
-            'type': 'bf:Person',
             '$ref': f'{mef_agents_url}/idref/XXXXXXXX'
         },
         'role': ['cre']
@@ -1540,8 +1539,7 @@ def test_marc21_provisionActivity_without_264():
     assert data.get('provisionActivity') == [{
         'type': 'bf:Publication',
         'place': [{
-            'country': 'sz',
-            'type': 'bf:Place'
+            'country': 'sz'
         }],
         'startDate': 2006,
         'endDate': 2010
@@ -1569,7 +1567,6 @@ def test_marc21_provisionActivity_without_264_with_752():
         'type': 'bf:Publication',
         'place': [{
             'country': 'sz',
-            'type': 'bf:Place',
             'identifiedBy': {
                     'type': 'IdRef',
                     'value': '027401421'
@@ -1594,8 +1591,7 @@ def test_marc21_provisionActivity_with_original_date():
     assert data.get('provisionActivity') == [{
         'type': 'bf:Publication',
         'place': [{
-            'country': 'sz',
-            'type': 'bf:Place'
+            'country': 'sz'
         }],
         'startDate': 1997,
         'original_date': 1849,
@@ -1646,8 +1642,7 @@ def test_marc21_to_provision_activity_canton():
             'type': 'bf:Publication',
             'place': [{
                 'canton': 'be',
-                'country': 'sz',
-                'type': 'bf:Place'
+                'country': 'sz'
             }],
             'statement': [
                 {
@@ -1719,8 +1714,7 @@ def test_marc21_to_provision_activity_canton():
             'type': 'bf:Publication',
             'place': [{
                 'canton': 'vd',
-                'country': 'sz',
-                'type': 'bf:Place'
+                'country': 'sz'
             }],
             'startDate': 1998
         }
@@ -1750,8 +1744,7 @@ def test_marc21_to_provision_activity_1_place_2_agents():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'fr',
-                'type': 'bf:Place'
+                'country': 'fr'
             }],
             'statement': [
                 {
@@ -1806,7 +1799,6 @@ def test_marc21_to_provision_activity_1_place_2_agents_with_one_752():
             'type': 'bf:Publication',
             'place': [{
                 'country': 'fr',
-                'type': 'bf:Place',
                 'identifiedBy': {
                     'type': 'IdRef',
                     'value': '027401421'
@@ -1870,14 +1862,12 @@ def test_marc21_to_provision_activity_1_place_2_agents_with_two_752():
             'type': 'bf:Publication',
             'place': [{
                     'country': 'fr',
-                    'type': 'bf:Place',
                     'identifiedBy': {
                         'type': 'IdRef',
                         'value': '027401421'
                     }
                 }, {
                     'country': 'xx',
-                    'type': 'bf:Place',
                     'identifiedBy': {
                         'type': 'RERO',
                         'value': 'A000000001'
@@ -1929,8 +1919,7 @@ def test_marc21_to_provision_activity_unknown_place_2_agents():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'be',
-                'type': 'bf:Place'
+                'country': 'be'
             }],
             'statement': [
                 {
@@ -1984,8 +1973,7 @@ def test_marc21_to_provision_activity_3_places_dann_2_agents():
         {
             'type': 'bf:Publication',
             'place': [{
-                 'country': 'gw',
-                 'type': 'bf:Place'
+                 'country': 'gw'
             }],
             'statement': [
                 {
@@ -2040,8 +2028,7 @@ def test_marc21_to_provision_activity_2_places_1_agent():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'sz',
-                'type': 'bf:Place'
+                'country': 'sz'
             }],
             'statement': [
                 {
@@ -2095,8 +2082,7 @@ def test_marc21_to_provision_activity_1_place_1_agent_reprint_date():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'xxu',
-                'type': 'bf:Place'
+                'country': 'xxu'
             }],
             'statement': [
                 {
@@ -2140,8 +2126,7 @@ def test_marc21_to_provision_activity_1_place_1_agent_uncertain_date():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'fr',
-                'type': 'bf:Place'
+                'country': 'fr'
             }],
             'statement': [
                 {
@@ -2204,8 +2189,7 @@ def test_marc21_to_provision_activity_1_place_1_agent_chi_hani():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'cc',
-                'type': 'bf:Place'
+                'country': 'cc'
             }],
             'statement': [
                 {
@@ -2269,8 +2253,7 @@ def test_marc21_to_provision_activity_1_place_1_agent_chi_hani():
     assert data.get('provisionActivity') == [{
         'type': 'bf:Publication',
         'place': [{
-            'country': 'cc',
-            'type': 'bf:Place'
+            'country': 'cc'
         }],
         'statement': [
             {
@@ -2546,8 +2529,7 @@ def test_marc21_to_provision_activity_1_place_1_agent_ara_arab():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'ua',
-                'type': 'bf:Place'
+                'country': 'ua'
             }],
             'statement': [
                 {
@@ -2630,8 +2612,7 @@ def test_marc21_to_provision_activity_2_places_2_agents_rus_cyrl():
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'ru',
-                'type': 'bf:Place'
+                'country': 'ru'
             }],
             'statement': [
                 {
@@ -2708,8 +2689,7 @@ def test_marc21_to_provision_activity_exceptions(capsys):
         {
             'type': 'bf:Publication',
             'place': [{
-                'country': 'ru',
-                'type': 'bf:Place'
+                'country': 'ru'
             }],
             'statement': [
                 {
@@ -4763,7 +4743,6 @@ def test_marc21_to_subjects(mock_get, mef_agents_url):
     data = marc21.do(marc21json)
     assert data.get('subjects') == [{
         'entity': {
-            'type': 'bf:Person',
             '$ref': f'{mef_agents_url}/idref/XXXXXXXX'
         }
     }]
@@ -5053,7 +5032,7 @@ def test_marc21_to_subjects_imported():
     assert data == {
         'provisionActivity': [{
             'note': 'Date not available and automatically set to 2050',
-            'place': [{'country': 'xx', 'type': 'bf:Place'}],
+            'place': [{'country': 'xx'}],
             'startDate': 2050,
             'type': 'bf:Publication'
         }]
@@ -5075,7 +5054,7 @@ def test_marc21_to_subjects_imported():
     assert data == {
         'provisionActivity': [{
             'note': 'Date not available and automatically set to 2050',
-            'place': [{'country': 'xx', 'type': 'bf:Place'}],
+            'place': [{'country': 'xx'}],
             'startDate': 2050,
             'type': 'bf:Publication'
         }]


### PR DESCRIPTION
* Removes `$ref` field into the `provisionActivity.places` structure :
  `places` authority are not yet supported by MEF project so none link
  could be done.
* Updates alembic tree dependencies for scripts into the `US-entity`
  branch.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>
