### PR TITLE
settings: remove obsolete settings.

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -3033,10 +3033,6 @@ RERO_ILS_THUMBNAIL_SERVICE_URL = 'https://services.test.rero.ch/cover'
 
 #: Entities
 RERO_ILS_AGENTS_SOURCES = ['idref', 'gnd', 'rero']
-RERO_ILS_AGENTS_AGENT_TYPES = {
-    'bf:Person': 'persons',
-    'bf:Organisation': 'corporate-bodies'
-}
 RERO_ILS_AGENTS_LABEL_ORDER = {
     'fallback': 'fr',
     'fr': ['idref', 'rero', 'gnd'],

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -131,7 +131,6 @@ def logged_user():
             'language': current_i18n.locale.language,
             'globalView': config.get('RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'),
             'baseUrl': get_base_url(),
-            'agentAgentTypes': config.get('RERO_ILS_AGENTS_AGENT_TYPES', {}),
             'agentLabelOrder': config.get('RERO_ILS_AGENTS_LABEL_ORDER', {}),
             'agentSources': config.get('RERO_ILS_AGENTS_SOURCES', []),
             'operationLogs': config.get('RERO_ILS_ENABLE_OPERATION_LOG', []),


### PR DESCRIPTION
Removes obsolete `agentAgentTypes` setting from logged user API response.

