### PR TITLE
stats: fix permissions

### DIFF
--- a/data/role_policies.json
+++ b/data/role_policies.json
@@ -680,43 +680,39 @@
   ],
   "stat-access": [
     "pro_full_permissions",
-    "pro_library_administrator"
+    "pro_statistic_manager"
   ],
   "stat-search": [
-    "admin",
-    "monitoring",
-    "pro_read_only",
-    "pro_full_permissions"
+    "pro_full_permissions",
+    "pro_statistic_manager"
   ],
   "stat-read": [
-    "admin",
-    "monitoring",
-    "pro_read_only",
-    "pro_full_permissions"
+    "pro_full_permissions",
+    "pro_statistic_manager"
   ],
   "stat_cfg-access": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-search": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-read": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-create": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-update": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-delete": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "tmpl-access": [
     "pro_full_permissions",

--- a/data/stats_cfg.json
+++ b/data/stats_cfg.json
@@ -24,7 +24,7 @@
       "indicator": {
         "type": "number_of_checkouts",
         "distributions": [
-          "time_range_month"
+          "transaction_month"
         ]
       }
     },
@@ -43,7 +43,7 @@
       "indicator": {
         "type": "number_of_checkouts",
         "distributions": [
-          "library"
+          "owning_library"
         ]
       }
     },
@@ -139,7 +139,7 @@
       "indicator": {
         "type": "number_of_checkouts",
         "distributions": [
-          "time_range_month"
+          "transaction_month"
         ]
       }
     },
@@ -158,7 +158,7 @@
       "indicator": {
         "type": "number_of_checkouts",
         "distributions": [
-          "library"
+          "owning_library"
         ]
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ patrons = "rero_ils.modules.patrons.views:api_blueprint"
 permissions ="rero_ils.modules.views:api_blueprint"
 rero_ils = "rero_ils.modules.views:api_blueprint"
 users = "rero_ils.modules.users.api_views:api_blueprint"
+stats_cfg = "rero_ils.modules.stats_cfg.views:api_blueprint"
 
 [tool.poetry.plugins."invenio_base.apps"]
 rero-ils = "rero_ils.modules.ext:REROILSAPP"

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -799,6 +799,7 @@ RECORDS_REST_ENDPOINTS = dict(
         record_class='rero_ils.modules.stats.api.api:Stat',
         item_route='/stats/<pid(stat, record_class="rero_ils.modules.stats.api.api:Stat"):pid_value>',
         default_media_type='application/json',
+        search_factory_imp='rero_ils.query:organisation_search_factory',
         max_result_window=MAX_RESULT_WINDOW,
         list_permission_factory_imp=lambda record: StatisticsPermissionPolicy('search', record=record),
         read_permission_factory_imp=lambda record: StatisticsPermissionPolicy('read', record=record),
@@ -2892,7 +2893,7 @@ RECORDS_UI_ENDPOINTS = {
         template='rero_ils/detailed_view_stats.html',
         record_class='rero_ils.modules.stats.api.api:Stat',
         view_imp='rero_ils.modules.stats.views.stats_view_method',
-        permission_factory_imp='rero_ils.modules.stats.permissions:stats_ui_permission_factory',
+        permission_factory_imp='rero_ils.permissions.admin_permission_factory',
     )
 }
 

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -440,7 +440,7 @@
           "pro_acquisition_manager",
           "pro_library_administrator",
           "pro_entity_manager",
-          "pro_statistics_manager"
+          "pro_statistic_manager"
         ]
       },
       "form": {
@@ -484,8 +484,8 @@
               "value": "pro_entity_manager"
             },
             {
-              "label": "pro_statistics_manager",
-              "value": "pro_statistics_manager"
+              "label": "pro_statistic_manager",
+              "value": "pro_statistic_manager"
             }
           ],
           "wrappers": [

--- a/rero_ils/modules/stats/api/api.py
+++ b/rero_ils/modules/stats/api/api.py
@@ -24,6 +24,7 @@ from rero_ils.modules.api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
 from rero_ils.modules.fetchers import id_fetcher
 from rero_ils.modules.minters import id_minter
 from rero_ils.modules.providers import Provider
+from rero_ils.modules.utils import extracted_data_from_ref
 
 from ..extensions import StatisticsDumperExtension
 from ..models import StatIdentifier, StatMetadata
@@ -70,6 +71,12 @@ class Stat(IlsRecord):
         """Update data for record."""
         super().update(data, commit, dbcommit, reindex)
         return self
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid from the config for report."""
+        if ref := self.get('config', {}).get('organisation', {}).get('$ref'):
+            return extracted_data_from_ref(ref)
 
 
 class StatsIndexer(IlsRecordsIndexer):

--- a/rero_ils/modules/stats/api/report.py
+++ b/rero_ils/modules/stats/api/report.py
@@ -276,7 +276,8 @@ class StatsReport:
                             ItemCirculationAction.CHECKOUT
                         ],
                         date_range=range_period)
-                    .filter('term', organisation__value=self.org_pid).scan()
+                    .filter(
+                        'terms', loan__item__library_pid=self.lib_pids).scan()
                 ]
                 return base_query.filter('terms', pid=active_patron_pids)
 
@@ -294,7 +295,7 @@ class StatsReport:
             # 0 if not period else 1 as a boolean is an integer
             'query': lambda: (
                 s := RecordsSearch(index=LoanOperationLog.index_name)[:0]
-                .filter('term', organisation__value=self.org_pid)
+                .filter('terms', loan__item__library_pid=self.lib_pids)
                 .filter('term', record__type='loan')
                 .filter('term', loan__trigger=trigger),
                 s.filter('range', date=self._get_range_period(self.period))
@@ -400,7 +401,7 @@ class StatsReport:
             data.append(values)
         return data
 
-    def compute(self, force=False):
+    def collect(self, force=False):
         """Collect data for report.
 
         :param force: compute even if the configuration is not active.

--- a/rero_ils/modules/stats/cli.py
+++ b/rero_ils/modules/stats/cli.py
@@ -29,14 +29,20 @@ from flask.cli import with_appcontext
 from .api.api import Stat
 from .api.librarian import StatsForLibrarian
 from .api.pricing import StatsForPricing
+from .models import StatType
 
 
 @click.group()
 def stats():
-    """Notification management commands."""
+    """Statistics management commands."""
 
 
-@stats.command('dumps')
+@stats.group()
+def report():
+    """Stats report management commands."""
+
+
+@stats.command()
 @click.argument('type')
 @with_appcontext
 def dumps(type):
@@ -44,25 +50,25 @@ def dumps(type):
 
     :param type: type of statistics can be 'billing' or 'librarian'
     """
-    if type == 'billing':
+    if type == StatType.BILLING:
         pprint(StatsForPricing(to_date=arrow.utcnow()).collect(), indent=2)
-    elif type == 'librarian':
+    elif type == StatType.LIBRARIAN:
         pprint(StatsForLibrarian(to_date=arrow.utcnow()).collect(), indent=2)
 
 
-@stats.command('collect')
+@stats.command()
 @click.argument('type')
 @with_appcontext
 def collect(type):
-    """Extract the stats value and store it.
+    """Extract the stats values and store it.
 
     :param type: type of statistics can be 'billing' or 'librarian'
     """
     to_date = arrow.utcnow() - relativedelta(days=1)
     date_range = {}
-    if type == 'billing':
+    if type == StatType.BILLING:
         _stats = StatsForPricing(to_date=to_date)
-    elif type == 'librarian':
+    elif type == StatType.LIBRARIAN:
         _from = f'{to_date.year}-{to_date.month:02d}-01T00:00:00'
         _to = to_date.format(fmt='YYYY-MM-DDT23:59:59')
         date_range = {'from': _from, 'to': _to}
@@ -82,7 +88,7 @@ def collect(type):
             New pid: {stat.pid}', fg='green')
 
 
-@stats.command('collect_year')
+@stats.command()
 @click.argument('year', type=int)
 @click.argument('timespan', default='yearly')
 @click.option('--n_months', default=12)
@@ -97,7 +103,7 @@ def collect_year(year, timespan, n_months, force):
     :param force: force update of stat.
     """
     stat_pid = None
-    type = 'librarian'
+    type = StatType.LIBRARIAN
     if year:
         if timespan == 'montly':
             if n_months not in range(1, 13):
@@ -186,3 +192,52 @@ def collect_year(year, timespan, n_months, force):
                             New pid: {stat.pid}', fg='green')
 
         return
+
+
+@report.command()
+@click.argument('pid')
+@with_appcontext
+def dumps(pid):
+    """Extract the stats value for preview.
+
+    :param pid: pid value of the configuration to use.
+    """
+    from .api.report import StatsReport
+    from ..stats_cfg.api import StatConfiguration
+    cfg = StatConfiguration.get_record_by_pid(pid)
+    if not cfg:
+        click.secho(f'Configuration does not exists.', fg='red')
+    else:
+        from pprint import pprint
+        pprint(StatsReport(cfg).collect())
+
+
+@report.command()
+@click.argument('pid')
+@with_appcontext
+def collect(pid):
+    """Extract the stats report values and store it.
+
+    :param pid: pid value of the configuration to use.
+    """
+    from .api.report import StatsReport
+    from ..stats_cfg.api import StatConfiguration
+    cfg = StatConfiguration.get_record_by_pid(pid)
+    if not cfg:
+        click.secho(f'Configuration does not exists.', fg='red')
+    else:
+        stat_report = StatsReport(cfg)
+        res = stat_report.collect()
+        data = dict(
+            type=StatType.REPORT,
+            config=cfg.dumps(),
+            values=[dict(results=res)]
+        )
+        if stat_report.period:
+            range = stat_report._get_range_period(stat_report.period)
+            data['date_range'] = {
+                'from': range['gte'],
+                'to': range['lte']
+            }
+
+        Stat.create(data, dbcommit=True, reindex=True)

--- a/rero_ils/modules/stats/mappings/v7/stats/stat-v0.0.1.json
+++ b/rero_ils/modules/stats/mappings/v7/stats/stat-v0.0.1.json
@@ -12,6 +12,84 @@
       "date_range": {
         "type": "object"
       },
+      "organisation": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "pid": {
+            "type": "keyword"
+          }
+        }
+      },
+      "config": {
+        "type": "object",
+        "properties": {
+          "$schema": {
+            "type": "keyword"
+          },
+          "pid": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text",
+            "fields": {
+              "raw": {
+                "type": "keyword"
+              }
+            }
+          },
+          "description": {
+            "type": "text"
+          },
+          "frequency": {
+            "type": "keyword"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "organisation": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "keyword"
+              },
+              "pid": {
+                "type": "keyword"
+              }
+            }
+          },
+          "category": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "keyword"
+              },
+              "indicator": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "keyword"
+                  },
+                  "distributions": {
+                    "type": "keyword"
+                  },
+                  "period": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          },
+          "_created": {
+            "type": "date"
+          },
+          "_updated": {
+            "type": "date"
+          }
+        }
+      },
       "pid": {
         "type": "keyword"
       },

--- a/rero_ils/modules/stats/serializers.py
+++ b/rero_ils/modules/stats/serializers.py
@@ -22,6 +22,8 @@ from flask import current_app
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 from invenio_records_rest.serializers.response import add_link_header
 
+from .models import StatType
+
 
 class StatCSVSerializer(CSVSerializer):
     """Process data to write in csv file."""
@@ -48,7 +50,7 @@ class StatCSVSerializer(CSVSerializer):
         assert len(records) == 1
         record = records[0]
 
-        if record['metadata'].get('type') == 'librarian':
+        if record['metadata'].get('type') == StatType.LIBRARIAN:
             # statistics of type librarian
             headers = [key.capitalize().replace('_', ' ')
                        for key in self.ordered_keys]
@@ -75,7 +77,7 @@ class StatCSVSerializer(CSVSerializer):
                 value = StatCSVSerializer.sort_dict_by_key(value)[1]
                 writer.writerow(value)
                 yield line.read()
-        else:
+        elif record['metadata'].get('type') == StatType.BILLING:
             # statistics of type billing
             headers = set(('library name', 'library id'))
             for value in record['metadata']['values']:
@@ -103,6 +105,13 @@ class StatCSVSerializer(CSVSerializer):
                         for k, m in value[v].items():
                             dict_to_text += f'{k} :{m}\r\n'
                         value[v] = dict_to_text
+                writer.writerow(value)
+                yield line.read()
+        elif record['metadata'].get('type') == StatType.REPORT:
+            values = record['metadata']['values'][0]['results']
+            for value in values:
+                line = Line()
+                writer = csv.writer(line)
                 writer.writerow(value)
                 yield line.read()
 

--- a/rero_ils/modules/stats/tasks.py
+++ b/rero_ils/modules/stats/tasks.py
@@ -23,6 +23,7 @@ from flask import current_app
 from .api.api import Stat
 from .api.librarian import StatsForLibrarian
 from .api.pricing import StatsForPricing
+from .models import StatType
 
 
 @shared_task()
@@ -31,7 +32,7 @@ def collect_stats_billing():
     stats_pricing = StatsForPricing().collect()
     with current_app.app_context():
         stat = Stat.create(
-            dict(type='billing', values=stats_pricing),
+            dict(type=StatType.BILLING, values=stats_pricing),
             dbcommit=True, reindex=True)
         return f'New statistics of type {stat["type"]} has\
             been created with a pid of: {stat.pid}'
@@ -46,7 +47,7 @@ def collect_stats_librarian():
     stats_values = stats_librarian.collect()
     with current_app.app_context():
         stat = Stat.create(
-            dict(type='librarian', date_range=date_range,
+            dict(type=StatType.LIBRARIAN, date_range=date_range,
                  values=stats_values),
             dbcommit=True, reindex=True)
         return f'New statistics of type {stat["type"]} has\

--- a/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
+++ b/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
@@ -4,11 +4,11 @@
   "title": "Statistics configuration",
   "additionalProperties": false,
   "propertiesOrder": [
+    "is_active",
     "name",
     "description",
     "frequency",
-    "category",
-    "is_active"
+    "category"
   ],
   "required": [
     "$schema",
@@ -48,10 +48,7 @@
         "formlyConfig": {
           "type": "textarea",
           "templateOptions": {
-            "rows": 3,
-            "navigation": {
-              "essential": true
-            }
+            "rows": 3
           }
         }
       }
@@ -60,6 +57,7 @@
       "title": "Frequency",
       "description": "Frequency at which the statistics reports are created.",
       "type": "string",
+      "default": "month",
       "enum": [
         "month",
         "year"
@@ -139,8 +137,7 @@
                   "additionalProperties": false,
                   "propertiesOrder": [
                     "type",
-                    "distributions",
-                    "filter"
+                    "distributions"
                   ],
                   "required": [
                     "type"
@@ -171,8 +168,8 @@
                             "title": "distributions",
                             "type": "string",
                             "enum": [
-                              "time_range_month",
-                              "time_range_year",
+                              "created_month",
+                              "created_year",
                               "library",
                               "imported"
                             ]
@@ -180,14 +177,17 @@
                           "widget": {
                             "formlyConfig": {
                               "type": "selectWithSort",
+                              "templateOptions": {
+                                "sort": false
+                              },
                               "options": [
                                 {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
+                                  "value": "created_month",
+                                  "label": "created_month"
                                 },
                                 {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
+                                  "value": "created_year",
+                                  "label": "created_year"
                                 },
                                 {
                                   "value": "library",
@@ -202,16 +202,6 @@
                           }
                         }
                       ]
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: documents"
-                        }
-                      ]
                     }
                   }
                 },
@@ -219,8 +209,7 @@
                   "additionalProperties": false,
                   "propertiesOrder": [
                     "type",
-                    "distributions",
-                    "filter"
+                    "distributions"
                   ],
                   "required": [
                     "type"
@@ -251,22 +240,25 @@
                             "title": "distributions",
                             "type": "string",
                             "enum": [
-                              "time_range_month",
-                              "time_range_year",
+                              "created_month",
+                              "created_year",
                               "library"
                             ]
                           },
                           "widget": {
                             "formlyConfig": {
                               "type": "selectWithSort",
+                              "templateOptions": {
+                                "sort": false
+                              },
                               "options": [
                                 {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
+                                  "value": "created_month",
+                                  "label": "created_month"
                                 },
                                 {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
+                                  "value": "created_year",
+                                  "label": "created_year"
                                 },
                                 {
                                   "value": "library",
@@ -277,16 +269,6 @@
                           }
                         }
                       ]
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: holdings"
-                        }
-                      ]
                     }
                   }
                 },
@@ -294,8 +276,7 @@
                   "additionalProperties": false,
                   "propertiesOrder": [
                     "type",
-                    "distributions",
-                    "filter"
+                    "distributions"
                   ],
                   "required": [
                     "type"
@@ -326,8 +307,8 @@
                             "title": "distributions",
                             "type": "string",
                             "enum": [
-                              "time_range_month",
-                              "time_range_year",
+                              "created_month",
+                              "created_year",
                               "library",
                               "location",
                               "type"
@@ -336,14 +317,17 @@
                           "widget": {
                             "formlyConfig": {
                               "type": "selectWithSort",
+                              "templateOptions": {
+                                "sort": false
+                              },
                               "options": [
                                 {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
+                                  "value": "created_month",
+                                  "label": "created_month"
                                 },
                                 {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
+                                  "value": "created_year",
+                                  "label": "created_year"
                                 },
                                 {
                                   "value": "library",
@@ -362,16 +346,6 @@
                           }
                         }
                       ]
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: items"
-                        }
-                      ]
                     }
                   }
                 },
@@ -380,12 +354,10 @@
                   "propertiesOrder": [
                     "type",
                     "period",
-                    "distributions",
-                    "filter"
+                    "distributions"
                   ],
                   "required": [
-                    "type",
-                    "period"
+                    "type"
                   ],
                   "title": "Number of deleted items",
                   "properties": {
@@ -413,24 +385,25 @@
                             "title": "distributions",
                             "type": "string",
                             "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
-                              "item_location",
-                              "type"
+                              "action_month",
+                              "action_year",
+                              "library"
                             ]
                           },
                           "widget": {
                             "formlyConfig": {
                               "type": "selectWithSort",
+                              "templateOptions": {
+                                "sort": false
+                              },
                               "options": [
                                 {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
+                                  "value": "action_month",
+                                  "label": "action_month"
                                 },
                                 {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
+                                  "value": "action_year",
+                                  "label": "action_year"
                                 },
                                 {
                                   "value": "library",
@@ -452,16 +425,6 @@
                     },
                     "period": {
                       "$ref": "#/definitions/period"
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: operation_logs"
-                        }
-                      ]
                     }
                   }
                 }
@@ -503,8 +466,7 @@
                   "propertiesOrder": [
                     "type",
                     "distributions",
-                    "period",
-                    "filter"
+                    "period"
                   ],
                   "required": [
                     "type"
@@ -534,27 +496,30 @@
                             "title": "distributions",
                             "type": "string",
                             "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
+                              "created_month",
+                              "created_year",
+                              "pickup_location",
                               "status"
                             ]
                           },
                           "widget": {
                             "formlyConfig": {
                               "type": "selectWithSort",
+                              "templateOptions": {
+                                "sort": false
+                              },
                               "options": [
                                 {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
+                                  "value": "created_month",
+                                  "label": "created_month"
                                 },
                                 {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
+                                  "value": "created_year",
+                                  "label": "created_year"
                                 },
                                 {
-                                  "value": "library",
-                                  "label": "library"
+                                  "value": "pickup_location",
+                                  "label": "pickup_location"
                                 },
                                 {
                                   "value": "status",
@@ -568,16 +533,6 @@
                     },
                     "period": {
                       "$ref": "#/definitions/period"
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: ill_requests"
-                        }
-                      ]
                     }
                   }
                 },
@@ -586,8 +541,7 @@
                   "propertiesOrder": [
                     "type",
                     "distributions",
-                    "period",
-                    "filter"
+                    "period"
                   ],
                   "required": [
                     "type"
@@ -608,79 +562,10 @@
                       }
                     },
                     "distributions": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/distributions"
-                        },
-                        {
-                          "items": {
-                            "title": "distributions",
-                            "type": "string",
-                            "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
-                              "item_owning_library",
-                              "item_location",
-                              "patron_type",
-                              "document_type",
-                              "transaction_channel"
-                            ]
-                          },
-                          "widget": {
-                            "formlyConfig": {
-                              "type": "selectWithSort",
-                              "options": [
-                                {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
-                                },
-                                {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
-                                },
-                                {
-                                  "value": "library",
-                                  "label": "library"
-                                },
-                                {
-                                  "value": "item_owning_library",
-                                  "label": "item_owning_library"
-                                },
-                                {
-                                  "value": "item_location",
-                                  "label": "item_location"
-                                },
-                                {
-                                  "value": "patron_type",
-                                  "label": "patron_type"
-                                },
-                                {
-                                  "value": "document_type",
-                                  "label": "document_type"
-                                },
-                                {
-                                  "value": "transaction_channel",
-                                  "label": "transaction_channel"
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "$ref": "#/definitions/circulation_distributions"
                     },
                     "period": {
                       "$ref": "#/definitions/period"
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: operation_logs"
-                        }
-                      ]
                     }
                   }
                 },
@@ -689,8 +574,7 @@
                   "propertiesOrder": [
                     "type",
                     "distributions",
-                    "period",
-                    "filter"
+                    "period"
                   ],
                   "required": [
                     "type"
@@ -711,79 +595,10 @@
                       }
                     },
                     "distributions": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/distributions"
-                        },
-                        {
-                          "items": {
-                            "title": "distributions",
-                            "type": "string",
-                            "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
-                              "item_owning_library",
-                              "item_location",
-                              "patron_type",
-                              "document_type",
-                              "transaction_channel"
-                            ]
-                          },
-                          "widget": {
-                            "formlyConfig": {
-                              "type": "selectWithSort",
-                              "options": [
-                                {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
-                                },
-                                {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
-                                },
-                                {
-                                  "value": "library",
-                                  "label": "library"
-                                },
-                                {
-                                  "value": "item_owning_library",
-                                  "label": "item_owning_library"
-                                },
-                                {
-                                  "value": "item_location",
-                                  "label": "item_location"
-                                },
-                                {
-                                  "value": "patron_type",
-                                  "label": "patron_type"
-                                },
-                                {
-                                  "value": "document_type",
-                                  "label": "document_type"
-                                },
-                                {
-                                  "value": "transaction_channel",
-                                  "label": "transaction_channel"
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "$ref": "#/definitions/circulation_distributions"
                     },
                     "period": {
                       "$ref": "#/definitions/period"
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: operation_logs"
-                        }
-                      ]
                     }
                   }
                 },
@@ -792,8 +607,7 @@
                   "propertiesOrder": [
                     "type",
                     "distributions",
-                    "period",
-                    "filter"
+                    "period"
                   ],
                   "required": [
                     "type"
@@ -803,8 +617,8 @@
                     "type": {
                       "title": "Type",
                       "type": "string",
-                      "const": "number_of_renewals",
-                      "default": "number_of_renewals",
+                      "const": "number_of_extends",
+                      "default": "number_of_extends",
                       "widget": {
                         "formlyConfig": {
                           "wrappers": [
@@ -814,79 +628,10 @@
                       }
                     },
                     "distributions": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/distributions"
-                        },
-                        {
-                          "items": {
-                            "title": "distributions",
-                            "type": "string",
-                            "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
-                              "item_owning_library",
-                              "item_location",
-                              "patron_type",
-                              "document_type",
-                              "transaction_channel"
-                            ]
-                          },
-                          "widget": {
-                            "formlyConfig": {
-                              "type": "selectWithSort",
-                              "options": [
-                                {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
-                                },
-                                {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
-                                },
-                                {
-                                  "value": "library",
-                                  "label": "library"
-                                },
-                                {
-                                  "value": "item_owning_library",
-                                  "label": "item_owning_library"
-                                },
-                                {
-                                  "value": "item_location",
-                                  "label": "item_location"
-                                },
-                                {
-                                  "value": "patron_type",
-                                  "label": "patron_type"
-                                },
-                                {
-                                  "value": "document_type",
-                                  "label": "document_type"
-                                },
-                                {
-                                  "value": "transaction_channel",
-                                  "label": "transaction_channel"
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "$ref": "#/definitions/circulation_distributions"
                     },
                     "period": {
                       "$ref": "#/definitions/period"
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: operation_logs"
-                        }
-                      ]
                     }
                   }
                 },
@@ -895,8 +640,7 @@
                   "propertiesOrder": [
                     "type",
                     "distributions",
-                    "period",
-                    "filter"
+                    "period"
                   ],
                   "required": [
                     "type"
@@ -917,79 +661,43 @@
                       }
                     },
                     "distributions": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/distributions"
-                        },
-                        {
-                          "items": {
-                            "title": "distributions",
-                            "type": "string",
-                            "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "item_owning_library",
-                              "item_location",
-                              "patron_type",
-                              "document_type",
-                              "transaction_channel",
-                              "location"
-                            ]
-                          },
-                          "widget": {
-                            "formlyConfig": {
-                              "type": "selectWithSort",
-                              "options": [
-                                {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
-                                },
-                                {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
-                                },
-                                {
-                                  "value": "item_owning_library",
-                                  "label": "item_owning_library"
-                                },
-                                {
-                                  "value": "item_location",
-                                  "label": "item_location"
-                                },
-                                {
-                                  "value": "patron_type",
-                                  "label": "patron_type"
-                                },
-                                {
-                                  "value": "document_type",
-                                  "label": "document_type"
-                                },
-                                {
-                                  "value": "transaction_channel",
-                                  "label": "transaction_channel"
-                                },
-                                {
-                                  "value": "location",
-                                  "label": "location"
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "$ref": "#/definitions/circulation_distributions"
                     },
                     "period": {
                       "$ref": "#/definitions/period"
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: operation_logs"
+                    }
+                  }
+                },
+                {
+                  "additionalProperties": false,
+                  "propertiesOrder": [
+                    "type",
+                    "distributions",
+                    "period"
+                  ],
+                  "required": [
+                    "type"
+                  ],
+                  "title": "Number of validated requests",
+                  "properties": {
+                    "type": {
+                      "title": "Type",
+                      "type": "string",
+                      "const": "number_of_validated_requests",
+                      "default": "number_of_validated_requests",
+                      "widget": {
+                        "formlyConfig": {
+                          "wrappers": [
+                            "hide"
+                          ]
                         }
-                      ]
+                      }
+                    },
+                    "distributions": {
+                      "$ref": "#/definitions/circulation_distributions"
+                    },
+                    "period": {
+                      "$ref": "#/definitions/period"
                     }
                   }
                 }
@@ -1030,8 +738,7 @@
                   "additionalProperties": false,
                   "propertiesOrder": [
                     "type",
-                    "distributions",
-                    "filter"
+                    "distributions"
                   ],
                   "required": [
                     "type"
@@ -1052,61 +759,7 @@
                       }
                     },
                     "distributions": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/distributions"
-                        },
-                        {
-                          "items": {
-                            "title": "distributions",
-                            "type": "string",
-                            "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
-                              "gender",
-                              "role"
-                            ]
-                          },
-                          "widget": {
-                            "formlyConfig": {
-                              "type": "selectWithSort",
-                              "options": [
-                                {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
-                                },
-                                {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
-                                },
-                                {
-                                  "value": "library",
-                                  "label": "library"
-                                },
-                                {
-                                  "value": "gender",
-                                  "label": "gender"
-                                },
-                                {
-                                  "value": "role",
-                                  "label": "role"
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: patrons"
-                        }
-                      ]
+                      "$ref": "#/definitions/patrons_distributions"
                     }
                   }
                 },
@@ -1115,7 +768,7 @@
                   "propertiesOrder": [
                     "type",
                     "distributions",
-                    "filter"
+                    "period"
                   ],
                   "required": [
                     "type"
@@ -1136,61 +789,10 @@
                       }
                     },
                     "distributions": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/distributions"
-                        },
-                        {
-                          "items": {
-                            "title": "distributions",
-                            "type": "string",
-                            "enum": [
-                              "time_range_month",
-                              "time_range_year",
-                              "library",
-                              "patron_postal_code",
-                              "gender"
-                            ]
-                          },
-                          "widget": {
-                            "formlyConfig": {
-                              "type": "selectWithSort",
-                              "options": [
-                                {
-                                  "value": "time_range_month",
-                                  "label": "time_range_month"
-                                },
-                                {
-                                  "value": "time_range_year",
-                                  "label": "time_range_year"
-                                },
-                                {
-                                  "value": "library",
-                                  "label": "library"
-                                },
-                                {
-                                  "value": "patron_postal_code",
-                                  "label": "patron_postal_code"
-                                },
-                                {
-                                  "value": "gender",
-                                  "label": "gender"
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "$ref": "#/definitions/patrons_distributions"
                     },
-                    "filter": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/filter"
-                        },
-                        {
-                          "description": "index: operation_logs"
-                        }
-                      ]
+                    "period": {
+                      "$ref": "#/definitions/period"
                     }
                   }
                 }
@@ -1205,7 +807,8 @@
     "distributions": {
       "title": "Distributions",
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
+      "default": [],
       "maxItems": 2,
       "uniqueItems": true
     },
@@ -1232,10 +835,135 @@
         }
       }
     },
-    "filter": {
-      "title": "Filter",
-      "type": "string",
-      "minLength": 1
+    "circulation_distributions": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/distributions"
+        },
+        {
+          "items": {
+            "title": "distributions",
+            "type": "string",
+            "enum": [
+              "transaction_month",
+              "transaction_year",
+              "owning_library",
+              "transaction_location",
+              "patron_type",
+              "patron_age",
+              "patron_postal_code",
+              "document_type",
+              "transaction_channel"
+            ]
+          },
+          "widget": {
+            "formlyConfig": {
+              "type": "selectWithSort",
+              "templateOptions": {
+                "sort": false
+              },
+              "options": [
+                {
+                  "value": "transaction_month",
+                  "label": "transaction_month"
+                },
+                {
+                  "value": "transaction_yaer",
+                  "label": "transaction_yaer"
+                },
+                {
+                  "value": "owning_library",
+                  "label": "owning_library"
+                },
+                {
+                  "value": "transaction_location",
+                  "label": "transaction_location"
+                },
+                {
+                  "value": "patron_type",
+                  "label": "patron_type"
+                },
+                {
+                  "value": "patron_age",
+                  "label": "patron_age"
+                },
+                {
+                  "value": "patron_postal_code",
+                  "label": "patron_postal_code"
+                },
+                {
+                  "value": "document_type",
+                  "label": "document_type"
+                },
+                {
+                  "value": "transaction_channel",
+                  "label": "transaction_channel"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "patrons_distributions": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/distributions"
+        },
+        {
+          "items": {
+            "title": "distributions",
+            "type": "string",
+            "enum": [
+              "created_month",
+              "created_year",
+              "gender",
+              "type",
+              "postal_code",
+              "birth_year",
+              "role"
+            ]
+          },
+          "widget": {
+            "formlyConfig": {
+              "type": "selectWithSort",
+              "templateOptions": {
+                "sort": false
+              },
+              "options": [
+                {
+                  "value": "created_month",
+                  "label": "create_month"
+                },
+                {
+                  "value": "created_year",
+                  "label": "created_year"
+                },
+                {
+                  "value": "gender",
+                  "label": "gender"
+                },
+                {
+                  "value": "type",
+                  "label": "type"
+                },
+                {
+                  "value": "postal_code",
+                  "label": "postal_code"
+                },
+                {
+                  "value": "birth_year",
+                  "label": "birth_year"
+                },
+                {
+                  "value": "role",
+                  "label": "role"
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/rero_ils/modules/stats_cfg/mappings/v7/stats_cfg/stat_cfg-v0.0.1.json
+++ b/rero_ils/modules/stats_cfg/mappings/v7/stats_cfg/stat_cfg-v0.0.1.json
@@ -54,9 +54,6 @@
               },
               "period": {
                 "type": "keyword"
-              },
-              "filter": {
-                "type": "keyword"
               }
             }
           }

--- a/rero_ils/modules/stats_cfg/views.py
+++ b/rero_ils/modules/stats_cfg/views.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2023 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Blueprint used for loading templates."""
+
+from __future__ import absolute_import, print_function
+
+from flask import Blueprint, abort, jsonify
+
+from rero_ils.modules.stats.api.report import StatsReport
+from rero_ils.modules.stats.permissions import check_logged_as_librarian
+
+from .api import StatConfiguration
+
+api_blueprint = Blueprint(
+    'stats_cfg',
+    __name__,
+    url_prefix='/stats_cfg',
+    template_folder='templates',
+    static_folder='static',
+)
+
+
+@api_blueprint.route('/live/<pid>', methods=['GET'])
+@check_logged_as_librarian
+def live_stats_reports(pid):
+    """Preview of the stats report values.
+
+    :param pid: pid value of the configuration.
+    """
+    cfg = StatConfiguration.get_record_by_pid(pid)
+    if not cfg:
+        abort(404, f'Configuration not found for pid {pid}.')
+    res = StatsReport(cfg).collect()
+    return jsonify(res)

--- a/rero_ils/modules/users/models.py
+++ b/rero_ils/modules/users/models.py
@@ -31,7 +31,7 @@ class UserRole:
     LIBRARY_ADMINISTRATOR = 'pro_library_administrator'
     USER_MANAGER = 'pro_user_manager'
     PRO_ENTITY_MANAGER = 'pro_entity_manager'
-    STATISTICS_MANAGER = 'pro_statistics_manager'
+    STATISTICS_MANAGER = 'pro_statistic_manager'
 
     LIBRARIAN_ROLES = [
         PROFESSIONAL_READ_ONLY, ACQUISITION_MANAGER,

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -45,8 +45,13 @@ editor_permission = Permission(RoleNeed('editor'), RoleNeed('admin'))
 monitoring_permission = Permission(RoleNeed('monitoring'))
 
 
+def admin_permission_factory(record, *args, **kwargs):
+    """User has admin role."""
+    return admin_permission
+
+
 def librarian_permission_factory(record, *args, **kwargs):
-    """User has editor role."""
+    """User has librarian role."""
     return librarian_permission
 
 

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -197,6 +197,7 @@ def schemaform(document_type):
     doc_type = document_type
     doc_type = re.sub('ies$', 'y', doc_type)
     doc_type = re.sub('s$', '', doc_type)
+    doc_type = re.sub('s_cfg$', '_cfg', doc_type)
     data = {}
     schema = None
     schema_name = None

--- a/scripts/setup
+++ b/scripts/setup
@@ -249,7 +249,7 @@ eval ${PREFIX} "invenio roles create -d 'Professional: User manager' pro_user_ma
 eval ${PREFIX} "invenio roles create -d 'Professional: Entity manager' pro_entity_manager"
 eval ${PREFIX} "invenio roles create -d 'Documentation Editor' editor"
 eval ${PREFIX} "invenio roles create -d 'Document Importing' document_importer"
-eval ${PREFIX} "invenio roles create -d 'Professional: Statistics manager' pro_statistics_manager"
+eval ${PREFIX} "invenio roles create -d 'Professional: Statistics manager' pro_statistic_manager"
 
 info_msg "Create action roles policies"
 eval ${PREFIX} "invenio reroils fixtures import_system_role_policies data/system_role_policies.json"

--- a/tests/api/stats/conftest.py
+++ b/tests/api/stats/conftest.py
@@ -31,7 +31,13 @@ def stats(item_lib_martigny, item_lib_fully, item_lib_sion,
     """Stats fixture."""
     stats = StatsForPricing(to_date=arrow.utcnow())
     yield Stat.create(
-        dict(values=stats.collect()), dbcommit=True, reindex=True)
+        data=dict(
+            type='billing',
+            values=stats.collect()
+        ),
+        dbcommit=True,
+        reindex=True
+    )
 
 
 @pytest.fixture(scope='module')
@@ -44,6 +50,11 @@ def stats_librarian(item_lib_martigny, item_lib_fully, item_lib_sion):
     }
     stats_values = stats_librarian.collect()
     yield Stat.create(
-        dict(type='librarian', date_range=date_range,  values=stats_values),
-        dbcommit=True, reindex=True
+        data=dict(
+            type='librarian',
+            date_range=date_range,
+            values=stats_values
+        ),
+        dbcommit=True,
+        reindex=True
     )

--- a/tests/api/stats/test_stats_permissions.py
+++ b/tests/api/stats/test_stats_permissions.py
@@ -26,6 +26,7 @@ from rero_ils.modules.stats.permissions import StatisticsPermissionPolicy
 
 def test_stats_permissions(
     patron_martigny, stats_librarian, librarian_martigny,
+    system_librarian_martigny
 ):
     """Test stat permissions class."""
 
@@ -61,6 +62,15 @@ def test_stats_permissions(
     #     - search/read: any items
     #     - create/update/delete: always disallowed
     login_user(librarian_martigny.user)
+    check_permission(StatisticsPermissionPolicy, {
+        'search': False,
+        'read': False,
+        'create': False,
+        'update': False,
+        'delete': False
+    }, stats_librarian)
+
+    login_user(system_librarian_martigny.user)
     check_permission(StatisticsPermissionPolicy, {
         'search': True,
         'read': True,

--- a/tests/api/stats_cfg/test_stats_cfg_permissions.py
+++ b/tests/api/stats_cfg/test_stats_cfg_permissions.py
@@ -37,18 +37,27 @@ def test_stats_cfg_permissions(
     )
     check_permission(StatisticsConfigurationPermissionPolicy, {
         'search': False,
-        'read': False
+        'read': False,
+        'create': False,
+        'update': False,
+        'delete': False
     }, None)
     check_permission(StatisticsConfigurationPermissionPolicy, {
         'search': False,
-        'read': False
+        'read': False,
+        'create': False,
+        'update': False,
+        'delete': False
     }, stats_cfg_martigny)
     login_user(patron_martigny.user)
     check_permission(StatisticsConfigurationPermissionPolicy,
                      {'create': False}, {})
     check_permission(StatisticsConfigurationPermissionPolicy, {
         'search': False,
-        'read': False
+        'read': False,
+        'create': False,
+        'update': False,
+        'delete': False
     }, stats_cfg_martigny)
 
     # Librarian with specific role
@@ -56,7 +65,10 @@ def test_stats_cfg_permissions(
     login_user(librarian_martigny.user)
     check_permission(StatisticsConfigurationPermissionPolicy, {
         'search': False,
-        'read': False
+        'read': False,
+        'create': False,
+        'update': False,
+        'delete': False
     }, stats_cfg_martigny)
 
     # System librarian with specific role
@@ -72,5 +84,8 @@ def test_stats_cfg_permissions(
 
     check_permission(StatisticsConfigurationPermissionPolicy, {
         'search': True,
-        'read': False
+        'read': False,
+        'create': False,
+        'update': False,
+        'delete': False
     }, stats_cfg_sion)

--- a/tests/api/stats_cfg/test_stats_cfg_views.py
+++ b/tests/api/stats_cfg/test_stats_cfg_views.py
@@ -20,59 +20,30 @@
 
 from __future__ import absolute_import, print_function
 
-import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 
-def test_view_status(
+def test_view_stats_cfg(
         client, patron_martigny, librarian_martigny,
         system_librarian_martigny
 ):
     """Test view status."""
     # User not logged
-    result = client.get(url_for('stats.stats_billing'))
+    result = client.get(url_for('stats_cfg.live_stats_reports', pid='1'))
     assert result.status_code == 401
 
     # User without access permissions
     login_user_via_session(client, patron_martigny.user)
-    result = client.get(url_for('stats.stats_billing'))
-    assert result.status_code == 403
-
-    result = client.get(url_for('stats.live_stats_billing'))
+    result = client.get(url_for('stats_cfg.live_stats_reports', pid='1'))
     assert result.status_code == 403
 
     # User with librarian permissions
     login_user_via_session(client, librarian_martigny.user)
-    result = client.get(url_for('stats.stats_billing'))
+    result = client.get(url_for('stats_cfg.live_stats_reports', pid='1'))
     assert result.status_code == 403
 
-    result = client.get(url_for('stats.live_stats_billing'))
-    assert result.status_code == 403
-
-    result = client.get(url_for('stats.stats_librarian'))
-    assert result.status_code == 403
-
-    result = client.get(url_for('stats.stats_librarian', record_pid=1))
-    assert result.status_code == 403
-
-    # User with system librarian permissions
+    # User with librarian permissions
     login_user_via_session(client, system_librarian_martigny.user)
-    result = client.get(url_for('stats.stats_billing'))
-    assert result.status_code == 403
-
-    result = client.get(url_for('stats.live_stats_billing'))
-    assert result.status_code == 403
-
-    result = client.get(url_for('stats.stats_librarian'))
-    assert result.status_code == 200
-
-    result = client.get(url_for('stats.stats_librarian', record_pid=1))
-    assert result.status_code == 200
-
-    with mock.patch(
-        'rero_ils.modules.stats.permissions.admin_permission',
-        mock.MagicMock()
-    ):
-        result = client.get(url_for('stats.stats_billing'))
-        assert result.status_code == 200
+    result = client.get(url_for('stats_cfg.live_stats_reports', pid='foo'))
+    assert result.status_code == 404

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -5206,7 +5206,7 @@
       "indicator": {
         "type": "number_of_documents",
         "distributions": [
-          "time_range_month",
+          "created_month",
           "library"
         ]
       }
@@ -5227,7 +5227,7 @@
       "indicator": {
         "type": "number_of_documents",
         "distributions": [
-          "time_range_month",
+          "created_month",
           "library"
         ]
       }

--- a/tests/data/policies/role_policies.json
+++ b/tests/data/policies/role_policies.json
@@ -562,32 +562,32 @@
     "pro_circulation_manager"
   ],
   "stat-search": [
-    "pro_read_only",
+    "pro_statistic_manager",
     "pro_full_permissions"
   ],
   "stat-read": [
-    "pro_read_only",
+    "pro_statistic_manager",
     "pro_full_permissions"
   ],
   "stat_cfg-search": [
-    "pro_statistics_manager",
+    "pro_statistic_manager",
     "pro_full_permissions"
   ],
   "stat_cfg-read": [
-    "pro_statistics_manager",
+    "pro_statistic_manager",
     "pro_full_permissions"
   ],
   "stat_cfg-create": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-update": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "stat_cfg-delete": [
     "pro_full_permissions",
-    "pro_statistics_manager"
+    "pro_statistic_manager"
   ],
   "tmpl-search": [
     "pro_full_permissions",

--- a/tests/ui/stats/test_stats_report_n_deleted_items.py
+++ b/tests/ui/stats/test_stats_report_n_deleted_items.py
@@ -108,7 +108,7 @@ def test_stats_report_number_of_deleted_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[2]]
+    assert StatsReport(cfg).collect() == [[2]]
 
     # one distrubtions
     cfg = {
@@ -123,7 +123,7 @@ def test_stats_report_number_of_deleted_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1]
     ]
@@ -141,7 +141,7 @@ def test_stats_report_number_of_deleted_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-01', '2024-01'],
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 0, 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1, 0]
@@ -160,7 +160,7 @@ def test_stats_report_number_of_deleted_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -183,7 +183,7 @@ def test_stats_report_number_of_deleted_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -211,6 +211,6 @@ def test_stats_report_number_of_deleted_items(
         'rero_ils.modules.stats.api.report.datetime'
     ) as mock_datetime:
         mock_datetime.now.return_value = datetime(year=2024, month=1, day=1)
-        assert StatsReport(cfg).compute() == [
+        assert StatsReport(cfg).collect() == [
             [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1]
         ]

--- a/tests/ui/stats/test_stats_report_n_docs.py
+++ b/tests/ui/stats/test_stats_report_n_docs.py
@@ -78,7 +78,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[2]]
+    assert StatsReport(cfg).collect() == [[2]]
 
     # one distrubtions
     cfg = {
@@ -93,7 +93,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1]
     ]
@@ -111,7 +111,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-02', '2024-01'],
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 0, 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1, 0]
@@ -130,7 +130,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -153,7 +153,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -176,7 +176,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', 'imported', 'not imported'],
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 0, 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1, 0]
@@ -195,7 +195,7 @@ def test_stats_report_number_of_documents(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',

--- a/tests/ui/stats/test_stats_report_n_ill_requests.py
+++ b/tests/ui/stats/test_stats_report_n_ill_requests.py
@@ -50,7 +50,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[0]]
+    assert StatsReport(cfg).collect() == [[0]]
 
     # fixtures
     es.index(index='ill_requests', id='1', body={
@@ -91,7 +91,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[3]]
+    assert StatsReport(cfg).collect() == [[3]]
     cfg = {
         "organisation": {
             "$ref": "https://bib.rero.ch/api/organisations/org1"
@@ -109,7 +109,7 @@ def test_stats_report_number_of_ill_requests(
         'rero_ils.modules.stats.api.report.datetime'
     ) as mock_datetime:
         mock_datetime.now.return_value = datetime(year=2024, month=1, day=1)
-        assert StatsReport(cfg).compute() == [[2]]
+        assert StatsReport(cfg).collect() == [[2]]
     # one distrubtions
     cfg = {
         "organisation": {
@@ -123,7 +123,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [label_loc_pub_martigny_bourg, 1],
         [label_loc_pub_martigny, 1],
         [label_loc_rest_martigny, 1]
@@ -142,7 +142,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-02', '2024-01'],
         [label_loc_pub_martigny_bourg, 0, 1],
         [label_loc_pub_martigny, 1, 0],
@@ -162,7 +162,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             label_loc_pub_martigny_bourg,
@@ -186,7 +186,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             label_loc_pub_martigny_bourg,
@@ -210,7 +210,7 @@ def test_stats_report_number_of_ill_requests(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             label_loc_pub_martigny_bourg,

--- a/tests/ui/stats/test_stats_report_n_items.py
+++ b/tests/ui/stats/test_stats_report_n_items.py
@@ -40,7 +40,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[0]]
+    assert StatsReport(cfg).collect() == [[0]]
 
     # fixtures
     es.index(index='items', id='1', body={
@@ -85,7 +85,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[3]]
+    assert StatsReport(cfg).collect() == [[3]]
 
     # one distrubtions
     cfg = {
@@ -100,7 +100,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 2]
     ]
@@ -118,7 +118,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-02', '2024-01'],
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 0, 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 2, 0]
@@ -137,7 +137,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -160,7 +160,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -183,7 +183,7 @@ def test_stats_report_number_of_items(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -214,7 +214,7 @@ def test_stats_report_number_of_items(
     label_loc_pub_martigny_bourg = f'{lib_martigny_bourg["name"]} / '\
         f'{loc_public_martigny_bourg["name"]} '\
         f'({loc_public_martigny_bourg.pid})'
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             label_loc_pub_martigny_bourg,

--- a/tests/ui/stats/test_stats_report_n_patrons.py
+++ b/tests/ui/stats/test_stats_report_n_patrons.py
@@ -27,8 +27,9 @@ from rero_ils.modules.stats.api.report import StatsReport
 
 
 def test_stats_report_number_of_patrons(
-        org_martigny, org_sion, patron_type_children_martigny,
-        patron_type_adults_martigny, patron_type_youngsters_sion
+        org_martigny, lib_martigny, org_sion,
+        patron_type_children_martigny, patron_type_adults_martigny,
+        patron_type_youngsters_sion
 ):
     """Test the number of patrons and active patrons."""
     # no data
@@ -43,7 +44,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[0]]
+    assert StatsReport(cfg).collect() == [[0]]
 
     # fixtures
     es.index(index='patrons', id='1', body={
@@ -100,7 +101,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[2]]
+    assert StatsReport(cfg).collect() == [[2]]
 
     # gender
     cfg = {
@@ -115,7 +116,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['female', 1],
         ['male', 1]
     ]
@@ -132,7 +133,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['1994', 1],
         ['2004', 1]
     ]
@@ -153,7 +154,7 @@ def test_stats_report_number_of_patrons(
         f'({patron_type_children_martigny.pid})'
     label_ptrn_type_adult = f'{patron_type_adults_martigny["name"]} '\
         f'({patron_type_adults_martigny.pid})'
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [label_ptrn_type_adult, 1],
         [label_ptrn_type_children, 1]
     ]
@@ -170,7 +171,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['1907', 1],
         ['1920', 1]
     ]
@@ -187,7 +188,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['librarian', 1],
         ['patron', 2]
     ]
@@ -204,7 +205,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-02', '2024-01'],
         [f'female', 1, 0],
         [f'male', 0, 1]
@@ -224,7 +225,7 @@ def test_stats_report_number_of_patrons(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             'female',
@@ -236,13 +237,13 @@ def test_stats_report_number_of_patrons(
 
     es.index(index='operation_logs-2020', id='1', body={
         "date": "2023-01-01",
-        "organisation": {
-          "value": org_martigny.pid
-        },
         "loan": {
             "trigger": "checkin",
             "patron": {
                 "pid": '1'
+            },
+            "item": {
+                "library_pid": lib_martigny.pid
             }
         },
         "record": {
@@ -267,4 +268,4 @@ def test_stats_report_number_of_patrons(
     ) as mock_datetime:
         mock_datetime.now.return_value = datetime(year=2024, month=1, day=1)
 
-    assert StatsReport(cfg).compute() == [[1]]
+    assert StatsReport(cfg).collect() == [[1]]

--- a/tests/ui/stats/test_stats_report_n_serial_holdings.py
+++ b/tests/ui/stats/test_stats_report_n_serial_holdings.py
@@ -39,7 +39,7 @@ def test_stats_report_number_of_serial_holdings(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[0]]
+    assert StatsReport(cfg).collect() == [[0]]
 
     # fixtures
     es.index(index='holdings', id='1', body={
@@ -80,7 +80,7 @@ def test_stats_report_number_of_serial_holdings(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[2]]
+    assert StatsReport(cfg).collect() == [[2]]
 
     # one distrubtions
     cfg = {
@@ -95,7 +95,7 @@ def test_stats_report_number_of_serial_holdings(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1]
     ]
@@ -113,7 +113,7 @@ def test_stats_report_number_of_serial_holdings(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-02', '2024-01'],
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 0, 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1, 0]
@@ -132,7 +132,7 @@ def test_stats_report_number_of_serial_holdings(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',
@@ -155,7 +155,7 @@ def test_stats_report_number_of_serial_holdings(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})',

--- a/tests/ui/stats/test_stats_report_number_of_ciculation.py
+++ b/tests/ui/stats/test_stats_report_number_of_ciculation.py
@@ -36,9 +36,6 @@ def test_stats_report_circulation_trigger(
     ]:
         es.index(index='operation_logs-2020', id='1', body={
             "date": "2023-01-01",
-            "organisation": {
-                "value": org_martigny.pid
-            },
             "loan": {
                 "trigger": trigger,
                 "item": {
@@ -73,7 +70,7 @@ def test_stats_report_circulation_trigger(
                 }
             }
         }
-        assert StatsReport(cfg).compute() == [[1]]
+        assert StatsReport(cfg).collect() == [[1]]
 
 
 def test_stats_report_number_of_checkins(
@@ -90,9 +87,6 @@ def test_stats_report_number_of_checkins(
     # fixtures
     es.index(index='operation_logs-2020', id='1', body={
         "date": "2023-01-01",
-        "organisation": {
-          "value": org_martigny.pid
-        },
         "loan": {
             "trigger": "checkin",
             "item": {
@@ -119,9 +113,6 @@ def test_stats_report_number_of_checkins(
 
     es.index(index='operation_logs-2020', id='2', body={
         "date": "2024-01-01",
-        "organisation": {
-          "value": org_martigny.pid
-        },
         "loan": {
             "trigger": "checkin",
             "item": {
@@ -148,9 +139,6 @@ def test_stats_report_number_of_checkins(
 
     es.index(index='operation_logs-2020', id='3', body={
         "date": "2023-01-01",
-        "organisation": {
-          "value": org_sion.pid
-        },
         "loan": {
             "trigger": "checkin",
             "item": {
@@ -174,9 +162,6 @@ def test_stats_report_number_of_checkins(
 
     es.index(index='operation_logs-2020', id='4', body={
         "date": "2023-01-01",
-        "organisation": {
-          "value": org_martigny.pid
-        },
         "loan": {
             "trigger": "checkin",
             "item": {
@@ -201,9 +186,6 @@ def test_stats_report_number_of_checkins(
 
     es.index(index='operation_logs-2020', id='5', body={
         "date": "2023-01-01",
-        "organisation": {
-          "value": org_martigny.pid
-        },
         "loan": {
             "trigger": "checkout",
             "item": {
@@ -237,7 +219,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [[2]]
+    assert StatsReport(cfg).collect() == [[2]]
 
     # limit by period
     cfg = {
@@ -256,7 +238,7 @@ def test_stats_report_number_of_checkins(
         'rero_ils.modules.stats.api.report.datetime'
     ) as mock_datetime:
         mock_datetime.now.return_value = datetime(year=2024, month=1, day=1)
-        assert StatsReport(cfg).compute() == [[1]]
+        assert StatsReport(cfg).collect() == [[1]]
 
     # one distrubtions
     cfg = {
@@ -271,7 +253,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [label_loc_pub_martigny_bourg, 1],
         [label_loc_pub_martigny, 1]
     ]
@@ -288,7 +270,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['', '2023-01', '2024-01'],
         [label_loc_pub_martigny_bourg, 0, 1],
         [label_loc_pub_martigny, 1, 0]
@@ -307,7 +289,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             label_loc_pub_martigny_bourg,
@@ -330,7 +312,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [
             '',
             label_loc_pub_martigny_bourg,
@@ -353,7 +335,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['Usager.ère moins de 14 ans', 1],
         ['Usager.ère plus de 18 ans', 1]
     ]
@@ -371,7 +353,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [13, 1],
         [30, 1]
     ]
@@ -389,7 +371,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['1920', 1],
         ['1930', 1]
     ]
@@ -407,7 +389,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['Usager.ère moins de 14 ans', 1],
         ['Usager.ère plus de 18 ans', 1]
     ]
@@ -425,7 +407,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['docsubtype_other_book', 1],
         ['ebook', 1]
     ]
@@ -443,7 +425,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         ['sip2', 1],
         ['system', 1]
     ]
@@ -461,7 +443,7 @@ def test_stats_report_number_of_checkins(
             }
         }
     }
-    assert StatsReport(cfg).compute() == [
+    assert StatsReport(cfg).collect() == [
         [f'{lib_martigny_bourg.get("name")} ({lib_martigny_bourg.pid})', 1],
         [f'{lib_martigny.get("name")} ({lib_martigny.pid})', 1]
     ]

--- a/tests/unit/test_stats_cfg_jsonschema.py
+++ b/tests/unit/test_stats_cfg_jsonschema.py
@@ -36,8 +36,8 @@ def test_valid_configuration(stats_cfg_schema, stats_cfg_martigny_data):
     validate(stats_cfg_martigny_data, stats_cfg_schema)
 
 
-def test_valid_catalogue_category(stats_cfg_schema):
-    """Test valid catalogue category field."""
+def test_valid_circulation_n_docs(stats_cfg_schema):
+    """Test number of documents."""
     data = {
         '$schema':
             'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
@@ -51,47 +51,183 @@ def test_valid_catalogue_category(stats_cfg_schema):
         'category': {
             'type': 'catalogue',
             'indicator': {
-                'type': 'number_of_documents',
-                'distributions': [
-                    'time_range_month'
-                ],
-                'filter': 'foo=bar'
+                'type': 'number_of_documents'
             }
         },
         'is_active': True
     }
-    validate(data, stats_cfg_schema)
+    for dist in ['created_month', 'created_year', 'imported', 'library']:
+        data['category']['indicator']['distributions'] = [dist]
+        validate(data, stats_cfg_schema)
 
-
-def test_invalid_catalogue_category(stats_cfg_schema):
-    """Test valid catalogue category field."""
-    data = {
-        '$schema':
-            'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
-        'pid': 'statcfg1',
-        'name': 'foo',
-        'description': 'bar',
-        'frequency': 'month',
-        'organisation': {
-            '$ref': 'https://bib.rero.ch/api/organisations/org1'
-        },
-        'category': {
-            'type': 'catalogue',
-            'indicator': {
-                'type': 'number_of_documents',
-                'distributions': [
-                    'item_location'
-                ]
-            }
-        },
-        'is_active': True
-    }
+    data['category']['indicator']['distributions'] = ["foo"]
     with pytest.raises(ValidationError):
         validate(data, stats_cfg_schema)
 
 
-def test_valid_circulation_category(stats_cfg_schema):
-    """Test valid circulation category field."""
+def test_valid_circulation_n_serial_holdings(stats_cfg_schema):
+    """Test number of serial holdings."""
+    data = {
+        '$schema':
+            'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
+        'pid': 'statcfg1',
+        'name': 'foo',
+        'description': 'bar',
+        'frequency': 'month',
+        'organisation': {
+            '$ref': 'https://bib.rero.ch/api/organisations/org1'
+        },
+        'category': {
+            'type': 'catalogue',
+            'indicator': {
+                'type': 'number_of_serial_holdings'
+            }
+        },
+        'is_active': True
+    }
+    for dist in ['created_month', 'created_year', 'library']:
+        data['category']['indicator']['distributions'] = [dist]
+        validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+
+def test_valid_circulation_n_items(stats_cfg_schema):
+    """Test number of items."""
+    data = {
+        '$schema':
+            'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
+        'pid': 'statcfg1',
+        'name': 'foo',
+        'description': 'bar',
+        'frequency': 'month',
+        'organisation': {
+            '$ref': 'https://bib.rero.ch/api/organisations/org1'
+        },
+        'category': {
+            'type': 'catalogue',
+            'indicator': {
+                'type': 'number_of_items'
+            }
+        },
+        'is_active': True
+    }
+    for dist in [
+        'created_month', 'created_year', 'library', 'location', 'type'
+    ]:
+        data['category']['indicator']['distributions'] = [dist]
+        validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+
+def test_valid_circulation_n_patrons(stats_cfg_schema):
+    """Test number of patrons."""
+    data = {
+        '$schema':
+            'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
+        'pid': 'statcfg1',
+        'name': 'foo',
+        'description': 'bar',
+        'frequency': 'month',
+        'organisation': {
+            '$ref': 'https://bib.rero.ch/api/organisations/org1'
+        },
+        'category': {
+            'type': 'user_management',
+            'indicator': {
+                'type': 'number_of_patrons'
+            }
+        },
+        'is_active': True
+    }
+    for dist in [
+        'created_month', 'created_year', 'postal_code', 'type', 'gender',
+        'birth_year', 'role'
+    ]:
+        data['category']['indicator']['distributions'] = [dist]
+        validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+
+def test_valid_circulation_n_active_patrons(stats_cfg_schema):
+    """Test number of active patrons."""
+    data = {
+        '$schema':
+            'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
+        'pid': 'statcfg1',
+        'name': 'foo',
+        'description': 'bar',
+        'frequency': 'month',
+        'organisation': {
+            '$ref': 'https://bib.rero.ch/api/organisations/org1'
+        },
+        'category': {
+            'type': 'user_management',
+            'indicator': {
+                'type': 'number_of_active_patrons'
+            }
+        },
+        'is_active': True
+    }
+    for period in ['year', 'month']:
+        data['category']['indicator']['period'] = period
+        for dist in [
+            'created_month', 'created_year', 'postal_code', 'type', 'gender',
+            'birth_year', 'role'
+        ]:
+            data['category']['indicator']['distributions'] = [dist]
+            validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+
+def test_valid_circulation_n_deleted_items(stats_cfg_schema):
+    """Test number of deleted items."""
+    data = {
+        '$schema':
+            'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
+        'pid': 'statcfg1',
+        'name': 'foo',
+        'description': 'bar',
+        'frequency': 'month',
+        'organisation': {
+            '$ref': 'https://bib.rero.ch/api/organisations/org1'
+        },
+        'category': {
+            'type': 'catalogue',
+            'indicator': {
+                'type': 'number_of_deleted_items'
+            }
+        },
+        'is_active': True
+    }
+    for period in ['year', 'month']:
+        data['category']['indicator']['period'] = period
+        for dist in ['action_month', 'action_year', 'library']:
+            data['category']['indicator']['distributions'] = [dist]
+            validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['period'] = 'day'
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+
+def test_valid_circulation_n_ill_requests(stats_cfg_schema):
+    """Test number of ill requests."""
     data = {
         '$schema':
             'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
@@ -105,22 +241,30 @@ def test_valid_circulation_category(stats_cfg_schema):
         'category': {
             'type': 'circulation',
             'indicator': {
-                'type': 'number_of_checkins',
-                'distributions': [
-                    'time_range_month',
-                    'library'
-                ],
-                'period': 'month',
-                'filter': 'foo=bar'
+                'type': 'number_of_ill_requests'
             }
         },
         'is_active': True
     }
-    validate(data, stats_cfg_schema)
+    for period in ['year', 'month']:
+        data['category']['indicator']['period'] = period
+        for dist in [
+            'created_month', 'created_year', 'pickup_location', 'status'
+        ]:
+            data['category']['indicator']['distributions'] = [dist]
+            validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['period'] = 'day'
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
 
 
-def test_invalid_circulation_category_period(stats_cfg_schema):
-    """Test invalid period field."""
+def test_valid_circulation_n_circulations(stats_cfg_schema):
+    """Test number of ill requests."""
     data = {
         '$schema':
             'https://bib.rero.ch/schemas/stats_cfg/stat_cfg-v0.0.1.json',
@@ -134,16 +278,29 @@ def test_invalid_circulation_category_period(stats_cfg_schema):
         'category': {
             'type': 'circulation',
             'indicator': {
-                'type': 'number_of_checkins',
-                'distributions': [
-                    'time_range_month',
-                    'library'
-                ],
-                'period': 'day',
-                'filter': 'foo=bar'
             }
         },
         'is_active': True
     }
+    for trigger in [
+        'checkin'
+    ]:
+        data['category']['indicator']['type'] = f'number_of_{trigger}s'
+        for period in ['year', 'month']:
+            data['category']['indicator']['period'] = period
+            for dist in [
+                'transaction_month', 'transaction_year',
+                'transaction_location', 'patron_type', 'patron_age',
+                'patron_postal_code', 'document_type', 'transaction_channel',
+                'owning_library'
+            ]:
+                data['category']['indicator']['distributions'] = [dist]
+                validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['distributions'] = ["foo"]
+    with pytest.raises(ValidationError):
+        validate(data, stats_cfg_schema)
+
+    data['category']['indicator']['period'] = 'day'
     with pytest.raises(ValidationError):
         validate(data, stats_cfg_schema)


### PR DESCRIPTION
* Adjusts the statitics permissions for each of the billing, librarian and report types.
* Renames some stat JSONSchema field names.
* Adds statistics configuration for the JSONSchema export view.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>