### PR TITLE
vendors: allow new 'serial' contact block

### DIFF
--- a/data/vendors.json
+++ b/data/vendors.json
@@ -10,14 +10,17 @@
       }
     ],
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor1@gmail.com",
-      "phone": "+39324993598",
-      "postal_code": "11100",
-      "street": "Via de Lostan 3",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor1@gmail.com",
+        "phone": "+39324993598",
+        "postal_code": "11100",
+        "street": "Via de Lostan 3",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -35,14 +38,17 @@
       }
     ],
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor1@gmail.com",
-      "phone": "+39324993598",
-      "postal_code": "11100",
-      "street": "Via de Lostan 3",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor1@gmail.com",
+        "phone": "+39324993598",
+        "postal_code": "11100",
+        "street": "Via de Lostan 3",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -60,14 +66,17 @@
       }
     ],
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor1@gmail.com",
-      "phone": "+39324993598",
-      "postal_code": "11100",
-      "street": "Via de Lostan 3",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor1@gmail.com",
+        "phone": "+39324993598",
+        "postal_code": "11100",
+        "street": "Via de Lostan 3",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -79,14 +88,17 @@
     "name": "FNAC Aoste",
     "website": "http://www.fnac.it",
     "communication_language": "fre",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor2@gmail.com",
-      "phone": "+39324867598",
-      "postal_code": "11100",
-      "street": "Via Chambery 82",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor2@gmail.com",
+        "phone": "+39324867598",
+        "postal_code": "11100",
+        "street": "Via Chambery 82",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -98,14 +110,17 @@
     "name": "FNAC Aoste",
     "website": "http://www.fnac.it",
     "communication_language": "fre",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor2@gmail.com",
-      "phone": "+39324867598",
-      "postal_code": "11100",
-      "street": "Via Chambery 82",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor2@gmail.com",
+        "phone": "+39324867598",
+        "postal_code": "11100",
+        "street": "Via Chambery 82",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -117,14 +132,17 @@
     "name": "FNAC Aoste",
     "website": "http://www.fnac.it",
     "communication_language": "fre",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor2@gmail.com",
-      "phone": "+39324867598",
-      "postal_code": "11100",
-      "street": "Via Chambery 82",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor2@gmail.com",
+        "phone": "+39324867598",
+        "postal_code": "11100",
+        "street": "Via Chambery 82",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -145,13 +163,16 @@
         "content": "accept all currencies"
       }
     ],
-    "default_contact": {
-      "city": "Saint-Vincent",
-      "email": "reroilstest+vendor3@gmail.com",
-      "postal_code": "11027",
-      "street": "Via G. Aichino 9",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Saint-Vincent",
+        "email": "reroilstest+vendor3@gmail.com",
+        "postal_code": "11027",
+        "street": "Via G. Aichino 9",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -162,13 +183,16 @@
     "pid": "8",
     "name": "Association des Alpes",
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Saint-Vincent",
-      "email": "reroilstest+vendor3@gmail.com",
-      "postal_code": "11027",
-      "street": "Via G. Aichino 9",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Saint-Vincent",
+        "email": "reroilstest+vendor3@gmail.com",
+        "postal_code": "11027",
+        "street": "Via G. Aichino 9",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -179,13 +203,16 @@
     "pid": "9",
     "name": "Association des Alpes",
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Saint-Vincent",
-      "email": "reroilstest+vendor3@gmail.com",
-      "postal_code": "11027",
-      "street": "Via G. Aichino 9",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Saint-Vincent",
+        "email": "reroilstest+vendor3@gmail.com",
+        "postal_code": "11027",
+        "street": "Via G. Aichino 9",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -203,13 +230,16 @@
       }
     ],
     "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor4@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "London",
+        "email": "reroilstest+vendor4@gmail.com",
+        "phone": "+448444825000",
+        "street": "Diagon Alley",
+        "country": "UK"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 20,
     "organisation": {
@@ -227,13 +257,16 @@
       }
     ],
     "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor4@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "London",
+        "email": "reroilstest+vendor4@gmail.com",
+        "phone": "+448444825000",
+        "street": "Diagon Alley",
+        "country": "UK"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 20,
     "organisation": {
@@ -251,13 +284,16 @@
       }
     ],
     "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor4@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "London",
+        "email": "reroilstest+vendor4@gmail.com",
+        "phone": "+448444825000",
+        "street": "Diagon Alley",
+        "country": "UK"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 20,
     "organisation": {
@@ -267,9 +303,20 @@
   {
     "pid": "13",
     "name": "Tomes and Scrolls",
-    "default_contact": {
-      "city": "Hogsmeade"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Hogsmeade"
+      },
+      {
+        "type": "order",
+        "city": "Tomes"
+      },
+      {
+        "type": "serial",
+        "city": "Scrolls"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 21.5,
     "organisation": {
@@ -279,9 +326,16 @@
   {
     "pid": "14",
     "name": "Tomes and Scrolls",
-    "default_contact": {
-      "city": "Hogsmeade"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Hogsmeade"
+      },
+      {
+        "type": "order",
+        "city": "Scrolls"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 21.5,
     "organisation": {
@@ -291,9 +345,12 @@
   {
     "pid": "15",
     "name": "Tomes and Scrolls",
-    "default_contact": {
-      "city": "Hogsmeade"
-    },
+    "contacts": [
+      {
+        "type": "order",
+        "city": "Scrolls"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 21.5,
     "organisation": {
@@ -304,14 +361,17 @@
     "pid": "16",
     "name": "Sempere and Sons",
     "communication_language": "eng",
-    "default_contact": {
-      "city": "Barcelona",
-      "email": "reroilstest+vendor6@gmail.com",
-      "phone": "+34932680900",
-      "postal_code": "08003",
-      "street": "Carrer dels Banys Vells 21",
-      "country": "Spain"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Barcelona",
+        "email": "reroilstest+vendor6@gmail.com",
+        "phone": "+34932680900",
+        "postal_code": "08003",
+        "street": "Carrer dels Banys Vells 21",
+        "country": "Spain"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 21,
     "organisation": {
@@ -322,14 +382,17 @@
     "pid": "17",
     "name": "Sempere and Sons",
     "communication_language": "eng",
-    "default_contact": {
-      "city": "Barcelona",
-      "email": "reroilstest+vendor6@gmail.com",
-      "phone": "+34932680900",
-      "postal_code": "08003",
-      "street": "Carrer dels Banys Vells 21",
-      "country": "Spain"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Barcelona",
+        "email": "reroilstest+vendor6@gmail.com",
+        "phone": "+34932680900",
+        "postal_code": "08003",
+        "street": "Carrer dels Banys Vells 21",
+        "country": "Spain"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 21,
     "organisation": {
@@ -340,14 +403,17 @@
     "pid": "18",
     "name": "Sempere and Sons",
     "communication_language": "eng",
-    "default_contact": {
-      "city": "Barcelona",
-      "email": "reroilstest+vendor6@gmail.com",
-      "phone": "+34932680900",
-      "postal_code": "08003",
-      "street": "Carrer dels Banys Vells 21",
-      "country": "Spain"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Barcelona",
+        "email": "reroilstest+vendor6@gmail.com",
+        "phone": "+34932680900",
+        "postal_code": "08003",
+        "street": "Carrer dels Banys Vells 21",
+        "country": "Spain"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 21,
     "organisation": {

--- a/rero_ils/alembic/e63e5dfa2416_new_vendor_serial_contact.py
+++ b/rero_ils/alembic/e63e5dfa2416_new_vendor_serial_contact.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""New vendor serial contact."""
+
+from logging import getLogger
+
+# revision identifiers, used by Alembic.
+from rero_ils.modules.vendors.api import Vendor, VendorsIndexer, VendorsSearch
+from rero_ils.modules.vendors.models import VendorContactType
+
+revision = 'e63e5dfa2416'
+down_revision = 'e3eb396b39bb'
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger('alembic')
+indexing_chunck_size = 1000
+
+
+def upgrade():
+    """Upgrade vendor data model."""
+    uuids = [hit.meta.id for hit in VendorsSearch().source(False).scan()]
+    uuids_to_reindex = []
+    for uuid in uuids:
+        record = Vendor.get_record(uuid)
+        changes = False
+        if contact_info := record.pop('default_contact', None):
+            contact_info['type'] = VendorContactType.DEFAULT
+            record.setdefault('contacts', []).append(contact_info)
+            changes = True
+        if contact_info := record.pop('order_contact', None):
+            contact_info['type'] = VendorContactType.ORDER
+            record.setdefault('contacts', []).append(contact_info)
+            changes = True
+        if changes:
+            LOGGER.info(f'* Updating vendor#{record.pid} [{uuid}]...')
+            record.update(record, dbcommit=True, reindex=False)
+            uuids_to_reindex.append(uuid)
+    _indexing_records(uuids_to_reindex)
+
+
+def downgrade():
+    """Downgrade vendor data model."""
+    uuids = [hit.meta.id for hit in VendorsSearch().source(False).scan()]
+    uuids_to_reindex = []
+    for uuid in uuids:
+        record = Vendor.get_record(uuid)
+        changes = False
+        for contact in record.pop('contacts', []):
+            contact_type = contact.pop('type', None)
+            if contact_type == VendorContactType.DEFAULT:
+                record['default_contact'] = contact
+                changes = True
+            if contact == VendorContactType.ORDER:
+                record['order_contact'] = contact
+                changes = True
+        if changes:
+            LOGGER.info(f'* Updating vendor#{record.pid} [{uuid}]...')
+            record.update(record, dbcommit=True, reindex=False)
+            uuids_to_reindex.append(uuid)
+    _indexing_records(uuids_to_reindex)
+
+
+def _indexing_records(record_ids):
+    """Indexing some record based on record uuid."""
+    if not record_ids:
+        return
+
+    LOGGER.info(f'Indexing {len(record_ids)} records ....')
+    indexer = VendorsIndexer()
+    chunks = [
+        record_ids[x:x + indexing_chunck_size]
+        for x in range(0, len(record_ids), indexing_chunck_size)
+    ]
+    total_indexed = 0
+    for chuncked_ids in chunks:
+        indexer.bulk_index(chuncked_ids)
+        count = indexer.process_bulk_queue()
+        total_indexed += count
+        LOGGER.info(f'{total_indexed}/{len(record_ids)} records indexed.')

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -10,8 +10,7 @@
     "communication_language",
     "currency",
     "vat_rate",
-    "default_contact",
-    "order_contact",
+    "contacts",
     "notes"
   ],
   "required": [
@@ -210,64 +209,152 @@
         ]
       }
     },
-    "default_contact": {
-      "title": "Default contact details",
-      "type": "object",
-      "propertiesOrder": [
-        "contact_person",
-        "street",
-        "postal_code",
-        "city",
-        "country",
-        "phone",
-        "email"
-      ],
-      "required": [
-        "city"
-      ],
-      "properties": {
-        "contact_person": {
-          "title": "Contact person",
-          "description": "Vendor contact person.",
-          "type": "string",
-          "minLength": 4
-        },
-        "street": {
-          "title": "Street",
-          "description": "Street and number of the address, separated by a coma.",
-          "type": "string",
-          "minLength": 4,
-          "form": {
-            "type": "textarea",
-            "templateOptions": {
-              "rows": 2
+    "contacts": {
+      "title": "Contacts",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Contact",
+        "type": "object",
+        "propertiesOrder": [
+          "type",
+          "contact_person",
+          "street",
+          "postal_code",
+          "city",
+          "country",
+          "phone",
+          "email"
+        ],
+        "required": [
+          "type",
+          "city"
+        ],
+        "properties": {
+          "type": {
+            "title": "Contact type",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "order",
+              "serial"
+            ],
+            "form": {
+              "type": "selectWithSort",
+              "options": [
+                {
+                  "value": "default",
+                  "label": "Default contact "
+                },
+                {
+                  "value": "order",
+                  "label": "Order contact"
+                },
+                {
+                  "value": "serial",
+                  "label": "Serial contact"
+                }
+              ],
+              "templateOptions": {
+                "itemCssClass": "col-lg-12",
+                "selectWithSortOptions": {
+                  "order": "label"
+                }
+              }
+            }
+          },
+          "contact_person": {
+            "title": "Contact person",
+            "description": "Vendor contact person.",
+            "type": "string",
+            "minLength": 4,
+            "form": {
+              "templateOptions": {
+                "itemCssClass": "col-lg-12",
+                "addonLeft": {
+                  "class": "fa fa-user"
+                }
+              }
+            }
+          },
+          "street": {
+            "title": "Street",
+            "description": "Street and number of the address, separated by a coma.",
+            "type": "string",
+            "minLength": 4,
+            "form": {
+              "type": "textarea",
+              "templateOptions": {
+                "itemCssClass": "col-lg-12",
+                "rows": 2
+              }
+            }
+          },
+          "postal_code": {
+            "title": "Postal code",
+            "type": "string",
+            "minLength": 4,
+            "form": {
+              "templateOptions": {
+                "itemCssClass": "col-lg-4"
+              }
+            }
+          },
+          "city": {
+            "title": "City",
+            "type": "string",
+            "minLength": 2,
+            "form": {
+              "templateOptions": {
+                "itemCssClass": "col-lg-8"
+              }
+            }
+          },
+          "country": {
+            "title": "Country",
+            "type": "string",
+            "minLength": 2,
+            "form": {
+              "templateOptions": {
+                "itemCssClass": "col-lg-12",
+                "addonLeft": {
+                  "class": "fa fa-globe"
+                }
+              }
+            }
+          },
+          "phone": {
+            "title": "Phone number",
+            "description": "Phone number with the international prefix, without spaces.",
+            "type": "string",
+            "form": {
+              "templateOptions": {
+                "itemCssClass": "col-lg-12",
+                "addonLeft": {
+                  "class": "fa fa-phone"
+                }
+              }
+            }
+          },
+          "email": {
+            "title": "Email",
+            "type": "string",
+            "format": "email",
+            "form": {
+              "templateOptions": {
+                "itemCssClass": "col-lg-12",
+                "addonLeft": {
+                  "class": "fa fa-at"
+                }
+              }
             }
           }
         },
-        "postal_code": {
-          "title": "Postal code",
-          "type": "string",
-          "minLength": 4
-        },
-        "city": {
-          "title": "City",
-          "type": "string",
-          "minLength": 2
-        },
-        "country": {
-          "title": "Country",
-          "type": "string",
-          "minLength": 2
-        },
-        "phone": {
-          "title": "Phone number",
-          "description": "Phone number with the international prefix, without spaces.",
-          "type": "string"
-        },
-        "email": {
-          "title": "Email",
-          "type": "string",
-          "format": "email"
+        "form": {
+          "templateOptions": {
+            "containerCssClass": "row"
+          }
         }
       },
       "form": {
@@ -275,65 +362,18 @@
           "wrappers": [
             "card"
           ]
-        }
-      }
-    },
-    "order_contact": {
-      "title": "Order contact details",
-      "type": "object",
-      "propertiesOrder": [
-        "contact_person",
-        "street",
-        "postal_code",
-        "city",
-        "country",
-        "phone",
-        "email"
-      ],
-      "properties": {
-        "contact_person": {
-          "title": "Contact name",
-          "description": "Name of the vendor contact person.",
-          "type": "string",
-          "minLength": 4
         },
-        "street": {
-          "title": "Street",
-          "description": "Street and number of the address, separated by a coma.",
-          "type": "string",
-          "minLength": 4
-        },
-        "postal_code": {
-          "title": "Postal code",
-          "type": "string",
-          "minLength": 4
-        },
-        "city": {
-          "title": "City",
-          "type": "string",
-          "minLength": 2
-        },
-        "country": {
-          "title": "Country",
-          "type": "string",
-          "minLength": 2
-        },
-        "phone": {
-          "title": "Phone number",
-          "description": "Phone number with the international prefix, without spaces.",
-          "type": "string"
-        },
-        "email": {
-          "title": "Email",
-          "type": "string",
-          "format": "email"
-        }
-      },
-      "form": {
-        "templateOptions": {
-          "wrappers": [
-            "card"
-          ]
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "type"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one contact per type is allowed"
+          }
         }
       }
     },

--- a/rero_ils/modules/vendors/mappings/v7/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/mappings/v7/vendors/vendor-v0.0.1.json
@@ -48,8 +48,11 @@
           }
         }
       },
-      "default_contact": {
+      "contacts": {
         "properties": {
+          "type": {
+            "type": "keyword"
+          },
           "contact_person": {
             "type": "text"
           },
@@ -72,37 +75,6 @@
             "type": "keyword"
           },
           "phone": {
-            "type": "keyword"
-          },
-          "postal_code": {
-            "type": "keyword"
-          },
-          "street": {
-            "type": "text"
-          }
-        }
-      },
-      "order_contact": {
-        "properties": {
-          "contact_person": {
-            "type": "text"
-          },
-          "city": {
-            "type": "text"
-          },
-          "country": {
-            "type": "text"
-          },
-          "email": {
-            "type": "keyword",
-            "fields": {
-              "analyzed": {
-                "type": "text",
-                "analyzer": "custom_keyword"
-              }
-            }
-          },
-          "home_phone": {
             "type": "keyword"
           },
           "postal_code": {

--- a/rero_ils/modules/vendors/models.py
+++ b/rero_ils/modules/vendors/models.py
@@ -42,6 +42,14 @@ class VendorMetadata(db.Model, RecordMetadataBase):
     __tablename__ = 'vendor_metadata'
 
 
+class VendorContactType:
+    """Type of vendor contact."""
+
+    DEFAULT = 'default'
+    ORDER = 'order'
+    SERIAL = 'serial'
+
+
 class VendorNoteType:
     """Type of vendor note."""
 

--- a/tests/api/acq_orders/test_acq_orders_views.py
+++ b/tests/api/acq_orders/test_acq_orders_views.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2021 RERO
-# Copyright (C) 2021 UCLouvain
+# Copyright (C) 2091-2023 RERO
+# Copyright (C) 2091-2023 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -30,6 +30,7 @@ from rero_ils.modules.acquisition.acq_orders.models import AcqOrderStatus
 from rero_ils.modules.notifications.api import Notification
 from rero_ils.modules.notifications.models import NotificationChannel, \
     NotificationStatus, NotificationType, RecipientType
+from rero_ils.modules.vendors.models import VendorContactType
 
 
 def test_order_notification_preview(
@@ -74,7 +75,9 @@ def test_send_order(
     """Test send order notification API."""
     login_user_via_session(client, librarian_martigny.user)
     acor = acq_order_fiction_martigny
-    address = vendor_martigny.get('default_contact').get('email')
+    address = vendor_martigny\
+        .get_contact(VendorContactType.DEFAULT)\
+        .get('email')
     emails = [{'type': 'cc', 'address': address}]
     mailbox.clear()
     # test when parent order is not in database

--- a/tests/api/acquisition/test_acquisition_reception_workflow.py
+++ b/tests/api/acquisition/test_acquisition_reception_workflow.py
@@ -38,6 +38,7 @@ from rero_ils.modules.notifications.api import Notification
 from rero_ils.modules.notifications.models import NotificationChannel, \
     NotificationStatus, NotificationType, RecipientType
 from rero_ils.modules.utils import get_ref_for_pid
+from rero_ils.modules.vendors.models import VendorContactType
 
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',
@@ -353,7 +354,9 @@ def test_acquisition_reception_workflow(
     #      - check order lines (status, order-date)
     #      - check order (status)
     #      - check notification
-    address = vendor_martigny.get('default_contact').get('email')
+    address = vendor_martigny\
+        .get_contact(VendorContactType.DEFAULT)\
+        .get('email')
     emails = [
         {'type': 'to', 'address': address},
         {'type': 'reply_to', 'address': lib_martigny.get('email')}

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -15,14 +15,17 @@
       }
     ],
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor1@gmail.com",
-      "phone": "+39324993598",
-      "postal_code": "11100",
-      "street": "Via de Lostan 3",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor1@gmail.com",
+        "phone": "+39324993598",
+        "postal_code": "11100",
+        "street": "Via de Lostan 3",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -35,14 +38,17 @@
     "name": "FNAC Aoste",
     "website": "http://www.fnac.it",
     "communication_language": "fre",
-    "default_contact": {
-      "city": "Aosta",
-      "email": "reroilstest+vendor2@gmail.com",
-      "phone": "+39324867598",
-      "postal_code": "11100",
-      "street": "Via Chambery 82",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Aosta",
+        "email": "reroilstest+vendor2@gmail.com",
+        "phone": "+39324867598",
+        "postal_code": "11100",
+        "street": "Via Chambery 82",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -54,13 +60,16 @@
     "pid": "vndr3",
     "name": "Association des Alpes",
     "communication_language": "ita",
-    "default_contact": {
-      "city": "Saint-Vincent",
-      "email": "reroilstest+vendor3@gmail.com",
-      "postal_code": "11027",
-      "street": "Via G. Aichino 9",
-      "country": "Italia"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Saint-Vincent",
+        "email": "reroilstest+vendor3@gmail.com",
+        "postal_code": "11027",
+        "street": "Via G. Aichino 9",
+        "country": "Italia"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 22,
     "organisation": {
@@ -79,13 +88,16 @@
       }
     ],
     "communication_language": "eng",
-    "default_contact": {
-      "city": "London",
-      "email": "reroilstest+vendor4@gmail.com",
-      "phone": "+448444825000",
-      "street": "Diagon Alley",
-      "country": "UK"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "London",
+        "email": "reroilstest+vendor4@gmail.com",
+        "phone": "+448444825000",
+        "street": "Diagon Alley",
+        "country": "UK"
+      }
+    ],
     "currency": "EUR",
     "vat_rate": 20,
     "organisation": {
@@ -96,9 +108,12 @@
     "$schema": "https://bib.rero.ch/schemas/vendors/vendor-v0.0.1.json",
     "pid": "vndr5",
     "name": "Tomes and Scrolls",
-    "default_contact": {
-      "city": "Hogsmeade"
-    },
+    "contacts": [
+      {
+        "type": "default",
+        "city": "Hogsmeade"
+      }
+    ],
     "currency": "CHF",
     "vat_rate": 21.5,
     "organisation": {

--- a/tests/ui/vendors/test_vendors_api.py
+++ b/tests/ui/vendors/test_vendors_api.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2021 RERO
-# Copyright (C) 2021 UCLouvain
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -17,13 +17,37 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Vendors API tests."""
-from rero_ils.modules.vendors.models import VendorNoteType
+from rero_ils.modules.vendors.models import VendorContactType, VendorNoteType
 
 
 def test_vendors_properties(vendor_martigny, vendor_sion):
-    """Test order properties."""
+    """Test vendor properties."""
 
     # NOTES -------------------------------------------------------------------
     assert vendor_martigny.get_note(VendorNoteType.CLAIM) is not None
     assert vendor_martigny.get_note(VendorNoteType.GENERAL) is None
     assert vendor_sion.get_note(VendorNoteType.RECEIPT) is not None
+
+    # CONTACTS ----------------------------------------------------------------
+    serial_info = {
+        'type': VendorContactType.SERIAL,
+        'city': 'Berne',
+        'email': 'serial@berne.ch'
+    }
+    vendor_martigny['contacts'].append(serial_info)
+    assert not vendor_martigny.get_contact(VendorContactType.ORDER)
+    assert vendor_martigny.get_contact(VendorContactType.SERIAL) == serial_info
+
+    # ORDER EMAIL -------------------------------------------------------------
+    #   With no specific ORDER contact type, the default contact email field
+    #   should be returned
+    assert vendor_martigny.order_email == \
+           vendor_martigny.get_contact(VendorContactType.DEFAULT).get('email')
+
+
+def test_vendors_get_links_to_me(
+    vendor_martigny, acq_invoice_fiction_martigny
+):
+    """Test vendors relations."""
+    links = vendor_martigny.get_links_to_me(True)
+    assert acq_invoice_fiction_martigny.pid in links['acq_invoices']

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -279,6 +279,15 @@ def operation_log_schema(monkeypatch):
 
 
 @pytest.fixture()
+def vendors_schema(monkeypatch):
+    """Local fields Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.vendors.jsonschemas',
+        'vendors/vendor-v0.0.1.json')
+    return get_schema(monkeypatch, schema_in_bytes)
+
+
+@pytest.fixture()
 def marc21_record():
     """Marc21 record."""
     return {

--- a/tests/unit/test_vendors_jsonschema.py
+++ b/tests/unit/test_vendors_jsonschema.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+# Copyright (C) 2019-2023 UCLouvain
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Vendors JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import copy
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+from rero_ils.modules.vendors.api import Vendor
+
+
+def test_vendors_special_rero_validation(
+    app, vendor_martigny_data, vendors_schema
+):
+    """Test RERO special validation data"""
+    record = copy.deepcopy(vendor_martigny_data)
+    validate(record, vendors_schema)
+
+    record['contacts'].append(record['contacts'][0])
+    with pytest.raises(ValidationError) as err:
+        Vendor.validate(Vendor(record))
+    assert 'Can not have multiple contacts with the same type' in str(err)
+
+    record['contacts'] = vendor_martigny_data['contacts']
+    record['notes'].append(record['notes'][0])
+    with pytest.raises(ValidationError) as err:
+        Vendor.validate(Vendor(record))
+    assert 'Can not have multiple notes with the same type' in str(err)


### PR DESCRIPTION
* Refactors contacts block into `Vendor` resource.
* Allow a new "serial" contact block
* Adds alembic migration script
* Adapts unitest and fixture