### PR TITLE
operation logs: anonymization respects jsonschema

### DIFF
--- a/rero_ils/modules/loans/logs/api.py
+++ b/rero_ils/modules/loans/logs/api.py
@@ -120,6 +120,6 @@ class LoanOperationLog(AbstractSpecificOperationLog):
         """
         for log in cls.get_logs_by_record_pid(loan_pid):
             record = log.to_dict()
-            record['loan']['patron'].pop('name', None)
-            record['loan']['patron'].pop('pid', None)
+            record['loan']['patron']['name'] = 'anonymized'
+            record['loan']['patron']['pid'] = 'anonymized'
             cls.update(log.meta.id, log['date'], record)

--- a/tests/ui/loans/test_loans_operation_logs.py
+++ b/tests/ui/loans/test_loans_operation_logs.py
@@ -111,5 +111,5 @@ def test_anonymize_logs(item2_on_loan_martigny_patron_and_loan_on_loan):
         log = log.to_dict()
         md5_hash = hashlib.md5(patron['pid'].encode()).hexdigest()
         assert log['loan']['patron']['hashed_pid'] == f'{md5_hash}'
-        assert not log['loan']['patron'].get('name')
-        assert not log['loan']['patron'].get('pid')
+        assert log['loan']['patron'].get('name') == 'anonymized'
+        assert log['loan']['patron'].get('pid') == 'anonymized'


### PR DESCRIPTION
* Existing invalid data will be corrected manually as an Alembic script would take 5 days to run with several million operation logs.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
