### PR TITLE
acquisition: change read permission

### DIFF
--- a/rero_ils/modules/acquisition/acq_accounts/permissions.py
+++ b/rero_ils/modules/acquisition/acq_accounts/permissions.py
@@ -20,7 +20,8 @@
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    AllowedByActionRestrictByManageableLibrary, DisallowedIfRollovered, \
+    AllowedByActionRestrictByManageableLibrary, \
+    AllowedByActionRestrictByOrganisation, DisallowedIfRollovered, \
     RecordPermissionPolicy
 
 from .api import AcqAccount
@@ -39,7 +40,7 @@ class AcqAccountPermissionPolicy(RecordPermissionPolicy):
     """Acquisition account Permission Policy used by the CRUD operations."""
 
     can_search = [AllowedByAction(search_action)]
-    can_read = [AllowedByActionRestrictByManageableLibrary(read_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
     can_create = [
         AllowedByActionRestrictByManageableLibrary(create_action),
         DisallowedIfRollovered(AcqAccount)

--- a/rero_ils/modules/acquisition/acq_invoices/permissions.py
+++ b/rero_ils/modules/acquisition/acq_invoices/permissions.py
@@ -21,7 +21,8 @@
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    AllowedByActionRestrictByManageableLibrary, DisallowedIfRollovered, \
+    AllowedByActionRestrictByManageableLibrary, \
+    AllowedByActionRestrictByOrganisation, DisallowedIfRollovered, \
     RecordPermissionPolicy
 
 from .api import AcquisitionInvoice
@@ -39,7 +40,7 @@ class AcqInvoicePermissionPolicy(RecordPermissionPolicy):
     """Acquisition invoice Permission Policy used by the CRUD operations."""
 
     can_search = [AllowedByAction(search_action)]
-    can_read = [AllowedByActionRestrictByManageableLibrary(read_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
     can_create = [
         AllowedByActionRestrictByManageableLibrary(create_action),
         DisallowedIfRollovered(AcquisitionInvoice)

--- a/rero_ils/modules/acquisition/acq_order_lines/permissions.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/permissions.py
@@ -20,7 +20,8 @@
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    AllowedByActionRestrictByManageableLibrary, DisallowedIfRollovered, \
+    AllowedByActionRestrictByManageableLibrary, \
+    AllowedByActionRestrictByOrganisation, DisallowedIfRollovered, \
     RecordPermissionPolicy
 
 from .api import AcqOrderLine
@@ -38,7 +39,7 @@ class AcqOrderLinePermissionPolicy(RecordPermissionPolicy):
     """Acquisition order line permission policy used by the CRUD operations."""
 
     can_search = [AllowedByAction(search_action)]
-    can_read = [AllowedByActionRestrictByManageableLibrary(read_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
     can_create = [
         AllowedByActionRestrictByManageableLibrary(create_action),
         DisallowedIfRollovered(AcqOrderLine)

--- a/rero_ils/modules/acquisition/acq_orders/permissions.py
+++ b/rero_ils/modules/acquisition/acq_orders/permissions.py
@@ -20,7 +20,8 @@
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    AllowedByActionRestrictByManageableLibrary, DisallowedIfRollovered, \
+    AllowedByActionRestrictByManageableLibrary, \
+    AllowedByActionRestrictByOrganisation, DisallowedIfRollovered, \
     RecordPermissionPolicy
 
 from .api import AcqOrder
@@ -38,7 +39,7 @@ class AcqOrderPermissionPolicy(RecordPermissionPolicy):
     """Acquisition order Permission Policy used by the CRUD operations."""
 
     can_search = [AllowedByAction(search_action)]
-    can_read = [AllowedByActionRestrictByManageableLibrary(read_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
     can_create = [
         AllowedByActionRestrictByManageableLibrary(create_action),
         DisallowedIfRollovered(AcqOrder)

--- a/rero_ils/modules/acquisition/acq_receipt_lines/permissions.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/permissions.py
@@ -20,7 +20,8 @@
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    AllowedByActionRestrictByManageableLibrary, DisallowedIfRollovered, \
+    AllowedByActionRestrictByManageableLibrary, \
+    AllowedByActionRestrictByOrganisation, DisallowedIfRollovered, \
     RecordPermissionPolicy
 
 from .api import AcqReceiptLine
@@ -38,7 +39,7 @@ class AcqReceiptLinePermissionPolicy(RecordPermissionPolicy):
     """Acq receipt line Permission Policy used by the CRUD operations."""
 
     can_search = [AllowedByAction(search_action)]
-    can_read = [AllowedByActionRestrictByManageableLibrary(read_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
     can_create = [
         AllowedByActionRestrictByManageableLibrary(create_action),
         DisallowedIfRollovered(AcqReceiptLine)

--- a/rero_ils/modules/acquisition/acq_receipts/permissions.py
+++ b/rero_ils/modules/acquisition/acq_receipts/permissions.py
@@ -20,7 +20,8 @@
 from invenio_access import action_factory
 
 from rero_ils.modules.permissions import AllowedByAction, \
-    AllowedByActionRestrictByManageableLibrary, DisallowedIfRollovered, \
+    AllowedByActionRestrictByManageableLibrary, \
+    AllowedByActionRestrictByOrganisation, DisallowedIfRollovered, \
     RecordPermissionPolicy
 
 from .api import AcqReceipt
@@ -38,7 +39,7 @@ class AcqReceiptPermissionPolicy(RecordPermissionPolicy):
     """Acquisition receipt Permission Policy used by the CRUD operations."""
 
     can_search = [AllowedByAction(search_action)]
-    can_read = [AllowedByActionRestrictByManageableLibrary(read_action)]
+    can_read = [AllowedByActionRestrictByOrganisation(read_action)]
     can_create = [
         AllowedByActionRestrictByManageableLibrary(create_action),
         DisallowedIfRollovered(AcqReceipt)

--- a/tests/api/acq_accounts/test_acq_accounts_permissions.py
+++ b/tests/api/acq_accounts/test_acq_accounts_permissions.py
@@ -76,7 +76,7 @@ def test_acq_accounts_permissions(patron_martigny,
 
     # As staff member with "library-administration" role :
     #   - Search :: everything
-    #   - Read :: record of its own library
+    #   - Read :: record of its own organisation
     #   - Create/Update/Delete :: record of its own library
     login_user(librarian_martigny.user)
     check_permission(AcqAccountPermissionPolicy, {
@@ -88,7 +88,7 @@ def test_acq_accounts_permissions(patron_martigny,
     }, acq_account_fiction_martigny)
     check_permission(AcqAccountPermissionPolicy, {
         'search': True,
-        'read': False,
+        'read': True,
         'create': False,
         'update': False,
         'delete': False

--- a/tests/api/acq_invoices/test_acq_invoices_permissions.py
+++ b/tests/api/acq_invoices/test_acq_invoices_permissions.py
@@ -75,7 +75,7 @@ def test_invoice_permissions(
 
     # As staff member with "library-administration" role :
     #   - Search :: everything
-    #   - Read :: record of its own library
+    #   - Read :: record of its own organisation
     #   - Create/Update/Delete :: record of its own library
     login_user(librarian_martigny.user)
     check_permission(AcqInvoicePermissionPolicy, {
@@ -87,7 +87,7 @@ def test_invoice_permissions(
     }, acq_invoice_fiction_martigny)
     check_permission(AcqInvoicePermissionPolicy, {
         'search': True,
-        'read': False,
+        'read': True,
         'create': False,
         'update': False,
         'delete': False

--- a/tests/api/acq_order_lines/test_acq_order_lines_permissions.py
+++ b/tests/api/acq_order_lines/test_acq_order_lines_permissions.py
@@ -77,7 +77,7 @@ def test_order_lines_permissions(patron_martigny,
 
     # As staff member with "library-administration" role :
     #   - Search :: everything
-    #   - Read :: record of its own library
+    #   - Read :: record of its own organisation
     #   - Create/Update/Delete :: record of its own library
     login_user(librarian_martigny.user)
     check_permission(AcqOrderLinePermissionPolicy, {
@@ -89,7 +89,7 @@ def test_order_lines_permissions(patron_martigny,
     }, acq_order_line_fiction_martigny)
     check_permission(AcqOrderLinePermissionPolicy, {
         'search': True,
-        'read': False,
+        'read': True,
         'create': False,
         'update': False,
         'delete': False

--- a/tests/api/acq_orders/test_acq_orders_permissions.py
+++ b/tests/api/acq_orders/test_acq_orders_permissions.py
@@ -75,7 +75,7 @@ def test_orders_permissions(
 
     # As staff member with "library-administration" role :
     #   - Search :: everything
-    #   - Read :: record of its own library
+    #   - Read :: record of its own organisation
     #   - Create/Update/Delete :: record of its own library
     login_user(librarian_martigny.user)
     check_permission(AcqOrderPermissionPolicy, {
@@ -87,7 +87,7 @@ def test_orders_permissions(
     }, acq_order_fiction_martigny)
     check_permission(AcqOrderPermissionPolicy, {
         'search': True,
-        'read': False,
+        'read': True,
         'create': False,
         'update': False,
         'delete': False

--- a/tests/api/acq_receipt_lines/test_acq_receipt_lines_permissions.py
+++ b/tests/api/acq_receipt_lines/test_acq_receipt_lines_permissions.py
@@ -74,7 +74,7 @@ def test_receipt_lines_permissions(
 
     # As staff member with "library-administration" role :
     #   - Search :: everything
-    #   - Read :: record of its own library
+    #   - Read :: record of its own organisation
     #   - Create/Update/Delete :: record of its own library
     login_user(librarian_martigny.user)
     check_permission(AcqReceiptLinePermissionPolicy, {
@@ -86,7 +86,7 @@ def test_receipt_lines_permissions(
     }, acq_receipt_line_1_fiction_martigny)
     check_permission(AcqReceiptLinePermissionPolicy, {
         'search': True,
-        'read': False,
+        'read': True,
         'create': False,
         'update': False,
         'delete': False

--- a/tests/api/acq_receipts/test_acq_receipts_permissions.py
+++ b/tests/api/acq_receipts/test_acq_receipts_permissions.py
@@ -75,7 +75,7 @@ def test_receipts_permissions(
 
     # As staff member with "library-administration" role :
     #   - Search :: everything
-    #   - Read :: record of its own library
+    #   - Read :: record of its own organisation
     #   - Create/Update/Delete :: record of its own library
     login_user(librarian_martigny.user)
     check_permission(AcqReceiptPermissionPolicy, {
@@ -87,7 +87,7 @@ def test_receipts_permissions(
     }, acq_receipt_fiction_martigny)
     check_permission(AcqReceiptPermissionPolicy, {
         'search': True,
-        'read': False,
+        'read': True,
         'create': False,
         'update': False,
         'delete': False


### PR DESCRIPTION
The "read" permission is allowed on the organization and no longer on the library.

* Closes #1763.
