### PR TITLE
ill requests: adapt facet label

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2261,7 +2261,7 @@ RECORDS_REST_FACETS = dict(
     ),
     ill_requests=dict(
         aggs=dict(
-            status=dict(
+            request_status=dict(
                 terms=dict(
                     field='status',
                     size=RERO_ILS_AGGREGATION_SIZE.get(


### PR DESCRIPTION
* The field `status` is now labelled "request_status". Adapts the facet title to adhere to this.