### PR TITLE
items+patrons: fix unique barcodes

### DIFF
--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -254,6 +254,7 @@ def test_overdue_limit(
 
     tmp_item_data = deepcopy(item_lib_martigny_data)
     del tmp_item_data['pid']
+    del tmp_item_data['barcode']
     tmp_item_data['library']['$ref'] = get_ref_for_pid('lib', lib_saxon.pid)
     tmp_item_data['location']['$ref'] = \
         get_ref_for_pid('loc', loc_public_saxon.pid)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -179,6 +179,7 @@ def item_lib_martigny_masked(
         item_type_standard_martigny):
     """Create item of martigny library."""
     data = deepcopy(item_lib_martigny_data)
+    data['barcode'] = 'masked'
     data['pid'] = f'maked-{data["pid"]}'
     data['_masked'] = True
     item = Item.create(

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -55,7 +55,6 @@ def test_documents_newacq_filters(app, client,
     new_acq1 = deepcopy(item_lib_martigny_data)
     new_acq1['pid'] = 'itemacq1'
     new_acq1['acquisition_date'] = today
-    del new_acq1['barcode']
     res, data = postdata(client, 'invenio_records_rest.item_list', new_acq1)
     assert res.status_code == 201
 
@@ -63,7 +62,6 @@ def test_documents_newacq_filters(app, client,
     new_acq2['pid'] = 'itemacq2'
     new_acq2['acquisition_date'] = future
     new_acq2['location']['$ref'] = get_ref_for_pid('loc', loc_public_saxon.pid)
-    del new_acq2['barcode']
     res, data = postdata(client, 'invenio_records_rest.item_list', new_acq2)
     assert res.status_code == 201
 

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -132,6 +132,7 @@ def test_items_post_put_delete(client, document, loc_public_martigny,
 
     # test when item has a dirty barcode
     item_lib_martigny_data['pid'] = '1'
+    item_lib_martigny_data['barcode'] = '123456'
     item_record_with_dirty_barcode = deepcopy(item_lib_martigny_data)
 
     item_record_with_dirty_barcode['barcode'] = ' {barcode} '.format(

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -259,6 +259,7 @@ def test_patrons_post_put_delete(
     list_url = url_for('invenio_records_rest.ptrn_list', q=f'pid:{pid_value}')
     patron_data = deepcopy(patron_martigny_data_tmp)
     patron_data['email'] = 'post_put_delete@test.ch'
+    patron_data['patron']['barcode'] = ['2384768231']
     patron_data['username'] = 'post_put_delete'
     patron_data = create_user_from_data(patron_data)
 
@@ -340,6 +341,7 @@ def test_patrons_post_without_email(
     patron_data = deepcopy(patron_martigny_data_tmp)
     patron_data['email'] = 'post_without_email@test.ch'
     patron_data['username'] = 'post_without_email'
+    patron_data['patron']['barcode'] = ['23841238231']
     del patron_data['pid']
     del patron_data['email']
     patron_data['patron']['communication_channel'] = CommunicationChannel.MAIL

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3753,7 +3753,6 @@
   "item1": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item1",
-    "barcode": "1234",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3792,7 +3791,6 @@
   "item2": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item2",
-    "barcode": "78431",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3809,7 +3807,6 @@
   "item3": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item3",
-    "barcode": "891011",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3836,7 +3833,6 @@
   "item4": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item4",
-    "barcode": "0123987123",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc3"
@@ -3853,7 +3849,6 @@
   "item5": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item5",
-    "barcode": "8712133",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3870,7 +3865,6 @@
   "item6": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item6",
-    "barcode": "87121336",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3887,7 +3881,6 @@
   "item7": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item7",
-    "barcode": "789123",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3904,7 +3897,6 @@
   "item8": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item8",
-    "barcode": "100200300",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3921,7 +3913,6 @@
   "item9": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item9",
-    "barcode": "91231",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3938,7 +3929,6 @@
   "item10": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item10",
-    "barcode": "123410",
     "type": "standard",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"
@@ -3964,7 +3954,6 @@
   "item11": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",
     "pid": "item11",
-    "barcode": "1234567890",
     "type": "provisional",
     "document": {
       "$ref": "https://bib.rero.ch/api/documents/doc1"

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -430,6 +430,7 @@ def patron_sion_without_email1(
     del data['email']
     data['pid'] = 'ptrn10wthoutemail'
     data['username'] = 'withoutemail'
+    data['patron']['barcode'] = ['18936287']
     data['patron']['communication_channel'] = CommunicationChannel.MAIL
     yield create_patron(data)
 
@@ -446,6 +447,7 @@ def patron_sion_with_additional_email(
     del data['email']
     data['pid'] = 'ptrn10additionalemail'
     data['username'] = 'additionalemail'
+    data['patron']['barcode'] = ['additionalemail']
     data['patron']['additional_communication_email'] = \
         'additional+jules@gmail.com'
     yield create_patron(data)

--- a/tests/ui/local_fields/test_local_fields_api.py
+++ b/tests/ui/local_fields/test_local_fields_api.py
@@ -81,6 +81,7 @@ def test_local_fields(
     assert len(list(fields)) == 0
 
     # TEST#4 :: Same as previous but for item.
+    del item_lib_martigny_data['barcode']
     item = Item.create(item_lib_martigny_data, dbcommit=True, reindex=True)
     assert 'local_fields' not in item.get_links_to_me()
     lofi_data.pop('pid', None)

--- a/tests/unit/documents/test_documents_dojson_marc21.py
+++ b/tests/unit/documents/test_documents_dojson_marc21.py
@@ -685,6 +685,9 @@ def test_holdings_items_to_marc21(app, marc21_record, document,
     assert result == record
 
     record = {'pid': document.pid}
+    item2_lib_sion_save_barcode = item2_lib_sion['barcode']
+    item2_lib_sion['barcode'] = '87121336'
+    item2_lib_sion.update(item2_lib_sion, dbcommit=True, reindex=True)
     result = to_marc21.do(record, with_holdings_items=True)
     record = deepcopy(marc21_record)
     record.update({
@@ -702,6 +705,10 @@ def test_holdings_items_to_marc21(app, marc21_record, document,
         })
     })
     assert result == record
+
+    # clean up modified data
+    item2_lib_sion['barcode'] = item2_lib_sion_save_barcode
+    item2_lib_sion.update(item2_lib_sion, dbcommit=True, reindex=True)
 
     record = {'pid': ebook_5.pid}
     result = to_marc21.do(record, with_holdings_items=True)


### PR DESCRIPTION
- Adds an extended validation method to patrons and items to ensure that barcode fields are unique.
- Deletes barcodes in item test fixtures so that they are generated and avoid duplicate barcode errors on item creation.
- Fixes test errors related to duplicate item and patron barcodes.
- Closes #3386.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
