### PR TITLE
partof: allow strings for volume and issue

### DIFF
--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -1441,7 +1441,7 @@
         },
         "numbering": [
           {
-            "volume": 81
+            "volume": "81"
           }
         ]
       }
@@ -3470,7 +3470,7 @@
         },
         "numbering": [
           {
-            "volume": 4
+            "volume": "4"
           }
         ]
       }
@@ -7871,7 +7871,7 @@
         },
         "numbering": [
           {
-            "volume": 2
+            "volume": "2"
           }
         ]
       }
@@ -8468,7 +8468,7 @@
         },
         "numbering": [
           {
-            "volume": 16
+            "volume": "16"
           }
         ]
       }
@@ -9207,7 +9207,7 @@
         },
         "numbering": [
           {
-            "volume": 1
+            "volume": "1"
           }
         ]
       }
@@ -12422,7 +12422,7 @@
         },
         "numbering": [
           {
-            "volume": 848
+            "volume": "848"
           }
         ]
       }
@@ -12588,7 +12588,7 @@
         },
         "numbering": [
           {
-            "volume": 3037
+            "volume": "3037"
           }
         ]
       }
@@ -12886,7 +12886,7 @@
         },
         "numbering": [
           {
-            "volume": 331
+            "volume": "331"
           }
         ]
       }
@@ -13641,7 +13641,7 @@
         },
         "numbering": [
           {
-            "volume": 5
+            "volume": "5"
           }
         ]
       }
@@ -14097,7 +14097,7 @@
         },
         "numbering": [
           {
-            "volume": 3
+            "volume": "3"
           }
         ]
       }
@@ -15448,7 +15448,7 @@
         },
         "numbering": [
           {
-            "volume": 4
+            "volume": "4"
           }
         ]
       }
@@ -15598,7 +15598,7 @@
         },
         "numbering": [
           {
-            "volume": 3243
+            "volume": "3243"
           }
         ]
       }
@@ -15887,7 +15887,7 @@
         },
         "numbering": [
           {
-            "volume": 796
+            "volume": "796"
           }
         ]
       }
@@ -16104,7 +16104,7 @@
         },
         "numbering": [
           {
-            "volume": 3
+            "volume": "3"
           }
         ]
       }
@@ -16412,7 +16412,7 @@
         },
         "numbering": [
           {
-            "volume": 880
+            "volume": "880"
           }
         ]
       }
@@ -17029,7 +17029,7 @@
         },
         "numbering": [
           {
-            "volume": 6
+            "volume": "6"
           }
         ]
       }
@@ -18029,7 +18029,7 @@
         },
         "numbering": [
           {
-            "volume": 2
+            "volume": "2"
           }
         ]
       }
@@ -40677,7 +40677,7 @@
         },
         "numbering": [
           {
-            "volume": 3
+            "volume": "3"
           }
         ]
       }
@@ -41925,7 +41925,7 @@
         },
         "numbering": [
           {
-            "volume": 2704
+            "volume": "2704"
           }
         ]
       }
@@ -42407,7 +42407,7 @@
         },
         "numbering": [
           {
-            "volume": 23
+            "volume": "23"
           }
         ]
       }
@@ -44602,7 +44602,7 @@
         },
         "numbering": [
           {
-            "volume": 1231
+            "volume": "1231"
           }
         ]
       }
@@ -45104,7 +45104,7 @@
         },
         "numbering": [
           {
-            "volume": 1
+            "volume": "1"
           }
         ]
       }
@@ -45637,7 +45637,7 @@
         },
         "numbering": [
           {
-            "volume": 4
+            "volume": "4"
           }
         ]
       },
@@ -45847,7 +45847,7 @@
         },
         "numbering": [
           {
-            "volume": 258
+            "volume": "258"
           }
         ]
       }
@@ -46621,7 +46621,7 @@
         },
         "numbering": [
           {
-            "volume": 608
+            "volume": "608"
           }
         ]
       }
@@ -47742,7 +47742,7 @@
         },
         "numbering": [
           {
-            "volume": 142
+            "volume": "142"
           }
         ]
       }
@@ -48870,7 +48870,7 @@
         },
         "numbering": [
           {
-            "volume": 10499
+            "volume": "10499"
           }
         ]
       }
@@ -49770,7 +49770,7 @@
         },
         "numbering": [
           {
-            "volume": 21531
+            "volume": "21531"
           }
         ]
       }
@@ -50284,7 +50284,7 @@
         },
         "numbering": [
           {
-            "volume": 1
+            "volume": "1"
           }
         ]
       }
@@ -51736,7 +51736,7 @@
         },
         "numbering": [
           {
-            "volume": 8581
+            "volume": "8581"
           }
         ]
       }
@@ -54111,7 +54111,7 @@
         },
         "numbering": [
           {
-            "volume": 646
+            "volume": "646"
           }
         ]
       }
@@ -54517,7 +54517,7 @@
         },
         "numbering": [
           {
-            "volume": 528
+            "volume": "528"
           }
         ]
       }
@@ -56865,7 +56865,7 @@
         },
         "numbering": [
           {
-            "volume": 1038
+            "volume": "1038"
           }
         ]
       }
@@ -57319,7 +57319,7 @@
         },
         "numbering": [
           {
-            "volume": 1856
+            "volume": "1856"
           }
         ]
       }
@@ -58043,7 +58043,7 @@
         },
         "numbering": [
           {
-            "volume": 1
+            "volume": "1"
           }
         ]
       }
@@ -59455,7 +59455,7 @@
         },
         "numbering": [
           {
-            "volume": 13
+            "volume": "13"
           }
         ]
       }
@@ -59919,7 +59919,7 @@
         },
         "numbering": [
           {
-            "volume": 216
+            "volume": "216"
           }
         ]
       }
@@ -60978,7 +60978,7 @@
         },
         "numbering": [
           {
-            "volume": 1
+            "volume": "1"
           }
         ]
       }
@@ -63411,7 +63411,7 @@
         },
         "numbering": [
           {
-            "volume": 94
+            "volume": "94"
           }
         ]
       }
@@ -63791,7 +63791,7 @@
         },
         "numbering": [
           {
-            "volume": 3
+            "volume": "3"
           }
         ]
       }
@@ -64508,7 +64508,7 @@
         },
         "numbering": [
           {
-            "volume": 1
+            "volume": "1"
           }
         ]
       }
@@ -66616,7 +66616,7 @@
         },
         "numbering": [
           {
-            "volume": 13
+            "volume": "13"
           }
         ]
       }
@@ -67759,7 +67759,7 @@
         },
         "numbering": [
           {
-            "volume": 25
+            "volume": "25"
           }
         ]
       }
@@ -68511,7 +68511,7 @@
         },
         "numbering": [
           {
-            "volume": 25
+            "volume": "25"
           }
         ]
       }

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
@@ -834,13 +834,13 @@ def marc21_to_part_of(self, key, value):
             """Constructor method."""
             self._numbering = {}
             self._year_regexp = re.compile(r'^\d{4}')
-            self._integer_regexp = re.compile(r'^\d+$')
+            self._string_regexp = re.compile(r'.*')
             self._pages_regexp = re.compile(r'^\d+(-\d+)?$')
             self._pattern_per_key = {
                 'year': self._year_regexp,
                 'pages': self._pages_regexp,
-                'issue': self._integer_regexp,
-                'volume': self._integer_regexp
+                'issue': self._string_regexp,
+                'volume': self._string_regexp
             }
 
         def add_numbering_value(self, key, value):
@@ -855,12 +855,7 @@ def marc21_to_part_of(self, key, value):
             :type value: str
             """
             if self._pattern_per_key[key].search(value):
-                if key in ('issue', 'volume'):
-                    value = int(value)
-                    if value > 0:
-                        self._numbering[key] = value
-                else:
-                    self._numbering[key] = value
+                self._numbering[key] = value
             elif key != 'year':
                 self._numbering['discard'] = True
 
@@ -968,7 +963,7 @@ def marc21_to_part_of(self, key, value):
             for subfield_v in utils.force_list(value.get('v', [])):
                 numbering = Numbering()
                 if subfield_v:
-                    numbering.add_numbering_value('volume', subfield_v)
+                    numbering.add_numbering_value('volume', str(subfield_v))
                 if numbering.is_valid():
                     numbering_list.append(numbering.get())
         if 'document' in part_of:

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
@@ -1494,13 +1494,13 @@ def do_part_of(data, marc21, key, value):
             """Constructor method."""
             self._numbering = {}
             self._year_regexp = re.compile(r'^\d{4}')
-            self._integer_regexp = re.compile(r'^\d+$')
+            self._string_regexp = re.compile(r'.*')
             self._pages_regexp = re.compile(r'^\d+(-\d+)?$')
             self._pattern_per_key = {
                 'year': self._year_regexp,
                 'pages': self._pages_regexp,
-                'issue': self._integer_regexp,
-                'volume': self._integer_regexp
+                'issue': self._string_regexp,
+                'volume': self._string_regexp
             }
 
         def add_numbering_value(self, key, value):
@@ -1515,12 +1515,7 @@ def do_part_of(data, marc21, key, value):
             :type value: str
             """
             if self._pattern_per_key[key].search(value):
-                if key in ('issue', 'volume'):
-                    value = int(value)
-                    if value > 0:
-                        self._numbering[key] = value
-                else:
-                    self._numbering[key] = value
+                self._numbering[key] = value
             elif key != 'year':
                 self._numbering['discard'] = True
 

--- a/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
@@ -487,38 +487,28 @@ def marc21_to_part_of(self, key, value):
         }}
         numbering = []
         if subfield_v := utils.force_list(value.get('v')):
-            # get volumes and pages split
-            volumes_pages = subfield_v[0].split(',')
-            # get a volume range
-            volumes = volumes_pages[0].split('-')
-            pages = volumes_pages[1] if len(volumes_pages) > 1 else None
             with contextlib.suppress(ValueError):
-                volumes = range(int(volumes[0]), int(volumes[1]) + 1) \
-                    if len(volumes) > 1 else [int(volumes[0])]
-                # TODO: save volume ranges as string ex: 3-4
-                for volume in volumes:
-                    numbering.append({'volume': volume})
-                    if pages:
-                        numbering[-1]['pages'] = pages
+                numbering.append({'volume': str(subfield_v[0])})
         if subfield_d := utils.force_list(value.get('d')):
             # get a years range
             years = subfield_d[0].split('-')
             with contextlib.suppress(ValueError):
-                years = range(int(years[0]), int(years[1]) + 1) \
-                    if len(years) > 1 else [int(years[0])]
-                if len(years) > 0:
-                    for number in numbering:
-                        number['year'] = years[0]
-                numbering_years = deepcopy(numbering)
-                # TODO: save year ranges as string ex: 2022-2024
-                # if we have a year range add the same numbering data for
-                # every year
-                for year in years[1:]:
-                    for number in numbering:
-                        number_year = deepcopy(number)
-                        number_year['year'] = year
-                        numbering_years.append(number_year)
-                numbering = numbering_years
+                if numbering:
+                    numbering[0]['year'] = str(years[0])
+                else:
+                    numbering.append({'year': str(years[0])})
+                if len(years) > 1:
+                    if years := range(int(years[0]), int(years[1]) + 1):
+                        numbering_years = deepcopy(numbering)
+                        # TODO: save year ranges as string ex: 2022-2024
+                        # if we have a year range add the same numbering data
+                        # for every year
+                        for year in years[1:]:
+                            if numbering:
+                                number_year = deepcopy(numbering[0])
+                            number_year['year'] = str(year)
+                            numbering_years.append(number_year)
+                        numbering = numbering_years
         if numbering:
             part_of['numbering'] = numbering
 

--- a/rero_ils/modules/documents/jsonschemas/documents/document_part_of-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_part_of-v0.0.1.json
@@ -78,7 +78,7 @@
               },
               "volume": {
                 "title": "Volume",
-                "type": "integer",
+                "type": "string",
                 "minimum": 1,
                 "form": {
                   "templateOptions": {
@@ -88,7 +88,7 @@
               },
               "issue": {
                 "title": "Issue",
-                "type": "integer",
+                "type": "string",
                 "minimum": 1,
                 "form": {
                   "templateOptions": {

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3360,15 +3360,15 @@
         },
         "numbering": [
           {
-            "issue": 5,
+            "issue": "5",
             "pages": "22-928",
-            "volume": 3,
+            "volume": "3",
             "year": "1988"
           },
           {
-            "issue": 8,
+            "issue": "8",
             "pages": "42",
-            "volume": 6,
+            "volume": "6",
             "year": "1998"
           }
         ]

--- a/tests/unit/documents/test_documents_dojson.py
+++ b/tests/unit/documents/test_documents_dojson.py
@@ -4057,8 +4057,8 @@ def test_marc21_to_part_of():
                 },
                 {
                     'year': '2020',
-                    'volume': 1,
-                    'issue': 2,
+                    'volume': "1",
+                    'issue': "2",
                     'pages': '300'
                 }]
         }]
@@ -4078,8 +4078,8 @@ def test_marc21_to_part_of():
             'document': {'$ref': 'https://bib.rero.ch/api/documents/123456'},
             'numbering': [
                 {
-                    'volume': 1,
-                    'issue': 2,
+                    'volume': "1",
+                    'issue': "2",
                     'pages': '300'
                 }]
         }]
@@ -4118,8 +4118,8 @@ def test_marc21_to_part_of():
                     'pages': '411'
                 },
                 {
-                    'volume': 1,
-                    'issue': 2
+                    'volume': "1",
+                    'issue': "2"
                 }]
         }]
 
@@ -4152,7 +4152,7 @@ def test_marc21_to_part_of():
     assert data.get('partOf') == [{
             'document': {'$ref': 'https://bib.rero.ch/api/documents/123456'},
             'numbering': [{
-                    'volume': 256
+                    'volume': "256"
                 }]
         }]
 
@@ -4483,7 +4483,7 @@ def test_marc21_to_part_of_with_multiple_800():
     assert data.get('partOf') == [{
             'document': {'$ref': 'https://bib.rero.ch/api/documents/780067'},
             'numbering': [{
-                    'volume': 3
+                    'volume': "3"
                 }]
         }]
     # the seriesStatement is generated form 490 and not from the 800

--- a/tests/unit/documents/test_documents_dojson_unimarc.py
+++ b/tests/unit/documents/test_documents_dojson_unimarc.py
@@ -1412,8 +1412,8 @@ def test_unimarc_partOf_with_link(document_with_issn):
     assert data['partOf'] == [{
         'document': {'$ref': 'https://bib.rero.ch/api/documents/doc5'},
         'numbering': [{
-            'volume': 24,
-            'year': 2024
+            'volume': '24',
+            'year': '2024'
         }]
     }]
 
@@ -1422,7 +1422,7 @@ def test_unimarc_partOf_with_link(document_with_issn):
       <datafield tag="410" ind1=" " ind2="0">
         <subfield code="t">Formation permanente en sciences humaines</subfield>
         <subfield code="x">0768-2026</subfield>
-        <subfield code="v">3-4,11-15</subfield>
+        <subfield code="v">No 770, 15 mai 2024, pp. 31-41</subfield>
         <subfield code="d">2024</subfield>
       </datafield>
     </record>
@@ -1432,13 +1432,8 @@ def test_unimarc_partOf_with_link(document_with_issn):
     assert data['partOf'] == [{
         'document': {'$ref': 'https://bib.rero.ch/api/documents/doc5'},
         'numbering': [{
-            'volume': 3,
-            'pages': '11-15',
-            'year': 2024
-        }, {
-            'volume': 4,
-            'pages': '11-15',
-            'year': 2024
+            'volume': 'No 770, 15 mai 2024, pp. 31-41',
+            'year': '2024'
         }]
     }]
 
@@ -1457,30 +1452,53 @@ def test_unimarc_partOf_with_link(document_with_issn):
     assert data['partOf'] == [{
         'document': {'$ref': 'https://bib.rero.ch/api/documents/doc5'},
         'numbering': [{
-            'volume': 3,
-            'pages': '11-15',
-            'year': 1867
+            'volume': '3-4,11-15',
+            'year': '1867'
         }, {
-            'volume': 4,
-            'pages': '11-15',
-            'year': 1867
+            'volume': '3-4,11-15',
+            'year': '1868'
         }, {
-            'volume': 3,
-            'pages': '11-15',
-            'year': 1868
-        }, {
-            'volume': 4,
-            'pages': '11-15',
-            'year': 1868
-        }, {
-            'volume': 3,
-            'pages': '11-15',
-            'year': 1869
-        }, {
-            'volume': 4,
-            'pages': '11-15',
-            'year': 1869
+            'volume': '3-4,11-15',
+            'year': '1869'
         }]
+    }]
+
+    unimarcxml = """
+    <record>
+      <datafield tag="410" ind1=" " ind2="0">
+        <subfield code="t">Formation permanente en sciences humaines</subfield>
+        <subfield code="x">0768-2026</subfield>
+        <subfield code="d">1867-1869</subfield>
+      </datafield>
+    </record>
+    """
+    unimarcjson = create_record(unimarcxml)
+    data = unimarc.do(unimarcjson)
+    assert data['partOf'] == [{
+        'document': {'$ref': 'https://bib.rero.ch/api/documents/doc5'},
+        'numbering': [{
+            'year': '1867'
+        }, {
+            'year': '1868'
+        }, {
+            'year': '1869'
+        }]
+    }]
+
+    unimarcxml = """
+    <record>
+      <datafield tag="410" ind1=" " ind2="0">
+        <subfield code="t">Formation permanente en sciences humaines</subfield>
+        <subfield code="x">0768-2026</subfield>
+        <subfield code="d">1869</subfield>
+      </datafield>
+    </record>
+    """
+    unimarcjson = create_record(unimarcxml)
+    data = unimarc.do(unimarcjson)
+    assert data['partOf'] == [{
+        'document': {'$ref': 'https://bib.rero.ch/api/documents/doc5'},
+        'numbering': [{'year': '1869'}]
     }]
 
 


### PR DESCRIPTION
* Closes #3570.
* Closes #1818.
* ⚠️ On migration, we need to convert the fields
`document.partOf.numbering.volume` and `document.partOf.numbering.issue`
from integers to strings in the db (the mappings stay the same).