### PR TITLE
ui: fix subjects in public document detailed views

### DIFF
--- a/rero_ils/es_templates/v7/record.json
+++ b/rero_ils/es_templates/v7/record.json
@@ -133,18 +133,6 @@
             "german_normalization"
           ]
         },
-        "autocomplete": {
-          "type": "custom",
-          "tokenizer": "standard",
-          "filter": [
-            "lowercase",
-            "icu_normalizer",
-            "icu_folding",
-            "french_elision",
-            "italian_elision",
-            "edge_ngram_filter"
-          ]
-        },
         "identifier-analyzer": {
           "tokenizer": "keyword",
           "char_filter": [

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -2,6 +2,18 @@
   "settings": {
     "analysis": {
       "analyzer": {
+        "autocomplete": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "icu_normalizer",
+            "icu_folding",
+            "french_elision",
+            "italian_elision",
+            "edge_ngram_filter"
+          ]
+        },
         "search_autocomplete": {
           "type": "custom",
           "tokenizer": "standard",

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -66,7 +66,7 @@
              {% if 'entity' in genreForm %}
                <li class="figure-caption">
                  <i class="fa fa-tag mr-1"></i>
-                 {{ genreForm.entity | entity_label(language=current_i18n.language) }}
+                 {{ genreForm.entity | doc_entity_label(language=current_i18n.language) }}
                </li>
              {% endif %}
            {% endfor %}
@@ -230,7 +230,7 @@
       {% for subject in record.subjects %}
         <span class="badge badge-secondary my-0" title="{{ _(subject.type) }}">
           {% if 'entity' in subject %}
-            <i class="fa fa-tag"></i> {{ subject.entity | entity_label(language=current_i18n.language) }}
+            <i class="fa fa-tag"></i> {{ subject.entity | doc_entity_label(language=current_i18n.language) }}
           {% endif %}
         </span>
       {% endfor %}

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -286,7 +286,7 @@ def contribution_format(contributions, language, viewcode, with_roles=False):
 
 
 @blueprint.app_template_filter()
-def entity_label(entity, language=None, part_separator=' - ') -> str:
+def doc_entity_label(entity, language=None, part_separator=' - ') -> str:
     """Format an entity according to the available keys.
 
     :param entity: the entity to analyze.
@@ -305,7 +305,8 @@ def entity_label(entity, language=None, part_separator=' - ') -> str:
 
     for subdivision in entity.get('subdivisions', []):
         if sub_entity := subdivision.get('entity'):
-            parts.append(entity_label(sub_entity, language, part_separator))
+            parts.append(
+                doc_entity_label(sub_entity, language, part_separator))
 
     return part_separator.join(filter(None, parts))
 

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -329,3 +329,22 @@ def test_documents_search(
     res = client.get(list_url)
     hits = get_json(res)['hits']
     assert hits
+
+    # test wildcard query with boolean sub property
+    # See: elasticsearch query_string lenient property
+    #      for more details
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q=r'autocomplete_title:travailleu'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total']['value'] != 0
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q=r'autocomplete_title:travailleur'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total']['value'] != 0

--- a/tests/ui/documents/test_documents_filter.py
+++ b/tests/ui/documents/test_documents_filter.py
@@ -17,7 +17,7 @@
 
 """Document filters tests."""
 from rero_ils.modules.documents.views import cartographic_attributes, \
-    contribution_format, entity_label, identified_by, main_title_text, \
+    contribution_format, doc_entity_label, identified_by, main_title_text, \
     note_general, notes_except_general, part_of_format, provision_activity, \
     provision_activity_not_publication, provision_activity_original_date, \
     provision_activity_publication, title_variants, work_access_point
@@ -547,7 +547,7 @@ def test_main_title_text():
     assert extract[0].get('_text') is not None
 
 
-def test_entity_label_filter(entity_person):
+def test_doc_entity_label_filter(entity_person):
     """Test entity label filter."""
     data = {
         'entity': {
@@ -555,8 +555,8 @@ def test_entity_label_filter(entity_person):
             'type': EntityType.TOPIC
         }
     }
-    assert entity_label(data['entity'], None) == 'subject topic'
-    assert entity_label(data['entity'], 'fr') == 'subject topic'
+    assert doc_entity_label(data['entity'], None) == 'subject topic'
+    assert doc_entity_label(data['entity'], 'fr') == 'subject topic'
 
     data = {
         'entity': {
@@ -565,9 +565,9 @@ def test_entity_label_filter(entity_person):
             'type': EntityType.TOPIC
         }
     }
-    assert entity_label(data['entity'], 'fr') == 'topic_fr'
-    assert entity_label(data['entity'], 'en') == 'topic_default'
-    assert entity_label(data['entity'], None) == 'topic_default'
+    assert doc_entity_label(data['entity'], 'fr') == 'topic_fr'
+    assert doc_entity_label(data['entity'], 'en') == 'topic_default'
+    assert doc_entity_label(data['entity'], None) == 'topic_default'
 
     data = {
         'entity': {
@@ -581,10 +581,12 @@ def test_entity_label_filter(entity_person):
             'type': EntityType.TOPIC
         }
     }
-    assert entity_label(data['entity'], 'fr') == 'topic_default - sub_fr'
-    assert entity_label(data['entity'], 'en') == 'topic_default - sub_default'
-    assert entity_label(data['entity'], None) == 'topic_default - sub_default'
+    assert doc_entity_label(data['entity'], 'fr') == 'topic_default - sub_fr'
+    assert doc_entity_label(
+        data['entity'], 'en') == 'topic_default - sub_default'
+    assert doc_entity_label(
+        data['entity'], None) == 'topic_default - sub_default'
 
     data = {'entity': {'pid': entity_person.pid}}
-    assert entity_label(data['entity'], 'fr') == 'Loy, Georg, 1885-19..'
-    assert entity_label(data['entity'], 'de') == 'Loy, Georg, 1885'
+    assert doc_entity_label(data['entity'], 'fr') == 'Loy, Georg, 1885-19..'
+    assert doc_entity_label(data['entity'], 'de') == 'Loy, Georg, 1885'


### PR DESCRIPTION
* Renames document entity label jinja filter to avoid entity function
  name conflict.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
