### PR TITLE
ill request: add ill pickup name on location

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -8,6 +8,8 @@
     },
     "is_pickup": true,
     "pickup_name": "AOSTE CANT1: Espaces publics",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "AOSTE CANT1: ILL Espaces publics",
     "allow_request": true
   },
   {
@@ -48,6 +50,8 @@
     },
     "is_pickup": true,
     "pickup_name": "AOSTE CANT2: Espaces publics",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "AOSTE CANT2: ILL Espaces publics",
     "allow_request": true
   },
   {
@@ -95,6 +99,8 @@
     },
     "is_pickup": true,
     "pickup_name": "AOSTE-AVISE-PUB: Espaces publics",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "AOSTE-AVISE-PUB: ILL Espaces publics",
     "allow_request": true
   },
   {
@@ -117,6 +123,8 @@
     },
     "is_pickup": true,
     "pickup_name": "AOSTE-LYCEE: Espaces publics",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "AOSTE-LYCEE: ILL Espaces publics",
     "allow_request": true
   },
   {
@@ -143,6 +151,8 @@
     "name": "Public Section",
     "is_pickup": true,
     "pickup_name": "Public Section",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Public Section",
     "library": {
       "$ref": "https://bib.rero.ch/api/libraries/5"
     },
@@ -168,6 +178,8 @@
     },
     "is_pickup": true,
     "pickup_name": "La Citadelle",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL La Citadelle",
     "is_online": false,
     "allow_request": true
   },
@@ -180,6 +192,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Beast's Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Beast's Library",
     "is_online": false,
     "allow_request": true
   },
@@ -192,6 +206,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Dream's Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Dream's Library",
     "is_online": false,
     "allow_request": true
   },
@@ -204,6 +220,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Lux Foundation Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Lux Foundation Library",
     "is_online": false,
     "allow_request": true
   },
@@ -216,6 +234,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Hogwarts Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Hogwarts Library",
     "is_online": false,
     "allow_request": true
   },
@@ -228,6 +248,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Biblioth\u00e8que de Babel",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Biblioth\u00e8que de Babel",
     "is_online": false,
     "allow_request": true
   },
@@ -240,6 +262,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Biblioth\u00e8que de l\u2019abbaye",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Biblioth\u00e8que de l\u2019abbaye",
     "is_online": false,
     "allow_request": true
   },
@@ -252,6 +276,8 @@
     },
     "is_pickup": true,
     "pickup_name": "The University's Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL The University's Library",
     "is_online": false,
     "allow_request": true
   },
@@ -264,6 +290,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Cemetery of Forgotten Books",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Cemetery of Forgotten Books",
     "is_online": false,
     "allow_request": true
   },
@@ -276,6 +304,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Ministry of Truth",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Ministry of Truth",
     "is_online": false,
     "allow_request": true
   },
@@ -288,6 +318,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Rivendell Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Rivendell Library",
     "is_online": false,
     "allow_request": true
   },
@@ -300,6 +332,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Matilda's Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Matilda's Library",
     "is_online": false,
     "allow_request": true
   },
@@ -312,6 +346,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Unseen University Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Unseen University Library",
     "is_online": false,
     "allow_request": true
   },
@@ -324,6 +360,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Wan Shi Tong's Library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Wan Shi Tong's Library",
     "is_online": false,
     "allow_request": true
   },
@@ -336,6 +374,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Sunnydale High School library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Sunnydale High School library",
     "is_online": false,
     "allow_request": true
   },
@@ -348,6 +388,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Jedi Archives",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Jedi Archives",
     "is_online": false,
     "allow_request": true
   },
@@ -360,6 +402,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Starfleet library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Starfleet library",
     "is_online": false,
     "allow_request": true
   },
@@ -372,6 +416,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Vulcan library",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "ILL Vulcan library",
     "is_online": false,
     "allow_request": true
   }

--- a/rero_ils/alembic/e3eb396b39bb_migration_ill_pickup.py
+++ b/rero_ils/alembic/e3eb396b39bb_migration_ill_pickup.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2023 RERO
+# Copyright (C) 2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Migration ill pickup."""
+
+from logging import getLogger
+
+from rero_ils.modules.locations.api import Location, LocationsSearch
+
+revision = 'e3eb396b39bb'
+down_revision = '8145a7cdef99'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+
+
+def upgrade():
+    """Upgrade locations records.
+
+    Assign ill pickup on locations that are pickup.
+    """
+    query = LocationsSearch() \
+        .filter('term', is_pickup=True) \
+        .source(['pid'])
+    hits = list(query.scan())
+    for hit in hits:
+        location = Location.get_record_by_pid(hit.pid)
+        location['is_ill_pickup'] = True
+        location['ill_pickup_name'] = location['pickup_name']
+        location.update(location, dbcommit=True, reindex=True)
+        LOGGER.info(f'  * Upgrade location#{location.pid}')
+    LOGGER.info(f'TOTAL :: {len(hits)}')
+
+
+def downgrade():
+    """Downgrade database."""
+    # Nothing to do

--- a/rero_ils/modules/ill_requests/cli.py
+++ b/rero_ils/modules/ill_requests/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019-2022 RERO
+# Copyright (C) 2019-2023 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -26,7 +26,6 @@ import click
 from flask.cli import with_appcontext
 
 from rero_ils.modules.ill_requests.api import ILLRequest
-from rero_ils.modules.items.cli import get_locations
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.utils import get_ref_for_pid
@@ -76,7 +75,7 @@ def get_locations():
     :return: A dict of locations pids by organisation
     """
     location_data = {}
-    for pid in Location.get_pickup_location_pids():
+    for pid in Location.get_pickup_location_pids(is_ill_pickup=True):
         record = Location.get_record_by_pid(pid)
         if record.organisation_pid not in location_data:
             location_data[record.organisation_pid] = pid

--- a/rero_ils/modules/ill_requests/serializers.py
+++ b/rero_ils/modules/ill_requests/serializers.py
@@ -33,7 +33,7 @@ class ILLRequestJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
         metadata = hit.get('metadata', {})
         if pid := metadata.get('pickup_location', {}).get('pid'):
             location = self.get_resource(LocationsSearch(), pid)
-            pickup_name = location.get('pickup_name', location.get('name'))
+            pickup_name = location.get('ill_pickup_name', location.get('name'))
             metadata['pickup_location']['name'] = pickup_name
         super()._postprocess_search_hit(hit)
 

--- a/rero_ils/modules/ill_requests/utils.py
+++ b/rero_ils/modules/ill_requests/utils.py
@@ -23,11 +23,13 @@ from rero_ils.modules.patrons.api import current_patrons
 
 
 def get_pickup_location_options():
-    """Get all pickup location for all patron accounts."""
+    """Get all ill pickup location for all patron accounts."""
     for ptrn_pid in [ptrn.pid for ptrn in current_patrons]:
-        for pid in Location.get_pickup_location_pids(ptrn_pid):
+        for pid in Location.get_pickup_location_pids(ptrn_pid,
+                                                     is_ill_pickup=True):
             location = Location.get_record_by_pid(pid)
-            location_name = location.get('pickup_name', location.get('name'))
+            location_name = location.get(
+                'ill_pickup_name', location.get('name'))
             yield (location.pid, location_name)
 
 

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -18,6 +18,8 @@
     "is_online",
     "is_pickup",
     "pickup_name",
+    "is_ill_pickup",
+    "ill_pickup_name",
     "allow_request",
     "send_notification",
     "notification_email",
@@ -65,6 +67,12 @@
       "default": false,
       "description": "Qualify this location as a pickup location."
     },
+    "is_ill_pickup": {
+      "title": "Is ILL pickup location",
+      "type": "boolean",
+      "default": false,
+      "description": "Qualify this location as a ILL pickup location."
+    },
     "is_online": {
       "title": "Is online location",
       "type": "boolean",
@@ -103,6 +111,27 @@
           },
           "messages": {
             "alreadyTakenMessage": "The pickup location name is already taken."
+          }
+        }
+      }
+    },
+    "ill_pickup_name": {
+      "title": "ILL Pickup location name",
+      "type": "string",
+      "description": "Displayed ILL pickup location name, if different from the location name.",
+      "form": {
+        "hideExpression": "model && model.is_ill_pickup === false",
+        "expressionProperties": {
+          "templateOptions.required": "model && model.is_ill_pickup === true"
+        },
+        "validation": {
+          "validators": {
+            "valueAlreadyExists": {
+              "filter": "'library.pid:' + model.library.pid"
+            }
+          },
+          "messages": {
+            "alreadyTakenMessage": "The ILL pickup location name is already taken."
           }
         }
       }

--- a/rero_ils/modules/locations/mappings/v7/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/mappings/v7/locations/location-v0.0.1.json
@@ -22,8 +22,19 @@
       "is_pickup": {
         "type": "boolean"
       },
+      "is_ill_pickup": {
+        "type": "boolean"
+      },
       "is_online": {
         "type": "boolean"
+      },
+      "ill_pickup_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
       },
       "pickup_name": {
         "type": "text",

--- a/tests/api/locations/test_locations_rest.py
+++ b/tests/api/locations/test_locations_rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2019-2023 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -38,15 +38,19 @@ def test_location_pickup_locations(locations, patron_martigny,
     # At the beginning, if we load all locations from fixtures, there are 4
     # pickup locations (loc1, loc3, loc5, loc7)
     pickup_locations = Location.get_pickup_location_pids()
-    assert set(pickup_locations) == set(['loc1', 'loc3', 'loc5', 'loc7'])
+    assert set(pickup_locations) == {'loc1', 'loc3', 'loc5', 'loc7'}
 
     # check pickup restrictions by patron_pid
     pickup_locations = Location.get_pickup_location_pids(
         patron_pid=patron_martigny.pid)
-    assert set(pickup_locations) == set(['loc1', 'loc3', 'loc5'])
+    assert set(pickup_locations) == {'loc1', 'loc3', 'loc5'}
     pickup_locations = Location.get_pickup_location_pids(
         patron_pid=patron_sion.pid)
-    assert set(pickup_locations) == set(['loc7'])
+    assert set(pickup_locations) == {'loc7'}
+
+    # check ill pickup
+    pickup_locations = Location.get_pickup_location_pids(is_ill_pickup=True)
+    assert set(pickup_locations) == {'loc1', 'loc3', 'loc5'}
 
     # check pickup restrictions by item_barcode
     #   * update `loc1` to restrict_pickup_to 'loc3' and 'loc6'
@@ -63,7 +67,7 @@ def test_location_pickup_locations(locations, patron_martigny,
     flush_index(LocationsSearch.Meta.index)
     pickup_locations = Location.get_pickup_location_pids(
         item_pid=item2_lib_martigny.pid)
-    assert set(pickup_locations) == set(['loc3'])
+    assert set(pickup_locations) == {'loc3'}
 
     pickup_locations = Location.get_pickup_location_pids(
         patron_pid=patron_sion.pid,

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -941,6 +941,8 @@
     },
     "is_pickup": true,
     "pickup_name": "MARTIGNY-PUBLIC: Public Space",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "MARTIGNY-PUBLIC: ILL Public Space",
     "allow_request": true
   },
   "loc2": {
@@ -963,6 +965,8 @@
     },
     "is_pickup": true,
     "pickup_name": "SAXON-PUBLIC: Public Space",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "SAXON-PUBLIC: ILL Public Space",
     "allow_request": true
   },
   "loc4": {
@@ -985,6 +989,8 @@
     },
     "is_pickup": true,
     "pickup_name": "FULLY-PUBLIC: Public Space",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "FULLY-PUBLIC: ILL Public Space",
     "allow_request": true
   },
   "loc6": {
@@ -1084,6 +1090,8 @@
     },
     "is_pickup": true,
     "pickup_name": "SAILLON-PUBLIC: Public Space",
+    "is_ill_pickup": true,
+    "ill_pickup_name": "SAILLON-PUBLIC: ILL Public Space",
     "allow_request": true
   },
   "loc15": {


### PR DESCRIPTION
Add the possibility to define a location as an ill pickup and to give it a ill pickup name.

* Adds is_ill_pickup and ill_pickup_name on location resource.
* Updates serializer ton use the new ill_pickup_name.
* Updates fixtures.
* Closes #3124.

### Dependencies

[ill request: ill pickup name (968)](https://github.com/rero/rero-ils-ui/pull/968)