### PR TITLE
records: fix related resources indexes deletion problem

### DIFF
--- a/rero_ils/modules/acquisition/acq_orders/extensions.py
+++ b/rero_ils/modules/acquisition/acq_orders/extensions.py
@@ -51,13 +51,14 @@ class AcquisitionOrderExtension(RecordExtension):
         """Called before a record is deleted.
 
         :param record: the record metadata.
+        :param force: force the deleting of the record.
         """
         # For pending orders, we are allowed to delete all of its
         # line orders without further checks.
         # there is no need to check if it is a pending order or not because
         # the can_delete is already execute in the method self.delete
         for line in record.get_order_lines():
-            line.delete()
+            line.delete(force=force, delindex=True)
 
 
 class AcquisitionOrderCompleteDataExtension(RecordExtension):

--- a/rero_ils/modules/local_fields/extensions.py
+++ b/rero_ils/modules/local_fields/extensions.py
@@ -36,4 +36,4 @@ class DeleteRelatedLocalFieldExtension(RecordExtension):
         """
         from .api import LocalField
         for local_field in LocalField.get_local_fields(record):
-            local_field.delete(force=force)
+            local_field.delete(force=force, delindex=True)

--- a/tests/ui/local_fields/test_local_fields_api.py
+++ b/tests/ui/local_fields/test_local_fields_api.py
@@ -67,14 +67,18 @@ def test_local_fields(
     #   - Ensure this LocalField is related to the document, but it's not a
     #     cause to block the document suppression
     #   - Delete the document and ensure the LocalField is now deleted.
+    #   - Ensure the LocalField index is coherent
     assert 'local_fields' not in document.get_links_to_me()
     lofi_data.pop('pid', None)
     local_field = LocalField.create(lofi_data, dbcommit=True, reindex=True)
     assert document.get_links_to_me()['local_fields'] == 1
     assert 'local_fields' not in \
            document.reasons_not_to_delete().get('links', {})
+    parent_pid = document.pid
     document.delete(delindex=True)
     assert not LocalField.get_record_by_pid(local_field.pid)
+    fields = LocalField.get_local_fields_by_id('doc', parent_pid)
+    assert len(list(fields)) == 0
 
     # TEST#4 :: Same as previous but for item.
     item = Item.create(item_lib_martigny_data, dbcommit=True, reindex=True)
@@ -86,8 +90,11 @@ def test_local_fields(
     assert item.get_links_to_me()['local_fields'] == 1
     assert 'local_fields' not in \
            item.reasons_not_to_delete().get('links', {})
+    parent_pid = item.pid
     item.delete(delindex=True)
     assert not LocalField.get_record_by_pid(local_field.pid)
+    fields = LocalField.get_local_fields_by_id('item', parent_pid)
+    assert len(list(fields)) == 0
 
 
 def test_local_fields_extended_validation(


### PR DESCRIPTION
When using the `pre_delete` hook to delete some related records, we need to ensure than corresponding indexes are cleaned too.

