### PR TITLE
pricing stats: fix number of ill requests

### DIFF
--- a/tests/api/stats/test_stats_rest.py
+++ b/tests/api/stats/test_stats_rest.py
@@ -50,14 +50,13 @@ def test_stats_get(client, stats, csv_header):
         'library id,library name,number_of_active_patrons,'
         'number_of_checkins,number_of_checkouts,'
         'number_of_deleted_items,number_of_documents,'
-        'number_of_items,number_of_librarians,number_of_libraries,'
-        'number_of_new_items,number_of_new_patrons,'
+        'number_of_ill_requests,number_of_items,number_of_librarians,'
+        'number_of_libraries,number_of_new_items,number_of_new_patrons,'
         'number_of_order_lines,number_of_patrons,'
-        'number_of_renewals,number_of_requests,'
-        'number_of_validated_ill_requests\r\n'
-        'lib3,Library of Fully,0,0,0,0,1,1,0,2,1,1,0,1,0,0,0\r\n'
-        'lib1,Library of Martigny-ville,0,0,0,0,1,1,0,2,1,1,0,1,0,0,0\r\n'
-        'lib4,Library of Sion,0,0,0,0,1,1,0,1,1,0,0,0,0,0,0\r\n'
+        'number_of_renewals,number_of_requests\r\n'
+        'lib3,Library of Fully,0,0,0,0,1,0,1,0,2,1,1,0,1,0,0\r\n'
+        'lib1,Library of Martigny-ville,0,0,0,0,1,1,1,0,2,1,1,0,1,0,0\r\n'
+        'lib4,Library of Sion,0,0,0,0,1,0,1,0,1,1,0,0,0,0,0\r\n'
     )
 
     list_url = url_for('invenio_records_rest.stat_list')

--- a/tests/ui/stats/test_stats_pricing.py
+++ b/tests/ui/stats/test_stats_pricing.py
@@ -35,7 +35,7 @@ def test_stats_pricing_collect(stat_for_pricing):
         'library', 'number_of_documents', 'number_of_libraries',
         'number_of_librarians', 'number_of_active_patrons',
         'number_of_order_lines', 'number_of_checkouts', 'number_of_renewals',
-        'number_of_validated_ill_requests', 'number_of_items',
+        'number_of_ill_requests', 'number_of_items',
         'number_of_new_items', 'number_of_deleted_items', 'number_of_patrons',
         'number_of_new_patrons', 'number_of_checkins', 'number_of_requests']
 
@@ -95,19 +95,19 @@ def test_stats_pricing_number_of_circ_operations(
             lib_martigny.pid, ItemCirculationAction.CHECKOUT) == 1
 
 
-def test_stats_pricing_number_of_ill_requests_operations(
+def test_stats_pricing_number_of_ill_requests(
         stat_for_pricing, ill_request_martigny, lib_martigny):
-    """Test the number of ILL requests creation or update operations."""
+    """Test the number of ILL requests."""
     assert stat_for_pricing\
-        .number_of_ill_requests_operations(
-            'foo', [ILLRequestStatus.VALIDATED]) == 0
+        .number_of_ill_requests(
+            'foo', [ILLRequestStatus.DENIED]) == 0
     lib_pid = lib_martigny.pid
     assert stat_for_pricing\
-        .number_of_ill_requests_operations(
-            lib_pid, [ILLRequestStatus.CLOSED]) == 0
+        .number_of_ill_requests(
+            lib_pid, [ILLRequestStatus.DENIED]) == 1
     assert stat_for_pricing\
-        .number_of_ill_requests_operations(
-            lib_pid, [ILLRequestStatus.PENDING]) == 1
+        .number_of_ill_requests(
+            lib_pid, [ILLRequestStatus.PENDING]) == 0
 
 
 def test_stats_pricing_number_of_items(


### PR DESCRIPTION
* Fix the count of number of ILL request to be coherent with RERO+'s pricing criteria. All ILL requests created within the timeframe except those with the status "denied" are counted.
* The calculation is simplified and does not use operation logs, which created problems.