### PR TITLE
users: fix get REST API for a user without profile

### DIFF
--- a/rero_ils/modules/users/api.py
+++ b/rero_ils/modules/users/api.py
@@ -233,7 +233,8 @@ class User(object):
         metadata = {
             'roles': [r.name for r in self.user.roles]
         }
-        metadata.update(self.user.user_profile)
+        if user_profile := self.user.user_profile:
+            metadata.update(user_profile)
         if self.user.email:
             metadata['email'] = self.user.email
         if self.user.username:

--- a/rero_ils/modules/users/views.py
+++ b/rero_ils/modules/users/views.py
@@ -170,7 +170,7 @@ class UsersCreateResource(ContentNegotiatedMethodView):
     @check_user_list_permission
     def get(self):
         """Get user info for the professionnal view."""
-        email_or_username = request.args.get('q', None).strip()
+        email_or_username = request.args.get('q', '').strip()
         hits = {
             'hits': {
                 'hits': [],

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -32,13 +32,28 @@ from rero_ils.modules.items.api import Item, ItemsSearch
 
 
 @pytest.fixture(scope='function')
+def user_without_profile(db, default_user_password):
+    """Create a simple invenio user with a profile."""
+    with db.session.begin_nested():
+        user = User(
+            email='user_without_profile@test.com',
+            password=hash_password(default_user_password),
+            user_profile=None,
+            active=True,
+        )
+        db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture(scope='function')
 def user_with_profile(db, default_user_password):
     """Create a simple invenio user with a profile."""
     with db.session.begin_nested():
         user = User(
             email='user_with_profile@test.com',
             password=hash_password(default_user_password),
-            profile={},
+            user_profile={},
             active=True,
         )
         db.session.add(user)


### PR DESCRIPTION
* Fixes internal serveur error when we search for a user without profile.
* Fixes internal serveur error for the user search API without the `q` parameter.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
