### PR TITLE
fix(jsonschemas): hide fields

### DIFF
--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -84,17 +84,12 @@
       "widget": {
         "formlyConfig": {
           "wrappers": [
-            "toggle-switch",
             "card"
           ],
           "props": {
             "addonRight": [
               "day(s)"
             ],
-            "toggle-switch": {
-              "label": "Allow checkout",
-              "description": "Checkouts are allowed or not."
-            },
             "navigation": {
               "essential": true
             }

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -145,7 +145,7 @@
       "widget": {
         "formlyConfig": {
           "expressions": {
-            "hide": "field?.parent?.model && field.parent.model.type === 'issue'"
+            "hide": "field?.parent?.model.type === 'issue'"
           },
           "props": {
             "cssClass": "editor-title"
@@ -191,7 +191,7 @@
       "widget": {
         "formlyConfig": {
           "expressions": {
-            "hide": "field?.parent?.model && field.parent.model.type === 'issue'"
+            "hide": "field?.parent?.model.type === 'issue'"
           },
           "props": {
             "cssClass": "editor-title"


### PR DESCRIPTION
* Fixes item fields not correctly hidden.
* Remove toggle-switch on circ-policy editor. It makes no sense and creates bugs when editor is in long mode.