### PR TITLE
documents: optimize availability

### DIFF
--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -127,27 +127,125 @@ class Document(IlsRecord):
         return json
 
     @classmethod
-    def is_available(cls, pid, view_code, raise_exception=False):
-        """Get availability for document."""
-        from ..holdings.api import Holding
+    def get_n_available_holdings(cls, pid, org_pid=None):
+        """Get the number of available and electronic holdings.
+
+        :param pid: str - the document pid.
+        :param org_pid: str - the organisation pid.
+        :returns: int, int - the number of available and electronic holdings.
+        """
+        from rero_ils.modules.holdings.api import HoldingsSearch
+
+        # create the holding search query
+        holding_query = HoldingsSearch().available_query()
+
+        # filter by the current document
+        filters = Q('term', document__pid=pid)
+
+        # filter by organisation
+        if org_pid:
+            filters &= Q('term', organisation__pid=org.pid)
+        holding_query.filter(filters)
+
+        # get the number of electronic holdings
+        n_electronic_holdings = holding_query\
+            .filter('term', holding_type='electronic')
+
+        return holding_query.count(), n_electronic_holdings.count()
+
+    @classmethod
+    def get_available_item_pids(cls, pid, org_pid):
+        """Get the list of the available item pids.
+
+        :param pid: str - the document pid.
+        :param org_pid: str - the organisation pid.
+        :returns: [str] - the list of the available item pids.
+        """
+        from rero_ils.modules.items.api import ItemsSearch
+
+        # create the item query
+        items_query = ItemsSearch().available_query()
+
+        # filter by the current document
+        filters = Q('term', document__pid=pid)
+
+        # filter by organisation
+        if org_pid:
+            filters &= Q('term', organisation__pid=org.pid)
+
+        return [
+            hit.pid for hit in items_query.filter(filters).source('pid').scan()
+        ]
+
+    @classmethod
+    def get_item_pids_with_active_loan(cls, pid, org_pid):
+        """Get the list of items pids that have active loans.
+
+        :param pid: str - the document pid.
+        :param org_pid: str - the organisation pid.
+        :returns: [str] - the list of the item pids having active loans.
+        """
+        from rero_ils.modules.loans.api import LoansSearch
+
+        loan_query = LoansSearch().unavailable_query()
+
+        # filter by the current document
+        filters = Q('term', document_pid=pid)
+
+        # filter by organisation
+        if org_pid:
+            filters &= Q('term', organisation__pid=org_pid)
+
+        loan_query = loan_query.filter(filters)
+
+        return [
+            hit.item_pid.value for hit in loan_query.source('item_pid').scan()
+        ]
+
+    @classmethod
+    def is_available(cls, pid, view_code=None):
+        """Get availability for document.
+
+        Note: if the logic has to be changed here please check also for items
+        and holdings availability.
+
+        :param pid: str - document pid value.
+        :param view_code: str - the view code.
+        """
+        # get the organisation pid corresponding to the view code
+        org_pid = None
         if view_code != current_app.config.get(
                 'RERO_ILS_SEARCH_GLOBAL_VIEW_CODE'):
-            view_id = Organisation.get_record_by_viewcode(view_code)['pid']
-            holding_pids = Holding.get_holdings_pid_by_document_pid_by_org(
-                    pid, view_id)
-        else:
-            holding_pids = Holding.get_holdings_pid_by_document_pid(pid)
-        for holding_pid in holding_pids:
-            if holding := Holding.get_record_by_pid(holding_pid):
-                if holding.available:
-                    return True
-            else:
-                msg = f'No holding: {holding_pid} in DB ' \
-                      f'for document: {pid}'
-                current_app.logger.error(msg)
-                if raise_exception:
-                    raise ValueError(msg)
-        return False
+            org_pid = Organisation.get_record_by_viewcode(view_code)['pid']
+
+        # -------------- Holdings --------------------
+        # get the number of available and electronic holdings
+        n_available_holdings, n_electronic_holdings = \
+            cls.get_n_available_holdings(pid, org_pid)
+
+        # available if an electronic holding exists
+        if n_electronic_holdings:
+            return True
+
+        # unavailable if no holdings exists
+        if not n_available_holdings:
+            return False
+
+        # -------------- Items --------------------
+        # get the available item pids
+        available_item_pids = cls.get_available_item_pids(pid, org_pid)
+
+        # unavailable if no items exists
+        if not available_item_pids:
+            return False
+
+        # --------------- Loans -------------------
+        # get item pids that have active loans
+        unavailable_item_pids = \
+            cls.get_item_pids_with_active_loan(pid, org_pid)
+
+        # available if at least one item don't have active loan
+        return bool(set(available_item_pids) - set(unavailable_item_pids))
 
     @property
     def harvested(self):

--- a/rero_ils/modules/holdings/api_views.py
+++ b/rero_ils/modules/holdings/api_views.py
@@ -315,6 +315,6 @@ def holding_availability(pid):
     """HTTP GET request for holding availability."""
     if holding := Holding.get_record_by_pid(pid):
         return jsonify({
-            'available': holding.available
+            'available': holding.is_available()
         })
     abort(404)

--- a/rero_ils/modules/items/utils.py
+++ b/rero_ils/modules/items/utils.py
@@ -89,7 +89,7 @@ def exists_available_item(items=None):
             item = Item.get_record_by_pid(item)
         if not isinstance(item, Item):
             raise ValueError('All items should be Item resource.')
-        if item.available:
+        if item.is_available():
             return True
     return False
 

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -472,7 +472,7 @@ def item_availability(pid):
     item = Item.get_record_by_pid(pid)
     if not item:
         abort(404)
-    data = dict(available=item.available)
+    data = dict(available=item.is_available())
     if flask_request.args.get('more_info'):
         extra = {
             'status': item['status'],

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -72,6 +72,17 @@ class LoansSearch(IlsRecordsSearch):
 
         default_filter = None
 
+    def unavailable_query(self):
+        """Base query to compute item availability.
+
+        Unavailable if some active loans exists.
+
+        :returns: an elasticsearch query
+        """
+        states = [LoanState.PENDING] + \
+            current_app.config['CIRCULATION_STATES_LOAN_ACTIVE']
+        return self.filter('terms', state=states)
+
 
 class Loan(IlsRecord):
     """Loan class."""

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -42,7 +42,7 @@ def test_item_dumps(client, item_lib_martigny, org_martigny,
     assert res.status_code == 200
 
     item_es = Item(get_json(res).get('metadata'))
-    assert item_es.available
+    assert item_es.is_available()
     assert item_es.organisation_pid == org_martigny.pid
 
 

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -209,7 +209,7 @@ def test_due_soon_loans(client, librarian_martigny,
     can, reasons = item.can_delete
     assert can
     assert reasons == {}
-    assert item.available
+    assert item.is_available()
     assert not get_last_transaction_loc_for_item(item_pid)
     assert not item.patron_has_an_active_loan_on_item(patron_martigny)
 
@@ -420,7 +420,7 @@ def test_checkout_item_transit(client, mailbox, item2_lib_martigny,
                                loc_public_martigny,
                                circulation_policies):
     """Test checkout of an item in transit."""
-    assert item2_lib_martigny.available
+    assert item2_lib_martigny.is_available()
     mailbox.clear()
 
     # request
@@ -447,7 +447,7 @@ def test_checkout_item_transit(client, mailbox, item2_lib_martigny,
     assert res.status_code == 200
     actions = data.get('action_applied')
     loan_pid = actions[LoanAction.REQUEST].get('pid')
-    assert not item2_lib_martigny.available
+    assert not item2_lib_martigny.is_available()
 
     assert len(mailbox) == 1
     assert mailbox[-1].recipients == [
@@ -477,9 +477,9 @@ def test_checkout_item_transit(client, mailbox, item2_lib_martigny,
         )
     )
     assert res.status_code == 200
-    assert not item2_lib_martigny.available
+    assert not item2_lib_martigny.is_available()
     item = Item.get_record_by_pid(item2_lib_martigny.pid)
-    assert not item.available
+    assert not item.is_available()
 
     loan = Loan.get_record_by_pid(loan_pid)
     assert loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
@@ -497,9 +497,9 @@ def test_checkout_item_transit(client, mailbox, item2_lib_martigny,
         )
     )
     assert res.status_code == 200
-    assert not item2_lib_martigny.available
+    assert not item2_lib_martigny.is_available()
     item = Item.get_record_by_pid(item2_lib_martigny.pid)
-    assert not item.available
+    assert not item.is_available()
 
     loan_before_checkout = get_loan_for_item(item_pid_to_object(item.pid))
     assert loan_before_checkout.get('state') == LoanState.ITEM_AT_DESK
@@ -640,7 +640,7 @@ def test_librarian_request_on_blocked_user(
         patron3_martigny_blocked,
         circulation_policies):
     """Librarian request on blocked user returns a specific 403 message."""
-    assert item_lib_martigny.available
+    assert item_lib_martigny.is_available()
 
     # request
     login_user_via_session(client, librarian_martigny.user)

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -202,8 +202,8 @@ def test_item_holding_document_availability(
     """Test item, holding and document availability."""
     assert item_availablity_status(
         client, item_lib_martigny.pid, librarian_martigny.user)
-    assert item_lib_martigny.available
-    assert holding_lib_martigny.available
+    assert item_lib_martigny.is_available()
+    assert holding_lib_martigny.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert Document.is_available(document.pid, view_code='global')
     assert document_availability_status(
@@ -235,11 +235,11 @@ def test_item_holding_document_availability(
     assert res.status_code == 200
     actions = data.get('action_applied')
     loan_pid = actions[LoanAction.REQUEST].get('pid')
-    assert not item_lib_martigny.available
+    assert not item_lib_martigny.is_available()
     assert not item_availablity_status(
         client, item_lib_martigny.pid, librarian_martigny.user)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
-    assert holding.available
+    assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert Document.is_available(document.pid, 'global')
     assert document_availability_status(
@@ -257,12 +257,12 @@ def test_item_holding_document_availability(
         )
     )
     assert res.status_code == 200
-    assert not item_lib_martigny.available
+    assert not item_lib_martigny.is_available()
     assert not item_availablity_status(
         client, item_lib_martigny.pid, librarian_martigny.user)
-    assert not item_lib_martigny.available
+    assert not item_lib_martigny.is_available()
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
-    assert holding.available
+    assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert Document.is_available(document.pid, 'global')
     assert document_availability_status(
@@ -280,13 +280,13 @@ def test_item_holding_document_availability(
         )
     )
     assert res.status_code == 200
-    assert not item_lib_martigny.available
+    assert not item_lib_martigny.is_available()
     assert not item_availablity_status(
         client, item_lib_martigny.pid, librarian_saxon.user)
     item = Item.get_record_by_pid(item_lib_martigny.pid)
-    assert not item.available
+    assert not item.is_available()
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
-    assert holding.available
+    assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert Document.is_available(document.pid, 'global')
     assert document_availability_status(
@@ -305,20 +305,20 @@ def test_item_holding_document_availability(
     assert res.status_code == 200
 
     item = Item.get_record_by_pid(item_lib_martigny.pid)
-    assert not item.available
+    assert not item.is_available()
     assert not item_availablity_status(
         client, item.pid, librarian_martigny.user)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
-    assert holding.available
+    assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert Document.is_available(document.pid, 'global')
     assert document_availability_status(
         client, document.pid, librarian_martigny.user)
 
-    # masked item isn't available
+    # masked item isn't.is_available()
     item['_masked'] = True
     item = item.update(item, dbcommit=True, reindex=True)
-    assert not item.available
+    assert not item.is_available()
     del item['_masked']
     item.update(item, dbcommit=True, reindex=True)
 
@@ -367,11 +367,11 @@ def test_item_holding_document_availability(
         )
     )
     assert res.status_code == 200
-    assert not item2_lib_martigny.available
+    assert not item2_lib_martigny.is_available()
     assert not item_availablity_status(
         client, item2_lib_martigny.pid, librarian_martigny.user)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
-    assert not holding.available
+    assert not holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert not Document.is_available(document.pid, 'global')
     assert not document_availability_status(

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -38,21 +38,6 @@ from rero_ils.modules.entities.utils import extract_data_from_mef_uri
 from rero_ils.modules.tasks import process_bulk_queue
 
 
-def test_document_properties(document):
-    """Test document properties."""
-    # As no item/holding are loaded into this test, `is_available` should
-    # return false/raise an error.
-    assert not Document.is_available(document.pid, 'global')
-
-    with mock.patch(
-        'rero_ils.modules.holdings.api.Holding.'
-        'get_holdings_pid_by_document_pid',
-        mock.MagicMock(return_value=['not_exists'])
-    ):
-        with pytest.raises(ValueError):
-            Document.is_available(document.pid, 'global', raise_exception=True)
-
-
 def test_document_create(db, document_data_tmp):
     """Test document creation."""
     ptty = Document.create(document_data_tmp, delete_pid=True)

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -72,9 +72,10 @@ def test_holding_availability(holding_lib_sion_electronic,
                               holding_lib_martigny, item_lib_martigny):
     """Test holding availability."""
     # An electronic holding is always available despite if no item are linked
-    assert holding_lib_sion_electronic.available
+    assert holding_lib_sion_electronic.is_available()
     # The availability of other holdings type depends on children availability
-    assert holding_lib_martigny.available == item_lib_martigny.available
+    assert holding_lib_martigny.is_available() == \
+        item_lib_martigny.is_available()
 
 
 def test_holding_extended_validation(
@@ -162,4 +163,4 @@ def test_holdings_properties(holding_lib_martigny_w_patterns, vendor_martigny):
     assert holding.days_before_next_claim == 7
 
     holding['_masked'] = True
-    assert not holding.available
+    assert not holding.is_available()

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -246,13 +246,13 @@ def test_items_availability(item_type_missing_martigny,
     item = Item.create(item_data, dbcommit=True, reindex=True)
 
     # test the availability and availability_text
-    assert not item.available
+    assert not item.is_available()
     assert len(item.availability_text) == \
         len(item_type_missing_martigny.get('displayed_status', [])) + 1
 
     del item['temporary_item_type']
     item = item.update(item, dbcommit=True, reindex=True)
-    assert item.available
+    assert item.is_available()
     assert len(item.availability_text) == 1  # only default value
 
     # test availability and availability_text for an issue
@@ -265,12 +265,12 @@ def test_items_availability(item_type_missing_martigny,
         'expected_date': '1970-01-01'
     }
     item = item.update(item, dbcommit=True, reindex=True)
-    assert item.available
+    assert item.is_available()
     assert item.availability_text[0]['label'] == item.status
 
     item['issue']['status'] = ItemIssueStatus.LATE
     item = item.update(item, dbcommit=True, reindex=True)
-    assert not item.available
+    assert not item.is_available()
     assert item.availability_text[0]['label'] == ItemIssueStatus.LATE
 
     # delete the created item


### PR DESCRIPTION
- Uses Elasticsearch to compute the documents, items and holdings availability.
- Search only one organisation when an organisation is retrived using a view code.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
