### PR TITLE
templates: add translation for spanish

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -172,6 +172,7 @@ I18N_LANGUAGES = [
     ('fr', _('French')),
     ('de', _('German')),
     ('it', _('Italian')),
+    ('es', _('Spanish'))
 ]
 # Define the default system currency in used. Each organisation can override
 # this parameter using the 'default_currency' field

--- a/rero_ils/manual_translations.txt
+++ b/rero_ils/manual_translations.txt
@@ -32,6 +32,7 @@ _('ui_language_en')
 _('ui_language_fr')
 _('ui_language_de')
 _('ui_language_it')
+_('ui_language_es')
 
 # provisionActivity
 _('bf:Publication')

--- a/rero_ils/modules/acquisition/acq_orders/templates/rero_ils/vendor_order_mail/spa.tpl.txt
+++ b/rero_ils/modules/acquisition/acq_orders/templates/rero_ils/vendor_order_mail/spa.tpl.txt
@@ -1,0 +1,49 @@
+{{ order.library.name }} - Pedido [{{ order.reference }}]
+
+Nuestra referencia: {{ order.reference }}
+Fecha: {{ order.order_date }}
+
+Estimado Sr./Sra,
+
+Nos gustaría pedir la siguiente lista de libros:
+
+------------------------------------------------------------
+{%- for line in order.order_lines %}
+Documento :
+  {{ line.document.title_text }}
+  {%- if line.document.provision_activity %}
+  Mención de la publicación : {{ line.document.provision_activity }}
+  {%- endif %}
+  {%- if line.document.serie_statement %}
+  Colección : {{ line.document.serie_statement }}
+  {%- endif %}
+  {%- if line.document.identifiers %}
+  ISBN : {{ line.document.identifiers | join(' ; ') }}
+  {%- endif %}
+  {%- if line.note %}
+  Nota : {{ line.note }}
+  {%- endif %}
+  Cantidad: {{ line.quantity }}
+  Cuenta local : {{ line.account.name }} {% if line.account.number: -%}
+  {{ line.account.number }}]
+  {%- endif %}
+------------------------------------------------------------
+{%- endfor -%}
+{%- if order.note %}
+
+Nos gustaría llamar su atención sobre la siguiente observación:
+
+{{ order.note }}
+{%- endif %}
+
+Saludos cordiales,
+
+{{ order.library.shipping_informations.name }}
+
+Dirección de entrega:
+{{ order.library.shipping_informations | address_block(language=order.vendor.language) }}
+
+{% if order.library.billing_informations -%}
+Dirección de facturación:
+{{ order.library.billing_informations | address_block(language=order.vendor.language) }}
+{%- endif %}

--- a/rero_ils/modules/notifications/templates/email/at_desk/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/at_desk/spa.txt
@@ -1,0 +1,17 @@
+Ejemplar en la oficina de préstamos
+
+{% for loan in loans -%}
+Fecha: {{ loan.creation_date }}
+Título: {{ loan.document.title_text }}
+Código de barras: {{ loan.document.barcode }}
+Localización: {{ loan.document.library_name }} / {{ loan.document.location_name }}
+{%- if loan.document.call_numbers %}
+Clasificación: {{ loan.document.call_numbers | join(' | ') }}
+{%- endif %}
+
+Lugar de recogida: {{ loan.pickup_name }}
+Usuario: {{ loan.patron.first_name }} {{ loan.patron.last_name }}
+{%- if loan.patron.barcode %} - {{ loan.patron.barcode | join(', ') }}{%- endif %}
+Vencimiento de la solicitud: {{ loan.request_expire_date }}
+
+{% endfor %}

--- a/rero_ils/modules/notifications/templates/email/availability/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/availability/spa.txt
@@ -1,0 +1,25 @@
+Invitación a recoger un documento
+{%- include('email/_patron_address.txt') %}
+Estimado Sr./Sra,
+
+El documento que ha solicitado ya está disponible. Puede recogerlo en el mostrador de préstamos de la biblioteca que se indica a continuación.
+{%- for loan in loans %}
+
+Título: {{ loan.document.title_text }}
+Código de barras: {{ loan.document.barcode }}
+{%- if loan.document.call_numbers %}
+Clasificación : {{ loan.document.call_numbers | join(' / ') }}
+{%- endif %}
+Lugar de recogida: {{ loan.pickup_name }}
+{%- if loan.pickup_until %}
+Está disponible hasta: {{ loan.pickup_until.strftime('%d/%m/%Y') }}
+{%- endif %}
+{%- endfor %}
+
+Si el documento no se recoge en la fecha límite, volverá a ponerse en circulación para otras personas.
+Puede consultar su cuenta y ampliar la duración del préstamo de sus documentos en: {{ patron.profile_url }}
+
+Atentamente
+
+{{ library.name }}
+{{ library.address }}

--- a/rero_ils/modules/notifications/templates/email/booking/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/booking/spa.txt
@@ -1,0 +1,16 @@
+Reservación{%- if loans[0].in_transit %} (en tránsito){%- endif %}
+
+{% for loan in loans -%}
+Fecha: {{ loan.creation_date }}
+Título: {{ loan.document.title_text }}
+Código de barras : {{ loan.document.barcode }}
+Localización : {{ loan.document.library_name }} / {{ loan.document.location_name }}
+{%- if loan.document.call_numbers %}
+Clasificación : {{ loan.document.call_numbers | join(' | ') }}
+{%- endif %}
+
+Lugar de recogida: {{ loan.pickup_name }}
+Usuario: {{ loan.patron.first_name }} {{ loan.patron.last_name }}
+{%- if loan.patron.barcode %} - {{ loan.patron.barcode | join(', ') }}{%- endif %}
+
+{% endfor %}

--- a/rero_ils/modules/notifications/templates/email/claim_issue/spa.tpl.txt
+++ b/rero_ils/modules/notifications/templates/email/claim_issue/spa.tpl.txt
@@ -1,0 +1,33 @@
+Reclamación "{{ issue.document.title_text }}" {{ issue | issue_client_reference }}
+
+Estimado Sr./Sra,
+
+Hemos observado que no hemos recibido el siguiente número:
+{{ issue.document.title_text }}
+{{ issue.enumerationAndChronology }}
+
+A continuación encontrará la información relativa a nuestra suscripción:
+{%- if issue.holdings %}
+{%- if issue.holdings.client_id %}
+Número de cliente: {{ issue.holdings.client_id }}
+{%- endif %}
+{%- if issue.holdings.order_reference %}
+Referencia del pedido: {{ issue.holdings.order_reference }}
+{%- endif %}
+{%- endif %}
+Número de reclamaciones para este número: {{ issue.claim_counter }}
+
+Por favor, haga todo lo posible para que recibamos el número lo antes posible.
+
+
+Atentamente
+
+{{ issue.library.shipping_informations.name }}
+
+Dirección de entrega:
+{{ issue.library.shipping_informations | address_block(language=issue.vendor.language) }}
+
+{% if issue.library.billing_informations -%}
+Dirección de facturación:
+{{ issue.library.billing_informations | address_block(language=idioma.vendedor.tema)}}
+{%- endif %}

--- a/rero_ils/modules/notifications/templates/email/due_soon/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/due_soon/spa.txt
@@ -1,0 +1,18 @@
+Aviso de vencimiento
+{%- include('email/_patron_address.txt') %}
+Estimado Sr./Sra,
+
+El período de préstamo de los documentos enumerados a continuación está llegando a su fin:
+
+{%- for loan in loans %}
+
+Título: {{ loan.document.title_text }}
+Fecha de vencimiento: {{ loan.end_date }}
+{%- endfor %}
+
+Puede consultar su cuenta y ampliar el periodo de préstamo de sus documentos en: {{ patron.profile_url }}
+
+Atentamente
+
+{{ library.name }}
+{{ library.address }}

--- a/rero_ils/modules/notifications/templates/email/overdue/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/overdue/spa.txt
@@ -1,0 +1,19 @@
+Recordatorio
+{%- include('email/_patron_address.txt') %}
+Estimado Sr./Sra,
+
+El periodo de préstamo de los documentos listados a continuación ha expirado:
+
+{%- for loan in loans %}
+
+Título: {{ loan.document.title_text }}
+Fecha de vencimiento: {{ loan.end_date }}
+Nota: {{ loan.reminder_counter }} recordatorio
+{%- endfor %}
+
+Puede consultar su cuenta y ampliar el periodo de préstamo de sus documentos en: {{ patron.profile_url }}
+
+Atentamente
+
+{{ library.name }}
+{{ library.address }}

--- a/rero_ils/modules/notifications/templates/email/recall/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/recall/spa.txt
@@ -1,0 +1,21 @@
+Documento no renovable
+{%- include('email/_patron_address.txt') %}
+Estimado Sr./Sra,
+
+El documento que ha tomado en préstamo acaba de ser reservado por otra persona.
+Le informamos de que no podremos prorrogar su préstamo y le rogamos que lo devuelva
+a más tardar en la fecha de vencimiento.
+
+{%- for loan in loans %}
+
+Título: {{ loan.document.title_text }}
+Fecha de vencimiento: {{ loan.end_date }}
+Nota: No renovable
+{%- endfor %}
+
+Puede consultar su cuenta en: {{ patron.profile_url }}
+
+Atentamente
+
+{{ library.name }}
+{{ library.address }}

--- a/rero_ils/modules/notifications/templates/email/request/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/request/spa.txt
@@ -1,0 +1,19 @@
+Reservación {%- if loans[0].in_transit %} (en tránsito){%- endif %}
+
+{% for loan in loans -%}
+Fecha: {{ loan.creation_date }}
+Título: {{ loan.document.title_text }}
+Código de barras: {{ loan.document.barcode }}
+Localización: {{ loan.document.library_name }} / {{ loan.document.location_name }}
+{%- if loan.document.call_numbers %}
+Clasificación : {{ loan.document.call_numbers | join(' | ') }}
+{%- endif %}
+{%- if loan.document.enumerationAndChronology %}
+Unidad: {{ loan.document.enumerationAndChronology }}
+{%- endif %}
+
+Lugar de recogida: {{ loan.pickup_name }}
+Usuario : {{ loan.patron.first_name }} {{ loan.patron.last_name }}
+{%- if loan.patron.barcode %} - {{ loan.patron.barcode | join(', ') }}{%- endif %}
+
+{% endfor %}

--- a/rero_ils/modules/notifications/templates/email/transit_notice/spa.txt
+++ b/rero_ils/modules/notifications/templates/email/transit_notice/spa.txt
@@ -1,0 +1,13 @@
+Aviso de tránsito
+
+{% for loan in loans %}
+Fecha: {{ loan.creation_date }}
+Título: {{ loan.document.title_text }}
+Código de barras: {{ loan.document.barcode }}
+{%- if loan.document.call_numbers %}
+Clasificación: {{ loan.document.call_numbers | join(' | ') }}
+{%- endif %}
+Origen: {{ loan.transaction_library.name }}
+Destinación: {{ loan.document.library_name }}: {{ loan.document.location_name }}
+
+{% endfor %}


### PR DESCRIPTION
* Adds a new file in spanish for each type of template.

## Dependencies

for front-end : https://github.com/rero/rero-ils-ui/pull/1003
for ng-core : https://github.com/rero/ng-core/pull/556

Co-Authored-by : Benoit Erken <erken.benoit@gmail.com>
Co-Authored-by : Mana Deweerdt <mana.deweerdt@uclouvain.be>

## Why are you opening this PR?

- To translate existing templates in spanish
