### PR TITLE
translations: fix unicode chars in jsonschemas

### DIFF
--- a/rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
@@ -96,7 +96,7 @@
           "type": "string",
           "pattern": "^https://bib.rero.ch/api/acq_accounts/.*?$",
           "form": {
-            "placeholder": "Choose a parent account\u2026",
+            "placeholder": "Choose a parent account",
             "type": "account-select",
             "templateOptions": {
               "label": ""

--- a/rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json
+++ b/rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json
@@ -60,7 +60,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: Universit\u00e9 de Bordeaux III"
+        "placeholder": "Example: University of Cambridge"
       }
     },
     "authorized_access_point": {
@@ -85,7 +85,7 @@
         "type": "string",
         "minLength": 1,
         "form": {
-          "placeholder": "Example: Institut d'histoire"
+          "placeholder": "Example: Faculty of Philosophy"
         }
       }
     },
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: 1955"
+        "placeholder": "Example: 1848"
       }
     },
     "end_date": {

--- a/rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json
+++ b/rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: Walk\u00fcre"
+        "placeholder": "Example: The Lord of the Rings"
       }
     },
     "creator": {
@@ -59,7 +59,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "placeholder": "Example: Wagner, Richard, 1813-1883"
+        "placeholder": "Example: Tolkien, John Ronald Reuel, 1892-1973"
       }
     },
     "authorized_access_point": {

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2021-10-24 13:38+0000\n"
 "Last-Translator: ButterflyOfFire <ButterflyOfFire@protonmail.com>\n"
 "Language: ar\n"
@@ -4438,7 +4438,7 @@ msgid "Account URI"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6307,7 +6307,6 @@ msgid "Birth date"
 msgstr "تاريخ الميلاد"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 #, fuzzy
 msgid "Example: 1955"
@@ -9312,7 +9311,7 @@ msgid "Deletion date"
 msgstr "تاريخ إنشاء "
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9327,7 +9326,11 @@ msgid "Authorized access point"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr ""
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
@@ -9436,7 +9439,7 @@ msgid "Example: Antiquities, Industrial"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
@@ -9447,7 +9450,7 @@ msgid "Creator"
 msgstr "أمين المكتبة"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
 msgstr ""
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
@@ -12809,5 +12812,8 @@ msgstr "تمت إعادة تعيين كلمتك السرية بنجاح."
 #~ msgstr "المستندات"
 
 #~ msgid "Select…"
+#~ msgstr ""
+
+#~ msgid "Example: Wagner, Richard, 1813-1883"
 #~ msgstr ""
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -16,17 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2023-10-06 08:22+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/de/>\n"
 "Language: de\n"
+"Language-Team: German <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/de/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.1-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -4443,7 +4442,7 @@ msgid "Account URI"
 msgstr "Konto URI"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr "Elternkonto wählen"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6189,8 +6188,8 @@ msgid ""
 "Link to a remote or local entity of type person, family or corporate body"
 " (including conferences)."
 msgstr ""
-"Link zu einer entfernten oder lokalen Entität des Typs Person, Familie oder "
-"Körperschaft (einschließlich Konferenzen)."
+"Link zu einer entfernten oder lokalen Entität des Typs Person, Familie "
+"oder Körperschaft (einschließlich Konferenzen)."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
@@ -6206,9 +6205,9 @@ msgid ""
 "conferences). Usually used temporarily until a link to an entity can be "
 "established."
 msgstr ""
-"Textliche Beschreibung einer Person, Familie oder Körperschaft ("
-"einschließlich Konferenzen). Wird in der Regel temporär verwendet, bis einer "
-"Link zu einer Entität hergestellt werden kann."
+"Textliche Beschreibung einer Person, Familie oder Körperschaft "
+"(einschließlich Konferenzen). Wird in der Regel temporär verwendet, bis "
+"einer Link zu einer Entität hergestellt werden kann."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
 msgid "Link to an agent"
@@ -6342,7 +6341,6 @@ msgid "Birth date"
 msgstr "Geburtsdatum"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr "Beispiel: 1955"
@@ -7477,9 +7475,9 @@ msgid ""
 "Textual description of a topic (including genre and forms), person, "
 "organisation (including conferences), place, temporal or work."
 msgstr ""
-"Textliche Beschreibung eines Themas (einschließlich Genre und Form), einer "
-"Person, einer Körperschaft (einschließlich Konferenzen), eines Ortes, einer "
-"Zeitraum oder eines Werks."
+"Textliche Beschreibung eines Themas (einschließlich Genre und Form), "
+"einer Person, einer Körperschaft (einschließlich Konferenzen), eines "
+"Ortes, einer Zeitraum oder eines Werks."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
@@ -7558,16 +7556,16 @@ msgid ""
 "Link to a remote or local entity of type topic accepted as a 'genre, "
 "form'."
 msgstr ""
-"Link zu einer entfernten oder lokalen Entität vom Typ Thema, die als \"Genre"
-", Form\" akzeptiert wird."
+"Link zu einer entfernten oder lokalen Entität vom Typ Thema, die als "
+"\"Genre, Form\" akzeptiert wird."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Textual description of a genre or form. Usually used temporarily until a "
 "link to an entity can be established."
 msgstr ""
-"Textliche Beschreibung eines Genres oder Form. Wird in der Regel temporär "
-"verwendet, bis einer Link zu einer Entität hergestellt werden kann."
+"Textliche Beschreibung eines Genres oder Form. Wird in der Regel temporär"
+" verwendet, bis einer Link zu einer Entität hergestellt werden kann."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
 msgid "Link to a genre, form"
@@ -8609,8 +8607,8 @@ msgid ""
 "Topic, person, organisation (including conferences), place, temporal or "
 "work that is a subject of the document."
 msgstr ""
-"Thema, Person, Organisation (einschließlich Konferenzen), Ort, Zeitraum oder "
-"Werk, das Gegenstand des Dokuments ist."
+"Thema, Person, Organisation (einschließlich Konferenzen), Ort, Zeitraum "
+"oder Werk, das Gegenstand des Dokuments ist."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 msgid ""
@@ -8626,10 +8624,10 @@ msgid ""
 "conferences), place, temporal or work. Usually used temporarily until a "
 "link to an entity can be established."
 msgstr ""
-"Textliche Beschreibung eines Themas, einer Person, einer Körperschaft ("
-"einschließlich Konferenzen), eines Ortes, eines Zeitraums oder eines Werks. "
-"Wird in der Regel temporär verwendet, bis einer Link zu einer Entität "
-"hergestellt werden kann."
+"Textliche Beschreibung eines Themas, einer Person, einer Körperschaft "
+"(einschließlich Konferenzen), eines Ortes, eines Zeitraums oder eines "
+"Werks. Wird in der Regel temporär verwendet, bis einer Link zu einer "
+"Entität hergestellt werden kann."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
 msgid "Link to a subject"
@@ -9306,8 +9304,8 @@ msgid "Deletion date"
 msgstr "Löschdatum"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
-msgstr "Beispiel: Université de Bordeaux III"
+msgid "Example: University of Cambridge"
+msgstr "Beispiel: University of Cambridge"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:65
@@ -9321,8 +9319,12 @@ msgid "Authorized access point"
 msgstr "Normierter Sucheinstieg"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
-msgstr "Beispiel: Institut für Geschichte"
+msgid "Example: Faculty of Philosophy"
+msgstr "Beispiel: Faculty of Philosophy"
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
+msgstr "Beispiel: 1848"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
 msgid "Example: 2015"
@@ -9428,8 +9430,8 @@ msgid "Example: Antiquities, Industrial"
 msgstr "Beispiel: Antiquitäten, Industrie"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
-msgstr "Beispiel: Walküre"
+msgid "Example: The Lord of the Rings"
+msgstr "Beispiel: Der Herr der Ringe"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
 #: rero_ils/modules/entities/templates/rero_ils/_local_work.html:21
@@ -9438,8 +9440,8 @@ msgid "Creator"
 msgstr "Ersteller"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
-msgstr "Beispiel: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
+msgstr "Beispiel: Tolkien, John Ronald Reuel, 1892-1973"
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
 msgid "Mef entity"

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -17,17 +17,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2023-10-04 09:42+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: English <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/en/>\n"
 "Language: en\n"
+"Language-Team: English <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/en/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.1-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -4444,7 +4443,7 @@ msgid "Account URI"
 msgstr "Account URI"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr "Choose a parent account"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6175,8 +6174,8 @@ msgid ""
 "Link to a remote or local entity of type person, family or corporate body"
 " (including conferences)."
 msgstr ""
-"Link to a remote or local entity of type person, family or corporate body ("
-"including conferences)."
+"Link to a remote or local entity of type person, family or corporate body"
+" (including conferences)."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
@@ -6328,7 +6327,6 @@ msgid "Birth date"
 msgstr "Date of birth"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr "Example: 1955"
@@ -7539,7 +7537,8 @@ msgid ""
 "Link to a remote or local entity of type topic accepted as a 'genre, "
 "form'."
 msgstr ""
-"Link to a remote or local entity of type topic accepted as a 'genre, form'."
+"Link to a remote or local entity of type topic accepted as a 'genre, "
+"form'."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
@@ -8579,16 +8578,16 @@ msgid ""
 "Topic, person, organisation (including conferences), place, temporal or "
 "work that is a subject of the document."
 msgstr ""
-"Topic, person, organisation (including conferences), place, temporal or work "
-"that is a subject of the document."
+"Topic, person, organisation (including conferences), place, temporal or "
+"work that is a subject of the document."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 msgid ""
 "Link to a remote or local entity of type topic, person, organisation "
 "(including conferences), place, temporal or work."
 msgstr ""
-"Link to a remote or local entity of type topic, person, organisation ("
-"including conferences), place, temporal or work."
+"Link to a remote or local entity of type topic, person, organisation "
+"(including conferences), place, temporal or work."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
 msgid ""
@@ -8596,9 +8595,9 @@ msgid ""
 "conferences), place, temporal or work. Usually used temporarily until a "
 "link to an entity can be established."
 msgstr ""
-"Textual description of a topic, person, organisation (including conferences)"
-", place, temporal or work. Usually used temporarily until a link to an "
-"entity can be established."
+"Textual description of a topic, person, organisation (including "
+"conferences), place, temporal or work. Usually used temporarily until a "
+"link to an entity can be established."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
 msgid "Link to a subject"
@@ -9274,8 +9273,8 @@ msgid "Deletion date"
 msgstr "Deletion date"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
-msgstr "Example: Université de Bordeaux III"
+msgid "Example: University of Cambridge"
+msgstr "Example: University of Cambridge"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:65
@@ -9289,8 +9288,12 @@ msgid "Authorized access point"
 msgstr "Authorized access point"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
-msgstr "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr "Example: Faculty of Philosophy"
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
+msgstr "Example: 1848"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
 msgid "Example: 2015"
@@ -9396,8 +9399,8 @@ msgid "Example: Antiquities, Industrial"
 msgstr "Example: Antiquities, Industrial"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
-msgstr "Example: Walküre"
+msgid "Example: The Lord of the Rings"
+msgstr "Example: The Lord of the Rings"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
 #: rero_ils/modules/entities/templates/rero_ils/_local_work.html:21
@@ -9406,8 +9409,8 @@ msgid "Creator"
 msgstr "Creator"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
-msgstr "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
+msgstr "Example: Tolkien, John Ronald Reuel, 1892-1973"
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
 msgid "Mef entity"

--- a/rero_ils/translations/eo/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/eo/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.0.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2021-06-09 13:00+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: eo\n"
@@ -4446,7 +4446,7 @@ msgid "Account URI"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6285,7 +6285,6 @@ msgid "Birth date"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr ""
@@ -9157,7 +9156,7 @@ msgid "Deletion date"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9172,7 +9171,11 @@ msgid "Authorized access point"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr ""
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
@@ -9279,7 +9282,7 @@ msgid "Example: Antiquities, Industrial"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
@@ -9289,7 +9292,7 @@ msgid "Creator"
 msgstr "Kreinto"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
 msgstr ""
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
@@ -12501,4 +12504,3 @@ msgstr ""
 
 #~ msgid "Select…"
 #~ msgstr ""
-

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,17 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2023-10-06 07:49+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/es/>\n"
 "Language: es\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/es/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.1-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -4439,7 +4438,7 @@ msgid "Account URI"
 msgstr "URI de la cuenta"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr "Elegir una cuenta principal"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6165,8 +6164,8 @@ msgid ""
 "Person, family or corporate body (including conferences) and their "
 "contributing role for the document."
 msgstr ""
-"Persona, familia o entidad corporativa (incluidas conferencias) y su papel "
-"contribuyente al documento."
+"Persona, familia o entidad corporativa (incluidas conferencias) y su "
+"papel contribuyente al documento."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
@@ -6196,9 +6195,9 @@ msgid ""
 "conferences). Usually used temporarily until a link to an entity can be "
 "established."
 msgstr ""
-"Descripción textual de una persona, familia o entidad corporativa ("
-"incluyendo conferencias). Normalmente se utiliza temporalmente hasta que se "
-"pueda establecer un enlace con una entidad."
+"Descripción textual de una persona, familia o entidad corporativa "
+"(incluyendo conferencias). Normalmente se utiliza temporalmente hasta que"
+" se pueda establecer un enlace con una entidad."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
 msgid "Link to an agent"
@@ -6332,7 +6331,6 @@ msgid "Birth date"
 msgstr "Fecha de nacimiento"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr "Ejemplo: 1955"
@@ -8610,8 +8608,8 @@ msgid ""
 "link to an entity can be established."
 msgstr ""
 "Descripción textual de un tema, persona, entidad corporativa (incluyendo "
-"conferencias), lugar, temporal u obra. Normalmente se utiliza temporalmente "
-"hasta que se pueda establecer un enlace con una entidad."
+"conferencias), lugar, temporal u obra. Normalmente se utiliza "
+"temporalmente hasta que se pueda establecer un enlace con una entidad."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
 msgid "Link to a subject"
@@ -9289,8 +9287,8 @@ msgid "Deletion date"
 msgstr "Fecha de supresión"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
-msgstr "Ejemplo: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
+msgstr "Ejemplo: University of Cambridge"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:65
@@ -9304,8 +9302,12 @@ msgid "Authorized access point"
 msgstr "Punto de acceso autorizado"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
-msgstr "Ejemplo: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr "Ejemplo: Faculty of Philosophy"
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
+msgstr "Ejemplo: 1848"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
 msgid "Example: 2015"
@@ -9411,8 +9413,8 @@ msgid "Example: Antiquities, Industrial"
 msgstr "Ejemplo: Antigüedades, Industrial"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
-msgstr "Ejemplo: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
+msgstr "Ejemplo: El Señor de los Anillos"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
 #: rero_ils/modules/entities/templates/rero_ils/_local_work.html:21
@@ -9421,8 +9423,8 @@ msgid "Creator"
 msgstr "Creador"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
-msgstr "Ejemplo: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
+msgstr "Ejemplo: Tolkien, John Ronald Reuel, 1892-1973"
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
 msgid "Mef entity"

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -20,17 +20,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2023-10-04 09:42+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/fr/>\n"
 "Language: fr\n"
+"Language-Team: French <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/fr/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 5.1-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -4447,7 +4446,7 @@ msgid "Account URI"
 msgstr "URI du compte"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr "Choisir un compte parent"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6173,8 +6172,8 @@ msgid ""
 "Person, family or corporate body (including conferences) and their "
 "contributing role for the document."
 msgstr ""
-"Personne, famille ou collectivité (y compris les conférences) et son rôle de "
-"contribution au document."
+"Personne, famille ou collectivité (y compris les conférences) et son rôle"
+" de contribution au document."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:14
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:13
@@ -6204,9 +6203,9 @@ msgid ""
 "conferences). Usually used temporarily until a link to an entity can be "
 "established."
 msgstr ""
-"Description textuelle d'une personne, d'une famille ou d'une collectivité (y "
-"compris conférences). Généralement temporaire, jusqu'à ce qu'un lien à une "
-"entité puisse être établi."
+"Description textuelle d'une personne, d'une famille ou d'une collectivité"
+" (y compris conférences). Généralement temporaire, jusqu'à ce qu'un lien "
+"à une entité puisse être établi."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
 msgid "Link to an agent"
@@ -6340,7 +6339,6 @@ msgid "Birth date"
 msgstr "Date de naissance"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr "Exemple : 1955"
@@ -7477,8 +7475,8 @@ msgid ""
 "organisation (including conferences), place, temporal or work."
 msgstr ""
 "Description textuelle d'un thème (y compris genre et formes), d'une "
-"personne, d'une collectivité (y compris conférences), d'un lieu, d'un laps "
-"de temps ou d'une œuvre."
+"personne, d'une collectivité (y compris conférences), d'un lieu, d'un "
+"laps de temps ou d'une œuvre."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
@@ -7557,16 +7555,16 @@ msgid ""
 "Link to a remote or local entity of type topic accepted as a 'genre, "
 "form'."
 msgstr ""
-"Lien vers une entité distante ou locale de type thème acceptée comme 'genre, "
-"forme'."
+"Lien vers une entité distante ou locale de type thème acceptée comme "
+"'genre, forme'."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:31
 msgid ""
 "Textual description of a genre or form. Usually used temporarily until a "
 "link to an entity can be established."
 msgstr ""
-"Description textuelle d'un genre ou forme. Généralement temporaire, jusqu'à "
-"ce qu'un lien à une entité puisse être établi."
+"Description textuelle d'un genre ou forme. Généralement temporaire, "
+"jusqu'à ce qu'un lien à une entité puisse être établi."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
 msgid "Link to a genre, form"
@@ -8607,8 +8605,8 @@ msgid ""
 "Topic, person, organisation (including conferences), place, temporal or "
 "work that is a subject of the document."
 msgstr ""
-"Thème, personne, collectivité (y compris conférences), lieu, laps de temps "
-"ou œuvre qui est un sujet du document."
+"Thème, personne, collectivité (y compris conférences), lieu, laps de "
+"temps ou œuvre qui est un sujet du document."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 msgid ""
@@ -9303,7 +9301,7 @@ msgid "Deletion date"
 msgstr "Date de suppression"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr "Exemple : Université de Bordeaux III"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9318,8 +9316,12 @@ msgid "Authorized access point"
 msgstr "Point d'accès autorisé"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
-msgstr "Exemple : Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr "Exemple :Institut d'Histoire"
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
+msgstr "Exemple : 1848"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
 msgid "Example: 2015"
@@ -9425,8 +9427,8 @@ msgid "Example: Antiquities, Industrial"
 msgstr "Exemple : Antiquités, Industriel"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
-msgstr "Exemple : Walküre"
+msgid "Example: The Lord of the Rings"
+msgstr "Exemple : Le seigneur des anneaux"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
 #: rero_ils/modules/entities/templates/rero_ils/_local_work.html:21
@@ -9435,8 +9437,8 @@ msgid "Creator"
 msgstr "Créateur"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
-msgstr "Exemple : Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
+msgstr "Exemple : Tolkien, John Ronald Reuel, 1892-1973"
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
 msgid "Mef entity"

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,17 +18,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2023-10-06 08:22+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/rero_plus/"
-"rero-ils/it/>\n"
 "Language: it\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/rero_plus"
+"/rero-ils/it/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.1-dev\n"
 "Generated-By: Babel 2.12.1\n"
 
 #: rero_ils/accounts_views.py:60
@@ -4445,7 +4444,7 @@ msgid "Account URI"
 msgstr "URI del conto"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr "Scegliere un conto genitore"
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6183,8 +6182,8 @@ msgid ""
 "Link to a remote or local entity of type person, family or corporate body"
 " (including conferences)."
 msgstr ""
-"Link a un'entità remota o locale di tipo persona, famiglia o ente (comprese "
-"le conferenze)."
+"Link a un'entità remota o locale di tipo persona, famiglia o ente "
+"(comprese le conferenze)."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:36
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:2
@@ -6200,9 +6199,9 @@ msgid ""
 "conferences). Usually used temporarily until a link to an entity can be "
 "established."
 msgstr ""
-"Descrizione testuale di una persona, di una famiglia o di un ente (comprese "
-"le conferenze). Di solito viene utilizzato temporaneamente fino a quando non "
-"si riesce a stabilire un link con un'entità."
+"Descrizione testuale di una persona, di una famiglia o di un ente "
+"(comprese le conferenze). Di solito viene utilizzato temporaneamente fino"
+" a quando non si riesce a stabilire un link con un'entità."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_entity_link-v0.0.1.json:2
 msgid "Link to an agent"
@@ -6336,7 +6335,6 @@ msgid "Birth date"
 msgstr "Data di nascita"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr "Esempio: 1955"
@@ -7469,9 +7467,9 @@ msgid ""
 "Textual description of a topic (including genre and forms), person, "
 "organisation (including conferences), place, temporal or work."
 msgstr ""
-"Descrizione testuale di un tema (compresi generi e forme), di una persona, "
-"di un ente (comprese le conferenze), di un luogo, di un arco di tempo o di "
-"un opera."
+"Descrizione testuale di un tema (compresi generi e forme), di una "
+"persona, di un ente (comprese le conferenze), di un luogo, di un arco di "
+"tempo o di un opera."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:121
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
@@ -7557,9 +7555,9 @@ msgid ""
 "Textual description of a genre or form. Usually used temporarily until a "
 "link to an entity can be established."
 msgstr ""
-"Descrizione testuale di un genere o di una forma. Di solito viene utilizzato "
-"temporaneamente fino a quando non si riesce a stabilire un link con "
-"un'entità."
+"Descrizione testuale di un genere o di una forma. Di solito viene "
+"utilizzato temporaneamente fino a quando non si riesce a stabilire un "
+"link con un'entità."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:2
 msgid "Link to a genre, form"
@@ -8598,16 +8596,16 @@ msgid ""
 "Topic, person, organisation (including conferences), place, temporal or "
 "work that is a subject of the document."
 msgstr ""
-"Tema, persona, ente (comprese le conferenze), luogo, arco di tempo o opera "
-"che è soggetto del documento."
+"Tema, persona, ente (comprese le conferenze), luogo, arco di tempo o "
+"opera che è soggetto del documento."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:15
 msgid ""
 "Link to a remote or local entity of type topic, person, organisation "
 "(including conferences), place, temporal or work."
 msgstr ""
-"Link a un'entità remota o locale di tipo tema, persona, ente (comprese le "
-"conferenze), luogo, arco di tempo o opera."
+"Link a un'entità remota o locale di tipo tema, persona, ente (comprese le"
+" conferenze), luogo, arco di tempo o opera."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:32
 msgid ""
@@ -8617,8 +8615,8 @@ msgid ""
 msgstr ""
 "Descrizione testuale di un tema, una persona, un ente (comprese le "
 "conferenze), un luogo, un arco di tempo o un opera. Di solito viene "
-"utilizzato temporaneamente fino a quando non si riesce a stabilire un link "
-"con un'entità."
+"utilizzato temporaneamente fino a quando non si riesce a stabilire un "
+"link con un'entità."
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:2
 msgid "Link to a subject"
@@ -9295,8 +9293,8 @@ msgid "Deletion date"
 msgstr "Data di eliminazione"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
-msgstr "Esempio: Université de Bordeaux III"
+msgid "Example: University of Cambridge"
+msgstr "Esempio: University of Cambridge"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:65
@@ -9310,8 +9308,12 @@ msgid "Authorized access point"
 msgstr "Punto d'accesso autorizzato"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
-msgstr "Esempio: Istituto di Storia"
+msgid "Example: Faculty of Philosophy"
+msgstr "Esempio: Faculty of Philosophy"
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
+msgstr "Esempio: 1848"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
 msgid "Example: 2015"
@@ -9417,8 +9419,8 @@ msgid "Example: Antiquities, Industrial"
 msgstr "Esempio: Antichità, Industriale"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
-msgstr "Esempio: Walküre"
+msgid "Example: The Lord of the Rings"
+msgstr "Esempio: Il Signore degli Anelli"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
 #: rero_ils/modules/entities/templates/rero_ils/_local_work.html:21
@@ -9427,8 +9429,8 @@ msgid "Creator"
 msgstr "Creatore"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
-msgstr "Esempio: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
+msgstr "Esempio: Tolkien, John Ronald Reuel, 1892-1973"
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
 msgid "Mef entity"

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.18.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4427,7 +4427,7 @@ msgid "Account URI"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6264,7 +6264,6 @@ msgid "Birth date"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr ""
@@ -9132,7 +9131,7 @@ msgid "Deletion date"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9147,7 +9146,11 @@ msgid "Authorized access point"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr ""
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
@@ -9254,7 +9257,7 @@ msgid "Example: Antiquities, Industrial"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
@@ -9264,7 +9267,7 @@ msgid "Creator"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
 msgstr ""
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2023-09-26 13:01+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
 "Language: nl\n"
@@ -4482,7 +4482,7 @@ msgid "Account URI"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6364,7 +6364,6 @@ msgid "Birth date"
 msgstr "Geboortedatum"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 #, fuzzy
 msgid "Example: 1955"
@@ -9403,7 +9402,7 @@ msgid "Deletion date"
 msgstr "Verwijderingsdatum"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9418,7 +9417,11 @@ msgid "Authorized access point"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr ""
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
@@ -9527,7 +9530,7 @@ msgid "Example: Antiquities, Industrial"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
@@ -9538,7 +9541,7 @@ msgid "Creator"
 msgstr "Operator"
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
 msgstr ""
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
@@ -12938,4 +12941,3 @@ msgstr ""
 
 #~ msgid "Select…"
 #~ msgstr ""
-

--- a/rero_ils/translations/ru/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ru/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2022-01-21 16:53+0000\n"
 "Last-Translator: lushnikov3d37b9a0863842c1 <pavel.lushnikov@gmail.com>\n"
 "Language: ru\n"
@@ -4444,7 +4444,7 @@ msgid "Account URI"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6282,7 +6282,6 @@ msgid "Birth date"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr ""
@@ -9150,7 +9149,7 @@ msgid "Deletion date"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9165,7 +9164,11 @@ msgid "Authorized access point"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr ""
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
@@ -9272,7 +9275,7 @@ msgid "Example: Antiquities, Industrial"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
@@ -9282,7 +9285,7 @@ msgid "Creator"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
 msgstr ""
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
@@ -12483,4 +12486,3 @@ msgstr ""
 
 #~ msgid "Select…"
 #~ msgstr ""
-

--- a/rero_ils/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.5.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2023-10-04 09:26+0200\n"
+"POT-Creation-Date: 2023-10-11 09:42+0200\n"
 "PO-Revision-Date: 2021-12-25 09:52+0000\n"
 "Last-Translator: Sam Tse <codefzer@gmail.com>\n"
 "Language: zh_Hant\n"
@@ -4462,7 +4462,7 @@ msgid "Account URI"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:99
-msgid "Choose a parent account\\u2026"
+msgid "Choose a parent account"
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:109
@@ -6305,7 +6305,6 @@ msgid "Birth date"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution_person-v0.0.1.json:51
-#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_person-v0.0.1.json:83
 msgid "Example: 1955"
 msgstr ""
@@ -9248,7 +9247,7 @@ msgid "Deletion date"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:63
-msgid "Example: Universit\\u00e9 de Bordeaux III"
+msgid "Example: University of Cambridge"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:67
@@ -9263,7 +9262,11 @@ msgid "Authorized access point"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:88
-msgid "Example: Institut d'histoire"
+msgid "Example: Faculty of Philosophy"
+msgstr ""
+
+#: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:97
+msgid "Example: 1848"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_organisation-v0.0.1.json:105
@@ -9370,7 +9373,7 @@ msgid "Example: Antiquities, Industrial"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:54
-msgid "Example: Walk\\u00fcre"
+msgid "Example: The Lord of the Rings"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:58
@@ -9380,7 +9383,7 @@ msgid "Creator"
 msgstr ""
 
 #: rero_ils/modules/entities/local_entities/jsonschemas/local_entities/local_entity_work-v0.0.1.json:62
-msgid "Example: Wagner, Richard, 1813-1883"
+msgid "Example: Tolkien, John Ronald Reuel, 1892-1973"
 msgstr ""
 
 #: rero_ils/modules/entities/remote_entities/jsonschemas/remote_entities/remote_entity-v0.0.1.json:4
@@ -12603,4 +12606,3 @@ msgstr "您的密碼已成功重置。"
 
 #~ msgid "Select…"
 #~ msgstr ""
-


### PR DESCRIPTION
* Unicode values are not correctly translated, so we should avoid using them in the jsonschemas.

