### PR TITLE
fix: add pending requests count to dumper

### DIFF
--- a/rero_ils/modules/items/dumpers.py
+++ b/rero_ils/modules/items/dumpers.py
@@ -136,7 +136,9 @@ class CirculationActionDumper(InvenioRecordsDumper):
 
         data['actions'] = list(record.actions)
 
-        # only the first request is used by the UI
+        # add the current pending requests count
+        data['current_pending_requests'] = record.get_requests(output='count')
+        # add metadata of the first pending request
         requests = record.get_requests(sort_by='_created')
         if first_request := next(requests, None):
             data['pending_loans'] = [

--- a/tests/ui/items/test_items_dumpers.py
+++ b/tests/ui/items/test_items_dumpers.py
@@ -66,6 +66,9 @@ def test_item_action_circulation_dumper(
     # pending loans
     assert len(data['pending_loans']) == 1
 
+    # number of pending requests
+    assert data['current_pending_requests'] == 1
+
 
 def test_item_circulation_dumper(item_lib_martigny):
     """Test item circulation dumper."""


### PR DESCRIPTION
* The UI needs to display the number of current pending requests for an item-loan couple so we add it in the dumper.