### PR TITLE
editor: correct label for Media Type

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_content_media_carrier-v0.0.1.json
@@ -4,7 +4,7 @@
     "type": "array",
     "minItems": 1,
     "items": {
-      "title": "Content, media, carrier type",
+      "title": "Media type",
       "type": "object",
       "oneOf": [
         {


### PR DESCRIPTION
* Corrects the label of the oneOf to be clearer for librarians.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
