### PR TITLE
fix(operation_log): circulation operation count

### DIFF
--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -554,7 +554,8 @@ def stats(item_pid):
     :param item_pid: the item pid
     """
     search = OperationLogsSearch()\
-        .filter('term', loan__item__pid=item_pid)
+        .filter('term', loan__item__pid=item_pid)\
+        .filter('term', record__type='loan')
     trigger = A(
         'terms',
         field='loan.trigger',

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -195,3 +195,16 @@ def test_item_stats(
             {
                 'total': {'checkin': 2},
                 'total_year': {'checkin': 1}}
+
+
+def test_item_stats_endpoint(
+    item_at_desk_martigny_patron_and_loan_at_desk,
+    client, librarian_martigny
+):
+    """Test loan filter on stats endpoint with real data."""
+    login_user_via_session(client, librarian_martigny.user)
+    res = client.get(url_for(
+        'api_item.stats',
+        item_pid=item_at_desk_martigny_patron_and_loan_at_desk[0].pid
+    ))
+    assert res.json['total']['request'] == 1


### PR DESCRIPTION
To obtain the correct count, operation logs must be filtered using loan records only.

* Closes #3656.