### PR TITLE
items: sorting for standard holdings

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2495,8 +2495,8 @@ RECORDS_REST_SORT_OPTIONS['items']['issue_sort_date'] = dict(
     default_order='asc'
 )
 RECORDS_REST_SORT_OPTIONS['items']['enumeration_chronology'] = dict(
-    fields=['-enumerationAndChronology'], title='Enumeration and Chronology',
-    default_order='desc'
+    fields=['enumerationAndChronology.sort'], title='Enumeration and Chronology',
+    default_order='asc'
 )
 RECORDS_REST_SORT_OPTIONS['items']['library'] = dict(
     fields=['library.pid'], title='Library',
@@ -2509,7 +2509,7 @@ RECORDS_REST_SORT_OPTIONS['items']['current_requests'] = dict(
 )
 
 RECORDS_REST_DEFAULT_SORT['items'] = dict(
-    query='bestmatch', noquery='enum_chronology')
+    query='bestmatch', noquery='enumeration_chronology')
 
 # ------ ITEM TYPES SORT
 RECORDS_REST_SORT_OPTIONS['item_types']['name'] = dict(

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -56,7 +56,14 @@
         }
       },
       "enumerationAndChronology": {
-        "type": "keyword"
+        "type": "keyword",
+        "fields": {
+          "sort": {
+            "type": "icu_collation_keyword",
+            "index": false,
+            "numeric": true
+          }
+        }
       },
       "location": {
         "properties": {


### PR DESCRIPTION
Items sorting on standard holdings takes into consideration the numerical values in the character string.

* Closes #2243.
* Fixes noquery configuration on items sort.

⚠️  migration: items reindexing.
