### PR TITLE
stats: fix number of requests report

### DIFF
--- a/rero_ils/modules/stats/api/indicators/requests.py
+++ b/rero_ils/modules/stats/api/indicators/requests.py
@@ -54,7 +54,8 @@ class NumberOfRequestsCfg(NumberOfCirculationCfg):
         """
         cfg = {
             'pickup_location': lambda:
-                f'{self.cfg.locations[bucket.key]} ({bucket.key})'
+                f'{self.cfg.locations.get(bucket.key, self.label_na_msg)} '
+                f'({bucket.key})'
         }
         if label_fn := cfg.get(distribution):
             return label_fn()


### PR DESCRIPTION
* Fixes error for deleted pickup location when the number of requests report stats
  is computed.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
