### PR TITLE
entities: add organisation pids

### DIFF
--- a/rero_ils/modules/entities/api.py
+++ b/rero_ils/modules/entities/api.py
@@ -133,8 +133,8 @@ class Entity(IlsRecord, ABC):
             subjects=with_subjects,
             imported_subjects=with_subjects_imported,
             genre_forms=with_genre_forms
-        ).source('pid')
-        return [hit.pid for hit in search.scan()]
+        )
+        return [hit.pid for hit in search.source('pid').scan()]
 
     def documents_ids(
         self, with_subjects=True, with_subjects_imported=True,

--- a/tests/data/mef.json
+++ b/tests/data/mef.json
@@ -50,7 +50,7 @@
         {
           "source": "IdRef",
           "type": "uri",
-          "value": "http://www.idref.fr/027828085"
+          "value": "http://www.idref.fr/ent_concept_idref"
         },
         {
           "source": "BNF",
@@ -151,7 +151,7 @@
           "noteType": "dataSource"
         }
       ],
-      "pid": "027828085",
+      "pid": "ent_concept_idref",
       "related": [
         {
           "authorized_access_point": "Enzymes"
@@ -167,7 +167,7 @@
         "Inhibiteurs enzymatiques"
       ]
     },
-    "pid": "163554",
+    "pid": "ent_concept",
     "sources": [
       "idref"
     ]

--- a/tests/unit/documents/test_documents_dojson_marc21.py
+++ b/tests/unit/documents/test_documents_dojson_marc21.py
@@ -434,8 +434,9 @@ def test_subjects_to_marc21(app, mef_agents_url, mef_concepts_url,
             }
         }, {
             'entity': {
-                '$ref': f'{mef_concepts_url}/api/concepts/idref/027828085',
-                'pid': '163554'
+                '$ref':
+                    f'{mef_concepts_url}/api/concepts/idref/ent_concept_idref',
+                'pid': 'ent_concept'
             }
         }, {
             'entity': {
@@ -575,8 +576,9 @@ def test_genre_form_to_marc21(app, mef_concepts_url, marc21_record,
             }
         }, {
             'entity': {
-                '$ref': f'{mef_concepts_url}/api/concepts/idref/027828085',
-                'pid': '163554'
+                '$ref':
+                    f'{mef_concepts_url}/api/concepts/idref/ent_concept_idref',
+                'pid': 'ent_concept'
             }
         }]
     }


### PR DESCRIPTION
* Adds organisation pids for `subjects` and `genreForm`` during document reindexing.
* Closes: #3672