### PR TITLE
tests: fix patron expiration date

### DIFF
--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -540,7 +540,8 @@ def test_patron_info(app, client, patron_martigny, librarian_martigny):
         'fullname':
         'Roduit, Louis',
         'patron_types': [{
-            'expiration_date': '2023-10-07T00:00:00',
+            'expiration_date':
+                patron_martigny['patron']['expiration_date']+'T00:00:00',
             'institution': 'org1',
             'patron_type': 'patron-code'
         }]

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -25,7 +25,7 @@ import pytest
 from invenio_circulation.search.api import LoansSearch
 from invenio_db import db
 from utils import create_patron, flush_index, \
-    item_record_to_a_specific_loan_state
+    item_record_to_a_specific_loan_state, patch_expiration_date
 
 from rero_ils.modules.cli.fixtures import load_role_policies, \
     load_system_role_policies
@@ -231,13 +231,13 @@ def librarian_fully(
 @pytest.fixture(scope="module")
 def patron_martigny_data(data):
     """Load Martigny patron data."""
-    return deepcopy(data.get('ptrn6'))
+    return deepcopy(patch_expiration_date(data.get('ptrn6')))
 
 
 @pytest.fixture(scope="function")
 def patron_martigny_data_tmp(data):
     """Load Martigny patron data scope function."""
-    return deepcopy(data.get('ptrn6'))
+    return deepcopy(patch_expiration_date(data.get('ptrn6')))
 
 
 @pytest.fixture(scope="module")
@@ -274,7 +274,7 @@ def librarian_patron_martigny(
 @pytest.fixture(scope="module")
 def patron2_martigny_data(data):
     """Load Martigny patron data."""
-    return deepcopy(data.get('ptrn7'))
+    return deepcopy(patch_expiration_date(data.get('ptrn7')))
 
 
 @pytest.fixture(scope="module")
@@ -293,7 +293,7 @@ def patron2_martigny(
 @pytest.fixture(scope="module")
 def patron3_martigny_blocked_data(data):
     """Load Martigny blocked patron data."""
-    return deepcopy(data.get('ptrn11'))
+    return deepcopy(patch_expiration_date(data.get('ptrn11')))
 
 
 @pytest.fixture(scope="module")
@@ -312,7 +312,7 @@ def patron3_martigny_blocked(
 @pytest.fixture(scope="module")
 def patron4_martigny_data(data):
     """Load Martigny patron data."""
-    return deepcopy(data.get('ptrn12'))
+    return deepcopy(patch_expiration_date((data.get('ptrn12'))))
 
 
 @pytest.fixture(scope="module")
@@ -373,13 +373,13 @@ def librarian_sion(
 @pytest.fixture(scope="module")
 def patron_sion_data(data):
     """Load Sion patron data."""
-    return deepcopy(data.get('ptrn10'))
+    return deepcopy(patch_expiration_date(data.get('ptrn10')))
 
 
 @pytest.fixture(scope="function")
 def patron_sion_data_tmp(data):
     """Load Sion patron data scope function."""
-    return deepcopy(data.get('ptrn10'))
+    return deepcopy(patch_expiration_date(data.get('ptrn10')))
 
 
 @pytest.fixture(scope="module")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@
 import csv
 import json
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import jsonref
 import requests
@@ -447,3 +447,12 @@ def create_selfcheck_terminal(data):
     selfcheck_terminal = SelfcheckTerminal(**data)
     db.session.add(selfcheck_terminal)
     return selfcheck_terminal
+
+
+def patch_expiration_date(data):
+    """Patch expiration date for patrons."""
+    if data.get('patron', {}).get('expiration_date'):
+        # expiration date in one year
+        data['patron']['expiration_date'] = \
+            (datetime.now() + timedelta(days=365)).strftime('%Y-%m-%d')
+    return data


### PR DESCRIPTION
The patron fixtures should have a variable expiration date to avoid circulation
errors.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?
