### PR TITLE
claims: manage missing data for claim notification

### DIFF
--- a/rero_ils/modules/commons/exceptions.py
+++ b/rero_ils/modules/commons/exceptions.py
@@ -20,7 +20,7 @@
 
 
 class RecordNotFound(Exception):
-    """Record con't be found into Invenio."""
+    """Record can't be found into Invenio."""
 
     def __init__(self, record_cls, record_pid):
         """Initialization method.
@@ -31,6 +31,24 @@ class RecordNotFound(Exception):
         self.record_cls = record_cls
         self.record_pid = record_pid
 
-    def __str__(self):
+    def __repr__(self):
         """String representation of the exception."""
         return f'{self.record_cls.__name__}#{self.record_pid} not found'
+
+
+class MissingDataException(KeyError):
+    """Exception when a data is missing."""
+
+    def __init__(self, missing_data):
+        """Initialization method.
+
+        :param missing_data: list of missing data field names.
+        :type missing_data: str|list<str>
+        """
+        if not isinstance(missing_data, list):
+            missing_data = [missing_data]
+        self.missing_data = missing_data
+
+    def __repr__(self):
+        """String representation of the exception."""
+        return f'Missing data :: {", ".join(self.missing_data)}'

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -52,6 +52,7 @@ from ..dumpers import ClaimIssueNotificationDumper
 from ..models import ItemCirculationAction
 from ..permissions import late_issue_management as late_issue_management_action
 from ..utils import get_recipient_suggestions, item_pid_to_object
+from ...commons.exceptions import MissingDataException
 
 api_blueprint = Blueprint(
     'api_item',
@@ -572,7 +573,11 @@ def claim_notification_preview(item_pid):
     if not record.is_issue:
         abort(400, 'Item isn\'t an issue')
 
-    issue_data = record.dumps(dumper=ClaimIssueNotificationDumper())
+    try:
+        issue_data = record.dumps(dumper=ClaimIssueNotificationDumper())
+    except (TypeError, MissingDataException) as exp:
+        abort(500, str(exp))
+
     # update the claims issue counter ::
     #   As this is preview for next claim, we need to add 1 to the returned
     #   claim counter

--- a/rero_ils/modules/libraries/dumpers.py
+++ b/rero_ils/modules/libraries/dumpers.py
@@ -20,6 +20,7 @@
 
 from invenio_records.dumpers import Dumper as InvenioRecordsDumper
 
+from rero_ils.modules.commons.exceptions import MissingDataException
 from rero_ils.modules.libraries.models import LibraryAddressType
 
 
@@ -55,6 +56,9 @@ class LibrarySerialClaimNotificationDumper(InvenioRecordsDumper):
         :param record: The record to dump.
         :param data: The initial dump data passed in by ``record.dumps()``.
         """
+        if 'serial_acquisition_settings' not in record:
+            raise MissingDataException('library.serial_acquisition_settings')
+
         data.update({
             'name': record.get('name'),
             'address': record.get_address(LibraryAddressType.MAIN_ADDRESS),

--- a/tests/ui/libraries/test_libraries_dumpers.py
+++ b/tests/ui/libraries/test_libraries_dumpers.py
@@ -17,12 +17,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Library Record dumpers."""
+import pytest
+
+from rero_ils.modules.commons.exceptions import MissingDataException
 from rero_ils.modules.libraries.dumpers import \
     LibraryAcquisitionNotificationDumper, LibrarySerialClaimNotificationDumper
 
 
-def test_library_serial_claim_dumper(lib_martigny, lib_saxon):
-    """Test serial claim library dumper."""
+def test_library_serial_dumpers(lib_martigny, lib_saxon):
+    """Test serial library dumpers."""
 
     # Acquisition dumper
     dump_data = lib_martigny.dumps(LibraryAcquisitionNotificationDumper())
@@ -37,7 +40,6 @@ def test_library_serial_claim_dumper(lib_martigny, lib_saxon):
     assert data['address']
     assert data['shipping_informations']
     assert data['billing_informations']
-    data = lib_saxon.dumps(LibrarySerialClaimNotificationDumper())
-    assert data['address']
-    assert 'shipping_informations' not in data
-    assert 'billing_informations' not in data
+    with pytest.raises(MissingDataException) as exc:
+        lib_saxon.dumps(LibrarySerialClaimNotificationDumper())
+    assert 'library.serial_acquisition_settings' in str(exc)


### PR DESCRIPTION
* Closes rero/rero-ils#3379.
* Checks if all requires data are available to render the claim notification content. If not, return a specific exception to specify the missing data.


