### PR TITLE
billing stats: process only validated ill_requests

### DIFF
--- a/rero_ils/modules/stats/api.py
+++ b/rero_ils/modules/stats/api.py
@@ -153,11 +153,9 @@ class StatsForPricing:
                 'number_of_renewals':
                     self.number_of_circ_operations(
                         lib.pid, ItemCirculationAction.EXTEND),
-                'number_of_satisfied_ill_request':
-                    self.number_of_satisfied_ill_request(
-                        lib.pid,
-                        [ILLRequestStatus.PENDING, ILLRequestStatus.VALIDATED,
-                         ILLRequestStatus.CLOSED]),
+                'number_of_validated_ill_requests':
+                    self.number_of_ill_requests_operations(
+                        lib.pid, [ILLRequestStatus.VALIDATED]),
                 'number_of_items': self.number_of_items(lib.pid),
                 'number_of_new_items': self.number_of_new_items(lib.pid),
                 'number_of_deleted_items': self.number_of_deleted_items(
@@ -261,8 +259,9 @@ class StatsForPricing:
             .filter('term', loan__item__library_pid=library_pid)\
             .count()
 
-    def number_of_satisfied_ill_request(self, library_pid, status):
-        """Number of ILL requests created during the specified timeframe.
+    def number_of_ill_requests_operations(self, library_pid, status):
+        """Number of ILL requests creation or update operations during the
+        specified timeframe.
 
         :param library_pid: string - the library to filter with
         :param status: list of status to filter with
@@ -271,7 +270,7 @@ class StatsForPricing:
         """
         query = RecordsSearch(index=LoanOperationLog.index_name)\
             .filter('term', record__type='illr')\
-            .filter('term', operation='create')\
+            .filter('terms', operation=['update', 'create'])\
             .filter('range', _created=self.date_range)\
             .filter('term', ill_request__library_pid=library_pid)\
             .filter('terms', ill_request__status=status)

--- a/tests/api/stats/test_stats_rest.py
+++ b/tests/api/stats/test_stats_rest.py
@@ -54,9 +54,9 @@ def test_stats_get(client, stats, csv_header):
         'number_of_new_items,number_of_new_patrons,'
         'number_of_order_lines,number_of_patrons,'
         'number_of_renewals,number_of_requests,'
-        'number_of_satisfied_ill_request\r\n'
+        'number_of_validated_ill_requests\r\n'
         'lib3,Library of Fully,0,0,0,0,1,1,0,2,1,1,0,1,0,0,0\r\n'
-        'lib1,Library of Martigny-ville,0,0,0,0,1,1,0,2,1,1,0,1,0,0,1\r\n'
+        'lib1,Library of Martigny-ville,0,0,0,0,1,1,0,2,1,1,0,1,0,0,0\r\n'
         'lib4,Library of Sion,0,0,0,0,1,1,0,1,1,0,0,0,0,0,0\r\n'
     )
 


### PR DESCRIPTION
- Fixes ill request stats processing for billing so only validated ill requests are counted.
- The stats collector counts all ill_requests that were created or updated.
- If a request changes to `validated` multiple times it will be counted multiple times.
- Adds no unit tests; they will be added later for the full module.
- Closes #3359.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
