### PR TITLE
Notification: send recall on checkout

### DIFF
--- a/rero_ils/modules/notifications/templates/email/recall/fre.txt
+++ b/rero_ils/modules/notifications/templates/email/recall/fre.txt
@@ -2,7 +2,8 @@ Document non prolongeable
 {%- include('email/_patron_address.txt') %}
 Chère lectrice, cher lecteur,
 
-Le document que vous avez emprunté vient d'être réservé par une autre personne. D'ores et déjà nous vous signalons que nous ne pourrons pas le prolonger et vous demandons de bien vouloir le restituer au plus tard à la date d'échéance.
+Le document que vous avez emprunté a été réservé par une autre personne.
+D'ores et déjà nous vous signalons que nous ne pourrons pas le prolonger et vous demandons de bien vouloir le restituer au plus tard à la date d'échéance.
 
 {%- for loan in loans %}
 


### PR DESCRIPTION
* When a checkout is operated on an item with pending requests (other than current patron) a recall notification should be sent to user.
* Closes rero/rero-ils#2673.
