### PR TITLE
dependencies: sentry-sdk error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5353,4 +5353,4 @@ sip2 = ["invenio-sip2"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.9, <3.10"
-content-hash = "2462230ef8646d3620e45cf60413e88d74d383c34963e2df38c1c8fdbdaf7450"
+content-hash = "61d4513e06562be562f852e55eab4adde199ea0d0cc58afd0ef654400821ba70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ invenio-records-permissions = ">=0.13.0"
 
 # Pinned due to before_first_request deprecation https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.before_first_request
 Flask = ">=2.2.0,<2.3.0"
-sentry-sdk = ">=1.0.0" # normaly in invenio-logging = {version = ">=2.0.0,<3.0.0", extras = ["sentry_sdk"]}
+sentry-sdk = "<2.0.0" # pinned due to https://github.com/inveniosoftware/invenio-rest/issues/135
 dojson = ">=1.4.0"
 # TODO: dojson problem = AttributeError: 'Group' object has no attribute 'resultcallback'
 click = "<8.1.0"


### PR DESCRIPTION
* Fixes `sentry-sdk` error as the version >= 2.0.0 cause an error due to `invenio-rest`.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
