### PR TITLE
chore: add google analytics configuration

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -211,6 +211,8 @@ SETTINGS_TEMPLATE = 'rero_ils/page_settings.html'
 # Google
 # =======================
 # THEME_GOOGLE_SITE_VERIFICATION = []
+# Example of id: UA-XXXXXX-XX
+# RERO_ILS_GOOGLE_ANALYTICS_TAG_ID =
 
 # Miscellaneous variable around templates
 # =======================

--- a/rero_ils/theme/templates/rero_ils/trackingcode.html
+++ b/rero_ils/theme/templates/rero_ils/trackingcode.html
@@ -1,7 +1,7 @@
 <!--
 
   RERO ILS
-  Copyright (C) 2019 RERO
+  Copyright (C) 2019-2024 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -16,12 +16,17 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 -->
+{% if config.get('RERO_ILS_GOOGLE_ANALYTICS_TAG_ID') %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-1831395-14"></script>
+
+{% set TAG_ID = config.get('RERO_ILS_GOOGLE_ANALYTICS_TAG_ID') %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ TAG_ID }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-1831395-14');
+  gtag('config', '{{ TAG_ID }}');
 </script>
+
+{% endif %}

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -205,3 +205,15 @@ def test_set_user_name(
     login_user(user=librarian_martigny.user)
     assert session['user_name'] == librarian_martigny.formatted_name
     logout_user()
+
+
+def test_google_analytics(client, app):
+    """Testing the insertion of the google analytics code in the html page."""
+    # The Google Analytics code must not be present on the page.
+    result = client.get(url_for('rero_ils.index'))
+    assert 'gtag' not in result.text
+
+    # The Google Analytics code must be present on the page.
+    app.config['RERO_ILS_GOOGLE_ANALYTICS_TAG_ID'] = 'GA-Foo'
+    result = client.get(url_for('rero_ils.index'))
+    assert 'gtag' in result.text


### PR DESCRIPTION
The key can be customised in the application configuration.

⚠️  add RERO_ILS_GOOGLE_ANALYTICS_TAG_ID on the configuration.