### PR TITLE
documents: load harvested not electronic

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -160,10 +160,6 @@ class Holding(IlsRecord):
                     and not patterns.get('next_expected_date'):
                 return _(
                     'Must have next expected date for regular frequencies.')
-        if document.harvested ^ self.is_electronic:
-            msg = _('Electronic Holding is not attached to the correct \
-                    document type. document: {pid}')
-            return _(msg.format(pid=document_pid))
         # the enumeration and chronology optional fields are only allowed for
         # serial or electronic holdings
         if not self.is_serial ^ self.is_electronic:

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -111,12 +111,8 @@ def test_holding_extended_validation(client,
     del holding_tmp['notes']
 
     # 2. holding type electronic
-    # 2.1. test holding type electronic attached to wrong document type
-    holding_tmp['holdings_type'] = 'electronic'
-    with pytest.raises(ValidationError):
-        holding_tmp.validate()
 
-    # 2.2 test electronic holding
+    # 2.1 test electronic holding
     # instantiate electronic holding
     holding_tmp = Holding.create(
         holding_lib_sion_electronic_data, delete_pid=True)


### PR DESCRIPTION
The harvested document must be able to have a holdings that is not electronic

* Closes #3147.
