### PR TITLE
notifications: set a maximum delay

### DIFF
--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -66,6 +66,7 @@
           "description": "Sending how many minutes after the item is available.",
           "type": "number",
           "minimum": 0,
+          "maximum": 720,
           "default": 0
         }
       }


### PR DESCRIPTION
* A delay too high can cause problems in the workers if a task is not acknowledged after the chosen RabbitMQ delay.