### PR TITLE
entites schemas: adapt field titles and defaults

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json
@@ -5,13 +5,13 @@
     "type": "array",
     "minItems": 1,
     "items": {
-      "title": "Agents",
+      "title": "Contribution",
       "description": "Person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
       "type": "object",
       "oneOf": [
         {
           "type": "object",
-          "title": "MEF Agents",
+          "title": "Link to an entity",
           "description": "Person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
           "additionalProperties": false,
           "propertiesOrder": [
@@ -24,7 +24,7 @@
           ],
           "properties": {
             "entity": {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_link-v0.0.1.json"
+              "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_entity_link-v0.0.1.json"
             },
             "role": {
               "$ref": "https://bib.rero.ch/schemas/documents/document_contribution_role-v0.0.1.json"
@@ -33,7 +33,7 @@
         },
         {
           "type": "object",
-          "title": "Local Agents",
+          "title": "Entity (local)",
           "description": "Person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
           "additionalProperties": false,
           "propertiesOrder": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "title": "MEF Entity",
+  "title": "Link to an agent",
   "type": "object",
   "additionalProperties": false,
   "propertiesOrder": [
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "$ref": {
-      "title": "MEF Link",
+      "title": "Agent",
       "type": "string",
       "pattern": "^https://mef.rero.ch/api/agents/(gnd|idref|rero)/.*?$",
       "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "title": "Local Entity",
+  "title": "Agent (local)",
   "type": "object",
   "additionalProperties": false,
   "propertiesOrder": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "title": "Local Entity",
+  "title": "Entity (local)",
   "type": "object",
   "additionalProperties": false,
   "propertiesOrder": [
@@ -64,7 +64,6 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: Musset, Alfred de, 1810-1857",
         "templateOptions": {
           "itemCssClass": "col-lg-12"
         }
@@ -90,7 +89,7 @@
       "uniqueItems": true,
       "items": {
         "type": "object",
-        "title": "Entities",
+        "title": "Entity (local)",
         "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
         "additionalProperties": false,
         "propertiesOrder": [
@@ -119,8 +118,8 @@
                 "$ref": "#/definitions/subtype"
               },
               "isGenreForm": {
-                "title": "Genre / form",
-                "description": "Is this entity is a genre/form ?",
+                "title": "Genre, form",
+                "description": "Is this entity a genre, form ?",
                 "type": "boolean",
                 "default": false,
                 "form": {

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json
@@ -5,29 +5,12 @@
     "type": "array",
     "minItems": 1,
     "items": {
-      "title": "Entities",
+      "title": "Genre, form",
       "type": "object",
       "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
       "oneOf": [
         {
-          "title": "Local Entities",
-          "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
-          "type": "object",
-          "additionalProperties": false,
-          "propertiesOrder": [
-            "entity"
-          ],
-          "required": [
-            "entity"
-          ],
-          "properties": {
-            "entity": {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_genre_form_local-v0.0.1.json"
-            }
-          }
-        },
-        {
-          "title": "MEF Entities",
+          "title": "Link to an entity",
           "type": "object",
           "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
           "additionalProperties": false,
@@ -40,6 +23,23 @@
           "properties": {
             "entity": {
               "$ref": "https://bib.rero.ch/schemas/documents/document_genre_form_link-v0.0.1.json"
+            }
+          }
+        },
+        {
+          "title": "Entity (local)",
+          "description": "Genre or form of the document. Always create a link to IdRef or GND, if possible.",
+          "type": "object",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity"
+          ],
+          "required": [
+            "entity"
+          ],
+          "properties": {
+            "entity": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_genre_form_local-v0.0.1.json"
             }
           }
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "title": "MEF Entity",
+  "title": "Link to a genre, form",
   "type": "object",
   "additionalProperties": false,
   "propertiesOrder": [
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "$ref": {
-      "title": "MEF Link",
+      "title": "Genre, form",
       "type": "string",
       "pattern": "^https://mef.rero.ch/api/concepts/idref/.*?$",
       "form": {
@@ -22,7 +22,7 @@
             "default": "concepts-genreForm",
             "options": [
               {
-                "label": "Concept",
+                "label": "Genre, form",
                 "value": "concepts-genreForm"
               }
             ]

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "title": "Local Entity",
+  "title": "Genre, form (local)",
   "type": "object",
   "additionalProperties": false,
   "propertiesOrder": [
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]",
+        "placeholder": "Example: Electronic serials",
         "templateOptions": {
           "itemCssClass": "col-lg-6"
         }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json
@@ -6,28 +6,11 @@
     "minItems": 1,
     "items": {
       "type": "object",
-      "title": "Entities",
+      "title": "Subject",
       "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
       "oneOf": [
         {
-          "title": "Local Entities",
-          "type": "object",
-          "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
-          "additionalProperties": false,
-          "propertiesOrder": [
-            "entity"
-          ],
-          "required": [
-            "entity"
-          ],
-          "properties": {
-            "entity": {
-              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_local-v0.0.1.json"
-            }
-          }
-        },
-        {
-          "title": "MEF Entities",
+          "title": "Link to an entity",
           "type": "object",
           "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
           "additionalProperties": false,
@@ -42,11 +25,31 @@
               "$ref": "https://bib.rero.ch/schemas/documents/document_subjects_entity_link-v0.0.1.json"
             }
           }
+        },
+        {
+          "title": "Entity (local)",
+          "type": "object",
+          "description": "Topic (including genre/form), place, temporal, person, family or corporate body (including conferences). Always create a link to IdRef or GND, if possible.",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "entity"
+          ],
+          "required": [
+            "entity"
+          ],
+          "properties": {
+            "entity": {
+              "$ref": "https://bib.rero.ch/schemas/documents/document_entity_local-v0.0.1.json"
+            }
+          }
         }
       ]
     },
     "form": {
-      "hide": true
+      "hide": true,
+      "navigation": {
+        "essential": true
+      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "title": "MEF Entity",
+  "title": "Link to a subject",
   "type": "object",
   "additionalProperties": false,
   "propertiesOrder": [
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "$ref": {
-      "title": "MEF Link",
+      "title": "Subject",
       "type": "string",
       "pattern": "^https://mef.rero.ch/api/(agents|concepts)/(gnd|idref|rero)/.*?$",
       "form": {
@@ -19,8 +19,12 @@
           "enableGroupField": true,
           "type": "mef",
           "filters": {
-            "default": "bf:Person",
+            "default": "bf:Topic",
             "options": [
+              {
+                "label": "Topic",
+                "value": "bf:Topic"
+              },
               {
                 "label": "Person",
                 "value": "bf:Person"
@@ -28,10 +32,6 @@
               {
                 "label": "Organisation",
                 "value": "bf:Organisation"
-              },
-              {
-                "label": "Concept",
-                "value": "bf:Topic"
               }
             ]
           }

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2021-10-24 13:38+0000\n"
 "Last-Translator: ButterflyOfFire <ButterflyOfFire@protonmail.com>\n"
 "Language: ar\n"
@@ -358,8 +358,8 @@ msgstr "إنتاج"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "مكان"
 
@@ -4362,8 +4362,8 @@ msgstr "URI للمكتبة"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4498,7 +4498,7 @@ msgstr "تم الحذف"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "التاريخ"
@@ -4671,7 +4671,7 @@ msgstr "سعر الصرف"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4702,13 +4702,13 @@ msgstr "ملاحظة"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4923,7 +4923,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5253,6 +5253,8 @@ msgid "Subjects"
 msgstr "المواضيع"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "الموضوع"
 
@@ -5289,6 +5291,7 @@ msgstr ""
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 #, fuzzy
 msgid "Contribution"
 msgstr "توزيع"
@@ -5355,9 +5358,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr ""
 
@@ -5483,7 +5483,7 @@ msgid "Not applicable"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5631,12 +5631,12 @@ msgid "classification_musicale_genres"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr ""
 
@@ -6073,11 +6073,6 @@ msgstr "كلمة منطوقة"
 msgid "Relationship to an agent associated with the document"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-#, fuzzy
-msgid "Agents"
-msgstr "صياغات"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6087,17 +6082,43 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "شخص"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
+msgid "Agent (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
@@ -6118,7 +6139,6 @@ msgid "Access Point"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr ""
 
@@ -6188,13 +6208,6 @@ msgstr ""
 #, fuzzy
 msgid "Example: 1989"
 msgstr "مثال: 1985-12-29"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "شخص"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7367,43 +7380,25 @@ msgstr "ملاحظة عامة"
 msgid "Example: Access only from the library"
 msgstr "مثال: الوصول هنا فقط عن طريق المكتبة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7413,12 +7408,15 @@ msgid ""
 "GND, if possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7474,30 +7472,23 @@ msgid "(MARC 655)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
@@ -8292,56 +8283,56 @@ msgstr "اماكن"
 msgid "Place"
 msgstr "مكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "صياغات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "صياغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr "بيان مكان وكيل النشاط المخصص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 #, fuzzy
 msgid "bf:Agent"
 msgstr "مكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "ملصقات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 #, fuzzy
 msgid "Date 1"
 msgstr "تاريخ الإعارة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 #, fuzzy
 msgid "Date 2"
 msgstr "تاريخ الإعارة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr "تاريخ النسخة الأصلية في حالة النسخ."
 
@@ -8524,6 +8515,14 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
@@ -9000,10 +8999,6 @@ msgstr "مثال: النسخ غير مسموح به"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -16,17 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2023-05-11 11:24+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/de/>\n"
 "Language: de\n"
+"Language-Team: German <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/de/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.18-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -364,8 +363,8 @@ msgstr "Entstehung"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "Ort"
 
@@ -4368,8 +4367,8 @@ msgstr "URI der Bibliothek"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4502,7 +4501,7 @@ msgstr "gelöscht"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Datum"
@@ -4669,7 +4668,7 @@ msgstr "Wechselkurs"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4700,13 +4699,13 @@ msgstr "Anmerkung"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4919,7 +4918,7 @@ msgstr "Gebühr"
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5252,6 +5251,8 @@ msgid "Subjects"
 msgstr "Themen"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Thema"
 
@@ -5287,6 +5288,7 @@ msgstr "ID der Sammlung"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Beitrag"
 
@@ -5352,9 +5354,6 @@ msgstr "Aus externen Daten importiertes Thema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr "Entitäten"
 
@@ -5364,9 +5363,9 @@ msgid ""
 "(including conferences), used for information. Do not enter data "
 "manually."
 msgstr ""
-"Importiertes Konzept, Ort, Zeitraum, Person, Familie oder Körperschaft ("
-"einschließlich Konferenzen), die für Informationen verwendet werden. Geben "
-"Sie die Daten nicht manuell ein."
+"Importiertes Thema, Ort, Zeitraum, Person, Familie oder Körperschaft "
+"(einschließlich Konferenzen), die für Informationen verwendet werden. "
+"Geben Sie die Daten nicht manuell ein."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:265
 msgid "Genres, forms (imported)"
@@ -5379,8 +5378,8 @@ msgstr "Aus externen Daten importiertes Genre oder Form"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Imported genre or form, used for information. Do not enter data manually."
 msgstr ""
-"Importiertes Genre oder Form, das für Informationen verwendet wird. Geben "
-"Sie die Daten nicht manuell ein."
+"Importiertes Genre oder Form, das für Informationen verwendet wird. Geben"
+" Sie die Daten nicht manuell ein."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Harvested"
@@ -5490,7 +5489,7 @@ msgid "Not applicable"
 msgstr "Nicht anwendbar"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5651,12 +5650,12 @@ msgid "classification_musicale_genres"
 msgstr "Musikklassifikation (Genres)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr "Unterteilungen"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr "Unterteilung"
 
@@ -6105,10 +6104,6 @@ msgstr "Gesprochenes Wort"
 msgid "Relationship to an agent associated with the document"
 msgstr "Beziehung zu einem mit dem Dokument verbundenen Bearbeiter"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr "Akteure"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6120,18 +6115,44 @@ msgstr ""
 "Erstellen Sie, wenn möglich, immer einen Link zu IdRef oder GND."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
-msgstr "MEF Akteure"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
+msgstr "Link zu einer Entität"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
-msgstr "Lokale Akteure"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr "Entität (lokal)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr "Link zu einem Akteur"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr "Akteur"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Person"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
+msgstr "MEF ID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
-msgstr "Lokale Entität"
+msgid "Agent (local)"
+msgstr "Akteur (lokal)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:35
@@ -6150,7 +6171,6 @@ msgid "Access Point"
 msgstr "Sucheinstig"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr "Beispiel: Musset, Alfred de, 1810-1857"
 
@@ -6218,13 +6238,6 @@ msgstr "Nur Jahre aufzeichnen."
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
 msgstr "Beispiel: 1989"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Person"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7336,43 +7349,25 @@ msgstr "Öffentliche Anmerkung"
 msgid "Example: Access only from the library"
 msgstr "Beispiel: Zugang nur von der Bibliothek aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr "MEF-Entität"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr "MEF-Link"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr "MEF ID"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr "Werk"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
-msgstr "Konzept"
+msgstr "Thema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr "Zeitraum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr "Quellkatalog, aus dem das Thema importiert wurde."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7385,12 +7380,15 @@ msgstr ""
 "Körperschaft (einschließlich Konferenzen). Erstellen Sie, wenn möglich, "
 "immer einen Link zu IdRef oder GND."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
-msgstr "Genre, Form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
+msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr "Ist diese Entität ein Genre, Form?"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7452,33 +7450,26 @@ msgid "(MARC 655)"
 msgstr "(MARC 655)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
-"Genre oder Form des Dokuments. Erstellen Sie, wenn möglich, immer einen Link "
-"zu IdRef oder GND."
+"Genre oder Form des Dokuments. Erstellen Sie, wenn möglich, immer einen "
+"Link zu IdRef oder GND."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
-msgstr "Lokale Entitäten"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
+msgstr "Link zu einem Genre, Form"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr "MEF-Entitäten"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
-msgstr "Konzept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
+msgstr "Genre, Form (lokal)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
-msgstr "Beispiel: Zermatt (Schweiz, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
+msgstr "Beispiel: Elektronische Zeitschriften"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
 msgid "Source of the subject."
@@ -8269,33 +8260,33 @@ msgstr "Orte"
 msgid "Place"
 msgstr "Ort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "Angaben"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "Angabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 "Angabe zum Ort und Akteur von Veröffentlichung, Herstellung, Vertrieb, "
 "Entstehung."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr "Akteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr "Datum 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
@@ -8304,11 +8295,11 @@ msgstr ""
 " (MARC 008). Ein Freitextdatum (übertragen) kann im Feld \"Angaben\" "
 "hinzugefügt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr "Datum 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
@@ -8318,12 +8309,12 @@ msgstr ""
 "Sortier- und Filtermöglichkeiten verwendet (MARC 008). Ein Freitextdatum "
 "(übertragen) kann im Feld \"Angaben\" hinzugefügt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr "Datum des Originals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr "Datum des Originals im Falle einer Reproduktion."
 
@@ -8520,6 +8511,14 @@ msgstr "Beispiel: Bd. 3"
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
 msgstr "(MARC 6XX)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr "Link zu einem Thema"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
+msgstr "Thema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
 msgid "Summaries"
@@ -8984,10 +8983,6 @@ msgstr "Beispiel: Kopieren nicht erlaubt"
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
 msgstr "Sucheinstieg des Werks"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
-msgstr "Akteur"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46
 msgid "Date of work"
@@ -12397,3 +12392,4 @@ msgstr "Ihre Bibliothek"
 #: rero_ils/theme/templates/security/email/reset_notice.html:26
 msgid "Your password has been successfully reset."
 msgstr "Ihr Passwort wurde erfolgreich zurückgesetzt."
+

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -17,17 +17,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2023-05-11 11:24+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: English <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/en/>\n"
 "Language: en\n"
+"Language-Team: English <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/en/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.18-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -365,8 +364,8 @@ msgstr "Production"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "Place"
 
@@ -4369,8 +4368,8 @@ msgstr "Library URI"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4503,7 +4502,7 @@ msgstr "deleted"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Date"
@@ -4670,7 +4669,7 @@ msgstr "Exchange rate"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4701,13 +4700,13 @@ msgstr "Note"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4922,7 +4921,7 @@ msgstr "Fee"
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5254,6 +5253,8 @@ msgid "Subjects"
 msgstr "Subjects"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Subject"
 
@@ -5289,6 +5290,7 @@ msgstr "Collection ID"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contribution"
 
@@ -5354,9 +5356,6 @@ msgstr "Subject imported from external data"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr "Entities"
 
@@ -5366,8 +5365,9 @@ msgid ""
 "(including conferences), used for information. Do not enter data "
 "manually."
 msgstr ""
-"Imported topic, place, temporal, person, family or corporate body (including "
-"conferences), used for information. Do not enter data manually."
+"Imported topic, place, temporal, person, family or corporate body "
+"(including conferences), used for information. Do not enter data "
+"manually."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:265
 msgid "Genres, forms (imported)"
@@ -5379,8 +5379,7 @@ msgstr "Genre or form imported from external data"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Imported genre or form, used for information. Do not enter data manually."
-msgstr ""
-"Imported genre or form, used for information. Do not enter data manually."
+msgstr "Imported genre or form, used for information. Do not enter data manually."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Harvested"
@@ -5486,7 +5485,7 @@ msgid "Not applicable"
 msgstr "Not applicable"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5641,12 +5640,12 @@ msgid "classification_musicale_genres"
 msgstr "Musical genre classification"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr "Subdivisions"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr "Subdivision"
 
@@ -6091,10 +6090,6 @@ msgstr "spoken word"
 msgid "Relationship to an agent associated with the document"
 msgstr "Relationship to an agent associated with the document"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr "Agents"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6106,18 +6101,44 @@ msgstr ""
 " link to IdRef or GND, if possible."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
-msgstr "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
-msgstr "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr "Entity (local)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr "Link to an agent"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr "Agent"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Person"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
+msgstr "MEF ID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
-msgstr "Local Entity"
+msgid "Agent (local)"
+msgstr "Agent (local)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:35
@@ -6136,7 +6157,6 @@ msgid "Access Point"
 msgstr "Access Point"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr "Example: Musset, Alfred de, 1810-1857"
 
@@ -6204,13 +6224,6 @@ msgstr "Record only years."
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
 msgstr "Example: 1989"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Person"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7319,43 +7332,25 @@ msgstr "Public note"
 msgid "Example: Access only from the library"
 msgstr "Example: Access only from the library"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr "MEF Entity"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr "MEF Link"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr "MEF ID"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr "Work"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
-msgstr "Concept"
+msgstr "Topic"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr "Temporal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr "Source catalog where the subject was imported from."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7364,16 +7359,19 @@ msgid ""
 "corporate body (including conferences). Always create a link to IdRef or "
 "GND, if possible."
 msgstr ""
-"Topic (including genre/form), place, temporal, person, family or corporate "
-"body (including conferences). Always create a link to IdRef or GND, if "
-"possible."
+"Topic (including genre/form), place, temporal, person, family or "
+"corporate body (including conferences). Always create a link to IdRef or "
+"GND, if possible."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr "Genre, form"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr "Is this entity a genre, form ?"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7434,8 +7432,8 @@ msgid "(MARC 655)"
 msgstr "(MARC 655)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
@@ -7443,24 +7441,17 @@ msgstr ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
-msgstr "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
+msgstr "Link to a genre, form"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr "MEF Entities"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
-msgstr "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
+msgstr "Genre, form (local)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
-msgstr "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
+msgstr "Example: Electronic serials"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
 msgid "Source of the subject."
@@ -8245,31 +8236,31 @@ msgstr "Places"
 msgid "Place"
 msgstr "Place"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "Statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "Statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr "Statement of place and agent."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr "agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr "Date 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
@@ -8277,11 +8268,11 @@ msgstr ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \"Statements\""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr "Date 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
@@ -8291,12 +8282,12 @@ msgstr ""
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \"Statements\"."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr "Date of the original"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr "Date of the original in case of a reproduction."
 
@@ -8492,6 +8483,14 @@ msgstr "Example: vol. 3"
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
 msgstr "(MARC 6XX)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr "Link to a subject"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
+msgstr "Topic"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
 msgid "Summaries"
@@ -8955,10 +8954,6 @@ msgstr "Example: Copy not allowed"
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
 msgstr "Work access point"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
-msgstr "Agent"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46
 msgid "Date of work"
@@ -12315,3 +12310,4 @@ msgstr "Your library"
 #: rero_ils/theme/templates/security/email/reset_notice.html:26
 msgid "Your password has been successfully reset."
 msgstr "Your password has been successfully reset."
+

--- a/rero_ils/translations/eo/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/eo/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.0.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2021-06-09 13:00+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: eo\n"
@@ -369,8 +369,8 @@ msgstr ""
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "Loko"
 
@@ -4371,8 +4371,8 @@ msgstr "URI de biblioteko"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4505,7 +4505,7 @@ msgstr "forigita"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Dato"
@@ -4672,7 +4672,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4703,13 +4703,13 @@ msgstr "Noto"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4923,7 +4923,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5240,6 +5240,8 @@ msgid "Subjects"
 msgstr "Temoj"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Temo"
 
@@ -5275,6 +5277,7 @@ msgstr "Identigilo de kolekto"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Kontribuo"
 
@@ -5340,9 +5343,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr ""
 
@@ -5467,7 +5467,7 @@ msgid "Not applicable"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5615,12 +5615,12 @@ msgid "classification_musicale_genres"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr ""
 
@@ -6056,10 +6056,6 @@ msgstr ""
 msgid "Relationship to an agent associated with the document"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6069,17 +6065,43 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Persono"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
+msgid "Agent (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
@@ -6100,7 +6122,6 @@ msgid "Access Point"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr ""
 
@@ -6166,13 +6187,6 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
 msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Persono"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7256,43 +7270,25 @@ msgstr "Publika noto"
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7302,12 +7298,15 @@ msgid ""
 "GND, if possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7363,30 +7362,23 @@ msgid "(MARC 655)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
@@ -8162,53 +8154,53 @@ msgstr "Lokoj"
 msgid "Place"
 msgstr "Loko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr ""
 
@@ -8391,6 +8383,14 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
@@ -8848,10 +8848,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,17 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2023-05-11 11:24+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/es/>\n"
 "Language: es\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/es/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.18-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -360,8 +359,8 @@ msgstr "Producción"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "Lugar"
 
@@ -4364,8 +4363,8 @@ msgstr "URI de la biblioteca"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4498,7 +4497,7 @@ msgstr "suprimido"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Fecha"
@@ -4667,7 +4666,7 @@ msgstr "Tasa de intercambio"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4698,13 +4697,13 @@ msgstr "Nota"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4919,7 +4918,7 @@ msgstr "Tasa"
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5255,6 +5254,8 @@ msgid "Subjects"
 msgstr "Sujetos"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Sujeto"
 
@@ -5290,6 +5291,7 @@ msgstr "Id. de colección"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contribución"
 
@@ -5355,9 +5357,6 @@ msgstr "Sujeto importado a partir de datos externos"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr "Entidades"
 
@@ -5367,9 +5366,9 @@ msgid ""
 "(including conferences), used for information. Do not enter data "
 "manually."
 msgstr ""
-"Sojeto, lugar, temporal, persona, familia u entidad corporativa importado ("
-"incluidas conferencias), utilizado para información. No introduzca datos "
-"manualmente."
+"Tema, lugar, temporal, persona, familia u entidad corporativa importado "
+"(incluidas conferencias), utilizado para información. No introduzca datos"
+" manualmente."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:265
 msgid "Genres, forms (imported)"
@@ -5382,8 +5381,8 @@ msgstr "Género o forma importada de datos externos"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Imported genre or form, used for information. Do not enter data manually."
 msgstr ""
-"Género o forma importada, utilizada para información. No introduzca datos "
-"manualmente."
+"Género o forma importada, utilizada para información. No introduzca datos"
+" manualmente."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Harvested"
@@ -5490,7 +5489,7 @@ msgid "Not applicable"
 msgstr "No aplicable"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5649,12 +5648,12 @@ msgid "classification_musicale_genres"
 msgstr "Clasificación de géneros musicales"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr "Subdivisiones"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr "Subdivisión"
 
@@ -6101,10 +6100,6 @@ msgstr "palabra hablada"
 msgid "Relationship to an agent associated with the document"
 msgstr "Relación a un agente asociado con el documento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr "Agentes"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6116,18 +6111,44 @@ msgstr ""
 " que sea posible, cree un vínculo con el IdRef o el GND."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
-msgstr "Agentes MEF"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
-msgstr "Agentes Locales"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr "Agente"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Persona"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
+msgstr "MEF ID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
-msgstr "Entidad local"
+msgid "Agent (local)"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:35
@@ -6146,7 +6167,6 @@ msgid "Access Point"
 msgstr "Punto de acceso"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr "Ejemplo: Musset, Alfred de, 1810-1857"
 
@@ -6214,13 +6234,6 @@ msgstr "Registre solo años."
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
 msgstr "Ejemplo: 1989"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Persona"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7332,43 +7345,25 @@ msgstr "Nota pública"
 msgid "Example: Access only from the library"
 msgstr "Ejemplo: Acceso sólo desde la biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr "Entidad MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr "Enlace MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr "MEF ID"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr "Obra"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
-msgstr "Concepto"
+msgstr "Tema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr "Período di tiempo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr "Catálogo de origen del sojeto importado."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7377,17 +7372,20 @@ msgid ""
 "corporate body (including conferences). Always create a link to IdRef or "
 "GND, if possible."
 msgstr ""
-"Tema (incluido género/forma), lugar, temporal, persona, familia o entidad "
-"corporativa (incluidas conferencias). Si es posible, cree siempre un enlace "
-"a IdRef o GND."
+"Tema (incluido género, forma), lugar, temporal, persona, familia o "
+"entidad corporativa (incluidas conferencias). Si es posible, cree siempre"
+" un enlace a IdRef o GND."
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
-msgstr "Género, forma"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
-msgstr "¿Es esta entidad un género, forma?"
+msgid "Is this entity a genre, form ?"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
 msgid "Extent"
@@ -7447,33 +7445,26 @@ msgid "(MARC 655)"
 msgstr "(MARC 655)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
-"Género o forma del documento. Si es posible, cree siempre un enlace a IdRef "
-"o GND."
+"Género o forma del documento. Si es posible, cree siempre un enlace a "
+"IdRef o GND."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
-msgstr "Entidades locales"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
+msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr "Entidades MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
-msgstr "Concepto"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
-msgstr "Ejemplo: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
 msgid "Source of the subject."
@@ -8262,31 +8253,31 @@ msgstr "Lugares"
 msgid "Place"
 msgstr "Lugar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "Menciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "Mención"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr "Mención"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr "agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr "Fecha 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
@@ -8295,11 +8286,11 @@ msgstr ""
 " (MARC 008). Se puede añadir una fecha de texto libre (transcripta) en el"
 " campo \\"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr "Fecha 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
@@ -8310,12 +8301,12 @@ msgstr ""
 "(MARC 008). Se puede añadir una fecha de texto libre (transcrita) en el "
 "campo \\"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr "Fecha del original"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr "Fecha del original en el caso de una reproducción."
 
@@ -8511,6 +8502,14 @@ msgstr "Ejemplo: vol. 3"
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
 msgstr "(MARC 6XX)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
+msgstr "Tema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
 msgid "Summaries"
@@ -8976,10 +8975,6 @@ msgstr "Ejemplo: Copia no permitida"
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
 msgstr "Punto de acceso al trabajo"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
-msgstr "Agente"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46
 msgid "Date of work"
@@ -12393,3 +12388,4 @@ msgstr "Su biblioteca"
 #: rero_ils/theme/templates/security/email/reset_notice.html:26
 msgid "Your password has been successfully reset."
 msgstr "Se ha restablecido su contraseña correctamente."
+

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -20,17 +20,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2023-05-11 11:24+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/fr/>\n"
 "Language: fr\n"
+"Language-Team: French <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/fr/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.18-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -368,8 +367,8 @@ msgstr "Production"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "Lieu"
 
@@ -4372,8 +4371,8 @@ msgstr "URI de la bibliothèque"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4506,7 +4505,7 @@ msgstr "supprimé"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Date"
@@ -4673,7 +4672,7 @@ msgstr "Taux de change"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4704,13 +4703,13 @@ msgstr "Note"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4925,7 +4924,7 @@ msgstr "Frais"
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5257,6 +5256,8 @@ msgid "Subjects"
 msgstr "Sujets"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Sujet"
 
@@ -5292,6 +5293,7 @@ msgstr "Identifiant de collection"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contribution"
 
@@ -5357,9 +5359,6 @@ msgstr "Sujet importé à partir de données externes"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr "Entités"
 
@@ -5369,8 +5368,8 @@ msgid ""
 "(including conferences), used for information. Do not enter data "
 "manually."
 msgstr ""
-"Motif, sujet, lieu, période, personne, famille ou personne morale (y compris "
-"les conférences) importés, utilisé à des fins d'information. Ne pas saisir "
+"Thème, lieu, période, personne, famille ou personne morale (y compris les"
+" conférences) importés, utilisé à des fins d'information. Ne pas saisir "
 "de données manuellement."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:265
@@ -5493,7 +5492,7 @@ msgid "Not applicable"
 msgstr "Non applicable"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5651,12 +5650,12 @@ msgid "classification_musicale_genres"
 msgstr "Classification des genres musicaux"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr "Subdivisions"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr "Subdivision"
 
@@ -6103,10 +6102,6 @@ msgstr "parole énoncée"
 msgid "Relationship to an agent associated with the document"
 msgstr "Relation entre un agent et un document"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr "Agents"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6118,18 +6113,44 @@ msgstr ""
 " IdRef ou GND, dès que c'est possible."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
-msgstr "Agents MEF"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
+msgstr "Lien à une entité"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
-msgstr "Agents locaux"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr "Entité (local)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr "Lien à un agent"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr "Agent"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Personne"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
+msgstr "MEF ID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
-msgstr "Entité locale"
+msgid "Agent (local)"
+msgstr "Agent (local)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:35
@@ -6148,7 +6169,6 @@ msgid "Access Point"
 msgstr "Point d'accès"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr "Exemple : Musset, Alfred de, 1810-1857"
 
@@ -6216,13 +6236,6 @@ msgstr "Enregistrer uniquement l'année."
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
 msgstr "Exemple : 1989"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Personne"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7335,43 +7348,25 @@ msgstr "Note publique"
 msgid "Example: Access only from the library"
 msgstr "Exemple : Accès uniquement depuis la bibliothèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr "Entité MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr "Lien MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr "MEF ID"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr "Œuvre"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
-msgstr "Concept"
+msgstr "Thème"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr "Laps de temps"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr "Catalogue source d'où le sujet a été importé."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7380,16 +7375,19 @@ msgid ""
 "corporate body (including conferences). Always create a link to IdRef or "
 "GND, if possible."
 msgstr ""
-"Motif, sujet (y compris genre/forme), lieu, époque, personne, famille ou "
+"Thème (y compris genre, forme), lieu, époque, personne, famille ou "
 "personne morale (y compris les conférences). Créez toujours un lien vers "
 "IdRef ou GND, si possible."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr "Genre, forme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr "Cette entité est-elle un genre, forme ?"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7451,8 +7449,8 @@ msgid "(MARC 655)"
 msgstr "(MARC 655)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
@@ -7460,24 +7458,17 @@ msgstr ""
 "Genre ou forme du document. Créez toujours un lien vers IdRef ou GND, si "
 "possible."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
-msgstr "Entités locales"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
+msgstr "Lien à un genre, forme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr "Entités MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
-msgstr "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
+msgstr "Genre, forme (local)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
-msgstr "Exemple : Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
+msgstr "Exemple: Périodiques électroniques"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
 msgid "Source of the subject."
@@ -8267,31 +8258,31 @@ msgstr "Lieux"
 msgid "Place"
 msgstr "Lieu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "Mentions"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "Mention"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr "Mention"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr "agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr "Date 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
@@ -8300,11 +8291,11 @@ msgstr ""
 " Une date en texte libre (transcrite) peut être ajoutée dans le champ « "
 "Mentions »."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr "Date 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
@@ -8314,12 +8305,12 @@ msgstr ""
 "utilisée pour les options de tri et de filtre (MARC 008). Une date en "
 "texte libre (transcrite) peut être ajoutée dans le champ « Mentions »."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr "Date de l'original"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr "Date de l'original dans le cas d'une reproduction."
 
@@ -8518,6 +8509,14 @@ msgstr "Exemple : vol. 3"
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
 msgstr "(MARC 6XX)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr "Lien à un sujet"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
+msgstr "Thème"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
 msgid "Summaries"
@@ -8981,10 +8980,6 @@ msgstr "Exemple : Copie interdite"
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
 msgstr "Point d'accès de l'œuvre"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
-msgstr "Agent"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46
 msgid "Date of work"
@@ -12406,3 +12401,4 @@ msgstr "Votre bibliothèque"
 #: rero_ils/theme/templates/security/email/reset_notice.html:26
 msgid "Your password has been successfully reset."
 msgstr "Votre mot de passe a été réinitialisé avec succès."
+

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,17 +18,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2023-05-11 11:24+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/it/>\n"
 "Language: it\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/it/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.18-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -366,8 +365,8 @@ msgstr "Produzione"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "Luogo"
 
@@ -4370,8 +4369,8 @@ msgstr "URI della biblioteca"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4504,7 +4503,7 @@ msgstr "eliminato"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Data"
@@ -4671,7 +4670,7 @@ msgstr "Tasso di cambio"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4702,13 +4701,13 @@ msgstr "Nota"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4921,7 +4920,7 @@ msgstr "Tassa"
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5253,6 +5252,8 @@ msgid "Subjects"
 msgstr "Soggetti"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Soggetto"
 
@@ -5288,6 +5289,7 @@ msgstr "ID della collezione"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contributo"
 
@@ -5353,9 +5355,6 @@ msgstr "Soggetto importato da dati esterni"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr "Entità"
 
@@ -5365,9 +5364,9 @@ msgid ""
 "(including conferences), used for information. Do not enter data "
 "manually."
 msgstr ""
-"Concetto, luogo, arco di tempo, persona, famiglia o ente (comprese le "
-"conferenze) importati, utilizzato per le informazioni. Non inserire i dati "
-"manualmente."
+"Tema, luogo, arco di tempo, persona, famiglia o ente (comprese le "
+"conferenze) importati, utilizzato per le informazioni. Non inserire i "
+"dati manualmente."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:265
 msgid "Genres, forms (imported)"
@@ -5380,8 +5379,8 @@ msgstr "Genere o forma importati da dati esterni"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Imported genre or form, used for information. Do not enter data manually."
 msgstr ""
-"Genere o forma importati, utilizzati a scopo informativo. Non immettere i "
-"dati manualmente."
+"Genere o forma importati, utilizzati a scopo informativo. Non immettere i"
+" dati manualmente."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Harvested"
@@ -5491,7 +5490,7 @@ msgid "Not applicable"
 msgstr "Non applicabile"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5647,12 +5646,12 @@ msgid "classification_musicale_genres"
 msgstr "Classificazione musicale (generi)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr "Suddivisioni"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr "Suddivisione"
 
@@ -6099,10 +6098,6 @@ msgstr "parlato"
 msgid "Relationship to an agent associated with the document"
 msgstr "Relazione con un agente associato al documento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr "Agenti"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6114,18 +6109,44 @@ msgstr ""
 " IdRef o GND, se possibile."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
-msgstr "Agenti MEF"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
+msgstr "Link a un'entità"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
-msgstr "Agenti locali"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr "Entità (locale)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr "Link a un agente"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr "Agente"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Persona"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
+msgstr "MEF ID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
-msgstr "Entità locale"
+msgid "Agent (local)"
+msgstr "Agente (locale)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:35
@@ -6144,7 +6165,6 @@ msgid "Access Point"
 msgstr "Punto di accesso"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr "Esempio: Musset, Alfred de, 1810-1857"
 
@@ -6212,13 +6232,6 @@ msgstr "Registrare solo l'anno."
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
 msgstr "Esempio: 1989"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Persona"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7328,43 +7341,25 @@ msgstr "Nota pubblica"
 msgid "Example: Access only from the library"
 msgstr "Esempio: Accesso solo dalla biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr "Entità MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr "MEF Link"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr "MEF ID"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr "Opera"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
-msgstr "Concetto"
+msgstr "Tema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr "Arco di tempo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr "Catalogo di origine da cui è stato importato il soggetto."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7373,15 +7368,18 @@ msgid ""
 "corporate body (including conferences). Always create a link to IdRef or "
 "GND, if possible."
 msgstr ""
-"Concetto, luogo, arco di tempo, persona, famiglia o ente (comprese le "
+"Tema, luogo, arco di tempo, persona, famiglia o ente (comprese le "
 "conferenze). Creare sempre un collegamento a IdRef o GND, se possibile."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr "Genere, forma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr "Questa entità è un genere, forma?"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7442,33 +7440,26 @@ msgid "(MARC 655)"
 msgstr "(MARC 655)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
-"Genere o forma del documento. Creare sempre un collegamento a IdRef o GND, "
-"se possibile."
+"Genere o forma del documento. Creare sempre un collegamento a IdRef o "
+"GND, se possibile."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
-msgstr "Entità locali"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
+msgstr "Link a un genere, forma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr "Entità MEF"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
-msgstr "Concetto"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
+msgstr "Genere, forma (locale)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
-msgstr "Esempio: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
+msgstr "Esempio: Seriali elettronici"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
 msgid "Source of the subject."
@@ -8258,31 +8249,31 @@ msgstr "Luoghi"
 msgid "Place"
 msgstr "Luogo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "Formulazioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "Formulazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr "Formulazione di luogo e agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr "agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "Etichette"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr "Data 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
@@ -8291,11 +8282,11 @@ msgstr ""
 " (MARC 008). Una data di testo libero (trascritta) può essere aggiunta "
 "nel campo \"Formulazioni\"."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr "Data 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
@@ -8305,12 +8296,12 @@ msgstr ""
 "l'ordinamento e le opzioni di filtraggio (MARC 008). Una data di testo "
 "libero (trascritta) può essere aggiunta nel campo \"Formulazioni\"."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr "Data dell'originale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr "Data dell'originale nel caso di una riproduzione."
 
@@ -8507,6 +8498,14 @@ msgstr "Esempio: vol. 3"
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
 msgstr "(MARC 6XX)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr "Link a un sogetto"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
+msgstr "Tema"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
 msgid "Summaries"
@@ -8971,10 +8970,6 @@ msgstr "Esempio: Copia non consentita"
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
 msgstr "Punto d'accesso all'opera"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
-msgstr "Agente"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46
 msgid "Date of work"
@@ -12386,3 +12381,4 @@ msgstr "La tua biblioteca"
 #: rero_ils/theme/templates/security/email/reset_notice.html:26
 msgid "Your password has been successfully reset."
 msgstr "La tua password è stata reimposta con successo."
+

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.16.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -352,8 +352,8 @@ msgstr ""
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr ""
 
@@ -4352,8 +4352,8 @@ msgstr ""
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4486,7 +4486,7 @@ msgstr ""
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4684,13 +4684,13 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4903,7 +4903,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5220,6 +5220,8 @@ msgid "Subjects"
 msgstr ""
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr ""
 
@@ -5255,6 +5257,7 @@ msgstr ""
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr ""
 
@@ -5320,9 +5323,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr ""
 
@@ -5447,7 +5447,7 @@ msgid "Not applicable"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5595,12 +5595,12 @@ msgid "classification_musicale_genres"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr ""
 
@@ -6036,10 +6036,6 @@ msgstr ""
 msgid "Relationship to an agent associated with the document"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6049,17 +6045,43 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
+msgid "Agent (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
@@ -6079,7 +6101,6 @@ msgid "Access Point"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr ""
 
@@ -6144,13 +6165,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
@@ -7235,43 +7249,25 @@ msgstr ""
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7281,12 +7277,15 @@ msgid ""
 "GND, if possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7342,30 +7341,23 @@ msgid "(MARC 655)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
@@ -8141,53 +8133,53 @@ msgstr ""
 msgid "Place"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr ""
 
@@ -8370,6 +8362,14 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
@@ -8824,10 +8824,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2022-03-10 17:56+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: nl\n"
@@ -392,8 +392,8 @@ msgstr "Productie"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr "bf:Place"
 
@@ -4408,8 +4408,8 @@ msgstr "URI van de bibliotheek"
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4544,7 +4544,7 @@ msgstr "Verwijderd"
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr "Datum"
@@ -4717,7 +4717,7 @@ msgstr "Wisselkoers"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4748,13 +4748,13 @@ msgstr "Nota"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4971,7 +4971,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5305,6 +5305,8 @@ msgid "Subjects"
 msgstr "Onderwerpen"
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr "Onderwerp"
 
@@ -5342,6 +5344,7 @@ msgstr "Collectie ID"
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 #, fuzzy
 msgid "Contribution"
 msgstr "Distributie"
@@ -5408,9 +5411,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr ""
 
@@ -5541,7 +5541,7 @@ msgid "Not applicable"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5689,12 +5689,12 @@ msgid "classification_musicale_genres"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr ""
 
@@ -6131,11 +6131,6 @@ msgstr "gesproken woord"
 msgid "Relationship to an agent associated with the document"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-#, fuzzy
-msgid "Agents"
-msgstr "Agent"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6145,17 +6140,43 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr "Agent"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr "Persoon"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
+msgid "Agent (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
@@ -6176,7 +6197,6 @@ msgid "Access Point"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr ""
 
@@ -6247,13 +6267,6 @@ msgstr ""
 #, fuzzy
 msgid "Example: 1989"
 msgstr "Voorbeeld: 1985-12-29"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
-msgstr "Persoon"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
 #: rero_ils/modules/entities/templates/rero_ils/_entity_by_source_data.html:23
@@ -7430,43 +7443,25 @@ msgstr "Openvare opmerking"
 msgid "Example: Access only from the library"
 msgstr "Voorbeeld: Toegang alleen vanuit de bibliotheek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7476,12 +7471,15 @@ msgid ""
 "GND, if possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7539,30 +7537,23 @@ msgid "(MARC 655)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
@@ -8383,56 +8374,56 @@ msgstr "Plaatsen"
 msgid "Place"
 msgstr "Plaats"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 #, fuzzy
 msgid "bf:Agent"
 msgstr "bf:Place"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 #, fuzzy
 msgid "Date 1"
 msgstr "Lening datum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 #, fuzzy
 msgid "Date 2"
 msgstr "Lening datum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr ""
 
@@ -8615,6 +8606,14 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
@@ -9093,10 +9092,6 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
 msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
-msgstr "Agent"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46
 msgid "Date of work"

--- a/rero_ils/translations/ru/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ru/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2022-01-21 16:53+0000\n"
 "Last-Translator: lushnikov3d37b9a0863842c1 <pavel.lushnikov@gmail.com>\n"
 "Language: ru\n"
@@ -367,8 +367,8 @@ msgstr ""
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 msgid "bf:Place"
 msgstr ""
 
@@ -4369,8 +4369,8 @@ msgstr ""
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4503,7 +4503,7 @@ msgstr ""
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr ""
@@ -4670,7 +4670,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4701,13 +4701,13 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4920,7 +4920,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5237,6 +5237,8 @@ msgid "Subjects"
 msgstr ""
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr ""
 
@@ -5272,6 +5274,7 @@ msgstr ""
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr ""
 
@@ -5337,9 +5340,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr ""
 
@@ -5464,7 +5464,7 @@ msgid "Not applicable"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5612,12 +5612,12 @@ msgid "classification_musicale_genres"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr ""
 
@@ -6053,10 +6053,6 @@ msgstr ""
 msgid "Relationship to an agent associated with the document"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6066,17 +6062,43 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+msgid "MEF ID"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
+msgid "Agent (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
@@ -6097,7 +6119,6 @@ msgid "Access Point"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr ""
 
@@ -6162,13 +6183,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
@@ -7253,43 +7267,25 @@ msgstr ""
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-msgid "MEF ID"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7299,12 +7295,15 @@ msgid ""
 "GND, if possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7360,30 +7359,23 @@ msgid "(MARC 655)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
@@ -8159,53 +8151,53 @@ msgstr ""
 msgid "Place"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr ""
 
@@ -8388,6 +8380,14 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
@@ -8842,10 +8842,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46

--- a/rero_ils/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.5.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-05-11 11:51+0200\n"
+"POT-Creation-Date: 2023-05-23 16:29+0200\n"
 "PO-Revision-Date: 2021-12-25 09:52+0000\n"
 "Last-Translator: Sam Tse <codefzer@gmail.com>\n"
 "Language: zh_Hant\n"
@@ -373,8 +373,8 @@ msgstr "生產"
 
 #: rero_ils/manual_translations.txt:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:51
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:150
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:151
 #, fuzzy
 msgid "bf:Place"
 msgstr "地點"
@@ -4387,8 +4387,8 @@ msgstr ""
 #: rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json:217
 #: rero_ils/modules/acquisition/budgets/jsonschemas/budgets/budget-v0.0.1.json:85
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:259
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:29
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
 #: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:26
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:90
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:216
@@ -4521,7 +4521,7 @@ msgstr ""
 #: rero_ils/modules/acquisition/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:39
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:28
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:158
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:40
 msgid "Date"
 msgstr ""
@@ -4688,7 +4688,7 @@ msgstr "匯率"
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:163
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:46
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:9
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:195
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:196
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:592
 #: rero_ils/modules/ill_requests/jsonschemas/ill_requests/ill_request-v0.0.1.json:298
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:527
@@ -4719,13 +4719,13 @@ msgstr "備注"
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:21
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:18
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:160
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:159
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:17
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:24
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_language-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:29
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:139
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:140
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:18
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:25
 #: rero_ils/modules/documents/jsonschemas/documents/document_temporal_coverage-v0.0.1.json:68
@@ -4939,7 +4939,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_document_relation-v0.0.1.json:243
 #: rero_ils/modules/documents/jsonschemas/documents/document_frequency-v0.0.1.json:20
 #: rero_ils/modules/documents/jsonschemas/documents/document_note-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:172
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:173
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:62
 #: rero_ils/modules/documents/jsonschemas/documents/document_scale_cartographic-v0.0.1.json:101
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:20
@@ -5258,6 +5258,8 @@ msgid "Subjects"
 msgstr ""
 
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
 msgid "Subject"
 msgstr ""
 
@@ -5293,6 +5295,7 @@ msgstr ""
 
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:61
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr ""
 
@@ -5358,9 +5361,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:271
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 msgid "Entities"
 msgstr ""
 
@@ -5485,7 +5485,7 @@ msgid "Not applicable"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_admin_metadata-v0.0.1.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:76
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:41
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:187
 #: rero_ils/modules/documents/jsonschemas/documents/document_identifier-v0.0.1.json:79
@@ -5633,12 +5633,12 @@ msgid "classification_musicale_genres"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:422
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:87
 msgid "Subdivisions"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:426
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:103
 msgid "Subdivision"
 msgstr ""
 
@@ -6075,10 +6075,6 @@ msgstr ""
 msgid "Relationship to an agent associated with the document"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
-msgid "Agents"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:37
@@ -6088,17 +6084,44 @@ msgid ""
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
-msgid "MEF Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
+msgid "Link to an entity"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
-msgid "Local Agents"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
+msgid "Entity (local)"
 msgstr ""
 
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
+msgid "Link to an agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
+msgid "Agent"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:25
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:29
+#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
+msgid "Person"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
+#, fuzzy
+msgid "MEF ID"
+msgstr "med"
+
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
-msgid "Local Entity"
+msgid "Agent (local)"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:28
@@ -6119,7 +6142,6 @@ msgid "Access Point"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_local-v0.0.1.json:44
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:67
 msgid "Example: Musset, Alfred de, 1810-1857"
 msgstr ""
 
@@ -6184,13 +6206,6 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_organisation-v0.0.1.json:103
 msgid "Example: 1989"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
-#: rero_ils/modules/entities/templates/rero_ils/detailed_view_entity.html:28
-msgid "Person"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:46
@@ -7340,44 +7355,25 @@ msgstr ""
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
-msgid "MEF Entity"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:13
-msgid "MEF Link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_link-v0.0.1.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:37
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:45
-#, fuzzy
-msgid "MEF ID"
-msgstr "med"
-
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:43
 msgid "bf:Work"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:174
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:173
 msgid "bf:Topic"
 msgstr "主题"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:55
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:182
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:181
 msgid "bf:Temporal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:78
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:77
 msgid "Source catalog where the subject was imported from."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:94
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:93
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:10
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
@@ -7387,12 +7383,15 @@ msgid ""
 "GND, if possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
-msgid "Genre / form"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:13
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
+msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:123
-msgid "Is this entity is a genre/form ?"
+#: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:122
+msgid "Is this entity a genre, form ?"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_extent-v0.0.1.json:3
@@ -7449,30 +7448,23 @@ msgid "(MARC 655)"
 msgstr "(MARC 655)"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:10
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:14
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:32
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:15
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Genre or form of the document. Always create a link to IdRef or GND, if "
 "possible."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:13
-msgid "Local Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
+msgid "Link to a genre, form"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:30
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:30
-msgid "MEF Entities"
+#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:2
+msgid "Genre, form (local)"
 msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:25
-#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:33
-msgid "Concept"
-msgstr "概念"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:34
-msgid "Example: Zermatt (Suisse, VS) - 19e s. (fin) - [carte postale]"
+msgid "Example: Electronic serials"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_local-v0.0.1.json:42
@@ -8248,53 +8240,53 @@ msgstr ""
 msgid "Place"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:122
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:123
 msgid "Statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:127
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
 msgid "Statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:128
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:129
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:155
 msgid "bf:Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:168
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:169
 msgid "Labels"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
 msgid "Date 1"
 msgstr "日期 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:207
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:208
 msgid ""
 "Normalised date used for sorting and filtering options (MARC 008). A free"
 " text date (transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
 msgid "Date 2"
 msgstr "日期 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:223
 msgid ""
 "Normalised end date if the provision activity covers more than one year, "
 "and used for sorting and filtering options (MARC 008). A free text date "
 "(transcripted) can be added in the field \\"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:351
 msgid "Date of the original"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document_provision_activity-v0.0.1.json:236
 msgid "Date of the original in case of a reproduction."
 msgstr ""
 
@@ -8478,6 +8470,14 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:4
 msgid "(MARC 6XX)"
 msgstr "(MARC 6XX)"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
+msgid "Link to a subject"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:25
+msgid "Topic"
+msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:3
 msgid "Summaries"
@@ -8939,10 +8939,6 @@ msgstr "例如：不允許複印"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:3
 msgid "Work access point"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:29
-msgid "Agent"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_work_access_point-v0.0.1.json:46


### PR DESCRIPTION
* Renamed subfields titles to be clearer for the user. Removed mentions of MEF in the editor.
* Set the default oneOf value to "link entites" for all concerned fields as it is the more frequent case.
* Corrected some placeholder examples.
* Renamed link contribution jsonschema for accuracy.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
