### PR TITLE
entities: refactoring of MEF proxy

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2986,9 +2986,22 @@ RERO_ILS_APP_GIT_HASH = None
 RERO_ILS_UI_GIT_HASH = None
 
 #: RERO_ILS MEF specific configurations.
-RERO_ILS_MEF_URLS = {
-    'agents': os.environ.get('RERO_ILS_MEF_AGENTS_URL', 'https://mef.rero.ch/api/agents'),
-    'concepts': os.environ.get('RERO_ILS_MEF_CONCEPTS_URL', 'https://mef.rero.ch/api/concepts')
+RERO_ILS_MEF_CONFIG = {
+    'agents': {
+        'base_url': os.environ.get('RERO_ILS_MEF_AGENTS_URL', 'https://mef.rero.ch/api/agents'),
+        'sources': ['idref', 'gnd']
+    },
+    'concepts': {
+        'base_url': os.environ.get('RERO_ILS_MEF_CONCEPTS_URL', 'https://mef.rero.ch/api/concepts'),
+        'sources': ['idref']
+    },
+    'concepts-rameau': {
+        'base_url': os.environ.get('RERO_ILS_MEF_CONCEPTS_URL', 'https://mef.rero.ch/api/concepts'),
+        'sources': ['idref'],
+        'filters': [
+            {'idref.bnf_type': 'sujet Rameau'}
+        ]
+    }
 }
 RERO_ILS_MEF_RESULT_SIZE = 100
 

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -39,7 +39,7 @@
           ],
           "properties": {
             "entity": {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
+              "$ref": "https://bib.rero.ch/schemas/documents/document_subjects_entity_link-v0.0.1.json"
             }
           }
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json
@@ -12,7 +12,7 @@
     "$ref": {
       "title": "MEF Link",
       "type": "string",
-      "pattern": "^https://mef.rero.ch/api/agents/(gnd|idref|rero)/.*?$",
+      "pattern": "^https://mef.rero.ch/api/(agents|concepts)/(gnd|idref|rero)/.*?$",
       "form": {
         "type": "remoteTypeahead",
         "remoteTypeahead": {
@@ -28,6 +28,10 @@
               {
                 "label": "Organisation",
                 "value": "bf:Organisation"
+              },
+              {
+                "label": "Concept",
+                "value": "bf:Topic"
               }
             ]
           }

--- a/rero_ils/modules/entities/proxy.py
+++ b/rero_ils/modules/entities/proxy.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Entity proxies."""
+import json
+from urllib.parse import quote_plus
+
+import requests
+from flask import abort, current_app, jsonify, request
+
+from rero_ils.modules.entities.models import EntityType
+from rero_ils.modules.utils import get_mef_url
+
+
+class MEFProxyFactory:
+    """MEF proxy factory.
+
+    Depending on the entity category we are searching, we need to use a
+    specific proxy class. This is the purpose of the factory : it will check
+    this category and return an instance of the correct proxy class to use.
+    We just need to run a search on some terms on this proxy instance to get
+    remote MEF authority server response.
+
+    USAGE:
+        >> proxy = MEFProxyFactory.create_proxy('agents')
+        >> proxy.search('my_search_term')
+    """
+
+    @staticmethod
+    def create_proxy(category):
+        """The concrete factory method.
+
+        :param category: the search category ('agents', 'organisation', ...)
+        :returns: a concrete instance of proxy to use for searching.
+        :raises ValueError: if no proxy instance can be created.
+        """
+        # Create the proxy configuration mapping table. For each entry in this
+        # dictionary, we need to specify 2 keys :
+        #   - 'class': the concrete `MEFProxy` class to use
+        #   - 'entities':
+        # DEV NOTES :: `agents` isn't yet used, but could be ASAP. This is why
+        #              it's already configured.
+        proxy_config = {
+            'agents': {
+                'class': MefAgentsProxy,
+                'entities': (EntityType.PERSON, EntityType.ORGANISATION)
+            },
+            'person': {
+                'class': MefAgentsProxy,
+                'entities': (EntityType.PERSON,)
+            },
+            'organisation': {
+                'class': MefAgentsProxy,
+                'entities': (EntityType.ORGANISATION,)
+            },
+            'concepts': {
+                'class': MefConceptsProxy,
+                'entities': (EntityType.TOPIC,)
+            },
+            'concepts-rameau': {
+                'class': MefConceptsRameauProxy,
+                'entities': (EntityType.TOPIC,)
+            }
+        }
+        # Create proxy configuration aliases
+        proxy_config[EntityType.PERSON] = proxy_config['person']
+        proxy_config[EntityType.ORGANISATION] = proxy_config['organisation']
+        proxy_config[EntityType.TOPIC] = proxy_config['concepts']
+
+        # Try to create the proxy, otherwise raise a ValueError
+        if data := proxy_config.get(category):
+            return data['class'](*(data['entities']))
+        raise ValueError(f'Unable to find a MEF factory for {category}')
+
+
+class MEFProxyMixin:
+    """Proxy on RERO-MEF authority system.
+
+    This is a ``Mixin`` class : It can't be used a concrete class to avoid any
+    `NotImplementedError` exception.
+
+    A MEF proxy is used to search authority entries on a remove MEF server.
+    This mixin class define basic behavior to search a term and return the
+    response where hits are cleaned/formatted.
+
+    Create a subclass inherits of this Mixin and override methods :
+      - `_get_query_params`: to get all params to use for the MEF query.
+      - `_post_process_result_hit`: to clean/format each MEF hit response.
+    """
+
+    # Headers that should be excluded from remote MEF system response.
+    excluded_headers = [
+        'Content-Encoding',
+        'Content-Length',
+        'Transfer-Encoding',
+        'Connection'
+    ]
+    mef_entrypoint = None  # Must be overridden by subclasses
+
+    def __init__(self, *args):
+        """Magic initialization method."""
+        self.entity_types = args
+        self.sources = current_app.config \
+            .get('RERO_ILS_MEF_CONFIG', {}) \
+            .get(self.mef_entrypoint, {}) \
+            .get('sources', [])
+        self.filters = current_app.config \
+            .get('RERO_ILS_MEF_CONFIG', {}) \
+            .get(self.mef_entrypoint, {}) \
+            .get('filters', [])
+
+    def search(self, term):
+        """Search specific term on MEF authority system.
+
+        :param term: the searched term.
+        :type term: str
+        :returns: the remote MEF response matching the search term
+        :rtype: flask.Response
+        """
+        # Call the remote MEF server removing the 'Host' headers from initial
+        # request to avoid security problems.
+        request_headers = {
+            key: value
+            for key, value in request.headers
+            if key != 'Host'
+        }
+        response = requests.request(
+            method=request.method,
+            url=self._build_url(term),
+            headers=request_headers,
+            data=request.get_data(),
+            cookies=request.cookies,
+            allow_redirects=True
+        )
+
+        # If remote server response failed, raise this HTTP error through a
+        # valid flask `abort` response.
+        if response.status_code != requests.codes.ok:
+            abort(response.status_code)
+
+        # Post-process the result hits to get a standard format against all
+        # format possibility depending on entity type searched.
+        content = json.loads(response.content)
+        for hit in content.get('hits', {}).get('hits', []):
+            self._post_process_result_hit(hit)
+
+        # Finally, return a flask `Response` from a `request.Response`. All
+        # remote server response headers were cloned in the new response except
+        # some inconsistent headers.
+        flask_response = jsonify(content)
+        for header_name, header_value in response.headers.items():
+            if header_name not in self.excluded_headers:
+                flask_response.headers[header_name] = header_value
+        return flask_response
+
+    def _get_query_params(self, term):
+        """Get all parameters to use to build the MEF query.
+
+        :param term: the searched term
+        :type term: str
+        :returns: a list of query parameters to build the `q` parameter to send
+           to the remote MEF server to filter the response. All these params
+           will be joined by 'AND' condition.
+        :rtype: list<str>
+        """
+
+        def _build_filter_value(value):
+            if isinstance(value, list):
+                return f'({" OR ".join(value)})'
+            return f'"{str(value)}"'
+
+        query_params = [f'((autocomplete_name:{term})^2 OR {term})']
+        if self.sources:
+            query_params.append(f'sources:{_build_filter_value(self.sources)}')
+        for filter_field in self.filters:
+            for key, value in filter_field.items():
+                filter_value = _build_filter_value(value)
+                query_params.append(f'{key}:{filter_value}')
+        return query_params
+
+    def _build_url(self, term):
+        """Build the HTTP query to call to search on MEF authority system.
+
+        :param term: the searched term.
+        :type term: str
+        :returns: the MEF URL to call to get response hits.
+        :rtype: str
+        """
+        query = quote_plus(' AND '.join(self._get_query_params(term)))
+        base_url = get_mef_url(self.mef_entrypoint)
+        return f'{base_url}/mef?q={query}&page=1&size=10&facets='
+
+    def _post_process_result_hit(self, hit):
+        """Modify a MEF hit response to return a standardized hit."""
+        # We would like to add the direct MEF URI for each source of the hit.
+        # This URI is the direct access for the source metadata on the remote
+        # MEF authority server.
+        # TODO :: this URI should be returned by MEF API
+        if not (metadata := hit.get('metadata')):
+            return
+        base_url = get_mef_url(self.mef_entrypoint)
+        for source_name in self.sources:
+            if not (src_data := metadata.get(source_name)):
+                continue
+            src_data.setdefault('identifiedBy', []).append({
+                'source': 'mef',
+                'type': 'uri',
+                'value': f'{base_url}/{source_name}/{src_data["pid"]}'
+            })
+
+
+class MefAgentsProxy(MEFProxyMixin):
+    """Proxy on RERO-MEF authority system when searching for `agents`."""
+
+    mef_entrypoint = 'agents'
+
+    def _get_query_params(self, term):
+        """Get all parameters to use to build the MEF query.
+
+        :param term: the searched term
+        :type term: str
+        :returns: a list of query parameters to build the `q` parameter to send
+           to the remote MEF server to filter the response. All these params
+           will be joined by 'AND' condition.
+        :rtype: list<str>
+        """
+        params = super()._get_query_params(term)
+        if self.entity_types:
+            ent_types = []
+            for _type in self.entity_types:
+                _type = _type.replace(":", "\\:")
+                ent_types.append(f'type:{_type}')
+            params += [f'({" OR ".join(ent_types)})']
+        return params
+
+    def _post_process_result_hit(self, hit):
+        """Modify a MEF hit response to return a standardized hit.
+
+        The modification to do on an 'Agent' hit are :
+          - for each used sources: (TODO :: Need MEF correction)
+            - rebuild an "identifiedBy" array based on "identifier" field.
+
+        :param hit: an elasticSearch hit already parsed as a dictionary.
+        """
+        if not (metadata := hit.get('metadata', {})):
+            return
+        for source_name in self.sources:
+            if not (src_data := metadata.get(source_name)):
+                continue
+            if identifier := src_data.pop('identifier', None):
+                src_data.setdefault('identifiedBy', []).append({
+                    'source': source_name,
+                    'type': 'uri',
+                    'value': identifier
+                })
+        super()._post_process_result_hit(hit)
+
+
+class MefConceptsProxy(MEFProxyMixin):
+    """Proxy on RERO-MEF authority system when searching for `concepts`."""
+
+    mef_entrypoint = 'concepts'
+
+    def _post_process_result_hit(self, hit):
+        """Modify a MEF hit response to return a standardized hit.
+
+        The modification to do on an 'Agent' hit are :
+          - for each used sources: (TODO :: Need MEF correction)
+            - add a `type` field
+
+        :param hit: an elasticSearch hit already parsed as a dictionary.
+        """
+        if not (metadata := hit.get('metadata', {})):
+            return
+        metadata['type'] = EntityType.TOPIC
+        super()._post_process_result_hit(hit)
+
+
+class MefConceptsRameauProxy(MefConceptsProxy):
+    """Proxy on RERO-MEF authority system for specific `RAMEAU concepts`."""
+
+    mef_entrypoint = 'concepts-rameau'

--- a/rero_ils/modules/entities/utils.py
+++ b/rero_ils/modules/entities/utils.py
@@ -89,13 +89,11 @@ def get_mef_data_by_type(pid_type, pid, entity_type='agents', verbose=False,
     """
     # Depending on the entity type, try to get the correct MEF base URL.
     # If no base URL could be found, a key error will be raised
-    try:
-        base_url = get_mef_url(entity_type)
-    except KeyError:
+    if not (base_url := get_mef_url(entity_type)):
         msg = f'Unable to find MEF base url for {entity_type}'
         if verbose:
             current_app.logger.warning(msg)
-        raise
+        raise KeyError(msg)
 
     if pid_type == 'mef':
         mef_url = f'{base_url}/mef/?q=pid:"{pid}"'

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -60,7 +60,10 @@ def get_mef_url(entity_type):
     :rtype str
     :raises KeyError if no URL could be found for this entity_type.
     """
-    return current_app.config.get('RERO_ILS_MEF_URLS', {})[entity_type]
+    return current_app.config\
+        .get('RERO_ILS_MEF_CONFIG', {})\
+        .get(entity_type, {})\
+        .get('base_url')
 
 
 def cached(timeout=50, key_prefix='default', query_string=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,9 +211,22 @@ def app_config(app_config):
     app_config['WTF_CSRF_ENABLED'] = False
     # enable operation logs validation for the tests
     app_config['RERO_ILS_ENABLE_OPERATION_LOG_VALIDATION'] = True
-    app_config['RERO_ILS_MEF_URLS'] = {
-        'agents': 'https://mef.rero.ch/api/agents',
-        'concepts': 'https://mef.rero.ch/api/concepts'
+    app_config['RERO_ILS_MEF_CONFIG'] = {
+        'agents': {
+            'base_url': 'https://mef.rero.ch/api/agents',
+            'sources': ['idref', 'gnd']
+        },
+        'concepts': {
+            'base_url': 'https://mef.rero.ch/api/concepts',
+            'sources': ['idref']
+        },
+        'concepts-rameau': {
+            'base_url': 'https://mef.rero.ch/api/concepts',
+            'sources': ['idref'],
+            'filters': [
+                {'idref.bnf_type': 'sujet Rameau'}
+            ]
+        }
     }
     return app_config
 
@@ -258,7 +271,10 @@ def instance_path():
 @pytest.fixture(scope='module')
 def mef_agents_url(app):
     """Get MEF agent URL from config."""
-    return app.config.get('RERO_ILS_MEF_URLS', {}).get('agents')
+    return app.config\
+        .get('RERO_ILS_MEF_CONFIG', {})\
+        .get('agents', {})\
+        .get('base_url')
 
 
 @pytest.fixture(scope="module")

--- a/tests/data/mef.json
+++ b/tests/data/mef.json
@@ -171,5 +171,127 @@
     "sources": [
       "idref"
     ]
+  },
+  "es_concepts_1": {
+    "hits": {
+      "hits": [
+        {
+          "created": "2022-09-20T08:58:39.434146+00:00",
+          "id": "124363",
+          "links": {
+            "self": "https://mef.rero.ch/api/concepts/mef/124363"
+          },
+          "metadata": {
+            "$schema": "https://mef.rero.ch/schemas/concepts_mef/mef-concept-v0.0.1.json",
+            "idref": {
+              "$schema": "https://mef.rero.ch/schemas/concepts_idref/idref-concept-v0.0.1.json",
+              "authorized_access_point": "Voyages en side-car",
+              "bnf_type": "sujet Rameau",
+              "broader": [
+                {
+                  "authorized_access_point": "Voyages \u00e0 motocyclette"
+                }
+              ],
+              "classification": [
+                {
+                  "classificationPortion": "793",
+                  "name": "Sports",
+                  "type": "bf:ClassificationDdc"
+                },
+                {
+                  "classificationPortion": "910",
+                  "name": "G\u00e9ographie",
+                  "type": "bf:ClassificationDdc"
+                }
+              ],
+              "identifiedBy": [
+                {
+                  "source": "IdRef",
+                  "type": "uri",
+                  "value": "http://www.idref.fr/184053064"
+                },
+                {
+                  "source": "BNF",
+                  "type": "uri",
+                  "value": "http://catalogue.bnf.fr/ark:/12148/cb16947261t"
+                }
+              ],
+              "md5": "a6f866961fc65fb7674ec28059c5a1e0",
+              "pid": "184053064",
+              "related": [
+                {
+                  "authorized_access_point": "Side-cars"
+                }
+              ],
+              "variant_access_point": [
+                "Balades en side-car",
+                "Randonn\u00e9e en side-car",
+                "Randonn\u00e9es en side-car"
+              ]
+            },
+            "pid": "124363",
+            "sources": [
+              "idref"
+            ]
+          },
+          "updated": "2022-09-20T08:58:39.434153+00:00"
+        },
+        {
+          "created": "2022-09-20T10:16:09.937646+00:00",
+          "id": "149909",
+          "links": {
+            "self": "https://mef.rero.ch/api/concepts/mef/149909"
+          },
+          "updated": "2022-09-20T10:16:09.937650+00:00"
+        }
+      ],
+      "total": 2
+    }
+  },
+  "es_agents_1": {
+    "hits": {
+      "hits": [
+        {
+          "created": "2021-11-06T05:05:27.295609+00:00",
+          "id": "13176076",
+          "links": {
+            "self": "https://mef.rero.ch/api/agents/mef/13176076"
+          },
+          "metadata": {
+            "$schema": "https://mef.rero.ch/schemas/mef/mef-v0.0.1.json",
+            "idref": {
+              "$schema": "https://mef.rero.ch/schemas/agents_idref/idref-agent-v0.0.1.json",
+              "authorized_access_point": "Universit\u00e9 catholique de Louvain",
+              "bf:Agent": "bf:Organisation",
+              "conference": false,
+              "country_associated": "be",
+              "identifier": "http://www.idref.fr/258289333",
+              "language": [
+                "fre"
+              ],
+              "md5": "204d97ee801fa61ba9edc6cc91953bf5",
+              "pid": "258289333",
+              "preferred_name": "Universit\u00e9 catholique de Louvain",
+              "variant_access_point": [
+                "UCLouvain",
+                "UCL"
+              ],
+              "variant_name": [
+                "UCLouvain",
+                "UCL"
+              ]
+            },
+            "pid": "13176076",
+            "sources": [
+              "idref"
+            ],
+            "type": "bf:Organisation",
+            "viaf_pid": "44163936631000832749"
+          },
+          "updated": "2022-09-23T10:12:43.203337+00:00"
+        }
+      ],
+      "total": 1
+    }
   }
 }

--- a/tests/fixtures/mef.py
+++ b/tests/fixtures/mef.py
@@ -24,13 +24,13 @@ import pytest
 
 @pytest.fixture(scope="module")
 def mef_concept1_data(mef_entities):
-    """Load Martigny librarian data."""
+    """Load MEF concept_1 data."""
     return deepcopy(mef_entities.get('concept_1'))
 
 
 @pytest.fixture(scope="module")
 def mef_concept1_data_tmp(mef_entities):
-    """Load Martigny librarian data."""
+    """Load MEF concept_1 data."""
     return deepcopy(mef_entities.get('concept_1'))
 
 
@@ -47,3 +47,15 @@ def mef_concept1_es_response(mef_concept1_data_tmp):
         'id': data['idref']['pid'],
         'metadata': data
     }]}}
+
+
+@pytest.fixture(scope="module")
+def mef_concept2_es_response(mef_entities):
+    """Load MEF es_concept_1 data."""
+    return deepcopy(mef_entities.get('es_concepts_1'))
+
+
+@pytest.fixture(scope="module")
+def mef_agents1_es_response(mef_entities):
+    """Load MEF es_concept_1 data."""
+    return deepcopy(mef_entities.get('es_agents_1'))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -197,9 +197,10 @@ def loaded_resources_report():
     return report
 
 
-def mock_response(status=200, content="CONTENT", json_data=None,
+def mock_response(status=200, content="CONTENT", headers=None, json_data=None,
                   raise_for_status=None):
     """Mock a request response."""
+    headers = headers or {'Content-Type': 'text/plain'}
     mock_resp = Mock()
     # mock raise_for_status call w/optional error
     mock_resp.raise_for_status = Mock()
@@ -208,11 +209,14 @@ def mock_response(status=200, content="CONTENT", json_data=None,
     # set status code and content
     mock_resp.status_code = status
     mock_resp.content = content
+    mock_resp.headers = headers
     mock_resp.text = content
     # add json data if provided
     if json_data:
+        mock_resp.headers['Content-Type'] = 'application/json'
         mock_resp.json = Mock(return_value=json_data)
         mock_resp.text = json.dumps(json_data)
+        mock_resp.content = json.dumps(json_data)
     return mock_resp
 
 


### PR DESCRIPTION
Refactors MEF Proxy view to allow more flexibility. Now the proxy
accept a search category and search terms. Depending of these
parameters the remove MEF query is build and MEF server response are
standardized for each categories.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>