### PR TITLE
fix(items): availability for in_transit items

### DIFF
--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -255,6 +255,17 @@ def test_items_availability(item_type_missing_martigny,
     assert item.is_available()
     assert len(item.availability_text) == 1  # only default value
 
+    # test availabilty by item status
+    item['status'] = ItemStatus.IN_TRANSIT
+    item = item.update(item, dbcommit=True, reindex=True)
+    assert not item.is_available()
+    assert item.availability_text[0]['label'] == ItemStatus.IN_TRANSIT
+
+    item['status'] = ItemStatus.ON_SHELF
+    item = item.update(item, dbcommit=True, reindex=True)
+    assert item.is_available()
+    assert len(item.availability_text) == 1  # only default value
+
     # test availability and availability_text for an issue
     item['type'] = TypeOfItem.ISSUE
     item['enumerationAndChronology'] = 'dummy'


### PR DESCRIPTION
* Items without loans that are in_transit should be marked as unavailable.
* Closes #2827.