### PR TITLE
librarian stats: fix incorrect new active patrons

### DIFF
--- a/rero_ils/modules/stats/api/librarian.py
+++ b/rero_ils/modules/stats/api/librarian.py
@@ -163,8 +163,8 @@ class StatsForLibrarian(StatsForPricing):
             for p in search_patron:
                 hashed_pid = hashlib.md5(p.pid.encode()).hexdigest()
                 new_patron_hashed_pids.add(hashed_pid)
-            search.filter(
-                'terms', loan__patron__hashed_pid=new_patron_hashed_pids)
+            search = search.filter(
+                'terms', loan__patron__hashed_pid=list(new_patron_hashed_pids))
         stats = {}
         patron_pids = set()
         # Main postal code from user profile


### PR DESCRIPTION
When this fix is deployed, we need to correct the numbers with this script: 

```python
from rero_ils.modules.stats.api.librarian import StatsForLibrarian
from rero_ils.modules.stats.api.api import Stat, StatsSearch

search = StatsSearch()\
    .filter('range', _created={'gte': '2023-05-30'})

for hit in list(search.source('pid').scan()):
    try:
        stat = Stat.get_record(hit.meta.id)
        if stat['type'] == 'librarian':
            compute = StatsForLibrarian()
            compute.date_range = stat['date_range']
            for val in stat.get('values', []):
                lib_pid = val['library']['pid']
                # new_active_patrons_by_postal_code
                new_new_active_patrons_by_postal_code = compute.active_patrons_by_postal_code(lib_pid, new_patrons=True)
                val['new_active_patrons_by_postal_code'] = new_new_active_patrons_by_postal_code

        stat.update(stat, commit=True, dbcommit=True, reindex=True)
    except Exception as err:
        print('ERROR', hit.pid, err)
```