### PR TITLE
fees: add invoice payment method

### DIFF
--- a/rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json
+++ b/rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json
@@ -186,6 +186,7 @@
         "subtype": {
           "enum": [
             "cash",
+            "invoice",
             "debit_card",
             "credit_card",
             "paypal"
@@ -195,6 +196,10 @@
               {
                 "label": "cash",
                 "value": "cash"
+              },
+              {
+                "label": "invoice",
+                "value": "invoice"
               },
               {
                 "label": "debit_card",


### PR DESCRIPTION
* A librarian can select an invoice payment method so that they can keep a trace of fees that have been externally invoiced.
* Requires patron_transaction_events update mapping

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* https://github.com/rero/rero-ils-ui/pull/997
