### PR TITLE
entity: configure the editor

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2053,7 +2053,7 @@ RECORDS_REST_FACETS = dict(
                     # This does not take into account
                     # env variable or instance config file
                     size=RERO_ILS_AGGREGATION_SIZE.get(
-                        'contribution', RERO_ILS_DEFAULT_AGGREGATION_SIZE)
+                        'entity', RERO_ILS_DEFAULT_AGGREGATION_SIZE)
                 )
             ),
             type=dict(
@@ -2062,7 +2062,7 @@ RECORDS_REST_FACETS = dict(
                     # This does not take into account
                     # env variable or instance config file
                     size=RERO_ILS_AGGREGATION_SIZE.get(
-                        'contribution', RERO_ILS_DEFAULT_AGGREGATION_SIZE)
+                        'entity', RERO_ILS_DEFAULT_AGGREGATION_SIZE)
                 )
             )
         ),
@@ -2251,8 +2251,8 @@ RERO_ILS_QUERY_BOOSTING = {
     'documents': {
         'autocomplete_title': 3,
         'title\.*': 3,
-        'contribution.name': 2,
-        'contribution.name_*': 2,
+        'contribution.entity.authorized_access_point_*': 2,
+        'contribution.entity.authorized_access_point': 2,
         'publicationYearText': 2,
         'freeFormedPublicationDate': 2,
         'subjects.term': 2,

--- a/rero_ils/es_templates/v7/record.json
+++ b/rero_ils/es_templates/v7/record.json
@@ -39,7 +39,7 @@
         "edge_ngram_filter": {
           "type": "edge_ngram",
           "min_gram": 3,
-          "max_gram": 10
+          "max_gram": 30
         },
         "french_elision": {
           "type": "elision",

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -252,12 +252,12 @@
           "entity": {
             "$ref": "https://bib.rero.ch/schemas/documents/document_entity_local-v0.0.1.json"
           }
-        },
-        "form": {
-          "hide": true,
-          "templateOptions": {
-            "cssClass": "editor-title"
-          }
+        }
+      },
+      "form": {
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -281,12 +281,12 @@
           "entity": {
             "$ref": "https://bib.rero.ch/schemas/documents/document_genre_form_local-v0.0.1.json"
           }
-        },
-        "form": {
-          "hide": true,
-          "templateOptions": {
-            "cssClass": "editor-title"
-          }
+        }
+      },
+      "form": {
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },

--- a/rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json
@@ -9,6 +9,7 @@
       "oneOf": [
         {
           "title": "bf:Classification",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -20,7 +21,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -50,6 +50,7 @@
         },
         {
           "title": "bf:ClassificationLcc",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -61,7 +62,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -91,6 +91,7 @@
         },
         {
           "title": "bf:ClassificationNlm",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -102,7 +103,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -132,6 +132,7 @@
         },
         {
           "title": "bf:ClassificationUdc",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -144,7 +145,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -177,6 +177,7 @@
         },
         {
           "title": "bf:ClassificationDdc",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -189,7 +190,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -222,6 +222,7 @@
         },
         {
           "title": "classification_brunetparguez",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -233,7 +234,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -263,6 +263,7 @@
         },
         {
           "title": "classification_droit",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -274,7 +275,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -342,14 +342,7 @@
               }
             },
             "subdivision": {
-              "title": "Subdivisions",
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "title": "Subdivision",
-                "type": "string",
-                "minLength": 2
-              }
+              "$ref": "#/definitions/subdivision"
             },
             "edition": {
               "title": "Edition",
@@ -370,6 +363,7 @@
         },
         {
           "title": "classification_musicale_genres",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -381,7 +375,6 @@
             "type",
             "classificationPortion"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -427,7 +420,7 @@
     },
     "subdivision": {
       "title": "Subdivisions",
-      "minItems": 0,
+      "minItems": 1,
       "type": "array",
       "items": {
         "title": "Subdivision",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
@@ -9,6 +9,7 @@
       "oneOf": [
         {
           "title": "unknown media",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType"
@@ -24,6 +25,7 @@
         },
         {
           "title": "rdamt:1001",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -114,6 +116,7 @@
         },
         {
           "title": "rdamt:1002",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -209,6 +212,7 @@
         },
         {
           "title": "rdamt:1003",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -299,6 +303,7 @@
         },
         {
           "title": "rdamt:1004",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -354,6 +359,7 @@
         },
         {
           "title": "rdamt:1005",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -449,6 +455,7 @@
         },
         {
           "title": "rdamt:1006",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -509,6 +516,7 @@
         },
         {
           "title": "rdamt:1007",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -589,6 +597,7 @@
         },
         {
           "title": "rdamt:1008",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",
@@ -659,6 +668,7 @@
         },
         {
           "title": "other",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "contentType",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json
@@ -5,33 +5,55 @@
     "type": "array",
     "minItems": 1,
     "items": {
-      "type": "object",
       "title": "Agents",
       "description": "Person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
-      "additionalProperties": false,
-      "propertiesOrder": [
-        "entity",
-        "role"
-      ],
-      "required": [
-        "entity",
-        "role"
-      ],
-      "properties": {
-        "entity": {
-          "oneOf": [
-            {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "MEF Agents",
+          "description": "Person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity",
+            "role"
+          ],
+          "required": [
+            "entity",
+            "role"
+          ],
+          "properties": {
+            "entity": {
               "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
             },
-            {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_local-v0.0.1.json"
+            "role": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_role-v0.0.1.json"
             }
-          ]
+          }
         },
-        "role": {
-          "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_role-v0.0.1.json"
+        {
+          "type": "object",
+          "title": "Local Agents",
+          "description": "Person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity",
+            "role"
+          ],
+          "required": [
+            "entity",
+            "role"
+          ],
+          "properties": {
+            "entity": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_local-v0.0.1.json"
+            },
+            "role": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_role-v0.0.1.json"
+            }
+          }
         }
-      }
+      ]
     },
     "form": {
       "hide": true,

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json
@@ -48,7 +48,7 @@
       }
     },
     "identifiedBy": {
-      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
     }
   },
   "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json
@@ -46,6 +46,7 @@
     "subordinate_unit": {
       "title": "Subordinate units",
       "type": "array",
+      "minItems": 1,
       "items": {
         "title": "Subordinate unit",
         "type": "string",
@@ -115,7 +116,7 @@
           }
         },
         {
-          "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+          "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
         }
       ]
     }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json
@@ -101,7 +101,7 @@
       }
     },
     "identifiedBy": {
-      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
     }
   },
   "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json
@@ -14,9 +14,23 @@
       "type": "string",
       "pattern": "^https://mef.rero.ch/api/.*(agents/)?gnd|idref|rero/.*?$",
       "form": {
+        "type": "remoteTypeahead",
         "remoteTypeahead": {
+          "enableGroupField": true,
           "type": "mef",
-          "enableGroupField": true
+          "filters": {
+            "default": "bf:Person",
+            "options": [
+              {
+                "label": "Person",
+                "value": "bf:Person"
+              },
+              {
+                "label": "Organisation",
+                "value": "bf:Organisation"
+              }
+            ]
+          }
         },
         "templateOptions": {
           "itemCssClass": "col-lg-12"

--- a/rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json
@@ -29,6 +29,7 @@
       "form": {
         "type": "selectWithSort",
         "templateOptions": {
+          "itemCssClass": "col-lg-6",
           "options": [
             {
               "label": "bf:Person",
@@ -65,12 +66,12 @@
       "form": {
         "placeholder": "Example: Musset, Alfred de, 1810-1857",
         "templateOptions": {
-          "itemCssClass": "col-lg-6"
+          "itemCssClass": "col-lg-12"
         }
       }
     },
     "identifiedBy": {
-      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
     },
     "source": {
       "title": "Source",
@@ -121,7 +122,7 @@
                 "$ref": "#/properties/authorized_access_point"
               },
               "identifiedBy": {
-                "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+                "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
               }
             },
             "form": {
@@ -159,6 +160,7 @@
       "form": {
         "type": "selectWithSort",
         "templateOptions": {
+          "itemCssClass": "col-lg-6",
           "options": [
             {
               "label": "bf:Concept",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
@@ -5,28 +5,45 @@
     "type": "array",
     "minItems": 1,
     "items": {
-      "type": "object",
       "title": "Entities",
+      "type": "object",
       "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
-      "additionalProperties": false,
-      "propertiesOrder": [
-        "entity"
-      ],
-      "required": [
-        "entity"
-      ],
-      "properties": {
-        "entity": {
-          "oneOf": [
-            {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
-            },
-            {
+      "oneOf": [
+        {
+          "title": "Local Entities",
+          "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
+          "type": "object",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity"
+          ],
+          "required": [
+            "entity"
+          ],
+          "properties": {
+            "entity": {
               "$ref": "https://bib.rero.ch/schemas/documents/document_genre_form_local-v0.0.1.json"
             }
-          ]
+          }
+        },
+        {
+          "title": "MEF Entities",
+          "type": "object",
+          "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity"
+          ],
+          "required": [
+            "entity"
+          ],
+          "properties": {
+            "entity": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
+            }
+          }
         }
-      }
+      ]
     },
     "form": {
       "hide": true,

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json
@@ -44,7 +44,7 @@
       "minLength": 3
     },
     "identifiedBy": {
-      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+      "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
     }
   },
   "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json
@@ -14,37 +14,6 @@
     ],
     "properties": {
       "type": {
-        "$ref": "#/definitions/type_main"
-      },
-      "value": {
-        "$ref": "#/definitions/value"
-      },
-      "source": {
-        "$ref": "#/definitions/source"
-      }
-    },
-    "form": {
-      "hide": true,
-      "templateOptions": {
-        "containerCssClass": "row"
-      }
-    }
-  },
-  "identifier_contribution": {
-    "title": "Identifier",
-    "type": "object",
-    "additionalProperties": false,
-    "propertiesOrder": [
-      "type",
-      "value",
-      "source"
-    ],
-    "required": [
-      "type",
-      "value"
-    ],
-    "properties": {
-      "type": {
         "$ref": "#/definitions/type_contribution"
       },
       "value": {
@@ -57,49 +26,12 @@
     "form": {
       "hide": true,
       "templateOptions": {
-        "containerCssClass": "row"
+        "containerCssClass": "row",
+        "itemCssClass": "col-lg-12"
       }
     }
   },
   "definitions": {
-    "type_main": {
-      "title": "Type",
-      "type": "string",
-      "enum": [
-        "bf:Local",
-        "IdRef",
-        "GND",
-        "RERO",
-        "RERO-RAMEAU"
-      ],
-      "form": {
-        "options": [
-          {
-            "value": "bf:Local",
-            "label": "bf:local"
-          },
-          {
-            "value": "IdRef",
-            "label": "IdRef"
-          },
-          {
-            "value": "GND",
-            "label": "GND"
-          },
-          {
-            "value": "RERO",
-            "label": "RERO"
-          },
-          {
-            "value": "RERO-RAMEAU",
-            "label": "RERO-RAMEAU"
-          }
-        ],
-        "templateOptions": {
-          "itemCssClass": "col-lg-12"
-        }
-      }
-    },
     "type_contribution": {
       "title": "Type",
       "type": "string",
@@ -129,7 +61,7 @@
           }
         ],
         "templateOptions": {
-          "itemCssClass": "col-lg-12"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -139,7 +71,7 @@
       "minLength": 1,
       "form": {
         "templateOptions": {
-          "itemCssClass": "col-lg-12"
+          "itemCssClass": "col-lg-6"
         }
       }
     },
@@ -150,7 +82,7 @@
       "minLength": 1,
       "form": {
         "templateOptions": {
-          "itemCssClass": "col-lg-12"
+          "itemCssClass": "col-lg-6"
         },
         "expressionProperties": {
           "templateOptions.required": "true"

--- a/rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json
@@ -10,6 +10,7 @@
       "oneOf": [
         {
           "title": "understanding_level",
+          "type": "object",
           "propertiesOrder": [
             "audienceType",
             "value"
@@ -18,7 +19,6 @@
             "audienceType",
             "value"
           ],
-          "type": "object",
           "properties": {
             "audienceType": {
               "title": "understanding_level",
@@ -184,6 +184,7 @@
         },
         {
           "title": "school_level",
+          "type": "object",
           "propertiesOrder": [
             "audienceType",
             "value"
@@ -192,7 +193,6 @@
             "audienceType",
             "value"
           ],
-          "type": "object",
           "properties": {
             "audienceType": {
               "title": "school_level",
@@ -299,6 +299,7 @@
         },
         {
           "title": "pegi_level",
+          "type": "object",
           "propertiesOrder": [
             "audienceType",
             "value"
@@ -307,7 +308,6 @@
             "audienceType",
             "value"
           ],
-          "type": "object",
           "properties": {
             "audienceType": {
               "title": "pegi_level",
@@ -364,6 +364,7 @@
         },
         {
           "title": "filmage_ch",
+          "type": "object",
           "propertiesOrder": [
             "audienceType",
             "value"
@@ -372,7 +373,6 @@
             "audienceType",
             "value"
           ],
-          "type": "object",
           "properties": {
             "audienceType": {
               "title": "filmage_ch",
@@ -444,6 +444,7 @@
         },
         {
           "title": "undefined",
+          "type": "object",
           "propertiesOrder": [
             "audienceType",
             "value"
@@ -452,7 +453,6 @@
             "audienceType",
             "value"
           ],
-          "type": "object",
           "properties": {
             "audienceType": {
               "title": "undefined",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_issuance-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_issuance-v0.0.1.json
@@ -5,6 +5,7 @@
     "oneOf": [
       {
         "title": "rdami:1001",
+        "type": "object",
         "additionalProperties": false,
         "propertiesOrder": [
           "main_type",
@@ -72,6 +73,7 @@
       },
       {
         "title": "rdami:1002",
+        "type": "object",
         "additionalProperties": false,
         "propertiesOrder": [
           "main_type",
@@ -134,6 +136,7 @@
       },
       {
         "title": "rdami:1003",
+        "type": "object",
         "additionalProperties": false,
         "propertiesOrder": [
           "main_type",
@@ -196,6 +199,7 @@
       },
       {
         "title": "rdami:1004",
+        "type": "object",
         "additionalProperties": false,
         "propertiesOrder": [
           "main_type",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json
@@ -103,7 +103,7 @@
                     }
                   },
                   {
-                    "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+                    "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
                   }
                 ]
               }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -8,25 +8,42 @@
       "type": "object",
       "title": "Entities",
       "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
-      "additionalProperties": false,
-      "propertiesOrder": [
-        "entity"
-      ],
-      "required": [
-        "entity"
-      ],
-      "properties": {
-        "entity": {
-          "oneOf": [
-            {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
-            },
-            {
+      "oneOf": [
+        {
+          "title": "Local Entities",
+          "type": "object",
+          "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity"
+          ],
+          "required": [
+            "entity"
+          ],
+          "properties": {
+            "entity": {
               "$ref": "https://bib.rero.ch/schemas/documents/document_entity_local-v0.0.1.json"
             }
-          ]
+          }
+        },
+        {
+          "title": "MEF Entities",
+          "type": "object",
+          "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity"
+          ],
+          "required": [
+            "entity"
+          ],
+          "properties": {
+            "entity": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
+            }
+          }
         }
-      }
+      ]
     },
     "form": {
       "hide": true

--- a/rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json
@@ -10,6 +10,7 @@
       "oneOf": [
         {
           "title": "time",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -19,7 +20,6 @@
           "required": [
             "type"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -52,6 +52,7 @@
         },
         {
           "title": "period",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "type",
@@ -62,7 +63,6 @@
           "required": [
             "type"
           ],
-          "type": "object",
           "properties": {
             "type": {
               "title": "Type",
@@ -111,7 +111,7 @@
   "definitions": {
     "period_code": {
       "title": "Period codes",
-      "minItems": 0,
+      "minItems": 1,
       "type": "array",
       "items": {
         "title": "Period code",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_types-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_types-v0.0.1.json
@@ -15,6 +15,7 @@
       "oneOf": [
         {
           "title": "docmaintype_archives",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -46,6 +47,7 @@
         },
         {
           "title": "docmaintype_article",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -77,6 +79,7 @@
         },
         {
           "title": "docmaintype_audio",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -144,6 +147,7 @@
         },
         {
           "title": "docmaintype_book",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -231,6 +235,7 @@
         },
         {
           "title": "docmaintype_children",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -262,6 +267,7 @@
         },
         {
           "title": "docmaintype_comic",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -319,6 +325,7 @@
         },
         {
           "title": "docmaintype_electronic",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -373,6 +380,7 @@
         },
         {
           "title": "docmaintype_game",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -440,6 +448,7 @@
         },
         {
           "title": "docmaintype_image",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -522,6 +531,7 @@
         },
         {
           "title": "docmaintype_language_method",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -553,6 +563,7 @@
         },
         {
           "title": "docmaintype_leaf",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -584,6 +595,7 @@
         },
         {
           "title": "docmaintype_map",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -638,6 +650,7 @@
         },
         {
           "title": "docmaintype_movie_series",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -700,6 +713,7 @@
         },
         {
           "title": "docmaintype_object",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -762,6 +776,7 @@
         },
         {
           "title": "docmaintype_other",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -793,6 +808,7 @@
         },
         {
           "title": "docmaintype_score",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",
@@ -855,6 +871,7 @@
         },
         {
           "title": "docmaintype_serial",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -886,6 +903,7 @@
         },
         {
           "title": "docmaintype_series",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type"
@@ -917,6 +935,7 @@
         },
         {
           "title": "docmaintype_teaching_material",
+          "type": "object",
           "additionalProperties": false,
           "propertiesOrder": [
             "main_type",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json
@@ -145,7 +145,7 @@
               "minLength": 1
             },
             "identifiedBy": {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier_contribution"
+              "$ref": "https://bib.rero.ch/schemas/documents/document_identifier-v0.0.1.json#/identifier"
             }
           }
         }

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -65,7 +65,7 @@
         {% for genre in record.genreForm %}
         <li class="figure-caption">
           <i class="fa fa-tag mr-1"></i>
-          {{ genre.term }}
+          {{ genre.entity.authorized_access_point }}
         </li>
         {% endfor %}
       </ul>

--- a/rero_ils/modules/serializers/base.py
+++ b/rero_ils/modules/serializers/base.py
@@ -43,6 +43,10 @@ class JSONSerializer(_JSONSerializer, PostprocessorMixin):
         links_factory = links_factory or (lambda x, record=None, **k: dict())
         if request and request.args.get('resolve') == '1':
             metadata = record.resolve()
+            # if not enable jsonref the dumps is already done in the resolve
+            # method
+            if getattr(record, 'enable_jsonref', False):
+                metadata = metadata.dumps()
         else:
             metadata = deepcopy(record.replace_refs()) if self.replace_refs \
                 else record.dumps()


### PR DESCRIPTION
- Configures the entity type select in the editor.
- Uses only one identifier definition.
- Fixes oneOf configurations.
- Fixes editor UI layout.
- Fixes $ref resolution in during the document importation.
- Uses the dump method in the serializer when the resolve=1.
- Fixes aggregations size configuration.
- Fixes query boosting.
- Fixes autocomplete max length.

Co-authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Dependencies

* https://github.com/rero/rero-ils-ui/pull/941
* https://github.com/rero/ng-core/pull/542

