### PR TITLE
Update README.md: Louvain (≠ Leuven)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ status](https://hosted.weblate.org/widgets/rero_plus/-/rero-ils/svg-badge.svg)](
 
 ## RERO ILS
 
-RERO ILS is a new generation open source [integrated library system](https://en.wikipedia.org/wiki/Integrated_library_system) developed in Switzerland by [RERO+](https://rero.ch/) in collaboration with the Catholic University of Leuven ([UCLouvain](https://uclouvain.be/)). It allows the management of library networks or independent libraries (document acquisition, circulation, cataloguing, search) and offers a public interface for users.
+RERO ILS is a new generation open source [integrated library system](https://en.wikipedia.org/wiki/Integrated_library_system) developed in Switzerland by [RERO+](https://rero.ch/) in collaboration with the Catholic University of Louvain ([UCLouvain](https://uclouvain.be/)). It allows the management of library networks or independent libraries (document acquisition, circulation, cataloguing, search) and offers a public interface for users.
 
 RERO ILS has been under heavy development since 2017 as a replacement for RERO network's legacy software. Its first major release (`v1.0.0`) was published at the end of 2020. The first real-life production instance has been live since June 2021. Since then, it is being actively maintained and developed by a committed team from Switzerland and Belgium, in order to improve upon its current features and satisfy its users' needs.
 


### PR DESCRIPTION
Very minor fix, but mentioning "Catholic University of Leuven" is pointing at the wrong university.

UCLouvain (University of Louvain) ≠ KU Leuven (University of Leuven)