### PR TITLE
acquisition: fix default vendor language

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -170,6 +170,7 @@ RATELIMIT_ENABLED = False
 # ====
 #: Default language
 BABEL_DEFAULT_LANGUAGE = 'en'
+RERO_ILS_APP_DEFAULT_LANGUAGE = 'eng'
 #: Default time zone
 BABEL_DEFAULT_TIMEZONE = 'Europe/Zurich'
 #: Other supported languages (do not include the default language in list).

--- a/rero_ils/modules/acquisition/acq_orders/views.py
+++ b/rero_ils/modules/acquisition/acq_orders/views.py
@@ -75,7 +75,9 @@ def order_notification_preview(order_pid):
               f'"{language}" language'
         current_app.logger.error(msg)
         response['message'] = [{'type': 'error', 'content': msg}]
-        tmpl_file = 'rero_ils/vendor_order_mail/eng.tpl.txt'
+        language = current_app.config.get(
+            'RERO_ILS_APP_DEFAULT_LANGUAGE', 'eng')
+        tmpl_file = f'rero_ils/vendor_order_mail/{language}.tpl.txt'
         response['preview'] = render_template(tmpl_file, order=order_data)
 
     return jsonify(response)

--- a/rero_ils/modules/notifications/subclasses/acq_order.py
+++ b/rero_ils/modules/notifications/subclasses/acq_order.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import, print_function
 
+from flask import current_app
 from werkzeug.utils import cached_property
 
 from rero_ils.modules.acquisition.acq_orders.dumpers import \
@@ -111,7 +112,10 @@ class AcquisitionOrderNotification(Notification):
         """Get the language to use for dispatching the notification."""
         # By default, the language to use to build the notification is defined
         # in the vendor setting. Override this method if needed in the future.
-        return self.order.vendor.get('communication_language')
+        return self.order.vendor.get(
+            'communication_language',
+            current_app.config.get('RERO_ILS_APP_DEFAULT_LANGUAGE', 'eng')
+        )
 
     def get_template_path(self):
         """Get the template to use to render the notification."""


### PR DESCRIPTION
If the vendor's communication language is not defined, we use the default language (eng).

* Closes #2714.