### PR TITLE
files: add file permissions configurations

### DIFF
--- a/data/role_policies.json
+++ b/data/role_policies.json
@@ -291,6 +291,21 @@
     "pro_catalog_manager",
     "pro_library_administrator"
   ],
+  "file-create": [
+    "pro_full_permissions",
+    "pro_catalog_manager",
+    "pro_library_administrator"
+  ],
+  "file-update": [
+    "pro_full_permissions",
+    "pro_catalog_manager",
+    "pro_library_administrator"
+  ],
+  "file-delete": [
+    "pro_full_permissions",
+    "pro_catalog_manager",
+    "pro_library_administrator"
+  ],
   "hold-create": [
     "pro_full_permissions",
     "pro_catalog_manager",

--- a/data/system_role_policies.json
+++ b/data/system_role_policies.json
@@ -14,6 +14,12 @@
   "doc-read": [
     "any_user"
   ],
+  "file-search": [
+    "any_user"
+  ],
+  "file-read": [
+    "any_user"
+  ],
   "hold-access": [
     "any_user"
   ],

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2815,6 +2815,12 @@ RERO_ILS_PERMISSIONS_ACTIONS = [
     'rero_ils.modules.documents.permissions:create_action',
     'rero_ils.modules.documents.permissions:update_action',
     'rero_ils.modules.documents.permissions:delete_action',
+    'rero_ils.modules.files.permissions:access_action',
+    'rero_ils.modules.files.permissions:search_action',
+    'rero_ils.modules.files.permissions:read_action',
+    'rero_ils.modules.files.permissions:create_action',
+    'rero_ils.modules.files.permissions:update_action',
+    'rero_ils.modules.files.permissions:delete_action',
     'rero_ils.modules.entities.local_entities.permissions.access_action',
     'rero_ils.modules.entities.local_entities.permissions.search_action',
     'rero_ils.modules.entities.local_entities.permissions.read_action',
@@ -4001,6 +4007,11 @@ FILES_REST_STORAGE_CLASS_LIST = {
     "L": "Local"
 }
 
+MAX_CONTENT_LENGTH = 500 * 1024 * 1024
+
 FILES_REST_DEFAULT_STORAGE_CLASS = "L"
 RECORDS_REFRESOLVER_CLS = "invenio_records.resolver.InvenioRefResolver"
 RECORDS_REFRESOLVER_STORE = "rero_ils.modules.utils.refresolver_store"
+
+RERO_FILES_RECORD_SERVICE_CONFIG = "rero_ils.modules.files.services.RecordServiceConfig"
+RERO_FILES_RECORD_FILE_SERVICE_CONFIG = "rero_ils.modules.files.services.RecordFileServiceConfig"

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -24,6 +24,7 @@ from functools import partial
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import Q
 from flask import current_app
+from invenio_access.permissions import system_identity
 from invenio_circulation.search.api import search_by_pid
 from invenio_search import current_search_client
 from jsonschema.exceptions import ValidationError
@@ -308,6 +309,7 @@ class Document(IlsRecord):
             document_pid=self.pid,
             exclude_states=[LoanState.CANCELLED, LoanState.ITEM_RETURNED]
         )
+        file_query = self.get_records_files_query().source()
         acq_order_lines_query = AcqOrderLinesSearch() \
             .filter('term', document__pid=self.pid)
         local_fields_query = LocalFieldsSearch()\
@@ -329,6 +331,7 @@ class Document(IlsRecord):
         if get_pids:
             holdings = sorted_pids(hold_query)
             items = sorted_pids(item_query)
+            files = [hit.id for hit in file_query.scan()]
             loans = sorted_pids(loan_query)
             acq_order_lines = sorted_pids(acq_order_lines_query)
             local_fields = sorted_pids(local_fields_query)
@@ -342,6 +345,7 @@ class Document(IlsRecord):
             holdings = hold_query.count()
             items = item_query.count()
             loans = loan_query.count()
+            files = file_query.count()
             acq_order_lines = acq_order_lines_query.count()
             local_fields = local_fields_query.count()
             documents = 0
@@ -353,12 +357,42 @@ class Document(IlsRecord):
         links = {
             'holdings': holdings,
             'items': items,
+            'files': files,
             'loans': loans,
             'acq_order_lines': acq_order_lines,
             'documents': documents,
             'local_fields': local_fields
         }
         return {k: v for k, v in links.items() if v}
+
+    def get_records_files_query(self, lib_pids=None):
+        """Creates an es query to retrieves the record files."""
+        ext = current_app.extensions['rero-invenio-files']
+        sfr = ext.records_service
+        search = sfr.search_request(
+            system_identity, dict(size=1), sfr.record_cls, sfr.config.search
+        )
+        # required to avoid exception during the `count()` call
+        # TODO: remove this once the issue is solved
+        search._params = {}
+        search = search.source(['uuid', 'id'])\
+            .filter('term', metadata__links=f'doc_{self.pid}')
+        # filter by library pids
+        if lib_pids:
+            # add lib_ prefix if it is needed
+            if not lib_pids[0].startswith('lib_'):
+                lib_pids = [f'lib_{pid}' for pid in lib_pids]
+            search = search.filter('terms', metadata__owners=lib_pids)
+        return search
+
+    def get_records_files(self, lib_pids=None):
+        """Get the record files linked to the current document."""
+        ext = current_app.extensions['rero-invenio-files']
+        sfr = ext.records_service
+        for rec in (self.get_records_files_query(
+            lib_pids=lib_pids).source().scan()
+        ):
+            yield sfr.record_cls.get_record(rec.uuid)
 
     def reasons_not_to_delete(self):
         """Get reasons not to delete record."""

--- a/rero_ils/modules/documents/dumpers/indexer.py
+++ b/rero_ils/modules/documents/dumpers/indexer.py
@@ -238,8 +238,7 @@ class IndexerDumper(Dumper):
         search = search.source('uuid')\
             .filter('term', metadata__links=f'doc_{record.pid}')
         files = []
-        for rec in search.scan():
-            record_file = sfr.record_cls.get_record(rec.uuid)
+        for record_file in record.get_records_files():
             for file_name in record_file.files:
                 file = record_file.files[file_name]
                 metadata = file.get('metadata', {})

--- a/rero_ils/modules/files/permissions.py
+++ b/rero_ils/modules/files/permissions.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2024 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Files permissions."""
+
+from invenio_access import action_factory
+from invenio_records_permissions.generators import SystemProcess
+
+from rero_ils.modules.permissions import AllowedByAction, \
+    AllowedByActionRestrictByManageableLibrary, RecordPermissionPolicy
+
+# Actions to control Record Files policies for CRUD operations
+search_action = action_factory("file-search")
+read_action = action_factory("file-read")
+create_action = action_factory("file-create")
+update_action = action_factory("file-update")
+delete_action = action_factory("file-delete")
+access_action = action_factory("file-access")
+
+
+def get_library_pid(record):
+    """Get the library pid from the record files.
+
+    @param record: a file record instance.
+    @returns: the library pid value.
+    @rtype: string.
+    """
+    return record.get("metadata", {}).get("owners", [])[0].replace("lib_", "")
+
+
+class FilePermissionPolicy(RecordPermissionPolicy):
+    """Files permission policies."""
+
+    # standard CRUD operation
+    can_search = [AllowedByAction(search_action), SystemProcess()]
+    can_read = [AllowedByAction(read_action), SystemProcess()]
+    can_create = [AllowedByAction(create_action), SystemProcess()]
+    can_update = [
+        AllowedByActionRestrictByManageableLibrary(
+            update_action, get_library_pid),
+        SystemProcess(),
+    ]
+    can_delete = [
+        AllowedByActionRestrictByManageableLibrary(
+            delete_action, get_library_pid),
+        SystemProcess(),
+    ]
+    # download/upload a file
+    can_get_content_files = [AllowedByAction(read_action), SystemProcess()]
+    can_set_content_files = [
+        AllowedByActionRestrictByManageableLibrary(
+            create_action, get_library_pid),
+        SystemProcess(),
+    ]
+    # files container
+    can_read_files = [AllowedByAction(read_action), SystemProcess()]
+    can_create_files = [AllowedByAction(create_action), SystemProcess()]
+    can_commit_files = [
+        AllowedByActionRestrictByManageableLibrary(
+            create_action, get_library_pid),
+        SystemProcess(),
+    ]
+    can_update_files = [
+        AllowedByActionRestrictByManageableLibrary(
+            update_action, get_library_pid),
+        SystemProcess(),
+    ]
+    can_delete_files = [
+        AllowedByActionRestrictByManageableLibrary(
+            delete_action, get_library_pid),
+        SystemProcess(),
+    ]

--- a/rero_ils/modules/files/services.py
+++ b/rero_ils/modules/files/services.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2024 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Files services."""
+
+from rero_invenio_files.records.services import FileServiceConfig, \
+    RecordServiceConfig
+
+from .permissions import FilePermissionPolicy
+
+
+class RecordServiceConfig(RecordServiceConfig):
+    """File record service."""
+
+    permission_policy_cls = FilePermissionPolicy
+
+
+class RecordFileServiceConfig(FileServiceConfig):
+    """Files service configuration."""
+
+    permission_policy_cls = FilePermissionPolicy
+
+    # maximum files per buckets
+    max_files_count = 1000

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -244,6 +244,23 @@ def get_record_class_and_permissions_from_route(route_name):
     """Get record class and permission factories for a record route name."""
     endpoints = current_app.config.get('RECORDS_REST_ENDPOINTS')
     endpoints.update(current_app.config.get('CIRCULATION_REST_ENDPOINTS', {}))
+    registry = current_app.extensions["invenio-records-resources"].registry
+    # invenio records resources case
+    try:
+        service = registry.get(route_name)
+        record_class = service.record_cls
+        permission_cls = service.permission_policy
+        permissions = dict(
+            read=lambda record: permission_cls('read', record=record),
+            list=lambda record: permission_cls('search', record=record),
+            create=lambda record: permission_cls('create', record=record),
+            update=lambda record: permission_cls('update', record=record),
+            delete=lambda record: permission_cls('delete', record=record)
+        )
+        return record_class, permissions
+    except KeyError:
+        pass
+    # legacy invenio records rest case
     for endpoint in endpoints.items():
         record = endpoint[1]
         list_route = record.get('list_route').replace('/', '')

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -455,7 +455,6 @@ def search_factory(self, search, query_parser=None):
     ):
         query_boosting = \
             [v for v in query_boosting if not v.startswith('fulltext')]
-    print(query_boosting)
     try:
         search = search.query(query_parser(query_string, query_boosting))
     except SyntaxError as err:

--- a/scripts/setup
+++ b/scripts/setup
@@ -427,7 +427,7 @@ info_msg "- Items: ${ITEMS} ${CREATE_LAZY} ${DONT_STOP}"
 eval ${PREFIX} invenio reroils fixtures create --pid_type item --schema 'https://bib.rero.ch/schemas/items/item-v0.0.1.json' ${ITEMS} --append ${CREATE_LAZY} ${DONT_STOP}
 
 info_msg "- Generate files"
-eval ${PREFIX} invenio reroils fixtures create-files 50
+eval ${PREFIX} invenio reroils fixtures create-files 75
 
 # index items
 eval ${PREFIX} invenio reroils index reindex -t item --yes-i-know

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -19,55 +19,16 @@
 
 from __future__ import absolute_import, print_function
 
-import shutil
-import tempfile
 from copy import deepcopy
 from datetime import datetime
 
 import pytest
 from flask_security.utils import hash_password
 from invenio_accounts.models import User
-from invenio_files_rest.models import Location
 from utils import flush_index
 
 from rero_ils.modules.documents.api import Document, DocumentsSearch
-from rero_ils.modules.files.cli import create_pdf_record_files
 from rero_ils.modules.items.api import Item, ItemsSearch
-
-
-@pytest.fixture(scope="module")
-def file_location(database):
-    """Creates a simple default location for a test.
-
-    Scope: function
-
-    Use this fixture if your test requires a `files location <https://invenio-
-    files-rest.readthedocs.io/en/latest/api.html#invenio_files_rest.models.
-    Location>`_. The location will be a default location with the name
-    ``pytest-location``.
-    """
-    uri = tempfile.mkdtemp()
-    location_obj = Location(name="pytest-location", uri=uri, default=True)
-
-    database.session.add(location_obj)
-    database.session.commit()
-
-    yield location_obj
-
-    shutil.rmtree(uri)
-
-
-@pytest.fixture(scope='module')
-def document_with_files(document, lib_martigny, file_location):
-    """Create a document with a pdf file attached."""
-    metadata = dict(
-        owners=[f'lib_{lib_martigny.pid}'],
-        collections=['col1', 'col2']
-    )
-    create_pdf_record_files(document, metadata, flush=True)
-    document.reindex()
-    flush_index(DocumentsSearch.Meta.index)
-    yield document
 
 
 @pytest.fixture(scope='function')

--- a/tests/api/files/test_files_permissions.py
+++ b/tests/api/files/test_files_permissions.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2024 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import mock
+from flask import current_app, url_for
+from flask_principal import AnonymousIdentity, identity_changed
+from flask_security import login_user
+from invenio_accounts.testutils import login_user_via_session
+from utils import check_permission, flush_index, get_json
+
+from rero_ils.modules.files.permissions import FilePermissionPolicy
+from rero_ils.modules.patrons.api import Patron, PatronsSearch
+
+
+def test_files_permissions_api(client, librarian_martigny,
+                               librarian_sion, patron_martigny,
+                               system_librarian_martigny,
+                               document_with_files):
+    """Test files permissions api."""
+    record_file = next(document_with_files.get_records_files())
+    permissions_list_url = url_for(
+        'api_blueprint.permissions',
+        route_name='records'
+    )
+    permissions_item_url = url_for(
+        'api_blueprint.permissions',
+        route_name='records',
+        record_pid=record_file.pid.pid_value
+    )
+
+    # Not logged
+    res = client.get(permissions_list_url)
+    assert res.status_code == 401
+
+    res = client.get(permissions_item_url)
+    assert res.status_code == 401
+
+    # logged as patron
+    login_user_via_session(client, patron_martigny.user)
+    res = client.get(permissions_item_url)
+    assert res.status_code == 403
+
+    res = client.get(permissions_list_url)
+    assert res.status_code == 403
+
+    # logged as librarian
+    login_user_via_session(client, librarian_martigny.user)
+    res = client.get(permissions_item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    for action in ['list', 'read', 'create', 'update', 'delete']:
+        assert data[action]['can']
+
+    res = client.get(permissions_list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    for action in ['list', 'create']:
+        assert data[action]['can']
+
+    # logged as librarian
+    login_user_via_session(client, system_librarian_martigny.user)
+    res = client.get(permissions_item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    for action in ['list', 'read', 'create', 'update', 'delete']:
+        assert data[action]['can']
+
+    res = client.get(permissions_list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    for action in ['list', 'create']:
+        assert data[action]['can']
+
+    # logged as librarian
+    login_user_via_session(client, librarian_sion.user)
+    res = client.get(permissions_item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    for action in ['list', 'create', 'read']:
+        assert data[action]['can']
+    for action in ['update', 'delete']:
+        assert not data[action]['can']
+
+    res = client.get(permissions_list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    for action in ['list', 'create']:
+        assert data[action]['can']
+
+
+@mock.patch.object(Patron, '_extensions', [])
+def test_files_permissions(
+    patron_martigny, librarian_martigny, librarian_sion,
+    system_librarian_martigny, document_with_files
+):
+    """Test files permissions."""
+
+    # Anonymous user & Patron user
+    #  - search/read any files are allowed.
+    #  - create/update/delete operations are disallowed.
+    identity_changed.send(
+        current_app._get_current_object(), identity=AnonymousIdentity()
+    )
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': False,
+        'update': False,
+        'delete': False
+    }, None)
+    record_file = next(document_with_files.get_records_files())
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': False,
+        'update': False,
+        'delete': False
+    }, record_file)
+    login_user(patron_martigny.user)
+    check_permission(FilePermissionPolicy, {'create': False}, {})
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': False,
+        'update': False,
+        'delete': False
+    }, record_file)
+
+    # Librarian with specific role
+    #     - search/read: any files
+    #     - create/update/delete: allowed for files of its own library
+    login_user(librarian_martigny.user)
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': True,
+        'update': True,
+        'delete': True
+    }, record_file)
+
+    # Librarian with specific role
+    #     - search/read: any files
+    #     - update/delete: disallowed for files of other libraries
+    login_user(librarian_sion.user)
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': True,
+        'update': False,
+        'delete': False
+    }, record_file)
+
+    # Librarian without specific role
+    #   - search/read: any files
+    #   - create/update/delete: allowed for any files of its own library
+    original_roles = librarian_martigny.get('roles', [])
+    librarian_martigny['roles'] = ['pro_catalog_manager']
+    librarian_martigny.update(librarian_martigny, dbcommit=True, reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+
+    login_user(librarian_martigny.user)  # to refresh identity !
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': True,
+        'update': True,
+        'delete': True
+    }, record_file)
+
+    librarian_martigny['roles'] = ['pro_user_manager']
+    librarian_martigny.update(librarian_martigny, dbcommit=True, reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+
+    login_user(librarian_martigny.user)  # to refresh identity !
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': False,
+        'update': False,
+        'delete': False
+    }, record_file)
+
+    # reset the librarian
+    librarian_martigny['roles'] = original_roles
+    librarian_martigny.update(librarian_martigny, dbcommit=True, reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+
+    # System librarian (aka. full-permissions)
+    #   - create/update/delete: allow for files if its own org
+    login_user(system_librarian_martigny.user)
+    check_permission(FilePermissionPolicy, {
+        'search': True,
+        'read': True,
+        'create': True,
+        'update': True,
+        'delete': True
+    }, record_file)

--- a/tests/data/policies/role_policies.json
+++ b/tests/data/policies/role_policies.json
@@ -240,6 +240,21 @@
     "pro_catalog_manager",
     "pro_library_administrator"
   ],
+  "file-create": [
+    "pro_full_permissions",
+    "pro_catalog_manager",
+    "pro_library_administrator"
+  ],
+  "file-update": [
+    "pro_full_permissions",
+    "pro_catalog_manager",
+    "pro_library_administrator"
+  ],
+  "file-delete": [
+    "pro_full_permissions",
+    "pro_catalog_manager",
+    "pro_library_administrator"
+  ],
   "hold-create": [
     "pro_full_permissions",
     "pro_catalog_manager",

--- a/tests/data/policies/system_role_policies.json
+++ b/tests/data/policies/system_role_policies.json
@@ -11,6 +11,12 @@
   "doc-read": [
     "any_user"
   ],
+  "file-search": [
+    "any_user"
+  ],
+  "file-read": [
+    "any_user"
+  ],
   "hold-search": [
     "any_user"
   ],

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -189,11 +189,20 @@ def test_document_add_cover_url(db, document):
     }]
 
 
-def test_document_can_not_delete(document, item_lib_martigny):
+def test_document_with_item_can_not_delete(document, item_lib_martigny):
     """Test can not delete."""
     can, reasons = document.can_delete
     assert not can
     assert reasons['links']['items']
+
+
+def test_document_with_files_can_not_delete(document_with_files):
+    """Test can not delete."""
+    links_to_me = document_with_files.get_links_to_me(True)
+    assert len(links_to_me['files']) > 0
+    can, reasons = document_with_files.can_delete
+    assert not can
+    assert reasons['links']['files']
 
 
 def test_document_can_delete(app, document_data_tmp):


### PR DESCRIPTION
* Adds record files service permission configurations.
* Adds invenio record files support for the permission web API.
* Avoids document deletion if files exists.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
