### PR TITLE
document: advanced search config and endpoint

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -159,6 +159,9 @@ RERO_ILS_PRIVACY_POLICY_URL = 'https://www.rero.ch/legal/privacy/declaration_pro
 RERO_ILS_ILL_REQUEST_ON_GLOBAL_VIEW = True
 RERO_ILS_ILL_DEFAULT_SOURCE = 'RERO +'
 
+# DOCUMENT ADVANCED SEARCH
+RERO_ILS_APP_DOCUMENT_ADVANCED_SEARCH = True
+
 # Rate limiting
 # =============
 #: Storage for ratelimiter.
@@ -3639,3 +3642,184 @@ RERO_ILS_PASSWORD_MIN_LENGTH = 8
 RERO_ILS_PASSWORD_SPECIAL_CHAR = False
 RERO_ILS_PASSWORD_GENERATOR = 'rero_ils.modules.utils:password_generator'
 RERO_ILS_PASSWORD_VALIDATOR = 'rero_ils.modules.utils:password_validator'
+
+# ADVANCED SEARCH CONFIG
+# ======================
+def search_type(field):
+    """Search type options.
+
+    :param: field: the field key.
+    :return: a list of options.
+    """
+    output = [];
+    if field not in [
+        'canton', 'country', 'rdaCarrierType', 'rdaContentType',
+        'rdaMediaType'
+    ]:
+        output.append({'label': _('contains'), 'value': 'contains'})
+    if field not in ['identifiedBy', 'isbn', 'issn']:
+        output.append({'label': _('phrase'), 'value': 'phrase'})
+    return output
+
+RERO_ILS_APP_ADVANCED_SEARCH_CONFIG = [
+    {
+        'label': 'Title',
+        'value': 'title',
+        'field': 'title.*',
+        'options': {
+            'search_type': search_type('title')
+        }
+    },
+    {
+        'label': 'Responsibility statement',
+        'value': 'responsibilityStatement',
+        'field': 'responsibilityStatement.value',
+        'options': {
+            'search_type': search_type('responsibilityStatement')
+        }
+    },
+    {
+        'label': 'Contribution',
+        'value': 'contribution',
+        'field': 'contribution.entity.*',
+        'options': {
+            'search_type': search_type('contribution')
+        }
+    },
+    {
+        'label': 'Country',
+        'value': 'country',
+        'field': 'provisionActivity.place.country',
+        'options': {
+            'search_type': search_type('country')
+        }
+    },
+    {
+        'label': 'Canton',
+        'value': 'canton',
+        'field': 'provisionActivity.place.canton',
+        'options': {
+            'search_type': search_type('canton')
+        }
+    },
+    {
+        'label': 'Provision activity statement',
+        'value': 'provisionActivityStatement',
+        'field': 'provisionActivity._text.value',
+        'options': {
+            'search_type': search_type('provisionActivityStatement')
+        }
+    },
+    {
+        'label': 'Series statement',
+        'value': 'seriesStatement',
+        'field': 'seriesStatement.*',
+        'options': {
+            'search_type': search_type('seriesStatement')
+        }
+    },
+    {
+        'label': 'Identifier',
+        'value': 'identifiedBy',
+        'field': 'identifiedBy.value',
+        'options': {
+            'search_type': search_type('identifiedBy')
+        }
+    },
+    {
+        'label': 'ISBN',
+        'value': 'isbn',
+        'field': 'isbn',
+        'options': {
+            'search_type': search_type('isbn')
+        }
+    },
+    {
+        'label': 'ISSN',
+        'value': 'issn',
+        'field': 'issn',
+        'options': {
+            'search_type': search_type('issn')
+        }
+    },
+    {
+        'label': 'Genre, form',
+        'value': 'genreForm',
+        'field': 'genreForm.entity.*',
+        'options': {
+            'search_type': search_type('genreForm')
+        }
+    },
+    {
+        'label': 'Subject',
+        'value': 'subjects',
+        'field': 'subjects.entity.*',
+        'options': {
+            'search_type': search_type('subjects')
+        }
+    },
+    {
+        'label': 'Call number',
+        'value': 'callNumber',
+        'field': 'call_numbers',
+        'options': {
+            'search_type': search_type('callNumber')
+        }
+    },
+    {
+        'label': 'Local fields (document)',
+        'value': 'documentLocalFields',
+        'field': 'local_fields.*',
+        'options': {
+            'search_type': search_type('documentLocalFields')
+        }
+    },
+    {
+        'label': 'Local fields (holdings)',
+        'value': 'holdingsLocalFields',
+        'field': 'holdings.local_fields.*',
+        'options': {
+            'search_type': search_type('holdingsLocalFields')
+        }
+    },
+    {
+        'label': 'Local fields (items)',
+        'value': 'itemLocalFields',
+        'field': 'holdings.items.local_fields.*',
+        'options': {
+            'search_type': search_type('itemLocalFields')
+        }
+    },
+    {
+        'label': 'Classification',
+        'value': 'classification',
+        'field': 'classification.*',
+        'options': {
+            'search_type': search_type('classification')
+        }
+    },
+    {
+        'label': 'RDA content type',
+        'value': 'rdaContentType',
+        'field': 'contentMediaCarrier.contentType',
+        'options': {
+            'search_type': search_type('rdaContentType')
+        }
+    },
+    {
+        'label': 'RDA media type',
+        'value': 'rdaMediaType',
+        'field': 'contentMediaCarrier.mediaType',
+        'options': {
+            'search_type': search_type('rdaMediaType')
+        }
+    },
+    {
+        'label': 'RDA carrier type',
+        'value': 'rdaCarrierType',
+        'field': 'contentMediaCarrier.carrierType',
+        'options': {
+            'search_type': search_type('rdaCarrierType')
+        }
+    },
+]

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -526,10 +526,10 @@
             "type": "object",
             "properties": {
               "canton": {
-                "type": "text"
+                "type": "keyword"
               },
               "country": {
-                "type": "text"
+                "type": "keyword"
               },
               "identifiedBy": {
                 "type": "object",
@@ -1139,10 +1139,12 @@
             }
           },
           "call_number": {
-            "type": "text"
+            "type": "text",
+            "copy_to": "call_numbers"
           },
           "second_call_number": {
-            "type": "text"
+            "type": "text",
+            "copy_to": "call_numbers"
           },
           "index": {
             "type": "text"
@@ -1166,10 +1168,12 @@
                 "type": "keyword"
               },
               "call_number": {
-                "type": "text"
+                "type": "text",
+                "copy_to": "call_numbers"
               },
               "second_call_number": {
-                "type": "text"
+                "type": "text",
+                "copy_to": "call_numbers"
               },
               "status": {
                 "type": "keyword"
@@ -2134,6 +2138,9 @@
             "ignore_above": 256
           }
         }
+      },
+      "call_numbers": {
+        "type": "text"
       },
       "_draft": {
         "type": "boolean"

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -134,6 +134,8 @@ def logged_user():
             'agentLabelOrder': config.get('RERO_ILS_AGENTS_LABEL_ORDER', {}),
             'agentSources': config.get('RERO_ILS_AGENTS_SOURCES', []),
             'operationLogs': config.get('RERO_ILS_ENABLE_OPERATION_LOG', []),
+            'documentAdvancedSearch': config.get(
+                'RERO_ILS_APP_DOCUMENT_ADVANCED_SEARCH', False),
             'userProfile': {
                 'readOnly': config.get(
                     'RERO_PUBLIC_USERPROFILES_READONLY', False),


### PR DESCRIPTION
* Adds configuration for enabled/disabled advanced search.
* Adds a new field in the document schema to group
  call number for holdings and items.
* Adds a new endpoint for advanced search config.

⚠️  update ES mapping and reindex ES documents