### PR TITLE
statistics: optimize active patron reports

### DIFF
--- a/data/stats_cfg.json
+++ b/data/stats_cfg.json
@@ -119,7 +119,7 @@
     "name": "library 5, no distributions",
     "description": "Statistics configuration with no distributions",
     "category": {
-      "type": "catalogue",
+      "type": "catalog",
       "indicator": {
         "type": "number_of_documents"
       }

--- a/rero_ils/manual_translations.txt
+++ b/rero_ils/manual_translations.txt
@@ -97,3 +97,24 @@ _('Mobile')
 
 # Login screen
 _('Hide password')
+
+# OneOf in the stats JSONschema
+
+## categories
+_('catalog')
+_('circulation')
+_('user_management')
+
+## indicators
+_('number_of_documents')
+_('number_of_serial_holdings')
+_('number_of_items')
+_('number_of_deleted_items')
+_('number_of_ill_requests')
+_('number_of_checkins')
+_('number_of_checkouts')
+_('number_of_extends')
+_('number_of_requests')
+_('number_of_validated_requests')
+_('number_of_patrons')
+_('number_of_active_patrons')

--- a/rero_ils/modules/stats/api/indicators/base.py
+++ b/rero_ils/modules/stats/api/indicators/base.py
@@ -30,6 +30,7 @@ class IndicatorCfg:
         :param report_cfg: StatsReport - the given report configuration
         """
         self.cfg = report_cfg
+        self.label_na_msg = 'not available'
 
     @property
     @abstractmethod

--- a/rero_ils/modules/stats/api/indicators/circulation.py
+++ b/rero_ils/modules/stats/api/indicators/circulation.py
@@ -137,7 +137,8 @@ class NumberOfCirculationCfg(IndicatorCfg):
         """
         cfg = {
             'transaction_location': lambda:
-                f'{self.cfg.locations[bucket.key]} ({bucket.key})',
+                f'{self.cfg.locations.get(bucket.key, self.label_na_msg)} '
+                f'({bucket.key})',
             'transaction_month': lambda: bucket.key_as_string,
             'transaction_year': lambda: bucket.key_as_string,
             'patron_type': lambda: bucket.key,
@@ -146,7 +147,8 @@ class NumberOfCirculationCfg(IndicatorCfg):
             'patron_postal_code': lambda: bucket.key,
             'transaction_channel': lambda: bucket.key,
             'owning_library': lambda:
-                f'{self.cfg.libraries[bucket.key]} ({bucket.key})',
+                f'{self.cfg.libraries.get(bucket.key, self.label_na_msg)} '
+                f'({bucket.key})',
             'owning_location': lambda: bucket.key,
         }
         return cfg[distribution]()

--- a/rero_ils/modules/stats/api/report.py
+++ b/rero_ils/modules/stats/api/report.py
@@ -93,7 +93,7 @@ class StatsReport:
             'number_of_checkouts': NumberOfCirculationCfg(self, 'checkout'),
             'number_of_extends': NumberOfCirculationCfg(self, 'extend'),
             'number_of_requests': NumberOfRequestsCfg(self, 'request'),
-            'number_of_validate_requests': NumberOfRequestsCfg(
+            'number_of_validated_requests': NumberOfRequestsCfg(
                 self, 'validate_request'),
             'number_of_patrons': NumberOfPatronsCfg(self),
             'number_of_active_patrons': NumberOfActivePatronsCfg(self)

--- a/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
+++ b/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
@@ -65,16 +65,18 @@
       ],
       "widget": {
         "formlyConfig": {
-          "options": [
-            {
-              "value": "month",
-              "label": "monthly"
-            },
-            {
-              "value": "year",
-              "label": "yearly"
-            }
-          ]
+          "templateOptions": {
+            "options": [
+              {
+                "value": "month",
+                "label": "monthly"
+              },
+              {
+                "value": "year",
+                "label": "yearly"
+              }
+            ]
+          }
         }
       }
     },
@@ -141,13 +143,13 @@
             "type",
             "indicator"
           ],
-          "title": "Catalogue",
+          "title": "Catalog",
           "properties": {
             "type": {
               "title": "Type",
               "type": "string",
-              "const": "catalogue",
-              "default": "catalogue",
+              "const": "catalog",
+              "default": "catalog",
               "widget": {
                 "formlyConfig": {
                   "wrappers": [
@@ -205,26 +207,26 @@
                             "formlyConfig": {
                               "type": "selectWithSort",
                               "templateOptions": {
-                                "sort": false
-                              },
-                              "options": [
-                                {
-                                  "value": "created_month",
-                                  "label": "created_month"
-                                },
-                                {
-                                  "value": "created_year",
-                                  "label": "created_year"
-                                },
-                                {
-                                  "value": "owning_library",
-                                  "label": "owning_library"
-                                },
-                                {
-                                  "value": "imported",
-                                  "label": "imported"
-                                }
-                              ]
+                                "sort": false,
+                                "options": [
+                                  {
+                                    "value": "created_month",
+                                    "label": "created_month"
+                                  },
+                                  {
+                                    "value": "created_year",
+                                    "label": "created_year"
+                                  },
+                                  {
+                                    "value": "owning_library",
+                                    "label": "owning_library"
+                                  },
+                                  {
+                                    "value": "imported",
+                                    "label": "imported"
+                                  }
+                                ]
+                              }
                             }
                           }
                         }
@@ -276,22 +278,22 @@
                             "formlyConfig": {
                               "type": "selectWithSort",
                               "templateOptions": {
-                                "sort": false
-                              },
-                              "options": [
-                                {
-                                  "value": "created_month",
-                                  "label": "created_month"
-                                },
-                                {
-                                  "value": "created_year",
-                                  "label": "created_year"
-                                },
-                                {
-                                  "value": "owning_library",
-                                  "label": "owning_library"
-                                }
-                              ]
+                                "sort": false,
+                                "options": [
+                                  {
+                                    "value": "created_month",
+                                    "label": "created_month"
+                                  },
+                                  {
+                                    "value": "created_year",
+                                    "label": "created_year"
+                                  },
+                                  {
+                                    "value": "owning_library",
+                                    "label": "owning_library"
+                                  }
+                                ]
+                              }
                             }
                           }
                         }
@@ -347,38 +349,38 @@
                             "formlyConfig": {
                               "type": "selectWithSort",
                               "templateOptions": {
-                                "sort": false
-                              },
-                              "options": [
-                                {
-                                  "value": "created_month",
-                                  "label": "created_month"
-                                },
-                                {
-                                  "value": "created_year",
-                                  "label": "created_year"
-                                },
-                                {
-                                  "value": "document_type",
-                                  "label": "document_type"
-                                },
-                                {
-                                  "value": "document_subtype",
-                                  "label": "document_subtype"
-                                },
-                                {
-                                  "value": "owning_library",
-                                  "label": "owning_library"
-                                },
-                                {
-                                  "value": "owning_location",
-                                  "label": "owning_location"
-                                },
-                                {
-                                  "value": "type",
-                                  "label": "type (standard/issue)"
-                                }
-                              ]
+                                "sort": false,
+                                "options": [
+                                  {
+                                    "value": "created_month",
+                                    "label": "created_month"
+                                  },
+                                  {
+                                    "value": "created_year",
+                                    "label": "created_year"
+                                  },
+                                  {
+                                    "value": "document_type",
+                                    "label": "document_type"
+                                  },
+                                  {
+                                    "value": "document_subtype",
+                                    "label": "document_subtype"
+                                  },
+                                  {
+                                    "value": "owning_library",
+                                    "label": "owning_library"
+                                  },
+                                  {
+                                    "value": "owning_location",
+                                    "label": "owning_location"
+                                  },
+                                  {
+                                    "value": "type",
+                                    "label": "type (standard/issue)"
+                                  }
+                                ]
+                              }
                             }
                           }
                         }
@@ -425,38 +427,33 @@
                               "action_month",
                               "action_year",
                               "owning_library",
-                              "owning_location",
-                              "type"
+                              "operator_library"
                             ]
                           },
                           "widget": {
                             "formlyConfig": {
                               "type": "selectWithSort",
                               "templateOptions": {
-                                "sort": false
-                              },
-                              "options": [
-                                {
-                                  "value": "action_month",
-                                  "label": "action_month"
-                                },
-                                {
-                                  "value": "action_year",
-                                  "label": "action_year"
-                                },
-                                {
-                                  "value": "owning_library",
-                                  "label": "owning_library"
-                                },
-                                {
-                                  "value": "owning_location",
-                                  "label": "owning_location"
-                                },
-                                {
-                                  "value": "type",
-                                  "label": "type (standard/issue)"
-                                }
-                              ]
+                                "sort": false,
+                                "options": [
+                                  {
+                                    "value": "action_month",
+                                    "label": "action_month"
+                                  },
+                                  {
+                                    "value": "action_year",
+                                    "label": "action_year"
+                                  },
+                                  {
+                                    "value": "owning_library",
+                                    "label": "owning_library"
+                                  },
+                                  {
+                                    "value": "operator_library",
+                                    "label": "operator_library"
+                                  }
+                                ]
+                              }
                             }
                           }
                         }
@@ -544,26 +541,26 @@
                             "formlyConfig": {
                               "type": "selectWithSort",
                               "templateOptions": {
-                                "sort": false
-                              },
-                              "options": [
-                                {
-                                  "value": "created_month",
-                                  "label": "created_month"
-                                },
-                                {
-                                  "value": "created_year",
-                                  "label": "created_year"
-                                },
-                                {
-                                  "value": "pickup_location",
-                                  "label": "pickup_location"
-                                },
-                                {
-                                  "value": "status",
-                                  "label": "request_status"
-                                }
-                              ]
+                                "sort": false,
+                                "options": [
+                                  {
+                                    "value": "created_month",
+                                    "label": "created_month"
+                                  },
+                                  {
+                                    "value": "created_year",
+                                    "label": "created_year"
+                                  },
+                                  {
+                                    "value": "pickup_location",
+                                    "label": "pickup_location"
+                                  },
+                                  {
+                                    "value": "status",
+                                    "label": "request_status"
+                                  }
+                                ]
+                              }
                             }
                           }
                         }
@@ -806,7 +803,8 @@
                     "period"
                   ],
                   "required": [
-                    "type"
+                    "type",
+                    "period"
                   ],
                   "title": "Number of active patrons",
                   "properties": {
@@ -858,16 +856,18 @@
       ],
       "widget": {
         "formlyConfig": {
-          "options": [
-            {
-              "value": "month",
-              "label": "month"
-            },
-            {
-              "value": "year",
-              "label": "year"
-            }
-          ]
+          "templateOptions": {
+            "options": [
+              {
+                "value": "month",
+                "label": "month"
+              },
+              {
+                "value": "year",
+                "label": "year"
+              }
+            ]
+          }
         }
       }
     },
@@ -897,50 +897,50 @@
             "formlyConfig": {
               "type": "selectWithSort",
               "templateOptions": {
-                "sort": false
-              },
-              "options": [
-                {
-                  "value": "transaction_month",
-                  "label": "transaction_month"
-                },
-                {
-                  "value": "transaction_year",
-                  "label": "transaction_year"
-                },
-                {
-                  "value": "owning_library",
-                  "label": "owning_library"
-                },
-                {
-                  "value": "owning_location",
-                  "label": "owning_location"
-                },
-                {
-                  "value": "transaction_location",
-                  "label": "transaction_location"
-                },
-                {
-                  "value": "patron_type",
-                  "label": "patron_type"
-                },
-                {
-                  "value": "patron_age",
-                  "label": "patron_age"
-                },
-                {
-                  "value": "patron_postal_code",
-                  "label": "patron_postal_code"
-                },
-                {
-                  "value": "document_type",
-                  "label": "document_type"
-                },
-                {
-                  "value": "transaction_channel",
-                  "label": "transaction_channel"
-                }
-              ]
+                "sort": false,
+                "options": [
+                  {
+                    "value": "transaction_month",
+                    "label": "transaction_month"
+                  },
+                  {
+                    "value": "transaction_year",
+                    "label": "transaction_year"
+                  },
+                  {
+                    "value": "owning_library",
+                    "label": "owning_library"
+                  },
+                  {
+                    "value": "owning_location",
+                    "label": "owning_location"
+                  },
+                  {
+                    "value": "transaction_location",
+                    "label": "transaction_location"
+                  },
+                  {
+                    "value": "patron_type",
+                    "label": "patron_type"
+                  },
+                  {
+                    "value": "patron_age",
+                    "label": "patron_age"
+                  },
+                  {
+                    "value": "patron_postal_code",
+                    "label": "patron_postal_code"
+                  },
+                  {
+                    "value": "document_type",
+                    "label": "document_type"
+                  },
+                  {
+                    "value": "transaction_channel",
+                    "label": "transaction_channel"
+                  }
+                ]
+              }
             }
           }
         }
@@ -972,50 +972,50 @@
             "formlyConfig": {
               "type": "selectWithSort",
               "templateOptions": {
-                "sort": false
-              },
-              "options": [
-                {
-                  "value": "transaction_month",
-                  "label": "transaction_month"
-                },
-                {
-                  "value": "transaction_year",
-                  "label": "transaction_year"
-                },
-                {
-                  "value": "owning_library",
-                  "label": "owning_library"
-                },
-                {
-                  "value": "owning_location",
-                  "label": "owning_location"
-                },
-                {
-                  "value": "patron_type",
-                  "label": "patron_type"
-                },
-                {
-                  "value": "patron_age",
-                  "label": "patron_age"
-                },
-                {
-                  "value": "patron_postal_code",
-                  "label": "patron_postal_code"
-                },
-                {
-                  "value": "document_type",
-                  "label": "document_type"
-                },
-                {
-                  "value": "transaction_channel",
-                  "label": "transaction_channel"
-                },
-                {
-                  "value": "pickup_location",
-                  "label": "pickup_location"
-                }
-              ]
+                "sort": false,
+                "options": [
+                  {
+                    "value": "transaction_month",
+                    "label": "transaction_month"
+                  },
+                  {
+                    "value": "transaction_year",
+                    "label": "transaction_year"
+                  },
+                  {
+                    "value": "owning_library",
+                    "label": "owning_library"
+                  },
+                  {
+                    "value": "owning_location",
+                    "label": "owning_location"
+                  },
+                  {
+                    "value": "patron_type",
+                    "label": "patron_type"
+                  },
+                  {
+                    "value": "patron_age",
+                    "label": "patron_age"
+                  },
+                  {
+                    "value": "patron_postal_code",
+                    "label": "patron_postal_code"
+                  },
+                  {
+                    "value": "document_type",
+                    "label": "document_type"
+                  },
+                  {
+                    "value": "transaction_channel",
+                    "label": "transaction_channel"
+                  },
+                  {
+                    "value": "pickup_location",
+                    "label": "pickup_location"
+                  }
+                ]
+              }
             }
           }
         }
@@ -1044,38 +1044,38 @@
             "formlyConfig": {
               "type": "selectWithSort",
               "templateOptions": {
-                "sort": false
-              },
-              "options": [
-                {
-                  "value": "created_month",
-                  "label": "created_month"
-                },
-                {
-                  "value": "created_year",
-                  "label": "created_year"
-                },
-                {
-                  "value": "gender",
-                  "label": "gender"
-                },
-                {
-                  "value": "type",
-                  "label": "patron_type"
-                },
-                {
-                  "value": "postal_code",
-                  "label": "postal_code"
-                },
-                {
-                  "value": "birth_year",
-                  "label": "birth_year"
-                },
-                {
-                  "value": "role",
-                  "label": "role"
-                }
-              ]
+                "sort": false,
+                "options": [
+                  {
+                    "value": "created_month",
+                    "label": "created_month"
+                  },
+                  {
+                    "value": "created_year",
+                    "label": "created_year"
+                  },
+                  {
+                    "value": "gender",
+                    "label": "gender"
+                  },
+                  {
+                    "value": "type",
+                    "label": "patron_type"
+                  },
+                  {
+                    "value": "postal_code",
+                    "label": "postal_code"
+                  },
+                  {
+                    "value": "birth_year",
+                    "label": "birth_year"
+                  },
+                  {
+                    "value": "role",
+                    "label": "role"
+                  }
+                ]
+              }
             }
           }
         }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -4416,6 +4416,7 @@
     "pid": "ptrn6",
     "first_name": "Louis",
     "last_name": "Roduit",
+    "gender": "male",
     "street": "Avenue Leopold-Robert, 13",
     "postal_code": "1920",
     "city": "Martigny",
@@ -4466,6 +4467,7 @@
     "pid": "ptrn7",
     "first_name": "Louise",
     "last_name": "Moret",
+    "gender": "female",
     "street": "Avenue de la Gare, 13",
     "postal_code": "1920",
     "city": "Martigny",
@@ -5203,7 +5205,7 @@
     "frequency": "month",
     "is_active": true,
     "category": {
-      "type": "catalogue",
+      "type": "catalog",
       "indicator": {
         "type": "number_of_documents",
         "distributions": [
@@ -5224,7 +5226,7 @@
     "frequency": "month",
     "is_active": true,
     "category": {
-      "type": "catalogue",
+      "type": "catalog",
       "indicator": {
         "type": "number_of_documents",
         "distributions": [

--- a/tests/ui/loans/test_loans_operation_logs.py
+++ b/tests/ui/loans/test_loans_operation_logs.py
@@ -58,7 +58,7 @@ def test_loan_operation_log(client, operation_log_data,
         'type': 'children',
         'age': patron.age,
         'postal_code': '1920',
-        'gender': 'no_information',
+        'gender': 'male',
         'local_codes': ['code1']
     }
     assert log_data['loan']['item'] == {

--- a/tests/ui/stats/test_stats_report.py
+++ b/tests/ui/stats/test_stats_report.py
@@ -39,7 +39,7 @@ def test_stats_report_create(lib_martigny, document):
         "name": "foo",
         "frequency": "month",
         "category": {
-            "type": "catalogue",
+            "type": "catalog",
             "indicator": {
                 "type": "number_of_documents",
                 "distributions": ['owning_library']

--- a/tests/unit/test_stats_cfg_jsonschema.py
+++ b/tests/unit/test_stats_cfg_jsonschema.py
@@ -49,7 +49,7 @@ def test_valid_circulation_n_docs(stats_cfg_schema):
             "$ref": "https://bib.rero.ch/api/libraries/lib1"
         },
         'category': {
-            'type': 'catalogue',
+            'type': 'catalog',
             'indicator': {
                 'type': 'number_of_documents'
             }
@@ -79,7 +79,7 @@ def test_valid_circulation_n_serial_holdings(stats_cfg_schema):
             "$ref": "https://bib.rero.ch/api/libraries/lib1"
         },
         'category': {
-            'type': 'catalogue',
+            'type': 'catalog',
             'indicator': {
                 'type': 'number_of_serial_holdings'
             }
@@ -108,7 +108,7 @@ def test_valid_circulation_n_items(stats_cfg_schema):
             "$ref": "https://bib.rero.ch/api/libraries/lib1"
         },
         'category': {
-            'type': 'catalogue',
+            'type': 'catalog',
             'indicator': {
                 'type': 'number_of_items'
             }
@@ -205,7 +205,7 @@ def test_valid_circulation_n_deleted_items(stats_cfg_schema):
             "$ref": "https://bib.rero.ch/api/libraries/lib1"
         },
         'category': {
-            'type': 'catalogue',
+            'type': 'catalog',
             'indicator': {
                 'type': 'number_of_deleted_items'
             }
@@ -214,8 +214,8 @@ def test_valid_circulation_n_deleted_items(stats_cfg_schema):
     }
     for period in ['year', 'month']:
         data['category']['indicator']['period'] = period
-        for dist in ['action_month', 'action_year', 'owning_library', 'type',
-                     'owning_location']:
+        for dist in ['action_month', 'action_year', 'owning_library',
+                     'operator_library']:
             data['category']['indicator']['distributions'] = [dist]
             validate(data, stats_cfg_schema)
 


### PR DESCRIPTION
* Uses facet to retrive the active patrons list.
* Fixes tanslations in the stat cfg editor.
* Makes the period required for the active patron stat report.

Co-authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
