### PR TITLE
fix(items): restore legacy checkout count

### DIFF
--- a/data/items_big.json
+++ b/data/items_big.json
@@ -19,6 +19,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -70,6 +71,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkout_note",
@@ -130,6 +132,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-09-08"
   },
   {
@@ -152,6 +155,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-09"
   },
   {
@@ -173,7 +177,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "6",
@@ -195,6 +200,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "general_note",
@@ -226,6 +232,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -277,6 +284,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 8,
     "second_call_number": "ABX4O"
   },
   {
@@ -298,7 +306,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 55
+    "price": 55,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "10",
@@ -320,6 +329,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -362,7 +372,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 93
+    "price": 93,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "12",
@@ -384,6 +395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkout_note",
@@ -427,6 +439,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-08",
     "notes": [
       {
@@ -475,6 +488,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-19",
     "notes": [
       {
@@ -507,6 +521,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -559,6 +574,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-17",
     "notes": [
       {
@@ -606,7 +622,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 83
+    "price": 83,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "18",
@@ -628,6 +645,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -667,6 +685,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-03"
   },
   {
@@ -689,6 +708,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-29",
     "second_call_number": "0N67C"
   },
@@ -711,7 +731,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 22
+    "price": 22,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "22",
@@ -733,6 +754,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 11,
     "second_call_number": "UIR9F"
   },
   {
@@ -754,7 +776,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 5
+    "price": 5,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "24",
@@ -776,6 +799,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-11",
     "notes": [
       {
@@ -809,6 +833,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-27"
   },
   {
@@ -831,6 +856,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-03-13",
     "notes": [
       {
@@ -887,6 +913,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-18",
     "notes": [
       {
@@ -923,6 +950,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -963,6 +991,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "condition_note",
@@ -1002,7 +1031,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 69
+    "price": 69,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "31",
@@ -1024,6 +1054,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-26"
   },
   {
@@ -1046,6 +1077,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-02"
   },
   {
@@ -1068,6 +1100,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-03-20"
   },
   {
@@ -1090,6 +1123,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-30",
     "second_call_number": "TYLZ1"
   },
@@ -1113,6 +1147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -1160,6 +1195,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-18",
     "second_call_number": "XDJIS"
   },
@@ -1183,6 +1219,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-08",
     "notes": [
       {
@@ -1243,6 +1280,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-12",
     "notes": [
       {
@@ -1290,7 +1328,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 75
+    "price": 75,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "40",
@@ -1312,6 +1351,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -1358,7 +1398,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 19
+    "price": 19,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "42",
@@ -1380,6 +1421,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 3,
     "second_call_number": "D6VPB"
   },
   {
@@ -1402,6 +1444,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -1461,6 +1504,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-26",
     "notes": [
       {
@@ -1496,7 +1540,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 85
+    "price": 85,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "46",
@@ -1518,6 +1563,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-19",
     "notes": [
       {
@@ -1562,6 +1608,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -1588,7 +1635,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "49",
@@ -1609,7 +1657,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "50",
@@ -1631,6 +1680,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkout_note",
@@ -1683,6 +1733,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -1730,6 +1781,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -1765,6 +1817,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 14,
     "second_call_number": "RJ8RI"
   },
   {
@@ -1787,6 +1840,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -1830,6 +1884,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "provenance_note",
@@ -1881,6 +1936,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-08",
     "notes": [
       {
@@ -1917,6 +1973,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-13",
     "notes": [
       {
@@ -1969,6 +2026,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-04-04",
     "notes": [
       {
@@ -2013,6 +2071,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-26"
   },
   {
@@ -2035,6 +2094,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -2078,6 +2138,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-21"
   },
   {
@@ -2100,6 +2161,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-23"
   },
   {
@@ -2122,6 +2184,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -2164,7 +2227,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "65",
@@ -2186,6 +2250,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -2222,6 +2287,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-25",
     "notes": [
       {
@@ -2258,7 +2324,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 74
+    "price": 74,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "68",
@@ -2280,6 +2347,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -2327,6 +2395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -2382,6 +2451,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-29",
     "notes": [
       {
@@ -2418,6 +2488,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-12",
     "second_call_number": "9FO5C"
   },
@@ -2441,6 +2512,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -2472,6 +2544,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-25",
     "notes": [
       {
@@ -2528,6 +2601,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "general_note",
@@ -2583,6 +2657,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "general_note",
@@ -2622,6 +2697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-04-08"
   },
   {
@@ -2644,6 +2720,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-23",
     "notes": [
       {
@@ -2680,6 +2757,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -2734,7 +2812,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 32
+    "price": 32,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "80",
@@ -2756,6 +2835,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-04-02"
   },
   {
@@ -2778,6 +2858,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-05",
     "notes": [
       {
@@ -2818,7 +2899,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 88
+    "price": 88,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "83",
@@ -2840,6 +2922,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -2874,7 +2957,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 55
+    "price": 55,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "85",
@@ -2896,6 +2980,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-25"
   },
   {
@@ -2918,6 +3003,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-01"
   },
   {
@@ -2940,6 +3026,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -2987,6 +3074,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-03",
     "notes": [
       {
@@ -3047,6 +3135,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -3102,6 +3191,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-23",
     "notes": [
       {
@@ -3138,6 +3228,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-11-11"
   },
   {
@@ -3160,6 +3251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-04",
     "notes": [
       {
@@ -3203,7 +3295,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "94",
@@ -3224,7 +3317,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "95",
@@ -3245,7 +3339,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 73
+    "price": 73,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "96",
@@ -3266,7 +3361,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "97",
@@ -3288,6 +3384,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-07-24"
   },
   {
@@ -3310,6 +3407,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-29",
     "notes": [
       {
@@ -3361,7 +3459,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 74
+    "price": 74,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "100",
@@ -3383,6 +3482,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkin_note",
@@ -3427,6 +3527,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-13",
     "notes": [
       {
@@ -3479,6 +3580,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-16",
     "notes": [
       {
@@ -3519,6 +3621,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -3571,6 +3674,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-25"
   },
   {
@@ -3593,6 +3697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-09",
     "second_call_number": "OO2WQ"
   },
@@ -3616,6 +3721,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -3676,6 +3782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-28",
     "second_call_number": "F08ND"
   },
@@ -3698,7 +3805,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 19
+    "price": 19,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "109",
@@ -3720,6 +3828,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-09"
   },
   {
@@ -3742,6 +3851,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -3797,6 +3907,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -3841,6 +3952,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -3876,6 +3988,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-03-11",
     "second_call_number": "ZF1FB"
   },
@@ -3899,6 +4012,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -3927,6 +4041,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 5,
     "second_call_number": "TVJ8R"
   },
   {
@@ -3948,7 +4063,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "117",
@@ -3969,7 +4085,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 64
+    "price": 64,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "118",
@@ -3991,6 +4108,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-23",
     "notes": [
       {
@@ -4043,6 +4161,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-06-08",
     "notes": [
       {
@@ -4071,6 +4190,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-01",
     "notes": [
       {
@@ -4111,6 +4231,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-19",
     "notes": [
       {
@@ -4167,6 +4288,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "acquisition_note",
@@ -4198,6 +4320,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-17",
     "notes": [
       {
@@ -4251,6 +4374,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-05",
     "notes": [
       {
@@ -4286,7 +4410,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 46
+    "price": 46,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "126",
@@ -4308,6 +4433,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-11"
   },
   {
@@ -4330,6 +4456,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-11-14"
   },
   {
@@ -4351,7 +4478,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 53
+    "price": 53,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "129",
@@ -4373,6 +4501,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-17",
     "notes": [
       {
@@ -4433,6 +4562,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -4469,6 +4599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-27"
   },
   {
@@ -4491,6 +4622,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-15",
     "notes": [
       {
@@ -4540,6 +4672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-26",
     "second_call_number": "M5130"
   },
@@ -4563,6 +4696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-05",
     "notes": [
       {
@@ -4615,6 +4749,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -4646,6 +4781,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -4704,7 +4840,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 46
+    "price": 46,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "138",
@@ -4726,6 +4863,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -4761,6 +4899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-07",
     "notes": [
       {
@@ -4798,6 +4937,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -4829,6 +4969,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-09",
     "notes": [
       {
@@ -4869,6 +5010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-28",
     "second_call_number": "V74I9"
   },
@@ -4892,6 +5034,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-27"
   },
   {
@@ -4914,6 +5057,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-27",
     "notes": [
       {
@@ -4958,6 +5102,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-22",
     "second_call_number": "AF2ZP"
   },
@@ -4981,6 +5126,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -5027,7 +5173,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "148",
@@ -5049,6 +5196,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "acquisition_note",
@@ -5104,6 +5252,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -5155,6 +5304,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-10",
     "notes": [
       {
@@ -5202,7 +5352,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 69
+    "price": 69,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "152",
@@ -5224,6 +5375,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-31",
     "notes": [
       {
@@ -5265,6 +5417,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -5304,6 +5457,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 10,
     "second_call_number": "TPK75"
   },
   {
@@ -5326,6 +5480,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-20",
     "notes": [
       {
@@ -5378,6 +5533,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 11,
     "second_call_number": "YBIWM"
   },
   {
@@ -5399,7 +5555,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 61
+    "price": 61,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "158",
@@ -5421,6 +5578,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -5468,6 +5626,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-05"
   },
   {
@@ -5490,6 +5649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 13,
     "second_call_number": "64Y7T"
   },
   {
@@ -5512,6 +5672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-31",
     "second_call_number": "VGUH2"
   },
@@ -5534,7 +5695,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "163",
@@ -5556,6 +5718,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-03-23",
     "notes": [
       {
@@ -5612,6 +5775,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-13",
     "notes": [
       {
@@ -5671,7 +5835,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 82
+    "price": 82,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "166",
@@ -5692,7 +5857,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 51
+    "price": 51,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "167",
@@ -5714,6 +5880,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "general_note",
@@ -5760,7 +5927,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 61
+    "price": 61,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "169",
@@ -5782,6 +5950,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-26",
     "notes": [
       {
@@ -5830,6 +5999,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkin_note",
@@ -5865,6 +6035,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -5904,6 +6075,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -5947,6 +6119,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-09",
     "second_call_number": "K47TT"
   },
@@ -5970,6 +6143,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "provenance_note",
@@ -6001,6 +6175,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-09",
     "notes": [
       {
@@ -6030,6 +6205,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-09"
   },
   {
@@ -6052,6 +6228,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 5,
     "second_call_number": "WD687"
   },
   {
@@ -6074,6 +6251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-07",
     "notes": [
       {
@@ -6131,6 +6309,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-08"
   },
   {
@@ -6152,7 +6331,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 22
+    "price": 22,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "181",
@@ -6174,6 +6354,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-12",
     "notes": [
       {
@@ -6234,6 +6415,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-24",
     "second_call_number": "84IAO"
   },
@@ -6257,6 +6439,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -6293,6 +6476,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-28",
     "notes": [
       {
@@ -6320,7 +6504,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 45
+    "price": 45,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "186",
@@ -6342,6 +6527,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "provenance_note",
@@ -6373,6 +6559,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-24",
     "notes": [
       {
@@ -6417,6 +6604,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-27"
   },
   {
@@ -6439,6 +6627,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -6485,7 +6674,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 22
+    "price": 22,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "191",
@@ -6507,6 +6697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -6538,6 +6729,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-13"
   },
   {
@@ -6560,6 +6752,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-08",
     "notes": [
       {
@@ -6589,6 +6782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "acquisition_note",
@@ -6645,6 +6839,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -6692,6 +6887,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-26"
   },
   {
@@ -6714,6 +6910,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-08"
   },
   {
@@ -6736,6 +6933,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-21",
     "notes": [
       {
@@ -6792,6 +6990,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -6843,6 +7042,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-05",
     "notes": [
       {
@@ -6903,7 +7103,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 26
+    "price": 26,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "202",
@@ -6924,7 +7125,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "203",
@@ -6946,6 +7148,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-08",
     "notes": [
       {
@@ -6990,6 +7193,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -7029,6 +7233,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-04-07",
     "notes": [
       {
@@ -7073,6 +7278,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -7124,6 +7330,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-16"
   },
   {
@@ -7146,6 +7353,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -7181,6 +7389,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-08-20"
   },
   {
@@ -7203,6 +7412,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-03-21"
   },
   {
@@ -7224,7 +7434,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 31
+    "price": 31,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "212",
@@ -7246,6 +7457,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "general_note",
@@ -7277,6 +7489,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-03-26",
     "notes": [
       {
@@ -7329,6 +7542,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-19",
     "second_call_number": "HOECZ"
   },
@@ -7352,6 +7566,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "general_note",
@@ -7411,6 +7626,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-01-05",
     "notes": [
       {
@@ -7448,6 +7664,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-15",
     "notes": [
       {
@@ -7492,6 +7709,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-02",
     "notes": [
       {
@@ -7536,6 +7754,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-13",
     "notes": [
       {
@@ -7596,6 +7815,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -7623,6 +7843,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-01"
   },
   {
@@ -7645,6 +7866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -7704,6 +7926,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-15",
     "notes": [
       {
@@ -7764,6 +7987,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-17",
     "second_call_number": "9QESJ"
   },
@@ -7787,6 +8011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -7819,6 +8044,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-13"
   },
   {
@@ -7841,6 +8067,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 7,
     "second_call_number": "YWV1T"
   },
   {
@@ -7863,6 +8090,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "general_note",
@@ -7906,6 +8134,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-19",
     "notes": [
       {
@@ -7962,6 +8191,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 3,
     "second_call_number": "YK55I"
   },
   {
@@ -7983,7 +8213,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 29
+    "price": 29,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "232",
@@ -8005,6 +8236,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-03-25",
     "notes": [
       {
@@ -8057,6 +8289,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 14,
     "second_call_number": "2WXHN"
   },
   {
@@ -8079,6 +8312,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -8109,7 +8343,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "236",
@@ -8131,6 +8366,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-20",
     "second_call_number": "K9QDV"
   },
@@ -8154,6 +8390,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-12",
     "notes": [
       {
@@ -8198,6 +8435,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-08",
     "notes": [
       {
@@ -8238,7 +8476,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 79
+    "price": 79,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "240",
@@ -8260,6 +8499,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-01",
     "notes": [
       {
@@ -8295,7 +8535,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "242",
@@ -8317,6 +8558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-09-15",
     "notes": [
       {
@@ -8353,6 +8595,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-09",
     "notes": [
       {
@@ -8385,6 +8628,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-24",
     "notes": [
       {
@@ -8413,6 +8657,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -8441,6 +8686,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-03",
     "notes": [
       {
@@ -8477,6 +8723,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 14,
     "second_call_number": "YUU8V"
   },
   {
@@ -8499,6 +8746,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-01"
   },
   {
@@ -8521,6 +8769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-08",
     "notes": [
       {
@@ -8582,6 +8831,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-25",
     "notes": [
       {
@@ -8619,6 +8869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-12",
     "notes": [
       {
@@ -8652,6 +8903,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -8698,7 +8950,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 46
+    "price": 46,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "254",
@@ -8720,6 +8973,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -8771,6 +9025,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-08",
     "notes": [
       {
@@ -8804,6 +9059,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -8852,6 +9108,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -8879,6 +9136,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-31",
     "notes": [
       {
@@ -8936,6 +9194,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-28",
     "notes": [
       {
@@ -8996,6 +9255,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkin_note",
@@ -9031,6 +9291,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 5,
     "second_call_number": "2O6AO"
   },
   {
@@ -9053,6 +9314,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-03-12"
   },
   {
@@ -9075,6 +9337,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-09"
   },
   {
@@ -9097,6 +9360,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-19",
     "second_call_number": "9MB6X"
   },
@@ -9120,6 +9384,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -9167,7 +9432,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "267",
@@ -9189,6 +9455,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -9240,7 +9507,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "269",
@@ -9262,6 +9530,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-18"
   },
   {
@@ -9284,6 +9553,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-01",
     "notes": [
       {
@@ -9331,7 +9601,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 48
+    "price": 48,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "272",
@@ -9353,6 +9624,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "general_note",
@@ -9400,6 +9672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -9443,6 +9716,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-05-11"
   },
   {
@@ -9465,6 +9739,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-28",
     "notes": [
       {
@@ -9508,7 +9783,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "277",
@@ -9530,6 +9806,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkin_note",
@@ -9577,6 +9854,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-11",
     "notes": [
       {
@@ -9637,6 +9915,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -9680,6 +9959,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-24"
   },
   {
@@ -9702,6 +9982,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -9760,7 +10041,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "283",
@@ -9782,6 +10064,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "provenance_note",
@@ -9829,6 +10112,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-10",
     "second_call_number": "CRNRH"
   },
@@ -9852,6 +10136,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-21",
     "notes": [
       {
@@ -9893,6 +10178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -9928,6 +10214,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -9971,6 +10258,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-03-20",
     "notes": [
       {
@@ -10026,7 +10314,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 20
+    "price": 20,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "290",
@@ -10048,6 +10337,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-31",
     "second_call_number": "Y25H1"
   },
@@ -10071,6 +10361,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-20"
   },
   {
@@ -10093,6 +10384,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 15,
     "second_call_number": "SXBGP"
   },
   {
@@ -10114,7 +10406,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "294",
@@ -10136,6 +10429,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -10187,6 +10481,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -10225,7 +10520,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 53
+    "price": 53,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "297",
@@ -10247,6 +10543,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-03-25",
     "notes": [
       {
@@ -10303,6 +10600,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkin_note",
@@ -10359,6 +10657,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-09"
   },
   {
@@ -10381,6 +10680,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -10432,6 +10732,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-26",
     "notes": [
       {
@@ -10492,6 +10793,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -10520,6 +10822,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -10556,6 +10859,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "general_note",
@@ -10615,6 +10919,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-24",
     "second_call_number": "YN7K2"
   },
@@ -10638,6 +10943,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 14,
     "second_call_number": "ELLJV"
   },
   {
@@ -10660,6 +10966,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-25",
     "notes": [
       {
@@ -10720,6 +11027,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 15,
     "second_call_number": "VE77W"
   },
   {
@@ -10741,7 +11049,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "310",
@@ -10763,6 +11072,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-06"
   },
   {
@@ -10784,7 +11094,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 93
+    "price": 93,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "312",
@@ -10806,6 +11117,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -10866,6 +11178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "condition_note",
@@ -10917,6 +11230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkout_note",
@@ -10948,6 +11262,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-19"
   },
   {
@@ -10970,6 +11285,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-01"
   },
   {
@@ -10991,7 +11307,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 96
+    "price": 96,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "318",
@@ -11013,6 +11330,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-15",
     "notes": [
       {
@@ -11057,6 +11375,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -11111,7 +11430,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "321",
@@ -11133,6 +11453,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 6,
     "second_call_number": "VCXJL"
   },
   {
@@ -11155,6 +11476,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "condition_note",
@@ -11214,7 +11536,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 29
+    "price": 29,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "324",
@@ -11236,6 +11559,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-11",
     "second_call_number": "ZSJRU"
   },
@@ -11259,6 +11583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkin_note",
@@ -11318,6 +11643,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-10",
     "notes": [
       {
@@ -11365,7 +11691,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 81
+    "price": 81,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "328",
@@ -11387,6 +11714,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-04",
     "notes": [
       {
@@ -11419,6 +11747,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-17",
     "notes": [
       {
@@ -11463,6 +11792,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-20"
   },
   {
@@ -11485,6 +11815,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -11531,7 +11862,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "333",
@@ -11553,6 +11885,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -11609,6 +11942,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -11668,6 +12002,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-21",
     "notes": [
       {
@@ -11700,6 +12035,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-29"
   },
   {
@@ -11722,6 +12058,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-28",
     "notes": [
       {
@@ -11775,6 +12112,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-14",
     "notes": [
       {
@@ -11811,6 +12149,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-16",
     "notes": [
       {
@@ -11864,6 +12203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-05-04",
     "notes": [
       {
@@ -11892,6 +12232,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-03-28",
     "notes": [
       {
@@ -11932,6 +12273,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -11959,6 +12301,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-03",
     "notes": [
       {
@@ -12007,6 +12350,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-22"
   },
   {
@@ -12029,6 +12373,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-27",
     "notes": [
       {
@@ -12074,6 +12419,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-25",
     "notes": [
       {
@@ -12134,6 +12480,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -12173,6 +12520,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-22"
   },
   {
@@ -12195,6 +12543,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkout_note",
@@ -12246,6 +12595,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-26",
     "notes": [
       {
@@ -12290,6 +12640,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -12322,6 +12673,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-22"
   },
   {
@@ -12344,6 +12696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -12400,6 +12753,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-29"
   },
   {
@@ -12422,6 +12776,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-07",
     "notes": [
       {
@@ -12471,6 +12826,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 11,
     "second_call_number": "JYLVT"
   },
   {
@@ -12493,6 +12849,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-16",
     "second_call_number": "UYP93"
   },
@@ -12516,6 +12873,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -12550,7 +12908,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "360",
@@ -12572,6 +12931,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -12616,6 +12976,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -12671,6 +13032,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -12710,7 +13072,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 20
+    "price": 20,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "364",
@@ -12732,6 +13095,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 6,
     "second_call_number": "0TKYB"
   },
   {
@@ -12754,6 +13118,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -12809,6 +13174,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-10",
     "notes": [
       {
@@ -12838,6 +13204,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-03-28",
     "second_call_number": "O025H"
   },
@@ -12860,7 +13227,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 29
+    "price": 29,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "369",
@@ -12881,7 +13249,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "370",
@@ -12903,6 +13272,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-16",
     "notes": [
       {
@@ -12958,7 +13328,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 5
+    "price": 5,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "372",
@@ -12980,6 +13351,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-27",
     "notes": [
       {
@@ -13020,6 +13392,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-10",
     "second_call_number": "E6Q3J"
   },
@@ -13043,6 +13416,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkin_note",
@@ -13099,6 +13473,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkin_note",
@@ -13126,6 +13501,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-04",
     "notes": [
       {
@@ -13174,6 +13550,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-04"
   },
   {
@@ -13195,7 +13572,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "379",
@@ -13217,6 +13595,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-04-06",
     "notes": [
       {
@@ -13277,6 +13656,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -13332,6 +13712,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 6,
     "second_call_number": "54DLL"
   },
   {
@@ -13354,6 +13735,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -13388,7 +13770,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 86
+    "price": 86,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "384",
@@ -13410,6 +13793,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-25"
   },
   {
@@ -13432,6 +13816,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "provenance_note",
@@ -13475,6 +13860,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -13522,6 +13908,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -13581,6 +13968,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 15,
     "second_call_number": "9L5EU"
   },
   {
@@ -13603,6 +13991,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-02",
     "second_call_number": "E2BTX"
   },
@@ -13626,6 +14015,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -13653,6 +14043,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-14",
     "notes": [
       {
@@ -13710,6 +14101,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-21"
   },
   {
@@ -13732,6 +14124,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -13779,6 +14172,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -13810,6 +14204,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-24"
   },
   {
@@ -13832,6 +14227,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-15",
     "second_call_number": "QK5KT"
   },
@@ -13855,6 +14251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-19"
   },
   {
@@ -13877,6 +14274,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -13932,6 +14330,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-31"
   },
   {
@@ -13953,7 +14352,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 88
+    "price": 88,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "401",
@@ -13975,6 +14375,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -14018,6 +14419,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-25"
   },
   {
@@ -14040,6 +14442,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-28",
     "notes": [
       {
@@ -14073,6 +14476,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-05-07",
     "notes": [
       {
@@ -14124,7 +14528,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "406",
@@ -14146,6 +14551,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -14201,6 +14607,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-20"
   },
   {
@@ -14223,6 +14630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -14251,6 +14659,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-04-01"
   },
   {
@@ -14273,6 +14682,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 13,
     "second_call_number": "HX2J1"
   },
   {
@@ -14295,6 +14705,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -14326,6 +14737,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-07",
     "notes": [
       {
@@ -14362,6 +14774,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -14421,6 +14834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -14480,6 +14894,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-03"
   },
   {
@@ -14502,6 +14917,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-08",
     "second_call_number": "S6XI6"
   },
@@ -14525,6 +14941,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -14557,6 +14974,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "provenance_note",
@@ -14593,6 +15011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-12-06",
     "second_call_number": "R700M"
   },
@@ -14616,6 +15035,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-06",
     "notes": [
       {
@@ -14672,6 +15092,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -14700,6 +15121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "general_note",
@@ -14742,7 +15164,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "424",
@@ -14764,6 +15187,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -14812,6 +15236,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -14863,6 +15288,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -14918,6 +15344,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-22"
   },
   {
@@ -14940,6 +15367,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -14979,6 +15407,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkin_note",
@@ -15017,7 +15446,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "431",
@@ -15038,7 +15468,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "432",
@@ -15059,7 +15490,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 96
+    "price": 96,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "433",
@@ -15080,7 +15512,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "434",
@@ -15101,7 +15534,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 36
+    "price": 36,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "435",
@@ -15123,6 +15557,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-17",
     "notes": [
       {
@@ -15175,6 +15610,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -15214,6 +15650,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-24",
     "notes": [
       {
@@ -15253,7 +15690,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 14
+    "price": 14,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "439",
@@ -15275,6 +15713,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-30"
   },
   {
@@ -15297,6 +15736,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-16",
     "notes": [
       {
@@ -15353,6 +15793,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -15396,6 +15837,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "binding_note",
@@ -15455,6 +15897,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-03-19",
     "second_call_number": "7YFMN"
   },
@@ -15478,6 +15921,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-23",
     "notes": [
       {
@@ -15533,7 +15977,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "446",
@@ -15555,6 +16000,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -15601,7 +16047,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 37
+    "price": 37,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "448",
@@ -15623,6 +16070,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-11",
     "notes": [
       {
@@ -15683,6 +16131,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -15743,6 +16192,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-05",
     "notes": [
       {
@@ -15779,6 +16229,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -15815,6 +16266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-08",
     "second_call_number": "L4OBT"
   },
@@ -15838,6 +16290,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 12,
     "second_call_number": "OA0S8"
   },
   {
@@ -15860,6 +16313,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -15911,6 +16365,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -15950,6 +16405,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-04",
     "notes": [
       {
@@ -15979,6 +16435,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-03-24",
     "notes": [
       {
@@ -16007,6 +16464,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-09"
   },
   {
@@ -16029,6 +16487,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-20",
     "notes": [
       {
@@ -16065,6 +16524,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -16100,6 +16560,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -16140,6 +16601,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-03",
     "notes": [
       {
@@ -16172,7 +16634,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 37
+    "price": 37,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "464",
@@ -16194,6 +16657,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-24",
     "notes": [
       {
@@ -16226,6 +16690,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-20"
   },
   {
@@ -16247,7 +16712,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "467",
@@ -16269,6 +16735,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-14"
   },
   {
@@ -16291,6 +16758,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-12",
     "notes": [
       {
@@ -16327,6 +16795,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-27"
   },
   {
@@ -16349,6 +16818,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -16400,6 +16870,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -16427,6 +16898,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-31",
     "notes": [
       {
@@ -16459,6 +16931,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-04",
     "notes": [
       {
@@ -16511,6 +16984,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -16550,6 +17024,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 5,
     "second_call_number": "CQB06"
   },
   {
@@ -16572,6 +17047,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-04-04",
     "notes": [
       {
@@ -16620,6 +17096,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-12",
     "notes": [
       {
@@ -16668,6 +17145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-01"
   },
   {
@@ -16690,6 +17168,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-03-17",
     "second_call_number": "UPCNF"
   },
@@ -16713,6 +17192,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "general_note",
@@ -16760,6 +17240,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-22",
     "notes": [
       {
@@ -16793,6 +17274,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 12,
     "second_call_number": "KEKHF"
   },
   {
@@ -16815,6 +17297,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-27",
     "second_call_number": "O8FW9"
   },
@@ -16838,6 +17321,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-12",
     "notes": [
       {
@@ -16894,6 +17378,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-31"
   },
   {
@@ -16916,6 +17401,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-04",
     "notes": [
       {
@@ -16956,6 +17442,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-19"
   },
   {
@@ -16978,6 +17465,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -17025,6 +17513,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-22"
   },
   {
@@ -17047,6 +17536,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-09-01",
     "notes": [
       {
@@ -17107,6 +17597,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-15",
     "notes": [
       {
@@ -17148,6 +17639,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -17183,6 +17675,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-25",
     "notes": [
       {
@@ -17239,6 +17732,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-06",
     "second_call_number": "66UI7"
   },
@@ -17262,6 +17756,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -17288,7 +17783,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 40
+    "price": 40,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "497",
@@ -17310,6 +17806,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "binding_note",
@@ -17341,6 +17838,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-31",
     "notes": [
       {
@@ -17381,6 +17879,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "acquisition_note",
@@ -17412,6 +17911,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-31"
   },
   {
@@ -17434,6 +17934,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -17482,6 +17983,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-23",
     "second_call_number": "WPPHF"
   },
@@ -17505,6 +18007,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-29",
     "second_call_number": "MMTOZ"
   },
@@ -17528,6 +18031,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -17559,6 +18063,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-21",
     "notes": [
       {
@@ -17618,7 +18123,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 56
+    "price": 56,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "507",
@@ -17640,6 +18146,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -17672,6 +18179,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 2,
     "second_call_number": "1LDLV"
   },
   {
@@ -17694,6 +18202,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-03-15",
     "notes": [
       {
@@ -17738,6 +18247,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-21",
     "notes": [
       {
@@ -17791,6 +18301,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -17818,6 +18329,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-02",
     "notes": [
       {
@@ -17851,6 +18363,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-31",
     "notes": [
       {
@@ -17883,6 +18396,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkin_note",
@@ -17918,6 +18432,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -17949,6 +18464,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -17977,6 +18493,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -18020,6 +18537,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-27"
   },
   {
@@ -18042,6 +18560,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-26"
   },
   {
@@ -18064,6 +18583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -18119,7 +18639,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 47
+    "price": 47,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "522",
@@ -18141,6 +18662,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-12",
     "notes": [
       {
@@ -18189,6 +18711,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-04-03",
     "notes": [
       {
@@ -18236,7 +18759,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 10
+    "price": 10,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "525",
@@ -18258,6 +18782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-15",
     "notes": [
       {
@@ -18294,6 +18819,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 13,
     "second_call_number": "RNTFH"
   },
   {
@@ -18316,6 +18842,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "acquisition_note",
@@ -18351,6 +18878,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-18"
   },
   {
@@ -18373,6 +18901,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -18400,6 +18929,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -18432,6 +18962,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -18475,6 +19006,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-16",
     "notes": [
       {
@@ -18530,7 +19062,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 43
+    "price": 43,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "534",
@@ -18552,6 +19085,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-17",
     "notes": [
       {
@@ -18604,6 +19138,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-04"
   },
   {
@@ -18626,6 +19161,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-12",
     "notes": [
       {
@@ -18667,6 +19203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-04"
   },
   {
@@ -18689,6 +19226,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-25"
   },
   {
@@ -18711,6 +19249,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -18750,6 +19289,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-12",
     "notes": [
       {
@@ -18810,6 +19350,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -18841,6 +19382,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-16",
     "notes": [
       {
@@ -18882,6 +19424,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-16"
   },
   {
@@ -18904,6 +19447,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -18955,6 +19499,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-18",
     "notes": [
       {
@@ -19015,6 +19560,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-02-15",
     "notes": [
       {
@@ -19071,6 +19617,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-30",
     "notes": [
       {
@@ -19128,6 +19675,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 4,
     "second_call_number": "VURF3"
   },
   {
@@ -19150,6 +19698,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 12,
     "second_call_number": "3FYCF"
   },
   {
@@ -19172,6 +19721,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-06",
     "notes": [
       {
@@ -19233,6 +19783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -19260,7 +19811,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 24
+    "price": 24,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "553",
@@ -19282,6 +19834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -19321,6 +19874,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-08"
   },
   {
@@ -19343,6 +19897,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -19382,6 +19937,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-07"
   },
   {
@@ -19404,6 +19960,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-02-23"
   },
   {
@@ -19426,6 +19983,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-11",
     "notes": [
       {
@@ -19467,6 +20025,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -19498,6 +20057,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-20",
     "notes": [
       {
@@ -19542,6 +20102,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 15,
     "second_call_number": "C2WCF"
   },
   {
@@ -19564,6 +20125,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -19620,6 +20182,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-12",
     "notes": [
       {
@@ -19668,6 +20231,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-04-13",
     "second_call_number": "YAKBY"
   },
@@ -19691,6 +20255,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-14",
     "notes": [
       {
@@ -19739,6 +20304,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -19782,6 +20348,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-23"
   },
   {
@@ -19804,6 +20371,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -19852,6 +20420,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-19",
     "notes": [
       {
@@ -19880,6 +20449,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 13,
     "second_call_number": "20Z3G"
   },
   {
@@ -19902,6 +20472,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-03-30",
     "notes": [
       {
@@ -19962,6 +20533,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-04"
   },
   {
@@ -19984,6 +20556,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -20035,6 +20608,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-14"
   },
   {
@@ -20056,7 +20630,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "576",
@@ -20078,6 +20653,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 14,
     "second_call_number": "4LOPP"
   },
   {
@@ -20100,6 +20676,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-28",
     "notes": [
       {
@@ -20156,6 +20733,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-17",
     "notes": [
       {
@@ -20208,6 +20786,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 11,
     "second_call_number": "K9E3C"
   },
   {
@@ -20230,6 +20809,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "provenance_note",
@@ -20281,6 +20861,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-09-06"
   },
   {
@@ -20303,6 +20884,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-11"
   },
   {
@@ -20325,6 +20907,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-02",
     "notes": [
       {
@@ -20384,7 +20967,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "585",
@@ -20405,7 +20989,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 33
+    "price": 33,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "586",
@@ -20427,6 +21012,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "binding_note",
@@ -20463,6 +21049,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -20520,6 +21107,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -20575,6 +21163,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-07",
     "second_call_number": "45WSL"
   },
@@ -20598,6 +21187,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-26",
     "notes": [
       {
@@ -20658,7 +21248,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 84
+    "price": 84,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "592",
@@ -20680,6 +21271,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-19",
     "notes": [
       {
@@ -20719,7 +21311,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 73
+    "price": 73,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "594",
@@ -20741,6 +21334,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-29"
   },
   {
@@ -20763,6 +21357,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -20818,6 +21413,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -20865,6 +21461,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 15,
     "second_call_number": "AX4N3"
   },
   {
@@ -20887,6 +21484,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-27",
     "notes": [
       {
@@ -20915,6 +21513,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -20962,6 +21561,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -21001,6 +21601,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -21035,7 +21636,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "603",
@@ -21057,6 +21659,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-15",
     "second_call_number": "ECB45"
   },
@@ -21080,6 +21683,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-06-15"
   },
   {
@@ -21102,6 +21706,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -21161,6 +21766,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-27"
   },
   {
@@ -21182,7 +21788,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "608",
@@ -21204,6 +21811,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-02",
     "notes": [
       {
@@ -21260,6 +21868,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-06",
     "second_call_number": "4CXCR"
   },
@@ -21283,6 +21892,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -21314,7 +21924,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "612",
@@ -21336,6 +21947,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-27"
   },
   {
@@ -21358,6 +21970,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-12",
     "notes": [
       {
@@ -21390,6 +22003,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-01-30",
     "notes": [
       {
@@ -21443,6 +22057,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-24",
     "notes": [
       {
@@ -21503,6 +22118,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -21555,6 +22171,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 5,
     "second_call_number": "2QS5E"
   },
   {
@@ -21577,6 +22194,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -21608,6 +22226,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-24",
     "notes": [
       {
@@ -21651,7 +22270,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 74
+    "price": 74,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "621",
@@ -21673,6 +22293,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -21725,6 +22346,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-02",
     "notes": [
       {
@@ -21757,6 +22379,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-21",
     "notes": [
       {
@@ -21812,7 +22435,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "625",
@@ -21834,6 +22458,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-23"
   },
   {
@@ -21855,7 +22480,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 85
+    "price": 85,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "627",
@@ -21877,6 +22503,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-23",
     "notes": [
       {
@@ -21934,6 +22561,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-12-18",
     "second_call_number": "20OXH"
   },
@@ -21957,6 +22585,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-25"
   },
   {
@@ -21979,6 +22608,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -22030,6 +22660,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkin_note",
@@ -22073,6 +22704,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkout_note",
@@ -22128,6 +22760,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-08-09"
   },
   {
@@ -22150,6 +22783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -22181,6 +22815,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-02",
     "notes": [
       {
@@ -22210,6 +22845,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-10",
     "notes": [
       {
@@ -22254,6 +22890,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-06"
   },
   {
@@ -22276,6 +22913,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-06",
     "notes": [
       {
@@ -22336,6 +22974,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -22375,6 +23014,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-20"
   },
   {
@@ -22397,6 +23037,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-18",
     "notes": [
       {
@@ -22444,7 +23085,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 14
+    "price": 14,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "643",
@@ -22465,7 +23107,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 82
+    "price": 82,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "644",
@@ -22486,7 +23129,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "645",
@@ -22508,6 +23152,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -22535,6 +23180,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-10",
     "second_call_number": "F2Y8W"
   },
@@ -22558,6 +23204,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-13"
   },
   {
@@ -22580,6 +23227,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkout_note",
@@ -22624,6 +23272,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-09-12"
   },
   {
@@ -22646,6 +23295,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-07-03",
     "second_call_number": "UN20D"
   },
@@ -22669,6 +23319,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-21"
   },
   {
@@ -22691,6 +23342,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-17"
   },
   {
@@ -22713,6 +23365,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-19"
   },
   {
@@ -22735,6 +23388,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-10"
   },
   {
@@ -22757,6 +23411,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-03",
     "notes": [
       {
@@ -22789,6 +23444,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -22836,6 +23492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-09-13",
     "notes": [
       {
@@ -22865,6 +23522,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "provenance_note",
@@ -22892,6 +23550,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-05",
     "notes": [
       {
@@ -22920,6 +23579,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -22948,6 +23608,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -23007,7 +23668,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 82
+    "price": 82,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "663",
@@ -23029,6 +23691,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-03"
   },
   {
@@ -23050,7 +23713,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "665",
@@ -23072,6 +23736,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "condition_note",
@@ -23115,7 +23780,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "667",
@@ -23137,6 +23803,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "general_note",
@@ -23180,6 +23847,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -23216,7 +23884,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 10
+    "price": 10,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "670",
@@ -23237,7 +23906,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 11
+    "price": 11,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "671",
@@ -23258,7 +23928,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 6
+    "price": 6,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "672",
@@ -23280,6 +23951,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-18",
     "notes": [
       {
@@ -23332,6 +24004,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-29",
     "notes": [
       {
@@ -23380,6 +24053,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -23435,6 +24109,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 9,
     "second_call_number": "B685Q"
   },
   {
@@ -23457,6 +24132,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -23500,6 +24176,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-11",
     "notes": [
       {
@@ -23560,6 +24237,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-02-18",
     "notes": [
       {
@@ -23588,6 +24266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-14"
   },
   {
@@ -23609,7 +24288,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 3
+    "price": 3,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "681",
@@ -23631,6 +24311,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-03-02",
     "notes": [
       {
@@ -23675,7 +24356,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "683",
@@ -23696,7 +24378,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "684",
@@ -23718,6 +24401,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -23756,7 +24440,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 90
+    "price": 90,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "686",
@@ -23777,7 +24462,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "687",
@@ -23798,7 +24484,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "688",
@@ -23820,6 +24507,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -23863,6 +24551,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkin_note",
@@ -23903,6 +24592,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "binding_note",
@@ -23934,6 +24624,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -23990,6 +24681,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 7,
     "second_call_number": "TWBTR"
   },
   {
@@ -24012,6 +24704,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-23",
     "notes": [
       {
@@ -24044,6 +24737,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -24091,6 +24785,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 9,
     "second_call_number": "IT40X"
   },
   {
@@ -24113,6 +24808,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -24156,6 +24852,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "acquisition_note",
@@ -24214,7 +24911,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "699",
@@ -24235,7 +24933,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 67
+    "price": 67,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "700",
@@ -24257,6 +24956,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-23"
   },
   {
@@ -24279,6 +24979,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -24306,6 +25007,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-06-30",
     "notes": [
       {
@@ -24366,6 +25068,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-22",
     "notes": [
       {
@@ -24411,6 +25114,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-11-07",
     "notes": [
       {
@@ -24451,7 +25155,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 19
+    "price": 19,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "706",
@@ -24473,6 +25178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-06",
     "second_call_number": "O9FZS"
   },
@@ -24496,6 +25202,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -24530,7 +25237,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 55
+    "price": 55,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "709",
@@ -24552,6 +25260,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -24591,7 +25300,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 81
+    "price": 81,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "711",
@@ -24612,7 +25322,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 100
+    "price": 100,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "712",
@@ -24634,6 +25345,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-11-17"
   },
   {
@@ -24656,6 +25368,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -24691,6 +25404,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -24719,6 +25433,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-14",
     "notes": [
       {
@@ -24774,7 +25489,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 50
+    "price": 50,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "717",
@@ -24796,6 +25512,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-13"
   },
   {
@@ -24818,6 +25535,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-11"
   },
   {
@@ -24840,6 +25558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-03-12",
     "notes": [
       {
@@ -24893,6 +25612,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-02",
     "notes": [
       {
@@ -24937,6 +25657,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-09"
   },
   {
@@ -24959,6 +25680,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-23"
   },
   {
@@ -24980,7 +25702,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 96
+    "price": 96,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "724",
@@ -25001,7 +25724,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 97
+    "price": 97,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "725",
@@ -25023,6 +25747,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -25082,6 +25807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-29",
     "notes": [
       {
@@ -25111,6 +25837,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -25158,6 +25885,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-23",
     "second_call_number": "OGFC5"
   },
@@ -25181,6 +25909,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-10-04"
   },
   {
@@ -25202,7 +25931,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "731",
@@ -25224,6 +25954,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-12",
     "second_call_number": "MSJFL"
   },
@@ -25247,6 +25978,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "general_note",
@@ -25286,6 +26018,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -25325,6 +26058,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-31",
     "second_call_number": "DN9FF"
   },
@@ -25348,6 +26082,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-10",
     "notes": [
       {
@@ -25384,6 +26119,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-27"
   },
   {
@@ -25406,6 +26142,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-16"
   },
   {
@@ -25428,6 +26165,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-03",
     "notes": [
       {
@@ -25484,6 +26222,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-06",
     "notes": [
       {
@@ -25516,6 +26255,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -25555,6 +26295,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "general_note",
@@ -25595,6 +26336,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-25"
   },
   {
@@ -25617,6 +26359,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -25665,6 +26408,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-03-17"
   },
   {
@@ -25687,6 +26431,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-08-13",
     "notes": [
       {
@@ -25736,6 +26481,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkin_note",
@@ -25764,6 +26510,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-03",
     "notes": [
       {
@@ -25796,6 +26543,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-11-15",
     "notes": [
       {
@@ -25852,6 +26600,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-24",
     "notes": [
       {
@@ -25900,6 +26649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-27",
     "notes": [
       {
@@ -25928,6 +26678,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-15"
   },
   {
@@ -25950,6 +26701,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-04-06"
   },
   {
@@ -25972,6 +26724,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-15",
     "notes": [
       {
@@ -26032,6 +26785,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkout_note",
@@ -26087,6 +26841,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -26135,6 +26890,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-11-29",
     "notes": [
       {
@@ -26187,6 +26943,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -26234,6 +26991,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -26278,6 +27036,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-25",
     "notes": [
       {
@@ -26326,6 +27085,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -26361,6 +27121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -26400,6 +27161,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -26455,6 +27217,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 2,
     "second_call_number": "4EDCV"
   },
   {
@@ -26477,6 +27240,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -26537,6 +27301,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-26",
     "notes": [
       {
@@ -26578,6 +27343,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -26606,6 +27372,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-20",
     "notes": [
       {
@@ -26634,6 +27401,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "acquisition_note",
@@ -26665,6 +27433,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -26724,6 +27493,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -26755,6 +27525,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-25",
     "notes": [
       {
@@ -26808,6 +27579,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -26855,6 +27627,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -26905,7 +27678,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 71
+    "price": 71,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "775",
@@ -26927,6 +27701,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-22"
   },
   {
@@ -26949,6 +27724,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-06",
     "notes": [
       {
@@ -26986,6 +27762,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "general_note",
@@ -27037,6 +27814,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-17",
     "notes": [
       {
@@ -27065,6 +27843,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-25"
   },
   {
@@ -27087,6 +27866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-08-07",
     "notes": [
       {
@@ -27130,7 +27910,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "782",
@@ -27152,6 +27933,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-04-30",
     "second_call_number": "0580H"
   },
@@ -27175,6 +27957,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-09",
     "notes": [
       {
@@ -27228,6 +28011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -27276,6 +28060,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-23",
     "notes": [
       {
@@ -27329,6 +28114,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -27360,6 +28146,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -27419,6 +28206,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-03-12"
   },
   {
@@ -27441,6 +28229,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -27492,7 +28281,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "791",
@@ -27514,6 +28304,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -27545,6 +28336,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-29"
   },
   {
@@ -27566,7 +28358,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "794",
@@ -27588,6 +28381,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -27631,6 +28425,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-21",
     "notes": [
       {
@@ -27659,6 +28454,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-08"
   },
   {
@@ -27681,6 +28477,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-23",
     "notes": [
       {
@@ -27717,6 +28514,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-19",
     "notes": [
       {
@@ -27769,6 +28567,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -27800,6 +28599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-24"
   },
   {
@@ -27821,7 +28621,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 29
+    "price": 29,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "802",
@@ -27843,6 +28644,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -27883,6 +28685,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-12",
     "notes": [
       {
@@ -27915,6 +28718,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "acquisition_note",
@@ -27958,6 +28762,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -28005,6 +28810,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-05",
     "notes": [
       {
@@ -28049,6 +28855,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -28108,6 +28915,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-22",
     "notes": [
       {
@@ -28156,6 +28964,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-17"
   },
   {
@@ -28177,7 +28986,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 24
+    "price": 24,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "811",
@@ -28199,6 +29009,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-04",
     "second_call_number": "2HYBX"
   },
@@ -28222,6 +29033,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 4,
     "second_call_number": "EQU4Z"
   },
   {
@@ -28244,6 +29056,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -28279,6 +29092,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-09"
   },
   {
@@ -28301,6 +29115,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -28344,6 +29159,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -28375,6 +29191,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -28406,6 +29223,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-03-14"
   },
   {
@@ -28428,6 +29246,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "acquisition_note",
@@ -28484,6 +29303,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 15,
     "second_call_number": "9DIHP"
   },
   {
@@ -28506,6 +29326,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -28549,6 +29370,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -28601,6 +29423,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-31"
   },
   {
@@ -28623,6 +29446,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -28670,6 +29494,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-15",
     "second_call_number": "GB700"
   },
@@ -28693,6 +29518,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-21",
     "notes": [
       {
@@ -28738,6 +29564,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -28781,6 +29608,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -28828,6 +29656,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-29",
     "notes": [
       {
@@ -28860,6 +29689,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "provenance_note",
@@ -28903,6 +29733,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-17",
     "notes": [
       {
@@ -28940,6 +29771,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-03-11",
     "notes": [
       {
@@ -28977,6 +29809,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-12",
     "notes": [
       {
@@ -29033,6 +29866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-03",
     "second_call_number": "L32D9"
   },
@@ -29056,6 +29890,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-13",
     "notes": [
       {
@@ -29096,6 +29931,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 12,
     "second_call_number": "L42RJ"
   },
   {
@@ -29118,6 +29954,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -29156,7 +29993,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 61
+    "price": 61,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "839",
@@ -29178,6 +30016,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -29237,6 +30076,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-01",
     "notes": [
       {
@@ -29265,6 +30105,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -29312,6 +30153,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-30"
   },
   {
@@ -29334,6 +30176,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-01",
     "notes": [
       {
@@ -29362,6 +30205,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -29410,6 +30254,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "staff_note",
@@ -29445,6 +30290,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-23"
   },
   {
@@ -29467,6 +30313,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-29",
     "notes": [
       {
@@ -29519,6 +30366,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-24",
     "notes": [
       {
@@ -29571,6 +30419,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-26",
     "notes": [
       {
@@ -29619,6 +30468,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 5,
     "second_call_number": "QP6UU"
   },
   {
@@ -29641,6 +30491,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-22"
   },
   {
@@ -29662,7 +30513,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 93
+    "price": 93,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "853",
@@ -29684,6 +30536,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-24",
     "notes": [
       {
@@ -29737,6 +30590,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -29776,6 +30630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-28",
     "notes": [
       {
@@ -29837,6 +30692,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 12,
     "second_call_number": "YTABY"
   },
   {
@@ -29859,6 +30715,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-25"
   },
   {
@@ -29881,6 +30738,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -29932,6 +30790,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-22",
     "notes": [
       {
@@ -29988,6 +30847,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "binding_note",
@@ -30039,6 +30899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-26"
   },
   {
@@ -30061,6 +30922,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -30105,6 +30967,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-03-23"
   },
   {
@@ -30127,6 +30990,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-08"
   },
   {
@@ -30149,6 +31013,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-27",
     "notes": [
       {
@@ -30177,6 +31042,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-21",
     "notes": [
       {
@@ -30237,6 +31103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -30265,6 +31132,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -30308,6 +31176,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "provenance_note",
@@ -30359,6 +31228,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-20",
     "notes": [
       {
@@ -30396,6 +31266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-22",
     "notes": [
       {
@@ -30440,6 +31311,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-02-26"
   },
   {
@@ -30462,6 +31334,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-11-05",
     "notes": [
       {
@@ -30522,6 +31395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-25"
   },
   {
@@ -30544,6 +31418,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -30592,6 +31467,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 11,
     "second_call_number": "D199Z"
   },
   {
@@ -30614,6 +31490,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -30645,6 +31522,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-09",
     "notes": [
       {
@@ -30693,6 +31571,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkin_note",
@@ -30731,7 +31610,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "881",
@@ -30753,6 +31633,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-04-02"
   },
   {
@@ -30775,6 +31656,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -30818,6 +31700,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-04",
     "second_call_number": "5F3IV"
   },
@@ -30841,6 +31724,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-08",
     "notes": [
       {
@@ -30873,6 +31757,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "acquisition_note",
@@ -30916,6 +31801,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-03-24",
     "notes": [
       {
@@ -30960,6 +31846,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 2,
     "second_call_number": "RZ4J7"
   },
   {
@@ -30982,6 +31869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-11"
   },
   {
@@ -31003,7 +31891,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 92
+    "price": 92,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "890",
@@ -31025,6 +31914,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "binding_note",
@@ -31072,6 +31962,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -31131,6 +32022,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-26"
   },
   {
@@ -31153,6 +32045,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-24",
     "notes": [
       {
@@ -31185,6 +32078,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -31228,6 +32122,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 5,
     "second_call_number": "0T0GB"
   },
   {
@@ -31250,6 +32145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "general_note",
@@ -31285,6 +32181,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-01",
     "second_call_number": "2J7GB"
   },
@@ -31308,6 +32205,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-04-07",
     "notes": [
       {
@@ -31352,6 +32250,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-01",
     "notes": [
       {
@@ -31405,6 +32304,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-24"
   },
   {
@@ -31427,6 +32327,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-10",
     "notes": [
       {
@@ -31455,6 +32356,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-26",
     "notes": [
       {
@@ -31491,6 +32393,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -31550,6 +32453,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-27",
     "notes": [
       {
@@ -31598,6 +32502,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-29",
     "notes": [
       {
@@ -31646,6 +32551,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -31677,6 +32583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -31724,6 +32631,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-09-21"
   },
   {
@@ -31746,6 +32654,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -31793,6 +32702,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -31852,6 +32762,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -31907,6 +32818,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -31957,7 +32869,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 72
+    "price": 72,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "914",
@@ -31979,6 +32892,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-05"
   },
   {
@@ -32001,6 +32915,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-06",
     "notes": [
       {
@@ -32034,6 +32949,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "general_note",
@@ -32076,7 +32992,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 86
+    "price": 86,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "918",
@@ -32098,6 +33015,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -32141,6 +33059,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -32184,6 +33103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-18",
     "notes": [
       {
@@ -32228,6 +33148,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "acquisition_note",
@@ -32288,6 +33209,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -32316,6 +33238,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-05",
     "notes": [
       {
@@ -32365,6 +33288,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-03-19",
     "second_call_number": "Y2FM6"
   },
@@ -32388,6 +33312,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-04",
     "notes": [
       {
@@ -32443,7 +33368,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "927",
@@ -32465,6 +33391,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 7,
     "second_call_number": "XYE1S"
   },
   {
@@ -32487,6 +33414,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-12-12"
   },
   {
@@ -32509,6 +33437,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-10",
     "notes": [
       {
@@ -32549,6 +33478,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -32584,6 +33514,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-27",
     "notes": [
       {
@@ -32620,6 +33551,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -32679,6 +33611,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-17"
   },
   {
@@ -32701,6 +33634,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-25",
     "notes": [
       {
@@ -32730,6 +33664,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-02",
     "notes": [
       {
@@ -32775,6 +33710,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-18"
   },
   {
@@ -32796,7 +33732,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "938",
@@ -32818,6 +33755,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-23",
     "notes": [
       {
@@ -32874,6 +33812,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-28"
   },
   {
@@ -32896,6 +33835,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "condition_note",
@@ -32956,6 +33896,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -33003,6 +33944,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -33050,6 +33992,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-16",
     "second_call_number": "UBGVK"
   },
@@ -33073,6 +34016,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-30",
     "notes": [
       {
@@ -33101,6 +34045,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -33152,6 +34097,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-11",
     "notes": [
       {
@@ -33184,6 +34130,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 5,
     "second_call_number": "ULE6G"
   },
   {
@@ -33206,6 +34153,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-10-16",
     "notes": [
       {
@@ -33254,6 +34202,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -33301,6 +34250,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-17",
     "second_call_number": "ZY86K"
   },
@@ -33324,6 +34274,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-14",
     "notes": [
       {
@@ -33364,6 +34315,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -33411,6 +34363,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-27"
   },
   {
@@ -33433,6 +34386,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-25",
     "notes": [
       {
@@ -33469,6 +34423,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-11",
     "notes": [
       {
@@ -33513,6 +34468,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-05",
     "notes": [
       {
@@ -33556,7 +34512,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 24
+    "price": 24,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "958",
@@ -33578,6 +34535,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -33617,6 +34575,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -33656,6 +34615,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "staff_note",
@@ -33691,6 +34651,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 5,
     "second_call_number": "GJ45X"
   },
   {
@@ -33713,6 +34674,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-02-24"
   },
   {
@@ -33734,7 +34696,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 90
+    "price": 90,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "964",
@@ -33755,7 +34718,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "965",
@@ -33777,6 +34741,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-14",
     "notes": [
       {
@@ -33825,6 +34790,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 12,
     "second_call_number": "EOW8Z"
   },
   {
@@ -33847,6 +34813,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-11-19",
     "notes": [
       {
@@ -33907,6 +34874,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 7,
     "second_call_number": "J0Y4X"
   },
   {
@@ -33929,6 +34897,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -33981,6 +34950,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-25"
   },
   {
@@ -34003,6 +34973,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -34063,6 +35034,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -34094,6 +35066,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-17"
   },
   {
@@ -34116,6 +35089,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -34171,6 +35145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-19"
   },
   {
@@ -34193,6 +35168,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-12"
   },
   {
@@ -34215,6 +35191,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-19",
     "notes": [
       {
@@ -34252,6 +35229,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-14",
     "second_call_number": "HFG4X"
   },
@@ -34274,7 +35252,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 82
+    "price": 82,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "980",
@@ -34295,7 +35274,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "981",
@@ -34317,6 +35297,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-10",
     "notes": [
       {
@@ -34366,6 +35347,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-09",
     "notes": [
       {
@@ -34427,6 +35409,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-17",
     "notes": [
       {
@@ -34456,6 +35439,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-22",
     "notes": [
       {
@@ -34484,6 +35468,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-05",
     "second_call_number": "XDLDB"
   },
@@ -34507,6 +35492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-21",
     "notes": [
       {
@@ -34563,6 +35549,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkout_note",
@@ -34614,6 +35601,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -34653,6 +35641,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 11,
     "second_call_number": "4BA8K"
   },
   {
@@ -34675,6 +35664,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -34703,6 +35693,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "condition_note",
@@ -34746,6 +35737,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-27"
   },
   {
@@ -34768,6 +35760,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -34795,6 +35788,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -34834,6 +35828,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-11",
     "notes": [
       {
@@ -34894,6 +35889,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-25",
     "notes": [
       {
@@ -34951,6 +35947,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-06",
     "notes": [
       {
@@ -35010,7 +36007,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 46
+    "price": 46,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "999",
@@ -35031,7 +36029,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 36
+    "price": 36,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1000",
@@ -35053,6 +36052,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-21",
     "notes": [
       {
@@ -35101,6 +36101,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-03",
     "second_call_number": "QFV3K"
   },
@@ -35124,6 +36125,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-16",
     "second_call_number": "97PKR"
   },
@@ -35147,6 +36149,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-16",
     "second_call_number": "GZJQT"
   },
@@ -35170,6 +36173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-01",
     "notes": [
       {
@@ -35206,6 +36210,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-28"
   },
   {
@@ -35228,6 +36233,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-26",
     "notes": [
       {
@@ -35276,6 +36282,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -35303,6 +36310,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-08",
     "notes": [
       {
@@ -35347,7 +36355,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1010",
@@ -35369,6 +36378,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-27",
     "notes": [
       {
@@ -35404,7 +36414,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 98
+    "price": 98,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1012",
@@ -35426,6 +36437,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkout_note",
@@ -35457,6 +36469,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-12",
     "notes": [
       {
@@ -35505,6 +36518,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-14",
     "notes": [
       {
@@ -35557,6 +36571,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-02"
   },
   {
@@ -35579,6 +36594,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "staff_note",
@@ -35610,6 +36626,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-06-05"
   },
   {
@@ -35632,6 +36649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-19",
     "notes": [
       {
@@ -35664,6 +36682,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-03-14"
   },
   {
@@ -35685,7 +36704,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 26
+    "price": 26,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1021",
@@ -35707,6 +36727,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 13,
     "second_call_number": "KEQT9"
   },
   {
@@ -35729,6 +36750,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-16",
     "notes": [
       {
@@ -35761,6 +36783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-10-31",
     "notes": [
       {
@@ -35797,6 +36820,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-23",
     "notes": [
       {
@@ -35849,6 +36873,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -35903,7 +36928,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1027",
@@ -35925,6 +36951,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -35968,6 +36995,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-20",
     "notes": [
       {
@@ -36007,7 +37035,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 9
+    "price": 9,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1030",
@@ -36029,6 +37058,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-30",
     "notes": [
       {
@@ -36058,6 +37088,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -36093,6 +37124,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-15",
     "notes": [
       {
@@ -36153,6 +37185,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-11-14",
     "notes": [
       {
@@ -36198,6 +37231,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-16"
   },
   {
@@ -36220,6 +37254,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-15",
     "notes": [
       {
@@ -36256,6 +37291,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "staff_note",
@@ -36308,6 +37344,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "general_note",
@@ -36339,6 +37376,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-09",
     "notes": [
       {
@@ -36383,6 +37421,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-06"
   },
   {
@@ -36404,7 +37443,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 61
+    "price": 61,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "1041",
@@ -36425,7 +37465,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1042",
@@ -36447,6 +37488,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -36493,7 +37535,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 49
+    "price": 49,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1044",
@@ -36515,6 +37558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-04",
     "notes": [
       {
@@ -36574,7 +37618,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 19
+    "price": 19,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1046",
@@ -36596,6 +37641,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-22"
   },
   {
@@ -36617,7 +37663,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1048",
@@ -36639,6 +37686,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-14",
     "notes": [
       {
@@ -36680,6 +37728,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-03-04",
     "notes": [
       {
@@ -36737,6 +37786,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-16",
     "notes": [
       {
@@ -36769,6 +37819,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-13"
   },
   {
@@ -36791,6 +37842,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-14",
     "notes": [
       {
@@ -36839,6 +37891,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-09",
     "notes": [
       {
@@ -36896,6 +37949,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-08"
   },
   {
@@ -36918,6 +37972,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 3,
     "second_call_number": "LWRWA"
   },
   {
@@ -36940,6 +37995,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -36979,6 +38035,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-03"
   },
   {
@@ -37001,6 +38058,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-24",
     "notes": [
       {
@@ -37029,6 +38087,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-05",
     "notes": [
       {
@@ -37073,6 +38132,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-12",
     "notes": [
       {
@@ -37117,6 +38177,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -37149,6 +38210,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-03",
     "notes": [
       {
@@ -37177,6 +38239,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -37219,7 +38282,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 79
+    "price": 79,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1065",
@@ -37241,6 +38305,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -37292,6 +38357,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-08-04",
     "notes": [
       {
@@ -37336,6 +38402,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -37379,6 +38446,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-30",
     "notes": [
       {
@@ -37424,6 +38492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-10",
     "second_call_number": "MQ2V9"
   },
@@ -37447,6 +38516,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-11",
     "notes": [
       {
@@ -37476,6 +38546,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-21",
     "notes": [
       {
@@ -37504,6 +38575,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-11",
     "notes": [
       {
@@ -37563,7 +38635,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1074",
@@ -37585,6 +38658,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-09-19",
     "notes": [
       {
@@ -37621,6 +38695,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-03",
     "notes": [
       {
@@ -37652,7 +38727,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 100
+    "price": 100,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1077",
@@ -37674,6 +38750,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -37702,6 +38779,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -37736,7 +38814,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1080",
@@ -37758,6 +38837,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-18",
     "notes": [
       {
@@ -37798,6 +38878,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-08-23",
     "notes": [
       {
@@ -37845,7 +38926,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1083",
@@ -37867,6 +38949,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-13"
   },
   {
@@ -37889,6 +38972,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "provenance_note",
@@ -37916,6 +39000,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-06-10"
   },
   {
@@ -37938,6 +39023,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "provenance_note",
@@ -37994,6 +39080,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-11"
   },
   {
@@ -38016,6 +39103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -38052,6 +39140,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-03-06",
     "notes": [
       {
@@ -38085,6 +39174,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -38124,6 +39214,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-03"
   },
   {
@@ -38146,6 +39237,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -38194,6 +39286,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -38225,6 +39318,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 9,
     "second_call_number": "AUGIK"
   },
   {
@@ -38247,6 +39341,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-19",
     "notes": [
       {
@@ -38307,6 +39402,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkin_note",
@@ -38354,6 +39450,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-18",
     "notes": [
       {
@@ -38414,6 +39511,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-20",
     "notes": [
       {
@@ -38474,6 +39572,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-08-22",
     "notes": [
       {
@@ -38510,6 +39609,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-03-09",
     "second_call_number": "FW1WL"
   },
@@ -38533,6 +39633,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -38592,6 +39693,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 4,
     "second_call_number": "U7EEM"
   },
   {
@@ -38614,6 +39716,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-04",
     "notes": [
       {
@@ -38642,6 +39745,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-01",
     "second_call_number": "WX1QX"
   },
@@ -38665,6 +39769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-27",
     "notes": [
       {
@@ -38709,6 +39814,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-18",
     "notes": [
       {
@@ -38770,6 +39876,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 7,
     "second_call_number": "ILVNC"
   },
   {
@@ -38792,6 +39899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-09-05",
     "notes": [
       {
@@ -38851,7 +39959,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 32
+    "price": 32,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1110",
@@ -38873,6 +39982,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-03",
     "notes": [
       {
@@ -38901,6 +40011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -38957,6 +40068,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 6,
     "second_call_number": "RUQ6V"
   },
   {
@@ -38979,6 +40091,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -39014,6 +40127,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-01-11",
     "notes": [
       {
@@ -39070,6 +40184,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-30"
   },
   {
@@ -39092,6 +40207,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-02",
     "notes": [
       {
@@ -39144,6 +40260,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 11,
     "second_call_number": "QYGEO"
   },
   {
@@ -39166,6 +40283,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -39204,7 +40322,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 97
+    "price": 97,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1120",
@@ -39226,6 +40345,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-13",
     "notes": [
       {
@@ -39262,6 +40382,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-31",
     "notes": [
       {
@@ -39322,6 +40443,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "condition_note",
@@ -39381,6 +40503,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-06-29",
     "notes": [
       {
@@ -39441,6 +40564,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-01-24",
     "notes": [
       {
@@ -39497,6 +40621,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -39544,6 +40669,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "provenance_note",
@@ -39595,6 +40721,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -39634,6 +40761,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-18"
   },
   {
@@ -39656,6 +40784,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-16"
   },
   {
@@ -39678,6 +40807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkout_note",
@@ -39713,6 +40843,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-09",
     "notes": [
       {
@@ -39753,6 +40884,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -39804,6 +40936,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-09"
   },
   {
@@ -39826,6 +40959,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -39857,6 +40991,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-06",
     "notes": [
       {
@@ -39905,6 +41040,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-16",
     "notes": [
       {
@@ -39948,7 +41084,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 4
+    "price": 4,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1138",
@@ -39970,6 +41107,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -40009,6 +41147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkin_note",
@@ -40068,6 +41207,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 12,
     "second_call_number": "Z5631"
   },
   {
@@ -40090,6 +41230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-25",
     "notes": [
       {
@@ -40130,6 +41271,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -40174,6 +41316,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-08-27"
   },
   {
@@ -40196,6 +41339,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-11",
     "second_call_number": "254MZ"
   },
@@ -40219,6 +41363,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-11-20"
   },
   {
@@ -40241,6 +41386,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-09-26",
     "notes": [
       {
@@ -40273,6 +41419,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-18"
   },
   {
@@ -40294,7 +41441,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 9
+    "price": 9,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1149",
@@ -40316,6 +41464,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -40348,6 +41497,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -40408,6 +41558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -40439,6 +41590,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 12,
     "second_call_number": "KO2Z1"
   },
   {
@@ -40460,7 +41612,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 48
+    "price": 48,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "1154",
@@ -40482,6 +41635,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -40513,6 +41667,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkout_note",
@@ -40544,6 +41699,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -40592,6 +41748,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-05"
   },
   {
@@ -40613,7 +41770,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1159",
@@ -40634,7 +41792,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 7
+    "price": 7,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1160",
@@ -40655,7 +41814,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 54
+    "price": 54,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1161",
@@ -40677,6 +41837,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 4,
     "second_call_number": "3JIPA"
   },
   {
@@ -40699,6 +41860,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-16",
     "notes": [
       {
@@ -40727,6 +41889,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -40762,6 +41925,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -40801,7 +41965,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 81
+    "price": 81,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1166",
@@ -40823,6 +41988,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-30",
     "notes": [
       {
@@ -40867,6 +42033,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -40911,6 +42078,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -40962,6 +42130,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-17",
     "second_call_number": "UG0S2"
   },
@@ -40985,6 +42154,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-31",
     "second_call_number": "541GY"
   },
@@ -41008,6 +42178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "condition_note",
@@ -41059,6 +42230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-27"
   },
   {
@@ -41081,6 +42253,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-04-02",
     "notes": [
       {
@@ -41121,6 +42294,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -41164,6 +42338,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-06",
     "notes": [
       {
@@ -41211,7 +42386,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1177",
@@ -41232,7 +42408,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1178",
@@ -41254,6 +42431,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -41282,6 +42460,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-29",
     "notes": [
       {
@@ -41321,7 +42500,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 45
+    "price": 45,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1181",
@@ -41343,6 +42523,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-13",
     "notes": [
       {
@@ -41384,6 +42565,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-12-11"
   },
   {
@@ -41406,6 +42588,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-27"
   },
   {
@@ -41428,6 +42611,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "provenance_note",
@@ -41455,6 +42639,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-05",
     "notes": [
       {
@@ -41495,6 +42680,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -41530,7 +42716,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1188",
@@ -41552,6 +42739,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-16"
   },
   {
@@ -41574,6 +42762,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "provenance_note",
@@ -41625,6 +42814,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-04",
     "second_call_number": "KVVFP"
   },
@@ -41648,6 +42838,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -41676,6 +42867,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-29",
     "notes": [
       {
@@ -41736,6 +42928,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-02"
   },
   {
@@ -41757,7 +42950,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1195",
@@ -41779,6 +42973,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-09-30",
     "notes": [
       {
@@ -41816,6 +43011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-04"
   },
   {
@@ -41838,6 +43034,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-02-24",
     "notes": [
       {
@@ -41881,7 +43078,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 40
+    "price": 40,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1199",
@@ -41902,7 +43100,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 97
+    "price": 97,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1200",
@@ -41924,6 +43123,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -41954,7 +43154,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1202",
@@ -41976,6 +43177,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-14",
     "notes": [
       {
@@ -42036,6 +43238,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-13",
     "notes": [
       {
@@ -42081,6 +43284,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "condition_note",
@@ -42132,6 +43336,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-06-29",
     "notes": [
       {
@@ -42160,6 +43365,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-15"
   },
   {
@@ -42182,6 +43388,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-28",
     "notes": [
       {
@@ -42230,6 +43437,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-29"
   },
   {
@@ -42252,6 +43460,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -42311,7 +43520,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 64
+    "price": 64,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1211",
@@ -42332,7 +43542,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 31
+    "price": 31,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "1212",
@@ -42354,6 +43565,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "acquisition_note",
@@ -42384,7 +43596,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 14
+    "price": 14,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1214",
@@ -42406,6 +43619,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "staff_note",
@@ -42441,6 +43655,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -42491,7 +43706,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1217",
@@ -42513,6 +43729,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-09"
   },
   {
@@ -42535,6 +43752,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-01-28",
     "notes": [
       {
@@ -42571,6 +43789,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-06",
     "notes": [
       {
@@ -42627,6 +43846,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-18",
     "notes": [
       {
@@ -42671,6 +43891,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -42703,6 +43924,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-26"
   },
   {
@@ -42725,6 +43947,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-05",
     "notes": [
       {
@@ -42777,6 +44000,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -42813,6 +44037,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -42871,7 +44096,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 46
+    "price": 46,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1227",
@@ -42892,7 +44118,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 47
+    "price": 47,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1228",
@@ -42913,7 +44140,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1229",
@@ -42935,6 +44163,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -42966,6 +44195,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-03-16",
     "notes": [
       {
@@ -43017,7 +44247,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1232",
@@ -43038,7 +44269,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 92
+    "price": 92,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1233",
@@ -43060,6 +44292,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-20",
     "notes": [
       {
@@ -43113,6 +44346,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-15"
   },
   {
@@ -43135,6 +44369,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -43163,6 +44398,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-22",
     "notes": [
       {
@@ -43203,6 +44439,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-02",
     "notes": [
       {
@@ -43255,6 +44492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-04-02",
     "second_call_number": "953NC"
   },
@@ -43278,6 +44516,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-23"
   },
   {
@@ -43300,6 +44539,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-27",
     "notes": [
       {
@@ -43344,6 +44584,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-09-12"
   },
   {
@@ -43366,6 +44607,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-06",
     "notes": [
       {
@@ -43407,6 +44649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-09-05"
   },
   {
@@ -43428,7 +44671,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 51
+    "price": 51,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1245",
@@ -43449,7 +44693,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 83
+    "price": 83,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1246",
@@ -43470,7 +44715,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 6
+    "price": 6,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1247",
@@ -43492,6 +44738,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -43519,6 +44766,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -43578,7 +44826,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 11
+    "price": 11,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1250",
@@ -43600,6 +44849,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-04"
   },
   {
@@ -43622,6 +44872,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-24"
   },
   {
@@ -43644,6 +44895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-24",
     "notes": [
       {
@@ -43699,7 +44951,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1254",
@@ -43721,6 +44974,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 3,
     "second_call_number": "P2DR5"
   },
   {
@@ -43743,6 +44997,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 15,
     "second_call_number": "69H53"
   },
   {
@@ -43764,7 +45019,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 42
+    "price": 42,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1257",
@@ -43786,6 +45042,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-10",
     "notes": [
       {
@@ -43842,6 +45099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -43897,6 +45155,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-01-11",
     "notes": [
       {
@@ -43938,6 +45197,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-02"
   },
   {
@@ -43960,6 +45220,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -44003,6 +45264,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -44049,7 +45311,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 54
+    "price": 54,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1264",
@@ -44070,7 +45333,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1265",
@@ -44092,6 +45356,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-11-09",
     "notes": [
       {
@@ -44140,6 +45405,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-04-04",
     "notes": [
       {
@@ -44168,6 +45434,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-20",
     "notes": [
       {
@@ -44216,6 +45483,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-08",
     "notes": [
       {
@@ -44268,6 +45536,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -44299,7 +45568,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 6
+    "price": 6,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1271",
@@ -44321,6 +45591,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-28",
     "notes": [
       {
@@ -44373,6 +45644,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -44420,6 +45692,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -44463,7 +45736,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 50
+    "price": 50,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1275",
@@ -44485,6 +45759,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-23",
     "notes": [
       {
@@ -44521,6 +45796,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-23",
     "notes": [
       {
@@ -44549,6 +45825,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-08",
     "notes": [
       {
@@ -44597,6 +45874,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-16",
     "second_call_number": "GUX3J"
   },
@@ -44620,6 +45898,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-10-16",
     "notes": [
       {
@@ -44680,6 +45959,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-03"
   },
   {
@@ -44701,7 +45981,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 58
+    "price": 58,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1282",
@@ -44723,6 +46004,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -44774,6 +46056,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-03-11",
     "notes": [
       {
@@ -44818,6 +46101,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-02",
     "notes": [
       {
@@ -44847,6 +46131,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-04"
   },
   {
@@ -44869,6 +46154,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-31",
     "notes": [
       {
@@ -44925,6 +46211,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 14,
     "second_call_number": "OB37P"
   },
   {
@@ -44947,6 +46234,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-15"
   },
   {
@@ -44969,6 +46257,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-15",
     "notes": [
       {
@@ -45008,7 +46297,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 24
+    "price": 24,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1291",
@@ -45030,6 +46320,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-03-23",
     "notes": [
       {
@@ -45058,6 +46349,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -45100,7 +46392,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 31
+    "price": 31,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1294",
@@ -45121,7 +46414,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 52
+    "price": 52,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1295",
@@ -45143,6 +46437,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-22",
     "notes": [
       {
@@ -45204,6 +46499,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-27",
     "notes": [
       {
@@ -45232,6 +46528,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -45283,6 +46580,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-12",
     "notes": [
       {
@@ -45319,7 +46617,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1300",
@@ -45341,6 +46640,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-22",
     "second_call_number": "WQ7EM"
   },
@@ -45364,6 +46664,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "acquisition_note",
@@ -45396,6 +46697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 5,
     "second_call_number": "A44K1"
   },
   {
@@ -45418,6 +46720,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-15",
     "second_call_number": "P0XNZ"
   },
@@ -45441,6 +46744,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-03-19",
     "notes": [
       {
@@ -45481,6 +46785,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "acquisition_note",
@@ -45508,7 +46813,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 80
+    "price": 80,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1307",
@@ -45530,6 +46836,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-05",
     "second_call_number": "DCYI1"
   },
@@ -45552,7 +46859,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 29
+    "price": 29,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1309",
@@ -45574,6 +46882,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -45605,6 +46914,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-12-21"
   },
   {
@@ -45627,6 +46937,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "binding_note",
@@ -45678,6 +46989,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-25",
     "notes": [
       {
@@ -45722,6 +47034,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-16"
   },
   {
@@ -45744,6 +47057,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-12",
     "notes": [
       {
@@ -45776,6 +47090,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -45832,6 +47147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -45887,6 +47203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-26"
   },
   {
@@ -45909,6 +47226,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-08",
     "notes": [
       {
@@ -45945,6 +47263,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-16",
     "notes": [
       {
@@ -45977,6 +47296,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-09",
     "notes": [
       {
@@ -46022,6 +47342,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-04-05",
     "notes": [
       {
@@ -46069,7 +47390,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1323",
@@ -46091,6 +47413,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -46126,6 +47449,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -46157,7 +47481,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1326",
@@ -46179,6 +47504,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-24"
   },
   {
@@ -46201,6 +47527,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-30",
     "notes": [
       {
@@ -46248,7 +47575,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1329",
@@ -46270,6 +47598,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-09",
     "notes": [
       {
@@ -46323,6 +47652,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-23"
   },
   {
@@ -46345,6 +47675,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-10",
     "notes": [
       {
@@ -46373,6 +47704,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkout_note",
@@ -46425,6 +47757,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-03-30",
     "notes": [
       {
@@ -46460,7 +47793,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 4
+    "price": 4,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1335",
@@ -46482,6 +47816,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-10",
     "notes": [
       {
@@ -46534,6 +47869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -46564,7 +47900,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 8
+    "price": 8,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1338",
@@ -46586,6 +47923,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -46613,6 +47951,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 8,
     "second_call_number": "1U78V"
   },
   {
@@ -46635,6 +47974,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -46682,6 +48022,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -46729,6 +48070,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "acquisition_note",
@@ -46775,7 +48117,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 11
+    "price": 11,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "1344",
@@ -46796,7 +48139,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 50
+    "price": 50,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1345",
@@ -46818,6 +48162,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-04-21",
     "notes": [
       {
@@ -46866,6 +48211,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -46902,6 +48248,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-19"
   },
   {
@@ -46924,6 +48271,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-07",
     "second_call_number": "HQD95"
   },
@@ -46946,7 +48294,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 12
+    "price": 12,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1350",
@@ -46968,6 +48317,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-01",
     "notes": [
       {
@@ -47004,6 +48354,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-28"
   },
   {
@@ -47026,6 +48377,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-28",
     "notes": [
       {
@@ -47058,6 +48410,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -47110,6 +48463,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-12-13",
     "notes": [
       {
@@ -47146,6 +48500,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-05"
   },
   {
@@ -47168,6 +48523,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-08-21"
   },
   {
@@ -47190,6 +48546,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-07"
   },
   {
@@ -47212,6 +48569,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-24"
   },
   {
@@ -47234,6 +48592,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-12"
   },
   {
@@ -47256,6 +48615,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-03-10",
     "notes": [
       {
@@ -47284,6 +48644,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-08",
     "second_call_number": "RFZC5"
   },
@@ -47307,6 +48668,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-27"
   },
   {
@@ -47329,6 +48691,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-21",
     "notes": [
       {
@@ -47361,6 +48724,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-12"
   },
   {
@@ -47383,6 +48747,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -47434,6 +48799,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-16",
     "notes": [
       {
@@ -47466,6 +48832,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-19"
   },
   {
@@ -47488,6 +48855,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -47524,6 +48892,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-02-22",
     "notes": [
       {
@@ -47576,6 +48945,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-07"
   },
   {
@@ -47598,6 +48968,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-20",
     "second_call_number": "8NCOH"
   },
@@ -47621,6 +48992,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-28"
   },
   {
@@ -47643,6 +49015,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-16"
   },
   {
@@ -47665,6 +49038,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-12",
     "notes": [
       {
@@ -47724,7 +49098,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1376",
@@ -47746,6 +49121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 15,
     "second_call_number": "R4OQO"
   },
   {
@@ -47768,6 +49144,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-08"
   },
   {
@@ -47790,6 +49167,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-30",
     "notes": [
       {
@@ -47830,6 +49208,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-05",
     "notes": [
       {
@@ -47862,6 +49241,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkout_note",
@@ -47889,6 +49269,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-21"
   },
   {
@@ -47911,6 +49292,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-29",
     "notes": [
       {
@@ -47947,6 +49329,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -47994,6 +49377,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-16"
   },
   {
@@ -48016,6 +49400,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-14",
     "second_call_number": "EFVUO"
   },
@@ -48039,6 +49424,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-25",
     "second_call_number": "CRNZ0"
   },
@@ -48062,6 +49448,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-28",
     "notes": [
       {
@@ -48118,6 +49505,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-05",
     "notes": [
       {
@@ -48174,6 +49562,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 6,
     "second_call_number": "DH45R"
   },
   {
@@ -48196,6 +49585,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-21"
   },
   {
@@ -48217,7 +49607,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1392",
@@ -48239,6 +49630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-08-13"
   },
   {
@@ -48261,6 +49653,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-03-26",
     "notes": [
       {
@@ -48313,6 +49706,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -48343,7 +49737,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 49
+    "price": 49,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1396",
@@ -48364,7 +49759,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 20
+    "price": 20,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1397",
@@ -48386,6 +49782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-12",
     "notes": [
       {
@@ -48421,7 +49818,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 80
+    "price": 80,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1399",
@@ -48443,6 +49841,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-03"
   },
   {
@@ -48465,6 +49864,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -48501,6 +49901,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkout_note",
@@ -48560,6 +49961,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -48615,6 +50017,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-22",
     "notes": [
       {
@@ -48659,6 +50062,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -48693,7 +50097,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 78
+    "price": 78,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1406",
@@ -48715,6 +50120,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-18",
     "notes": [
       {
@@ -48755,6 +50161,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -48794,6 +50201,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-10"
   },
   {
@@ -48816,6 +50224,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-19"
   },
   {
@@ -48838,6 +50247,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -48886,6 +50296,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-08",
     "notes": [
       {
@@ -48923,6 +50334,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 4,
     "second_call_number": "7CASF"
   },
   {
@@ -48944,7 +50356,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 84
+    "price": 84,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1414",
@@ -48966,6 +50379,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -48993,6 +50407,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-11",
     "notes": [
       {
@@ -49029,6 +50444,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -49084,7 +50500,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 1
+    "price": 1,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1418",
@@ -49105,7 +50522,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1419",
@@ -49127,6 +50545,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "acquisition_note",
@@ -49175,6 +50594,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-01-17",
     "notes": [
       {
@@ -49218,7 +50638,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 52
+    "price": 52,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1422",
@@ -49240,6 +50661,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-27",
     "notes": [
       {
@@ -49288,6 +50710,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -49323,6 +50746,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-15",
     "notes": [
       {
@@ -49350,7 +50774,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 84
+    "price": 84,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1426",
@@ -49372,6 +50797,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-29"
   },
   {
@@ -49394,6 +50820,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-22"
   },
   {
@@ -49416,6 +50843,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-13",
     "notes": [
       {
@@ -49460,6 +50888,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-12-19",
     "notes": [
       {
@@ -49508,6 +50937,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-02-03",
     "notes": [
       {
@@ -49568,6 +50998,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-20",
     "notes": [
       {
@@ -49612,6 +51043,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -49667,6 +51099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-09-22",
     "notes": [
       {
@@ -49722,7 +51155,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1435",
@@ -49744,6 +51178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-01-29"
   },
   {
@@ -49766,6 +51201,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-15",
     "notes": [
       {
@@ -49810,6 +51246,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-09"
   },
   {
@@ -49832,6 +51269,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -49868,6 +51306,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-06"
   },
   {
@@ -49890,6 +51329,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-14",
     "notes": [
       {
@@ -49939,6 +51379,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-23"
   },
   {
@@ -49961,6 +51402,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-16"
   },
   {
@@ -49983,6 +51425,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "acquisition_note",
@@ -50042,6 +51485,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -50101,6 +51545,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-05"
   },
   {
@@ -50123,6 +51568,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-21",
     "notes": [
       {
@@ -50184,6 +51630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 5,
     "second_call_number": "CG9G0"
   },
   {
@@ -50206,6 +51653,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -50252,7 +51700,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1450",
@@ -50274,6 +51723,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkin_note",
@@ -50317,6 +51767,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-22",
     "notes": [
       {
@@ -50369,6 +51820,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-20",
     "notes": [
       {
@@ -50429,6 +51881,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-05-28"
   },
   {
@@ -50451,6 +51904,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -50495,6 +51949,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -50527,6 +51982,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkin_note",
@@ -50586,6 +52042,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-11",
     "second_call_number": "APBGP"
   },
@@ -50608,7 +52065,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1459",
@@ -50630,6 +52088,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -50661,6 +52120,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-08-22",
     "second_call_number": "VQXW7"
   },
@@ -50684,6 +52144,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "condition_note",
@@ -50743,6 +52204,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-04"
   },
   {
@@ -50765,6 +52227,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "provenance_note",
@@ -50815,7 +52278,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1465",
@@ -50837,6 +52301,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-26",
     "second_call_number": "H4ZCB"
   },
@@ -50860,6 +52325,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -50895,6 +52361,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-20",
     "second_call_number": "4Y358"
   },
@@ -50918,6 +52385,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-02",
     "notes": [
       {
@@ -50962,6 +52430,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -51006,6 +52475,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -51057,6 +52527,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-26"
   },
   {
@@ -51079,6 +52550,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-10",
     "notes": [
       {
@@ -51127,6 +52599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-05"
   },
   {
@@ -51149,6 +52622,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-15",
     "notes": [
       {
@@ -51194,6 +52668,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-03-18"
   },
   {
@@ -51216,6 +52691,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-08"
   },
   {
@@ -51238,6 +52714,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-12-05",
     "notes": [
       {
@@ -51285,7 +52762,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1479",
@@ -51306,7 +52784,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 56
+    "price": 56,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1480",
@@ -51328,6 +52807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-22"
   },
   {
@@ -51349,7 +52829,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 16
+    "price": 16,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1482",
@@ -51371,6 +52852,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -51397,7 +52879,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 83
+    "price": 83,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1484",
@@ -51419,6 +52902,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-25",
     "second_call_number": "ZYO6D"
   },
@@ -51442,6 +52926,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-30",
     "notes": [
       {
@@ -51469,7 +52954,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1487",
@@ -51491,6 +52977,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 6,
     "second_call_number": "PB9PY"
   },
   {
@@ -51513,6 +53000,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-09",
     "notes": [
       {
@@ -51562,6 +53050,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-06",
     "notes": [
       {
@@ -51614,6 +53103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-07"
   },
   {
@@ -51636,6 +53126,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-22",
     "notes": [
       {
@@ -51677,6 +53168,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -51704,7 +53196,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 40
+    "price": 40,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1494",
@@ -51726,6 +53219,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-24",
     "notes": [
       {
@@ -51762,6 +53256,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -51814,6 +53309,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-13",
     "notes": [
       {
@@ -51873,7 +53369,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 64
+    "price": 64,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1498",
@@ -51895,6 +53392,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -51937,7 +53435,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 52
+    "price": 52,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1500",
@@ -51959,6 +53458,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-03",
     "notes": [
       {
@@ -52003,6 +53503,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -52059,6 +53560,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 14,
     "second_call_number": "L1K8C"
   },
   {
@@ -52081,6 +53583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-18",
     "notes": [
       {
@@ -52137,6 +53640,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-28",
     "second_call_number": "TNXKW"
   },
@@ -52160,6 +53664,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-27",
     "notes": [
       {
@@ -52197,6 +53702,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-24",
     "notes": [
       {
@@ -52241,6 +53747,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "acquisition_note",
@@ -52296,6 +53803,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-29",
     "second_call_number": "VI7V3"
   },
@@ -52319,6 +53827,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-07",
     "notes": [
       {
@@ -52379,6 +53888,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 13,
     "second_call_number": "MNDHJ"
   },
   {
@@ -52400,7 +53910,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 86
+    "price": 86,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1512",
@@ -52422,6 +53933,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-06",
     "notes": [
       {
@@ -52450,6 +53962,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -52490,6 +54003,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-30"
   },
   {
@@ -52512,6 +54026,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -52538,7 +54053,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "1517",
@@ -52560,6 +54076,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-12"
   },
   {
@@ -52582,6 +54099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-03-26",
     "notes": [
       {
@@ -52614,6 +54132,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-04-05"
   },
   {
@@ -52636,6 +54155,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -52683,6 +54203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -52730,6 +54251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "binding_note",
@@ -52785,6 +54307,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -52820,6 +54343,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -52875,6 +54399,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-05",
     "notes": [
       {
@@ -52920,6 +54445,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-04",
     "notes": [
       {
@@ -52953,6 +54479,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-13",
     "notes": [
       {
@@ -53013,6 +54540,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-03",
     "notes": [
       {
@@ -53042,6 +54570,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-29",
     "notes": [
       {
@@ -53102,6 +54631,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 5,
     "second_call_number": "VP8Y5"
   },
   {
@@ -53124,6 +54654,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-19",
     "notes": [
       {
@@ -53160,6 +54691,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-22",
     "notes": [
       {
@@ -53200,6 +54732,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -53259,6 +54792,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkout_note",
@@ -53306,6 +54840,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-04-01",
     "notes": [
       {
@@ -53334,6 +54869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 6,
     "second_call_number": "R5LA1"
   },
   {
@@ -53356,6 +54892,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-12",
     "notes": [
       {
@@ -53412,6 +54949,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-03",
     "notes": [
       {
@@ -53452,6 +54990,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 8,
     "second_call_number": "GKTFZ"
   },
   {
@@ -53474,6 +55013,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -53530,6 +55070,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-04"
   },
   {
@@ -53552,6 +55093,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -53592,6 +55134,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 3,
     "second_call_number": "OS9UX"
   },
   {
@@ -53614,6 +55157,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-02-03"
   },
   {
@@ -53636,6 +55180,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-20",
     "notes": [
       {
@@ -53692,6 +55237,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "binding_note",
@@ -53727,6 +55273,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-12",
     "second_call_number": "8KQB0"
   },
@@ -53750,6 +55297,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-24"
   },
   {
@@ -53772,6 +55320,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-02",
     "notes": [
       {
@@ -53831,7 +55380,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1551",
@@ -53853,6 +55403,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -53897,6 +55448,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-27",
     "notes": [
       {
@@ -53948,7 +55500,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 73
+    "price": 73,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1554",
@@ -53970,6 +55523,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-07",
     "second_call_number": "K7TQG"
   },
@@ -53993,6 +55547,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -54020,6 +55575,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-24",
     "notes": [
       {
@@ -54061,6 +55617,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkin_note",
@@ -54092,6 +55649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -54123,6 +55681,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "acquisition_note",
@@ -54178,6 +55737,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-28",
     "notes": [
       {
@@ -54210,7 +55770,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 88
+    "price": 88,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1562",
@@ -54231,7 +55792,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1563",
@@ -54252,7 +55814,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1564",
@@ -54274,6 +55837,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-09",
     "notes": [
       {
@@ -54309,7 +55873,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 37
+    "price": 37,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "1566",
@@ -54331,6 +55896,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 3,
     "second_call_number": "RRU5C"
   },
   {
@@ -54353,6 +55919,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "acquisition_note",
@@ -54385,6 +55952,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-05",
     "notes": [
       {
@@ -54426,6 +55994,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-22",
     "notes": [
       {
@@ -54462,6 +56031,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -54512,7 +56082,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 74
+    "price": 74,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1572",
@@ -54534,6 +56105,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-04-05",
     "notes": [
       {
@@ -54562,6 +56134,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-05-24",
     "notes": [
       {
@@ -54610,7 +56183,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 84
+    "price": 84,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1575",
@@ -54632,6 +56206,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-05"
   },
   {
@@ -54654,6 +56229,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -54693,6 +56269,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -54745,6 +56322,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-10",
     "notes": [
       {
@@ -54777,6 +56355,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -54812,6 +56391,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -54848,6 +56428,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-04-12"
   },
   {
@@ -54870,6 +56451,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-06",
     "notes": [
       {
@@ -54914,6 +56496,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -54960,7 +56543,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1585",
@@ -54982,6 +56566,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -55037,6 +56622,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-21",
     "notes": [
       {
@@ -55086,6 +56672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-06",
     "notes": [
       {
@@ -55118,7 +56705,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 6
+    "price": 6,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1589",
@@ -55139,7 +56727,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 3
+    "price": 3,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1590",
@@ -55160,7 +56749,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 50
+    "price": 50,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1591",
@@ -55181,7 +56771,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 71
+    "price": 71,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1592",
@@ -55203,6 +56794,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-06",
     "notes": [
       {
@@ -55232,6 +56824,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-15"
   },
   {
@@ -55254,6 +56847,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "condition_note",
@@ -55310,6 +56904,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -55361,6 +56956,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-19"
   },
   {
@@ -55383,6 +56979,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -55414,6 +57011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-03-21",
     "notes": [
       {
@@ -55455,6 +57053,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-06-14"
   },
   {
@@ -55477,6 +57076,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 2,
     "second_call_number": "1LJ77"
   },
   {
@@ -55498,7 +57098,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1602",
@@ -55520,6 +57121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-16",
     "notes": [
       {
@@ -55548,7 +57150,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1604",
@@ -55570,6 +57173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-18"
   },
   {
@@ -55592,6 +57196,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-24",
     "notes": [
       {
@@ -55628,6 +57233,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-30",
     "notes": [
       {
@@ -55676,6 +57282,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-08"
   },
   {
@@ -55698,6 +57305,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -55742,6 +57350,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "provenance_note",
@@ -55797,6 +57406,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -55825,7 +57435,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 97
+    "price": 97,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1612",
@@ -55846,7 +57457,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1613",
@@ -55868,6 +57480,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-17",
     "notes": [
       {
@@ -55900,7 +57513,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 31
+    "price": 31,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1615",
@@ -55922,6 +57536,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -55974,6 +57589,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -56005,6 +57621,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-03-16",
     "notes": [
       {
@@ -56042,6 +57659,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -56085,6 +57703,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-20",
     "notes": [
       {
@@ -56145,6 +57764,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-02",
     "notes": [
       {
@@ -56189,6 +57809,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-24",
     "notes": [
       {
@@ -56230,6 +57851,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-26"
   },
   {
@@ -56252,6 +57874,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-29",
     "second_call_number": "N2J5H"
   },
@@ -56275,6 +57898,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-21"
   },
   {
@@ -56297,6 +57921,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -56352,6 +57977,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-22"
   },
   {
@@ -56374,6 +58000,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -56413,6 +58040,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-27"
   },
   {
@@ -56435,6 +58063,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 3,
     "second_call_number": "41PV7"
   },
   {
@@ -56457,6 +58086,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -56499,7 +58129,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 17
+    "price": 17,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1632",
@@ -56521,6 +58152,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-27"
   },
   {
@@ -56543,6 +58175,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-20",
     "notes": [
       {
@@ -56580,6 +58213,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-11",
     "notes": [
       {
@@ -56609,6 +58243,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-03-25"
   },
   {
@@ -56630,7 +58265,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 48
+    "price": 48,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1637",
@@ -56652,6 +58288,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -56687,6 +58324,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -56717,7 +58355,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 7
+    "price": 7,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1640",
@@ -56739,6 +58378,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkout_note",
@@ -56773,7 +58413,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1642",
@@ -56794,7 +58435,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 17
+    "price": 17,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1643",
@@ -56816,6 +58458,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 12,
     "second_call_number": "I01DQ"
   },
   {
@@ -56838,6 +58481,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-16",
     "notes": [
       {
@@ -56870,6 +58514,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 3,
     "second_call_number": "65QIL"
   },
   {
@@ -56892,6 +58537,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "second_call_number": "SMPBV"
   },
   {
@@ -56914,6 +58560,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-22"
   },
   {
@@ -56936,6 +58583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -56994,7 +58642,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 75
+    "price": 75,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1650",
@@ -57016,6 +58665,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-29"
   },
   {
@@ -57038,6 +58688,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -57085,7 +58736,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 78
+    "price": 78,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1653",
@@ -57107,6 +58759,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-12",
     "second_call_number": "8DR1E"
   },
@@ -57130,6 +58783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-11-02",
     "notes": [
       {
@@ -57173,7 +58827,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1656",
@@ -57195,6 +58850,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-03",
     "notes": [
       {
@@ -57256,6 +58912,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-05"
   },
   {
@@ -57277,7 +58934,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1659",
@@ -57299,6 +58957,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -57354,6 +59013,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -57397,6 +59057,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-09"
   },
   {
@@ -57419,6 +59080,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-01",
     "notes": [
       {
@@ -57448,6 +59110,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -57487,6 +59150,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-27",
     "notes": [
       {
@@ -57531,6 +59195,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -57590,6 +59255,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-24",
     "notes": [
       {
@@ -57626,7 +59292,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1668",
@@ -57648,6 +59315,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -57690,7 +59358,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1670",
@@ -57712,6 +59381,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-31"
   },
   {
@@ -57734,6 +59404,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-24",
     "notes": [
       {
@@ -57770,6 +59441,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -57822,6 +59494,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-18"
   },
   {
@@ -57843,7 +59516,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1675",
@@ -57865,6 +59539,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-20"
   },
   {
@@ -57887,6 +59562,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-30"
   },
   {
@@ -57909,6 +59585,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "staff_note",
@@ -57964,6 +59641,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-04",
     "notes": [
       {
@@ -58024,6 +59702,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -58079,6 +59758,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-05-30",
     "notes": [
       {
@@ -58127,6 +59807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-07",
     "notes": [
       {
@@ -58179,6 +59860,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-08",
     "notes": [
       {
@@ -58207,6 +59889,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -58255,6 +59938,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-02",
     "notes": [
       {
@@ -58315,6 +59999,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-10",
     "notes": [
       {
@@ -58347,6 +60032,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-14",
     "notes": [
       {
@@ -58383,6 +60069,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-12"
   },
   {
@@ -58405,6 +60092,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -58464,6 +60152,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 4,
     "second_call_number": "G3HZT"
   },
   {
@@ -58485,7 +60174,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 78
+    "price": 78,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "1691",
@@ -58507,6 +60197,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -58561,7 +60252,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 17
+    "price": 17,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1693",
@@ -58583,6 +60275,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-28",
     "notes": [
       {
@@ -58615,6 +60308,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-31",
     "notes": [
       {
@@ -58668,6 +60362,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-26"
   },
   {
@@ -58690,6 +60385,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-06-19",
     "notes": [
       {
@@ -58742,6 +60438,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-11",
     "notes": [
       {
@@ -58789,7 +60486,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1699",
@@ -58811,6 +60509,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-02-01",
     "notes": [
       {
@@ -58860,6 +60559,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -58911,6 +60611,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-01",
     "second_call_number": "DX6PX"
   },
@@ -58933,7 +60634,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1703",
@@ -58955,6 +60657,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-23",
     "notes": [
       {
@@ -58991,6 +60694,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-02",
     "second_call_number": "TQDQT"
   },
@@ -59014,6 +60718,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-18",
     "notes": [
       {
@@ -59046,6 +60751,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "general_note",
@@ -59094,6 +60800,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -59141,6 +60848,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-25",
     "notes": [
       {
@@ -59197,6 +60905,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -59224,6 +60933,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-03"
   },
   {
@@ -59246,6 +60956,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-09",
     "notes": [
       {
@@ -59277,7 +60988,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 92
+    "price": 92,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1713",
@@ -59299,6 +61011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "second_call_number": "N37DD"
   },
   {
@@ -59321,6 +61034,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-02-21"
   },
   {
@@ -59343,6 +61057,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-15"
   },
   {
@@ -59365,6 +61080,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-06",
     "notes": [
       {
@@ -59420,7 +61136,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 75
+    "price": 75,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1718",
@@ -59441,7 +61158,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1719",
@@ -59463,6 +61181,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -59494,6 +61213,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-07"
   },
   {
@@ -59516,6 +61236,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-05",
     "notes": [
       {
@@ -59548,6 +61269,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -59587,6 +61309,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-09-22",
     "notes": [
       {
@@ -59640,6 +61363,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -59671,6 +61395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -59731,6 +61456,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -59763,6 +61489,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 9,
     "second_call_number": "DZDL8"
   },
   {
@@ -59785,6 +61512,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-14",
     "notes": [
       {
@@ -59817,6 +61545,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-30",
     "notes": [
       {
@@ -59845,6 +61574,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-02-17",
     "notes": [
       {
@@ -59886,6 +61616,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-21",
     "notes": [
       {
@@ -59934,6 +61665,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -59962,6 +61694,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "acquisition_note",
@@ -60013,6 +61746,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-15"
   },
   {
@@ -60035,6 +61769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-13",
     "notes": [
       {
@@ -60063,6 +61798,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkout_note",
@@ -60110,6 +61846,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 1,
     "second_call_number": "FRV0N"
   },
   {
@@ -60132,6 +61869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-05",
     "notes": [
       {
@@ -60173,6 +61911,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkout_note",
@@ -60208,6 +61947,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "condition_note",
@@ -60255,6 +61995,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-18",
     "notes": [
       {
@@ -60294,7 +62035,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1743",
@@ -60316,6 +62058,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -60371,7 +62114,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 46
+    "price": 46,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1745",
@@ -60393,6 +62137,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "general_note",
@@ -60436,7 +62181,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1747",
@@ -60458,6 +62204,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -60493,6 +62240,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -60543,7 +62291,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 35
+    "price": 35,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1750",
@@ -60565,6 +62314,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-15",
     "second_call_number": "BKGA4"
   },
@@ -60588,6 +62338,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-06-08",
     "notes": [
       {
@@ -60620,6 +62371,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-25"
   },
   {
@@ -60642,6 +62394,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-04",
     "second_call_number": "VSKQ7"
   },
@@ -60664,7 +62417,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 32
+    "price": 32,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1755",
@@ -60686,6 +62440,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "acquisition_note",
@@ -60729,6 +62484,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-24",
     "notes": [
       {
@@ -60789,6 +62545,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-10",
     "notes": [
       {
@@ -60822,6 +62579,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -60873,6 +62631,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -60907,7 +62666,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 93
+    "price": 93,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1761",
@@ -60929,6 +62689,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -60969,6 +62730,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-10",
     "notes": [
       {
@@ -61005,6 +62767,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-14"
   },
   {
@@ -61027,6 +62790,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -61067,6 +62831,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-07",
     "notes": [
       {
@@ -61115,6 +62880,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-06"
   },
   {
@@ -61137,6 +62903,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-19"
   },
   {
@@ -61159,6 +62926,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-12",
     "notes": [
       {
@@ -61208,6 +62976,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 4,
     "second_call_number": "WAZVQ"
   },
   {
@@ -61230,6 +62999,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-04",
     "notes": [
       {
@@ -61278,6 +63048,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -61309,6 +63080,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -61360,6 +63132,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-06",
     "second_call_number": "JVKO4"
   },
@@ -61383,6 +63156,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkout_note",
@@ -61415,6 +63189,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -61442,6 +63217,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-06",
     "notes": [
       {
@@ -61470,6 +63246,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-18",
     "notes": [
       {
@@ -61527,6 +63304,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-03-25",
     "notes": [
       {
@@ -61562,7 +63340,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 16
+    "price": 16,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1780",
@@ -61584,6 +63363,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-08-24",
     "notes": [
       {
@@ -61625,6 +63405,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 8,
     "second_call_number": "7FUIQ"
   },
   {
@@ -61647,6 +63428,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -61706,6 +63488,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -61734,6 +63517,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -61786,6 +63570,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-21"
   },
   {
@@ -61807,7 +63592,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1787",
@@ -61829,6 +63615,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 8,
     "second_call_number": "40S84"
   },
   {
@@ -61851,6 +63638,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-06-19",
     "notes": [
       {
@@ -61884,6 +63672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -61916,6 +63705,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-17"
   },
   {
@@ -61938,6 +63728,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-11",
     "notes": [
       {
@@ -61982,6 +63773,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-04-09",
     "notes": [
       {
@@ -62010,6 +63802,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -62041,6 +63834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-15",
     "second_call_number": "F96ZV"
   },
@@ -62064,6 +63858,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -62115,6 +63910,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-01",
     "notes": [
       {
@@ -62144,6 +63940,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-17",
     "notes": [
       {
@@ -62188,6 +63985,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "general_note",
@@ -62215,6 +64013,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-07"
   },
   {
@@ -62237,6 +64036,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-25",
     "notes": [
       {
@@ -62276,7 +64076,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1802",
@@ -62298,6 +64099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-13"
   },
   {
@@ -62320,6 +64122,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-28"
   },
   {
@@ -62342,6 +64145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-11",
     "notes": [
       {
@@ -62383,6 +64187,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-09-13",
     "notes": [
       {
@@ -62439,6 +64244,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-12"
   },
   {
@@ -62461,6 +64267,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -62501,6 +64308,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-12"
   },
   {
@@ -62523,6 +64331,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkout_note",
@@ -62566,6 +64375,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "binding_note",
@@ -62606,6 +64416,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -62637,6 +64448,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -62684,6 +64496,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-09",
     "notes": [
       {
@@ -62733,6 +64546,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "general_note",
@@ -62792,6 +64606,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-26",
     "notes": [
       {
@@ -62829,6 +64644,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-24",
     "notes": [
       {
@@ -62877,6 +64693,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 15,
     "second_call_number": "BQS5G"
   },
   {
@@ -62899,6 +64716,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-26",
     "notes": [
       {
@@ -62927,6 +64745,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-01",
     "notes": [
       {
@@ -62962,7 +64781,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1821",
@@ -62984,6 +64804,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -63032,6 +64853,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkout_note",
@@ -63067,6 +64889,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-17"
   },
   {
@@ -63089,6 +64912,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -63148,6 +64972,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-04"
   },
   {
@@ -63170,6 +64995,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -63205,6 +65031,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -63243,7 +65070,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 98
+    "price": 98,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1829",
@@ -63265,6 +65093,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -63312,6 +65141,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-26"
   },
   {
@@ -63334,6 +65164,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-02",
     "second_call_number": "H0A1D"
   },
@@ -63357,6 +65188,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 1,
     "second_call_number": "75FEK"
   },
   {
@@ -63379,6 +65211,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -63418,6 +65251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-05",
     "second_call_number": "RT6DY"
   },
@@ -63441,6 +65275,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-19",
     "notes": [
       {
@@ -63489,6 +65324,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -63537,6 +65373,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -63580,6 +65417,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-12",
     "notes": [
       {
@@ -63640,6 +65478,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-23",
     "second_call_number": "W1JPO"
   },
@@ -63663,6 +65502,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "acquisition_note",
@@ -63710,6 +65550,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -63765,6 +65606,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-11",
     "notes": [
       {
@@ -63809,6 +65651,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-10-15",
     "notes": [
       {
@@ -63853,6 +65696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-05-02",
     "notes": [
       {
@@ -63913,6 +65757,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-02-01"
   },
   {
@@ -63935,6 +65780,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -63971,6 +65817,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-27",
     "notes": [
       {
@@ -64019,6 +65866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-30"
   },
   {
@@ -64041,6 +65889,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-25",
     "notes": [
       {
@@ -64085,6 +65934,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -64129,6 +65979,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-28",
     "notes": [
       {
@@ -64173,6 +66024,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -64208,6 +66060,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-30"
   },
   {
@@ -64230,6 +66083,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -64285,6 +66139,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -64344,6 +66199,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-06",
     "notes": [
       {
@@ -64393,6 +66249,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-11-02",
     "second_call_number": "CT5TW"
   },
@@ -64416,6 +66273,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -64475,7 +66333,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 90
+    "price": 90,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1860",
@@ -64497,6 +66356,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-29",
     "second_call_number": "8B7FH"
   },
@@ -64519,7 +66379,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 78
+    "price": 78,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1862",
@@ -64541,6 +66402,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-24",
     "notes": [
       {
@@ -64576,7 +66438,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 49
+    "price": 49,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "1864",
@@ -64598,6 +66461,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 9,
     "second_call_number": "PCLND"
   },
   {
@@ -64620,6 +66484,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -64679,6 +66544,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -64726,6 +66592,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "general_note",
@@ -64761,6 +66628,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-30",
     "second_call_number": "WRSBL"
   },
@@ -64784,6 +66652,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-29",
     "notes": [
       {
@@ -64828,6 +66697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-09",
     "notes": [
       {
@@ -64864,6 +66734,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-01"
   },
   {
@@ -64886,6 +66757,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-27",
     "notes": [
       {
@@ -64934,6 +66806,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -64980,7 +66853,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 36
+    "price": 36,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1875",
@@ -65002,6 +66876,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 11,
     "second_call_number": "XP726"
   },
   {
@@ -65024,6 +66899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-12",
     "notes": [
       {
@@ -65052,6 +66928,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -65110,7 +66987,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 11
+    "price": 11,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1879",
@@ -65132,6 +67010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-09-23",
     "second_call_number": "NAZ2D"
   },
@@ -65154,7 +67033,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 50
+    "price": 50,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "1881",
@@ -65176,6 +67056,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -65215,6 +67096,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -65265,7 +67147,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 10
+    "price": 10,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1884",
@@ -65287,6 +67170,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -65331,6 +67215,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-04-07",
     "notes": [
       {
@@ -65380,6 +67265,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -65439,6 +67325,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "general_note",
@@ -65477,7 +67364,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 43
+    "price": 43,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "1889",
@@ -65499,6 +67387,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -65526,6 +67415,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-31",
     "notes": [
       {
@@ -65579,6 +67469,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-03",
     "notes": [
       {
@@ -65607,6 +67498,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 13,
     "second_call_number": "QKBZE"
   },
   {
@@ -65628,7 +67520,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 72
+    "price": 72,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "1894",
@@ -65650,6 +67543,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -65689,6 +67583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -65744,6 +67639,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-16",
     "notes": [
       {
@@ -65800,6 +67696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-19",
     "notes": [
       {
@@ -65832,6 +67729,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-30",
     "notes": [
       {
@@ -65868,6 +67766,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-01",
     "second_call_number": "HH0MP"
   },
@@ -65891,6 +67790,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-04-25",
     "notes": [
       {
@@ -65924,6 +67824,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-09-30"
   },
   {
@@ -65946,6 +67847,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -65993,6 +67895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "staff_note",
@@ -66036,6 +67939,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-22",
     "notes": [
       {
@@ -66064,6 +67968,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -66091,6 +67996,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-11",
     "second_call_number": "RPXB3"
   },
@@ -66114,6 +68020,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-10",
     "notes": [
       {
@@ -66169,7 +68076,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 34
+    "price": 34,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "1909",
@@ -66191,6 +68099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -66241,7 +68150,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "1911",
@@ -66263,6 +68173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-06",
     "notes": [
       {
@@ -66319,6 +68230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-17"
   },
   {
@@ -66341,6 +68253,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-30",
     "notes": [
       {
@@ -66369,6 +68282,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-16",
     "notes": [
       {
@@ -66421,6 +68335,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "general_note",
@@ -66480,6 +68395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -66535,6 +68451,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-07"
   },
   {
@@ -66557,6 +68474,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -66588,6 +68506,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 5,
     "second_call_number": "1F11V"
   },
   {
@@ -66610,6 +68529,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-10",
     "second_call_number": "3N3H9"
   },
@@ -66633,6 +68553,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-25",
     "notes": [
       {
@@ -66672,7 +68593,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "1923",
@@ -66694,6 +68616,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -66722,6 +68645,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-10"
   },
   {
@@ -66744,6 +68668,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-09",
     "notes": [
       {
@@ -66780,6 +68705,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -66839,6 +68765,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-17",
     "notes": [
       {
@@ -66872,6 +68799,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-07",
     "notes": [
       {
@@ -66920,6 +68848,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-06",
     "notes": [
       {
@@ -66968,6 +68897,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -67019,6 +68949,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkin_note",
@@ -67054,6 +68985,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-25"
   },
   {
@@ -67076,6 +69008,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "acquisition_note",
@@ -67116,6 +69049,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-21",
     "notes": [
       {
@@ -67173,6 +69107,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -67208,6 +69143,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-14"
   },
   {
@@ -67230,6 +69166,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -67277,6 +69214,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -67316,6 +69254,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-21",
     "notes": [
       {
@@ -67375,7 +69314,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 15
+    "price": 15,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "1941",
@@ -67397,6 +69337,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-05-23"
   },
   {
@@ -67419,6 +69360,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-08",
     "notes": [
       {
@@ -67452,6 +69394,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-03-25",
     "second_call_number": "BVMLY"
   },
@@ -67475,6 +69418,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-05-15",
     "notes": [
       {
@@ -67515,6 +69459,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-04"
   },
   {
@@ -67537,6 +69482,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-12",
     "notes": [
       {
@@ -67573,6 +69519,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-08"
   },
   {
@@ -67595,6 +69542,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-29"
   },
   {
@@ -67617,6 +69565,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -67676,6 +69625,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-19",
     "second_call_number": "LA3HT"
   },
@@ -67699,6 +69649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-08"
   },
   {
@@ -67721,6 +69672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -67760,6 +69712,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-03-19",
     "notes": [
       {
@@ -67820,6 +69773,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "provenance_note",
@@ -67880,6 +69834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -67919,7 +69874,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 72
+    "price": 72,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1957",
@@ -67941,6 +69897,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-09",
     "notes": [
       {
@@ -67978,6 +69935,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-14"
   },
   {
@@ -68000,6 +69958,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-17",
     "notes": [
       {
@@ -68052,6 +70011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -68088,6 +70048,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -68136,6 +70097,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-18",
     "second_call_number": "7CZO1"
   },
@@ -68159,6 +70121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -68202,6 +70165,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -68246,6 +70210,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -68281,6 +70246,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-02",
     "notes": [
       {
@@ -68308,7 +70274,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 18
+    "price": 18,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "1968",
@@ -68330,6 +70297,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-28",
     "notes": [
       {
@@ -68361,7 +70329,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 55
+    "price": 55,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "1970",
@@ -68383,6 +70352,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-30"
   },
   {
@@ -68405,6 +70375,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -68447,7 +70418,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "1973",
@@ -68469,6 +70441,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-15",
     "notes": [
       {
@@ -68505,6 +70478,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-01",
     "notes": [
       {
@@ -68542,6 +70516,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -68574,6 +70549,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-31",
     "notes": [
       {
@@ -68601,7 +70577,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 5
+    "price": 5,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "1978",
@@ -68623,6 +70600,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-18",
     "notes": [
       {
@@ -68683,6 +70661,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-09"
   },
   {
@@ -68705,6 +70684,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-11-23"
   },
   {
@@ -68727,6 +70707,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-11",
     "notes": [
       {
@@ -68774,7 +70755,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 49
+    "price": 49,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "1983",
@@ -68796,6 +70778,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-09-11",
     "notes": [
       {
@@ -68839,7 +70822,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 26
+    "price": 26,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1985",
@@ -68861,6 +70845,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -68889,6 +70874,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "provenance_note",
@@ -68948,6 +70934,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-14",
     "notes": [
       {
@@ -69008,6 +70995,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-03"
   },
   {
@@ -69029,7 +71017,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 55
+    "price": 55,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "1990",
@@ -69051,6 +71040,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 6,
     "second_call_number": "QSKKK"
   },
   {
@@ -69073,6 +71063,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 6,
     "second_call_number": "AU3AG"
   },
   {
@@ -69095,6 +71086,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-02",
     "notes": [
       {
@@ -69136,6 +71128,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -69166,7 +71159,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 56
+    "price": 56,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "1995",
@@ -69188,6 +71182,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-31",
     "notes": [
       {
@@ -69216,6 +71211,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 9,
     "second_call_number": "IA55J"
   },
   {
@@ -69238,6 +71234,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-05"
   },
   {
@@ -69260,6 +71257,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-29",
     "notes": [
       {
@@ -69316,6 +71314,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -69351,6 +71350,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -69402,6 +71402,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-18",
     "notes": [
       {
@@ -69430,6 +71431,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkout_note",
@@ -69461,6 +71463,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-10-03",
     "notes": [
       {
@@ -69513,6 +71516,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-03",
     "notes": [
       {
@@ -69553,6 +71557,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkout_note",
@@ -69612,6 +71617,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -69648,6 +71654,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-03-25"
   },
   {
@@ -69670,6 +71677,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-02-22",
     "notes": [
       {
@@ -69710,6 +71718,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-27",
     "notes": [
       {
@@ -69758,6 +71767,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-11",
     "notes": [
       {
@@ -69791,6 +71801,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -69831,6 +71842,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-30",
     "notes": [
       {
@@ -69868,6 +71880,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-17"
   },
   {
@@ -69890,6 +71903,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -69921,6 +71935,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-04"
   },
   {
@@ -69943,6 +71958,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-01-18"
   },
   {
@@ -69965,6 +71981,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -70020,6 +72037,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -70051,6 +72069,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-27"
   },
   {
@@ -70073,6 +72092,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -70100,6 +72120,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-09",
     "notes": [
       {
@@ -70155,7 +72176,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 2
+    "price": 2,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2023",
@@ -70177,6 +72199,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-11"
   },
   {
@@ -70199,6 +72222,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-27",
     "notes": [
       {
@@ -70239,6 +72263,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-21",
     "notes": [
       {
@@ -70271,6 +72296,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -70307,6 +72333,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-22",
     "notes": [
       {
@@ -70339,6 +72366,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-21",
     "notes": [
       {
@@ -70391,6 +72419,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-08"
   },
   {
@@ -70412,7 +72441,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 36
+    "price": 36,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2031",
@@ -70433,7 +72463,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 40
+    "price": 40,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2032",
@@ -70455,6 +72486,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 13,
     "second_call_number": "7OJD8"
   },
   {
@@ -70477,6 +72509,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 10,
     "second_call_number": "JZ8YV"
   },
   {
@@ -70499,6 +72532,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -70534,6 +72568,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-04",
     "notes": [
       {
@@ -70595,6 +72630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-24",
     "notes": [
       {
@@ -70638,7 +72674,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2038",
@@ -70660,6 +72697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-06-29"
   },
   {
@@ -70682,6 +72720,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-29",
     "notes": [
       {
@@ -70733,7 +72772,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 8
+    "price": 8,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2041",
@@ -70754,7 +72794,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 78
+    "price": 78,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2042",
@@ -70776,6 +72817,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -70812,6 +72854,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -70848,6 +72891,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-18"
   },
   {
@@ -70870,6 +72914,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-05",
     "notes": [
       {
@@ -70913,7 +72958,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 78
+    "price": 78,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2047",
@@ -70935,6 +72981,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -70963,6 +73010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -70994,7 +73042,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2050",
@@ -71015,7 +73064,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 36
+    "price": 36,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2051",
@@ -71037,6 +73087,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 12,
     "second_call_number": "0HQ62"
   },
   {
@@ -71059,6 +73110,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-08-18",
     "notes": [
       {
@@ -71119,6 +73171,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-06"
   },
   {
@@ -71141,6 +73194,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-01-05",
     "second_call_number": "TH9YO"
   },
@@ -71164,6 +73218,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -71215,6 +73270,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "general_note",
@@ -71271,6 +73327,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "condition_note",
@@ -71302,6 +73359,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -71352,7 +73410,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 65
+    "price": 65,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2060",
@@ -71374,6 +73433,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-13",
     "notes": [
       {
@@ -71433,7 +73493,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 51
+    "price": 51,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2062",
@@ -71455,6 +73516,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-13",
     "second_call_number": "V01PI"
   },
@@ -71478,6 +73540,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-09-04",
     "notes": [
       {
@@ -71522,6 +73585,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-01"
   },
   {
@@ -71543,7 +73607,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 97
+    "price": 97,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2066",
@@ -71565,6 +73630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-22"
   },
   {
@@ -71587,6 +73653,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-19"
   },
   {
@@ -71609,6 +73676,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-01-04",
     "notes": [
       {
@@ -71638,6 +73706,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-03-24"
   },
   {
@@ -71660,6 +73729,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-03-10",
     "notes": [
       {
@@ -71704,6 +73774,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -71758,7 +73829,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2073",
@@ -71780,6 +73852,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-10"
   },
   {
@@ -71802,6 +73875,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -71862,6 +73936,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-16",
     "second_call_number": "UTB7G"
   },
@@ -71885,6 +73960,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-11-27",
     "notes": [
       {
@@ -71933,6 +74009,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-08",
     "notes": [
       {
@@ -71977,6 +74054,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-25",
     "notes": [
       {
@@ -72026,6 +74104,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-27"
   },
   {
@@ -72048,6 +74127,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -72087,6 +74167,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -72122,6 +74203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-25"
   },
   {
@@ -72143,7 +74225,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2084",
@@ -72164,7 +74247,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 18
+    "price": 18,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "2085",
@@ -72186,6 +74270,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -72237,6 +74322,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-21",
     "notes": [
       {
@@ -72273,6 +74359,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-12"
   },
   {
@@ -72295,6 +74382,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -72338,6 +74426,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "condition_note",
@@ -72388,7 +74477,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2091",
@@ -72410,6 +74500,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-01",
     "notes": [
       {
@@ -72467,6 +74558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-09",
     "notes": [
       {
@@ -72504,6 +74596,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-04",
     "notes": [
       {
@@ -72532,7 +74625,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 72
+    "price": 72,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2095",
@@ -72554,6 +74648,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -72584,7 +74679,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2097",
@@ -72606,6 +74702,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-05"
   },
   {
@@ -72627,7 +74724,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 58
+    "price": 58,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2099",
@@ -72648,7 +74746,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2100",
@@ -72670,6 +74769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-04-04",
     "second_call_number": "UMDQK"
   },
@@ -72693,6 +74793,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-14"
   },
   {
@@ -72715,6 +74816,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-12",
     "notes": [
       {
@@ -72743,6 +74845,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-30",
     "notes": [
       {
@@ -72804,6 +74907,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -72851,6 +74955,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-30",
     "notes": [
       {
@@ -72900,6 +75005,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-01"
   },
   {
@@ -72922,6 +75028,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-10",
     "notes": [
       {
@@ -72962,6 +75069,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-06"
   },
   {
@@ -72984,6 +75092,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-12-10",
     "notes": [
       {
@@ -73028,6 +75137,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-12",
     "notes": [
       {
@@ -73056,6 +75166,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -73087,6 +75198,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -73126,7 +75238,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 57
+    "price": 57,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2114",
@@ -73148,6 +75261,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-07"
   },
   {
@@ -73170,6 +75284,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-06"
   },
   {
@@ -73192,6 +75307,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "provenance_note",
@@ -73219,6 +75335,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-19",
     "notes": [
       {
@@ -73263,6 +75380,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-05",
     "notes": [
       {
@@ -73303,6 +75421,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "staff_note",
@@ -73358,6 +75477,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-02-28",
     "notes": [
       {
@@ -73386,6 +75506,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -73429,6 +75550,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-05-08",
     "notes": [
       {
@@ -73458,6 +75580,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-15",
     "notes": [
       {
@@ -73514,6 +75637,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "binding_note",
@@ -73549,6 +75673,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -73592,6 +75717,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -73630,7 +75756,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "2128",
@@ -73652,6 +75779,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -73706,7 +75834,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2130",
@@ -73728,6 +75857,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -73759,6 +75889,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-11",
     "notes": [
       {
@@ -73799,6 +75930,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-03-05"
   },
   {
@@ -73821,6 +75953,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-01-24",
     "notes": [
       {
@@ -73849,6 +75982,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -73877,6 +76011,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-22",
     "notes": [
       {
@@ -73925,6 +76060,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -73981,6 +76117,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-13",
     "notes": [
       {
@@ -74041,7 +76178,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 16
+    "price": 16,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2139",
@@ -74062,7 +76200,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 40
+    "price": 40,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2140",
@@ -74084,6 +76223,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-18"
   },
   {
@@ -74106,6 +76246,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-01",
     "second_call_number": "K6ON8"
   },
@@ -74128,7 +76269,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 72
+    "price": 72,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2143",
@@ -74150,6 +76292,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -74177,6 +76320,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-25",
     "second_call_number": "BRSUC"
   },
@@ -74199,7 +76343,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 53
+    "price": 53,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2146",
@@ -74221,6 +76366,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-30"
   },
   {
@@ -74243,6 +76389,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-30",
     "notes": [
       {
@@ -74300,6 +76447,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "condition_note",
@@ -74351,6 +76499,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 13,
     "second_call_number": "R4ETZ"
   },
   {
@@ -74373,6 +76522,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -74432,6 +76582,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-27",
     "notes": [
       {
@@ -74476,6 +76627,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -74527,6 +76679,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -74563,6 +76716,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-09-27",
     "notes": [
       {
@@ -74599,6 +76753,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "condition_note",
@@ -74626,6 +76781,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-18",
     "notes": [
       {
@@ -74678,6 +76834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-15",
     "second_call_number": "B42RA"
   },
@@ -74700,7 +76857,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 61
+    "price": 61,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2159",
@@ -74722,6 +76880,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-02-20",
     "notes": [
       {
@@ -74782,6 +76941,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-27",
     "second_call_number": "8F83X"
   },
@@ -74805,6 +76965,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-17",
     "notes": [
       {
@@ -74833,6 +76994,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-05"
   },
   {
@@ -74855,6 +77017,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 14,
     "second_call_number": "43DX7"
   },
   {
@@ -74877,6 +77040,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -74912,6 +77076,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-02-08"
   },
   {
@@ -74933,7 +77098,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 36
+    "price": 36,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2167",
@@ -74954,7 +77120,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 80
+    "price": 80,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2168",
@@ -74976,6 +77143,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-06",
     "notes": [
       {
@@ -75004,6 +77172,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-04-06"
   },
   {
@@ -75026,6 +77195,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -75058,6 +77228,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -75097,7 +77268,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 56
+    "price": 56,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2173",
@@ -75119,6 +77291,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-09-16",
     "notes": [
       {
@@ -75162,7 +77335,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 24
+    "price": 24,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2175",
@@ -75183,7 +77357,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 81
+    "price": 81,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2176",
@@ -75205,6 +77380,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-29",
     "notes": [
       {
@@ -75257,6 +77433,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-01-12",
     "notes": [
       {
@@ -75292,7 +77469,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2179",
@@ -75314,6 +77492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "general_note",
@@ -75346,6 +77525,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -75397,6 +77577,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-25",
     "second_call_number": "R8P2B"
   },
@@ -75420,6 +77601,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-11",
     "notes": [
       {
@@ -75476,6 +77658,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-14",
     "notes": [
       {
@@ -75505,6 +77688,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -75548,6 +77732,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -75591,6 +77776,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-10",
     "notes": [
       {
@@ -75635,6 +77821,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-20",
     "notes": [
       {
@@ -75667,6 +77854,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-27"
   },
   {
@@ -75688,7 +77876,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 53
+    "price": 53,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2190",
@@ -75710,6 +77899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "acquisition_note",
@@ -75754,6 +77944,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -75796,7 +77987,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 83
+    "price": 83,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2193",
@@ -75818,6 +78010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -75872,7 +78065,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 4
+    "price": 4,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2195",
@@ -75894,6 +78088,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkout_note",
@@ -75953,6 +78148,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -76013,6 +78209,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-01-01",
     "notes": [
       {
@@ -76054,6 +78251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -76085,6 +78283,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-13",
     "notes": [
       {
@@ -76121,6 +78320,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "provenance_note",
@@ -76156,6 +78356,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-20",
     "notes": [
       {
@@ -76213,6 +78414,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-25",
     "notes": [
       {
@@ -76241,6 +78443,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-03-28"
   },
   {
@@ -76263,6 +78466,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-24",
     "notes": [
       {
@@ -76311,6 +78515,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-01",
     "second_call_number": "O1QPC"
   },
@@ -76334,6 +78539,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -76385,6 +78591,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-03",
     "second_call_number": "CXSSK"
   },
@@ -76408,6 +78615,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-20",
     "notes": [
       {
@@ -76456,6 +78664,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-08-13",
     "notes": [
       {
@@ -76507,7 +78716,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2211",
@@ -76528,7 +78738,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2212",
@@ -76549,7 +78760,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 50
+    "price": 50,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2213",
@@ -76571,6 +78783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -76599,6 +78812,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-07",
     "notes": [
       {
@@ -76632,6 +78846,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-12",
     "notes": [
       {
@@ -76680,6 +78895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-01",
     "second_call_number": "5KJTS"
   },
@@ -76702,7 +78918,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 42
+    "price": 42,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2218",
@@ -76723,7 +78940,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 65
+    "price": 65,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2219",
@@ -76745,6 +78963,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-25"
   },
   {
@@ -76767,6 +78986,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-03-18",
     "notes": [
       {
@@ -76794,7 +79014,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 42
+    "price": 42,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2222",
@@ -76816,6 +79037,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-09",
     "notes": [
       {
@@ -76845,6 +79067,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -76876,6 +79099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-10"
   },
   {
@@ -76898,6 +79122,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-01-01",
     "notes": [
       {
@@ -76933,7 +79158,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2227",
@@ -76955,6 +79181,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-29",
     "notes": [
       {
@@ -77003,6 +79230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-03-15"
   },
   {
@@ -77025,6 +79253,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-14"
   },
   {
@@ -77047,6 +79276,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -77106,6 +79336,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-05-07"
   },
   {
@@ -77127,7 +79358,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2233",
@@ -77149,6 +79381,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -77196,6 +79429,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 8,
     "second_call_number": "YTB9P"
   },
   {
@@ -77217,7 +79451,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 29
+    "price": 29,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2236",
@@ -77238,7 +79473,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 67
+    "price": 67,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2237",
@@ -77260,6 +79496,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-04",
     "notes": [
       {
@@ -77296,6 +79533,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-07-15",
     "second_call_number": "RQPEG"
   },
@@ -77318,7 +79556,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 11
+    "price": 11,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2240",
@@ -77340,6 +79579,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-22",
     "notes": [
       {
@@ -77400,6 +79640,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-18",
     "notes": [
       {
@@ -77456,6 +79697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-15"
   },
   {
@@ -77478,6 +79720,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 3,
     "second_call_number": "JWEAK"
   },
   {
@@ -77500,6 +79743,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-29",
     "notes": [
       {
@@ -77536,6 +79780,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-02-14",
     "notes": [
       {
@@ -77580,6 +79825,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 3,
     "second_call_number": "VFSAH"
   },
   {
@@ -77601,7 +79847,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 7
+    "price": 7,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2248",
@@ -77623,6 +79870,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 10,
     "second_call_number": "H56HB"
   },
   {
@@ -77645,6 +79893,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "staff_note",
@@ -77671,7 +79920,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 47
+    "price": 47,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2251",
@@ -77693,6 +79943,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "acquisition_note",
@@ -77745,6 +79996,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkin_note",
@@ -77781,6 +80033,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -77812,6 +80065,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-01-11",
     "second_call_number": "U6ONU"
   },
@@ -77834,7 +80088,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2256",
@@ -77856,6 +80111,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -77911,6 +80167,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -77962,6 +80219,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkout_note",
@@ -78008,7 +80266,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2260",
@@ -78030,6 +80289,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-03-28"
   },
   {
@@ -78051,7 +80311,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 15
+    "price": 15,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "2262",
@@ -78073,6 +80334,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-16",
     "notes": [
       {
@@ -78109,6 +80371,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "condition_note",
@@ -78157,6 +80420,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-11",
     "notes": [
       {
@@ -78194,6 +80458,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-05"
   },
   {
@@ -78216,6 +80481,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 11,
     "second_call_number": "2RX0V"
   },
   {
@@ -78238,6 +80504,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-10-12",
     "notes": [
       {
@@ -78291,6 +80558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-15",
     "notes": [
       {
@@ -78323,6 +80591,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -78353,7 +80622,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 88
+    "price": 88,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2271",
@@ -78375,6 +80645,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-03-16",
     "notes": [
       {
@@ -78404,6 +80675,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -78451,6 +80723,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-07",
     "notes": [
       {
@@ -78503,6 +80776,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-08",
     "notes": [
       {
@@ -78532,6 +80806,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "general_note",
@@ -78575,6 +80850,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-03-23",
     "notes": [
       {
@@ -78603,6 +80879,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-06",
     "notes": [
       {
@@ -78655,6 +80932,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-13",
     "second_call_number": "F4T3D"
   },
@@ -78678,6 +80956,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-03-06",
     "notes": [
       {
@@ -78738,6 +81017,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-08",
     "notes": [
       {
@@ -78778,6 +81058,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-14",
     "notes": [
       {
@@ -78831,6 +81112,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "binding_note",
@@ -78858,6 +81140,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-10"
   },
   {
@@ -78880,6 +81163,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -78931,6 +81215,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-04",
     "notes": [
       {
@@ -78967,6 +81252,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-11",
     "notes": [
       {
@@ -78999,6 +81285,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-12",
     "notes": [
       {
@@ -79051,6 +81338,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -79102,6 +81390,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-12",
     "notes": [
       {
@@ -79138,6 +81427,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -79197,6 +81487,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-07",
     "notes": [
       {
@@ -79253,7 +81544,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 85
+    "price": 85,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2293",
@@ -79274,7 +81566,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 45
+    "price": 45,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2294",
@@ -79296,6 +81589,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -79355,6 +81649,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-09",
     "notes": [
       {
@@ -79392,6 +81687,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -79419,6 +81715,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-29",
     "notes": [
       {
@@ -79463,6 +81760,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkout_note",
@@ -79513,7 +81811,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2300",
@@ -79535,6 +81834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 1,
     "second_call_number": "EGUY0"
   },
   {
@@ -79556,7 +81856,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 17
+    "price": 17,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2302",
@@ -79577,7 +81878,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 37
+    "price": 37,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2303",
@@ -79599,6 +81901,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -79658,6 +81961,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-08-14",
     "notes": [
       {
@@ -79706,6 +82010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -79765,6 +82070,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-10"
   },
   {
@@ -79787,6 +82093,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-09"
   },
   {
@@ -79809,6 +82116,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -79868,6 +82176,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-08"
   },
   {
@@ -79890,6 +82199,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "general_note",
@@ -79937,6 +82247,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-04",
     "notes": [
       {
@@ -79981,7 +82292,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2313",
@@ -80003,6 +82315,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-01-02",
     "notes": [
       {
@@ -80043,6 +82356,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-06",
     "notes": [
       {
@@ -80071,6 +82385,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-13",
     "second_call_number": "LKCDH"
   },
@@ -80094,6 +82409,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-23",
     "notes": [
       {
@@ -80134,6 +82450,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-08"
   },
   {
@@ -80156,6 +82473,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -80215,6 +82533,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-02",
     "notes": [
       {
@@ -80263,6 +82582,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -80315,6 +82635,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-06",
     "second_call_number": "G6IKB"
   },
@@ -80338,6 +82659,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -80373,6 +82695,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 3,
     "second_call_number": "FULZT"
   },
   {
@@ -80395,6 +82718,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-27"
   },
   {
@@ -80417,6 +82741,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-27",
     "notes": [
       {
@@ -80445,6 +82770,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -80504,6 +82830,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -80559,6 +82886,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-18",
     "notes": [
       {
@@ -80590,7 +82918,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 76
+    "price": 76,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "2330",
@@ -80611,7 +82940,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2331",
@@ -80633,6 +82963,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-29"
   },
   {
@@ -80655,6 +82986,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-13",
     "notes": [
       {
@@ -80708,6 +83040,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -80763,6 +83096,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-06",
     "notes": [
       {
@@ -80824,6 +83158,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -80868,6 +83203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -80915,6 +83251,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-12",
     "notes": [
       {
@@ -80943,6 +83280,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-06",
     "notes": [
       {
@@ -80982,7 +83320,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "2340",
@@ -81004,6 +83343,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-10"
   },
   {
@@ -81026,6 +83366,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 14,
     "second_call_number": "CWBT7"
   },
   {
@@ -81048,6 +83389,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-19",
     "notes": [
       {
@@ -81095,7 +83437,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 45
+    "price": 45,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "2344",
@@ -81117,6 +83460,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-22"
   },
   {
@@ -81139,6 +83483,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-31"
   },
   {
@@ -81161,6 +83506,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-14",
     "notes": [
       {
@@ -81190,6 +83536,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-02",
     "notes": [
       {
@@ -81226,6 +83573,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-26",
     "notes": [
       {
@@ -81270,6 +83618,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-28"
   },
   {
@@ -81291,7 +83640,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 98
+    "price": 98,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2351",
@@ -81313,6 +83663,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -81372,6 +83723,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-29"
   },
   {
@@ -81394,6 +83746,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 3,
     "second_call_number": "HGKE1"
   },
   {
@@ -81416,6 +83769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-30",
     "notes": [
       {
@@ -81465,6 +83819,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-04",
     "notes": [
       {
@@ -81509,6 +83864,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -81556,6 +83912,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -81590,7 +83947,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 49
+    "price": 49,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2359",
@@ -81612,6 +83970,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-23",
     "notes": [
       {
@@ -81660,6 +84019,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-04-08",
     "notes": [
       {
@@ -81721,6 +84081,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-09-17"
   },
   {
@@ -81742,7 +84103,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 26
+    "price": 26,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2363",
@@ -81764,6 +84126,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-17",
     "notes": [
       {
@@ -81812,6 +84175,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 2,
     "second_call_number": "F5HGF"
   },
   {
@@ -81834,6 +84198,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-18"
   },
   {
@@ -81856,6 +84221,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -81886,7 +84252,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 16
+    "price": 16,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2368",
@@ -81908,6 +84275,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -81951,6 +84319,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -82007,6 +84376,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-23",
     "notes": [
       {
@@ -82047,6 +84417,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -82078,6 +84449,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-05",
     "notes": [
       {
@@ -82126,6 +84498,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-15",
     "notes": [
       {
@@ -82158,6 +84531,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -82213,6 +84587,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-01",
     "second_call_number": "0XHS3"
   },
@@ -82236,6 +84611,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-14",
     "notes": [
       {
@@ -82292,6 +84668,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "provenance_note",
@@ -82319,6 +84696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-10"
   },
   {
@@ -82341,6 +84719,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -82376,6 +84755,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-13",
     "notes": [
       {
@@ -82404,6 +84784,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -82436,6 +84817,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-17",
     "notes": [
       {
@@ -82489,6 +84871,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-07",
     "second_call_number": "4J3RC"
   },
@@ -82512,6 +84895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-03-08",
     "notes": [
       {
@@ -82539,7 +84923,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2386",
@@ -82561,6 +84946,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-14",
     "notes": [
       {
@@ -82601,6 +84987,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -82637,6 +85024,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-06",
     "second_call_number": "PEW43"
   },
@@ -82660,6 +85048,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -82699,7 +85088,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2391",
@@ -82721,6 +85111,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "acquisition_note",
@@ -82756,6 +85147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -82790,7 +85182,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 26
+    "price": 26,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2394",
@@ -82811,7 +85204,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2395",
@@ -82833,6 +85227,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-08"
   },
   {
@@ -82854,7 +85249,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 83
+    "price": 83,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "2397",
@@ -82876,6 +85272,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-07"
   },
   {
@@ -82897,7 +85294,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2399",
@@ -82918,7 +85316,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 43
+    "price": 43,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2400",
@@ -82940,6 +85339,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-05",
     "notes": [
       {
@@ -82996,6 +85396,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -83031,6 +85432,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -83078,6 +85480,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-03"
   },
   {
@@ -83100,6 +85503,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-26",
     "notes": [
       {
@@ -83144,6 +85548,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-06",
     "notes": [
       {
@@ -83181,6 +85586,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -83216,6 +85622,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkin_note",
@@ -83247,6 +85654,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 14,
     "second_call_number": "XTYR1"
   },
   {
@@ -83269,6 +85677,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-08"
   },
   {
@@ -83291,6 +85700,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 8,
     "second_call_number": "HYYOC"
   },
   {
@@ -83313,6 +85723,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-04-05",
     "notes": [
       {
@@ -83369,6 +85780,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-03-30",
     "notes": [
       {
@@ -83429,6 +85841,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-03-10",
     "notes": [
       {
@@ -83490,6 +85903,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -83525,7 +85939,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 7
+    "price": 7,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2416",
@@ -83547,6 +85962,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-09-21",
     "notes": [
       {
@@ -83608,6 +86024,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 7,
     "second_call_number": "YUTY6"
   },
   {
@@ -83630,6 +86047,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkout_note",
@@ -83681,6 +86099,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-24"
   },
   {
@@ -83703,6 +86122,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-07"
   },
   {
@@ -83725,6 +86145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-19",
     "notes": [
       {
@@ -83781,6 +86202,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-30",
     "notes": [
       {
@@ -83813,6 +86235,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-20",
     "notes": [
       {
@@ -83853,6 +86276,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-19",
     "notes": [
       {
@@ -83889,6 +86313,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -83924,6 +86349,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-03-07",
     "notes": [
       {
@@ -83975,7 +86401,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2428",
@@ -83997,6 +86424,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -84052,6 +86480,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkin_note",
@@ -84095,6 +86524,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -84130,6 +86560,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-12",
     "notes": [
       {
@@ -84186,6 +86617,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-09",
     "notes": [
       {
@@ -84230,6 +86662,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 14,
     "second_call_number": "VXBBE"
   },
   {
@@ -84252,6 +86685,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-08-15"
   },
   {
@@ -84274,6 +86708,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-03-09",
     "second_call_number": "4HY2J"
   },
@@ -84297,6 +86732,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 2,
     "second_call_number": "74BPW"
   },
   {
@@ -84319,6 +86755,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-17",
     "notes": [
       {
@@ -84362,7 +86799,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 93
+    "price": 93,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2439",
@@ -84383,7 +86821,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 15
+    "price": 15,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2440",
@@ -84405,6 +86844,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-02-15",
     "notes": [
       {
@@ -84432,7 +86872,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 12
+    "price": 12,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "2442",
@@ -84454,6 +86895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -84500,7 +86942,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2444",
@@ -84522,6 +86965,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-09"
   },
   {
@@ -84544,6 +86988,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -84603,6 +87048,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "provenance_note",
@@ -84630,6 +87076,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkin_note",
@@ -84681,6 +87128,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-26",
     "notes": [
       {
@@ -84718,6 +87166,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -84769,6 +87218,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-21",
     "notes": [
       {
@@ -84813,6 +87263,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-31",
     "notes": [
       {
@@ -84862,6 +87313,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "provenance_note",
@@ -84922,6 +87374,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-18",
     "notes": [
       {
@@ -84950,6 +87403,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-16"
   },
   {
@@ -84971,7 +87425,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2456",
@@ -84993,6 +87448,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -85040,6 +87496,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-03",
     "notes": [
       {
@@ -85096,7 +87553,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2459",
@@ -85118,6 +87576,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "second_call_number": "BZ31B"
   },
   {
@@ -85140,6 +87599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-30",
     "notes": [
       {
@@ -85188,6 +87648,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "provenance_note",
@@ -85240,6 +87701,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-18",
     "notes": [
       {
@@ -85284,6 +87746,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-17"
   },
   {
@@ -85306,6 +87769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-26",
     "notes": [
       {
@@ -85343,6 +87807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-04-08",
     "notes": [
       {
@@ -85383,7 +87848,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2467",
@@ -85405,6 +87871,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkin_note",
@@ -85456,6 +87923,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 14,
     "second_call_number": "JC8ML"
   },
   {
@@ -85478,6 +87946,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-18",
     "second_call_number": "BO4YH"
   },
@@ -85501,6 +87970,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-29",
     "notes": [
       {
@@ -85545,6 +88015,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -85600,6 +88071,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-05",
     "notes": [
       {
@@ -85641,6 +88113,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -85700,6 +88173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-08"
   },
   {
@@ -85722,6 +88196,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-26"
   },
   {
@@ -85744,6 +88219,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-06"
   },
   {
@@ -85766,6 +88242,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-23",
     "notes": [
       {
@@ -85798,6 +88275,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -85841,6 +88319,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-28",
     "notes": [
       {
@@ -85901,6 +88380,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -85940,6 +88420,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "provenance_note",
@@ -86000,6 +88481,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 1,
     "second_call_number": "6IGQY"
   },
   {
@@ -86022,6 +88504,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-01-14",
     "notes": [
       {
@@ -86070,7 +88553,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2485",
@@ -86092,6 +88576,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-30"
   },
   {
@@ -86113,7 +88598,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 73
+    "price": 73,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2487",
@@ -86135,6 +88621,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "acquisition_note",
@@ -86193,7 +88680,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2489",
@@ -86214,7 +88702,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 66
+    "price": 66,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2490",
@@ -86236,6 +88725,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-07-20",
     "notes": [
       {
@@ -86268,6 +88758,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-12",
     "second_call_number": "H8SB7"
   },
@@ -86291,6 +88782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -86350,6 +88842,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-28",
     "notes": [
       {
@@ -86394,6 +88887,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-01",
     "notes": [
       {
@@ -86438,6 +88932,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-23",
     "second_call_number": "EWF60"
   },
@@ -86461,6 +88956,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-11-04",
     "second_call_number": "B05U9"
   },
@@ -86484,6 +88980,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-11-30",
     "notes": [
       {
@@ -86523,7 +89020,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 58
+    "price": 58,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2499",
@@ -86544,7 +89042,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 74
+    "price": 74,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2500",
@@ -86566,6 +89065,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-09",
     "notes": [
       {
@@ -86623,6 +89123,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-08-18"
   },
   {
@@ -86645,6 +89146,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkout_note",
@@ -86684,6 +89186,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-03",
     "notes": [
       {
@@ -86712,6 +89215,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 7,
     "second_call_number": "2B3K6"
   },
   {
@@ -86734,6 +89238,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-10",
     "notes": [
       {
@@ -86774,6 +89279,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -86817,6 +89323,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -86865,6 +89372,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "binding_note",
@@ -86892,6 +89400,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-14"
   },
   {
@@ -86914,6 +89423,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-16"
   },
   {
@@ -86936,6 +89446,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "second_call_number": "BSI7Z"
   },
   {
@@ -86958,6 +89469,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-25"
   },
   {
@@ -86980,6 +89492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-04-17",
     "notes": [
       {
@@ -87008,6 +89521,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-02",
     "notes": [
       {
@@ -87056,6 +89570,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "general_note",
@@ -87083,6 +89598,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-01-26",
     "notes": [
       {
@@ -87119,6 +89635,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-10"
   },
   {
@@ -87141,6 +89658,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-12",
     "notes": [
       {
@@ -87190,6 +89708,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-12"
   },
   {
@@ -87211,7 +89730,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 42
+    "price": 42,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "2521",
@@ -87233,6 +89753,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-15",
     "notes": [
       {
@@ -87262,6 +89783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -87317,6 +89839,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -87361,6 +89884,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -87416,6 +89940,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 11,
     "second_call_number": "30BVJ"
   },
   {
@@ -87438,6 +89963,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-20",
     "notes": [
       {
@@ -87470,6 +89996,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -87529,6 +90056,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -87560,6 +90088,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -87596,6 +90125,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -87643,6 +90173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -87702,6 +90233,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-09"
   },
   {
@@ -87724,6 +90256,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-13"
   },
   {
@@ -87746,6 +90279,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -87805,6 +90339,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-30",
     "notes": [
       {
@@ -87861,6 +90396,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-04-05",
     "notes": [
       {
@@ -87894,6 +90430,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-15"
   },
   {
@@ -87916,6 +90453,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-05-14",
     "notes": [
       {
@@ -87952,6 +90490,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -87990,7 +90529,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "2541",
@@ -88012,6 +90552,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -88059,6 +90600,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -88103,6 +90645,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-17"
   },
   {
@@ -88125,6 +90668,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "provenance_note",
@@ -88152,6 +90696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -88191,6 +90736,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-09-18",
     "notes": [
       {
@@ -88238,7 +90784,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2548",
@@ -88260,6 +90807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -88303,6 +90851,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -88342,6 +90891,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "staff_note",
@@ -88373,6 +90923,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -88429,6 +90980,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-03-30"
   },
   {
@@ -88451,6 +91003,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-02-21",
     "notes": [
       {
@@ -88491,6 +91044,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-20",
     "notes": [
       {
@@ -88551,6 +91105,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-07",
     "notes": [
       {
@@ -88592,6 +91147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-23",
     "notes": [
       {
@@ -88644,7 +91200,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 65
+    "price": 65,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2558",
@@ -88665,7 +91222,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 67
+    "price": 67,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2559",
@@ -88687,6 +91245,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-20",
     "notes": [
       {
@@ -88719,6 +91278,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-08",
     "notes": [
       {
@@ -88771,6 +91331,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-05-11"
   },
   {
@@ -88792,7 +91353,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2563",
@@ -88814,6 +91376,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkin_note",
@@ -88845,6 +91408,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-06-26",
     "notes": [
       {
@@ -88901,6 +91465,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-24",
     "notes": [
       {
@@ -88934,6 +91499,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-16",
     "notes": [
       {
@@ -88969,7 +91535,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 98
+    "price": 98,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2568",
@@ -88991,6 +91558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-16",
     "notes": [
       {
@@ -89031,6 +91599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-14"
   },
   {
@@ -89052,7 +91621,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 79
+    "price": 79,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2571",
@@ -89074,6 +91644,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -89108,7 +91679,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2573",
@@ -89129,7 +91701,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 9
+    "price": 9,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "2574",
@@ -89151,6 +91724,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "acquisition_note",
@@ -89190,6 +91764,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-22",
     "second_call_number": "9WQ2T"
   },
@@ -89213,6 +91788,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-05",
     "second_call_number": "HZ1G5"
   },
@@ -89236,6 +91812,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-14",
     "second_call_number": "ECNVD"
   },
@@ -89259,6 +91836,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-14",
     "notes": [
       {
@@ -89312,6 +91890,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -89367,6 +91946,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -89419,6 +91999,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -89462,6 +92043,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-24"
   },
   {
@@ -89484,6 +92066,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-13",
     "notes": [
       {
@@ -89520,6 +92103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "general_note",
@@ -89575,6 +92159,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -89633,7 +92218,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 80
+    "price": 80,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2587",
@@ -89654,7 +92240,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 65
+    "price": 65,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2588",
@@ -89676,6 +92263,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-06-14",
     "notes": [
       {
@@ -89717,6 +92305,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-21",
     "notes": [
       {
@@ -89764,7 +92353,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 9
+    "price": 9,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2591",
@@ -89786,6 +92376,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 11,
     "second_call_number": "SWZG6"
   },
   {
@@ -89808,6 +92399,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-14",
     "notes": [
       {
@@ -89848,6 +92440,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-11",
     "second_call_number": "PF9ZR"
   },
@@ -89871,6 +92464,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -89897,7 +92491,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 95
+    "price": 95,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2596",
@@ -89919,6 +92514,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-16"
   },
   {
@@ -89941,6 +92537,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -89980,6 +92577,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-24"
   },
   {
@@ -90002,6 +92600,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-03-27",
     "notes": [
       {
@@ -90051,6 +92650,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-04-01",
     "notes": [
       {
@@ -90110,7 +92710,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 8
+    "price": 8,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2602",
@@ -90132,6 +92733,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -90184,6 +92786,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 5,
     "second_call_number": "JUYUQ"
   },
   {
@@ -90206,6 +92809,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -90265,6 +92869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-09",
     "notes": [
       {
@@ -90293,6 +92898,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -90336,6 +92942,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-16",
     "notes": [
       {
@@ -90364,6 +92971,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-08-17",
     "notes": [
       {
@@ -90420,6 +93028,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -90475,6 +93084,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-29",
     "notes": [
       {
@@ -90511,6 +93121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-03-14"
   },
   {
@@ -90533,6 +93144,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-12-04",
     "notes": [
       {
@@ -90570,6 +93182,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -90597,6 +93210,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "provenance_note",
@@ -90652,6 +93266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -90711,6 +93326,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -90765,7 +93381,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 73
+    "price": 73,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "2618",
@@ -90787,6 +93404,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "provenance_note",
@@ -90839,6 +93457,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "acquisition_note",
@@ -90878,6 +93497,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-17",
     "second_call_number": "38MHU"
   },
@@ -90901,6 +93521,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "second_call_number": "BC88B"
   },
   {
@@ -90923,6 +93544,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-10-13",
     "second_call_number": "Q16DJ"
   },
@@ -90946,6 +93568,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkout_note",
@@ -90986,6 +93609,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -91046,6 +93670,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -91096,7 +93721,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 4
+    "price": 4,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "2627",
@@ -91117,7 +93743,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 10
+    "price": 10,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "2628",
@@ -91139,6 +93766,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -91182,6 +93810,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-28",
     "notes": [
       {
@@ -91226,6 +93855,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-11-01",
     "notes": [
       {
@@ -91282,6 +93912,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-30",
     "notes": [
       {
@@ -91322,6 +93953,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -91365,6 +93997,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-15",
     "notes": [
       {
@@ -91424,7 +94057,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 48
+    "price": 48,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2635",
@@ -91446,6 +94080,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-14",
     "notes": [
       {
@@ -91478,6 +94113,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-04-23",
     "notes": [
       {
@@ -91538,6 +94174,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -91588,7 +94225,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 71
+    "price": 71,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2639",
@@ -91610,6 +94248,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-15"
   },
   {
@@ -91632,6 +94271,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 8,
     "second_call_number": "X4VCE"
   },
   {
@@ -91654,6 +94294,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -91697,6 +94338,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-09"
   },
   {
@@ -91719,6 +94361,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "condition_note",
@@ -91771,6 +94414,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-18",
     "notes": [
       {
@@ -91804,6 +94448,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-07-25",
     "notes": [
       {
@@ -91852,7 +94497,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 73
+    "price": 73,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2647",
@@ -91874,6 +94520,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-09-21",
     "notes": [
       {
@@ -91903,6 +94550,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-06-15"
   },
   {
@@ -91925,6 +94573,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-17",
     "notes": [
       {
@@ -91960,7 +94609,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 88
+    "price": 88,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2651",
@@ -91982,6 +94632,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -92025,6 +94676,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "staff_note",
@@ -92072,6 +94724,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "acquisition_note",
@@ -92131,6 +94784,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-03"
   },
   {
@@ -92153,6 +94807,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "provenance_note",
@@ -92212,6 +94867,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -92243,6 +94899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkin_note",
@@ -92274,7 +94931,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 62
+    "price": 62,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "2659",
@@ -92296,6 +94954,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-14"
   },
   {
@@ -92318,6 +94977,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-18"
   },
   {
@@ -92339,7 +94999,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2662",
@@ -92361,6 +95022,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -92409,6 +95071,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "acquisition_note",
@@ -92440,6 +95103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-28"
   },
   {
@@ -92462,6 +95126,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-02",
     "notes": [
       {
@@ -92510,6 +95175,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-10-06"
   },
   {
@@ -92532,6 +95198,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-31",
     "notes": [
       {
@@ -92575,7 +95242,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "2669",
@@ -92597,6 +95265,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-01-13",
     "notes": [
       {
@@ -92644,7 +95313,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 84
+    "price": 84,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2671",
@@ -92665,7 +95335,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "2672",
@@ -92687,6 +95358,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-24"
   },
   {
@@ -92708,7 +95380,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 14
+    "price": 14,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2674",
@@ -92730,6 +95403,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-02",
     "second_call_number": "W0HUV"
   },
@@ -92752,7 +95426,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 31
+    "price": 31,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2676",
@@ -92774,6 +95449,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -92817,6 +95493,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 14,
     "second_call_number": "C7JMA"
   },
   {
@@ -92839,6 +95516,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-21",
     "notes": [
       {
@@ -92871,6 +95549,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-12",
     "notes": [
       {
@@ -92904,6 +95583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-04",
     "notes": [
       {
@@ -92965,6 +95645,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "provenance_note",
@@ -93012,6 +95693,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-09-12",
     "notes": [
       {
@@ -93073,6 +95755,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 6,
     "second_call_number": "YG2LA"
   },
   {
@@ -93095,6 +95778,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "general_note",
@@ -93154,6 +95838,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -93205,6 +95890,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -93232,6 +95918,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-07"
   },
   {
@@ -93254,6 +95941,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -93305,6 +95993,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -93365,6 +96054,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -93400,6 +96090,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -93440,6 +96131,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "general_note",
@@ -93490,7 +96182,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2694",
@@ -93511,7 +96204,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2695",
@@ -93533,6 +96227,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -93564,6 +96259,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-04-15"
   },
   {
@@ -93586,6 +96282,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-01-18",
     "notes": [
       {
@@ -93641,7 +96338,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "2699",
@@ -93663,6 +96361,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -93690,6 +96389,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 11,
     "second_call_number": "LRL30"
   },
   {
@@ -93711,7 +96411,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 43
+    "price": 43,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "2702",
@@ -93733,6 +96434,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-14"
   },
   {
@@ -93755,6 +96457,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-17",
     "notes": [
       {
@@ -93799,6 +96502,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 14,
     "second_call_number": "OOQ4S"
   },
   {
@@ -93821,6 +96525,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -93871,7 +96576,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 51
+    "price": 51,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "2707",
@@ -93893,6 +96599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-01"
   },
   {
@@ -93915,6 +96622,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-09",
     "notes": [
       {
@@ -93955,6 +96663,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-13",
     "notes": [
       {
@@ -94011,6 +96720,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-03",
     "notes": [
       {
@@ -94059,7 +96769,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 41
+    "price": 41,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "2712",
@@ -94081,6 +96792,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 4,
     "second_call_number": "ODM5T"
   },
   {
@@ -94103,6 +96815,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-09",
     "notes": [
       {
@@ -94135,6 +96848,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-02-28"
   },
   {
@@ -94156,7 +96870,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 32
+    "price": 32,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "2716",
@@ -94178,6 +96893,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-20",
     "notes": [
       {
@@ -94231,6 +96947,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -94274,6 +96991,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-02"
   },
   {
@@ -94296,6 +97014,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "binding_note",
@@ -94342,7 +97061,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 52
+    "price": 52,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "2721",
@@ -94364,6 +97084,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "provenance_note",
@@ -94390,7 +97111,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 52
+    "price": 52,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "2723",
@@ -94411,7 +97133,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 85
+    "price": 85,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "2724",
@@ -94432,7 +97155,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 18
+    "price": 18,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "2725",
@@ -94454,6 +97178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-08"
   },
   {
@@ -94475,6 +97200,7 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 26
+    "price": 26,
+    "legacy_checkout_count": 14
   }
 ]

--- a/data/items_small.json
+++ b/data/items_small.json
@@ -19,6 +19,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -66,6 +67,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -101,6 +103,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -132,6 +135,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-29",
     "notes": [
       {
@@ -188,6 +192,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -219,6 +224,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -253,7 +259,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 79
+    "price": 79,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "8",
@@ -275,6 +282,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -302,6 +310,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "staff_note",
@@ -354,6 +363,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-29"
   },
   {
@@ -376,6 +386,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-18",
     "notes": [
       {
@@ -425,6 +436,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-16",
     "second_call_number": "19LI6"
   },
@@ -447,7 +459,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 79
+    "price": 79,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "14",
@@ -469,6 +482,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -521,6 +535,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-29"
   },
   {
@@ -543,6 +558,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-04",
     "notes": [
       {
@@ -583,6 +599,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkin_note",
@@ -627,6 +644,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-15",
     "second_call_number": "EGPJK"
   },
@@ -650,6 +668,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 4,
     "second_call_number": "CMF11"
   },
   {
@@ -672,6 +691,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-27"
   },
   {
@@ -694,6 +714,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -745,6 +766,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-06",
     "notes": [
       {
@@ -800,7 +822,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "24",
@@ -822,6 +845,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-01",
     "second_call_number": "EAI3G"
   },
@@ -845,6 +869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-22",
     "second_call_number": "RCS0E"
   },
@@ -868,6 +893,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-05",
     "notes": [
       {
@@ -928,6 +954,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -955,6 +982,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 5,
     "second_call_number": "GURHS"
   },
   {
@@ -977,6 +1005,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-25",
     "second_call_number": "T2HR5"
   },
@@ -1000,6 +1029,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-17",
     "second_call_number": "SCZA7"
   },
@@ -1022,7 +1052,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 53
+    "price": 53,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "32",
@@ -1043,7 +1074,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 81
+    "price": 81,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "33",
@@ -1065,6 +1097,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-27"
   },
   {
@@ -1087,6 +1120,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -1139,6 +1173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-15",
     "notes": [
       {
@@ -1187,6 +1222,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-07-31"
   },
   {
@@ -1209,6 +1245,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "condition_note",
@@ -1236,6 +1273,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-18",
     "notes": [
       {
@@ -1271,7 +1309,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 59
+    "price": 59,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "40",
@@ -1293,6 +1332,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkin_note",
@@ -1336,6 +1376,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -1367,6 +1408,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -1423,6 +1465,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-03",
     "notes": [
       {
@@ -1460,6 +1503,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-12",
     "notes": [
       {
@@ -1500,6 +1544,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-03-25",
     "notes": [
       {
@@ -1528,6 +1573,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -1579,6 +1625,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -1630,6 +1677,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-06",
     "notes": [
       {
@@ -1666,6 +1714,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -1725,6 +1774,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-29"
   },
   {
@@ -1747,6 +1797,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-26"
   },
   {
@@ -1769,6 +1820,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-03"
   },
   {
@@ -1791,6 +1843,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-02-26"
   },
   {
@@ -1813,6 +1866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -1841,6 +1895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -1900,6 +1955,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-04-02"
   },
   {
@@ -1922,6 +1978,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -1961,6 +2018,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-02",
     "notes": [
       {
@@ -1993,6 +2051,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-27",
     "notes": [
       {
@@ -2029,6 +2088,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 4,
     "second_call_number": "EYPGZ"
   },
   {
@@ -2050,7 +2110,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 85
+    "price": 85,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "62",
@@ -2072,6 +2133,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-11",
     "second_call_number": "COHN8"
   },
@@ -2095,6 +2157,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-17",
     "notes": [
       {
@@ -2146,7 +2209,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 67
+    "price": 67,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "65",
@@ -2168,6 +2232,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-04",
     "notes": [
       {
@@ -2196,6 +2261,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-01"
   },
   {
@@ -2218,6 +2284,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-04-06"
   },
   {
@@ -2240,6 +2307,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 3,
     "second_call_number": "U8AFH"
   },
   {
@@ -2261,7 +2329,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "70",
@@ -2282,7 +2351,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "71",
@@ -2304,6 +2374,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-18",
     "second_call_number": "ZZN2Y"
   },
@@ -2327,6 +2398,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-04-05"
   },
   {
@@ -2349,6 +2421,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-03-24",
     "notes": [
       {
@@ -2397,6 +2470,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-27"
   },
   {
@@ -2418,7 +2492,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 23
+    "price": 23,
+    "legacy_checkout_count": 6
   },
   {
     "pid": "76",
@@ -2440,6 +2515,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -2491,7 +2567,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 43
+    "price": 43,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "78",
@@ -2513,6 +2590,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -2568,6 +2646,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-23"
   },
   {
@@ -2590,6 +2669,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-01",
     "notes": [
       {
@@ -2646,6 +2726,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-23"
   },
   {
@@ -2668,6 +2749,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-21",
     "notes": [
       {
@@ -2728,6 +2810,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 94,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -2783,6 +2866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-15",
     "notes": [
       {
@@ -2818,7 +2902,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "86",
@@ -2840,6 +2925,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -2875,6 +2961,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-10-23"
   },
   {
@@ -2897,6 +2984,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -2952,6 +3040,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-26",
     "notes": [
       {
@@ -2996,6 +3085,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -3046,7 +3136,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 71
+    "price": 71,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "92",
@@ -3067,7 +3158,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "93",
@@ -3088,7 +3180,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "94",
@@ -3110,6 +3203,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-24"
   },
   {
@@ -3132,6 +3226,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-23",
     "notes": [
       {
@@ -3184,6 +3279,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-24",
     "second_call_number": "EJA89"
   },
@@ -3207,6 +3303,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "staff_note",
@@ -3246,6 +3343,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-05",
     "notes": [
       {
@@ -3286,6 +3384,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -3321,6 +3420,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -3352,6 +3452,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-18"
   },
   {
@@ -3374,6 +3475,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 11,
     "second_call_number": "M74Q6"
   },
   {
@@ -3395,7 +3497,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 15
+    "price": 15,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "104",
@@ -3417,6 +3520,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -3452,6 +3556,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-28",
     "notes": [
       {
@@ -3501,6 +3606,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-05",
     "notes": [
       {
@@ -3549,6 +3655,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -3601,6 +3708,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-03-22",
     "notes": [
       {
@@ -3661,6 +3769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-01-22"
   },
   {
@@ -3683,6 +3792,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -3730,6 +3840,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-10",
     "second_call_number": "YH2D7"
   },
@@ -3753,6 +3864,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-07-07",
     "notes": [
       {
@@ -3793,6 +3905,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -3853,6 +3966,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 8,
     "second_call_number": "BQKOM"
   },
   {
@@ -3875,6 +3989,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-12-04"
   },
   {
@@ -3897,6 +4012,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -3928,6 +4044,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-05-27",
     "notes": [
       {
@@ -3980,6 +4097,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -4027,6 +4145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-03-27",
     "second_call_number": "9X6Z3"
   },
@@ -4049,7 +4168,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "121",
@@ -4071,6 +4191,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -4123,6 +4244,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-12"
   },
   {
@@ -4145,6 +4267,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-04",
     "notes": [
       {
@@ -4205,6 +4328,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -4239,7 +4363,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 52
+    "price": 52,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "126",
@@ -4260,7 +4385,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 47
+    "price": 47,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "127",
@@ -4282,6 +4408,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "second_call_number": "6SMH6"
   },
   {
@@ -4304,6 +4431,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-08"
   },
   {
@@ -4326,6 +4454,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -4361,6 +4490,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-20",
     "notes": [
       {
@@ -4413,6 +4543,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-07-02"
   },
   {
@@ -4435,6 +4566,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -4490,6 +4622,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -4541,7 +4674,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 37
+    "price": 37,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "135",
@@ -4563,6 +4697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "staff_note",
@@ -4606,6 +4741,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-12"
   },
   {
@@ -4628,6 +4764,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-28",
     "notes": [
       {
@@ -4687,7 +4824,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 20
+    "price": 20,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "139",
@@ -4709,6 +4847,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -4740,7 +4879,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 42
+    "price": 42,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "141",
@@ -4762,6 +4902,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -4790,6 +4931,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-15",
     "notes": [
       {
@@ -4838,6 +4980,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 9,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkin_note",
@@ -4897,7 +5040,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "145",
@@ -4919,6 +5063,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-07"
   },
   {
@@ -4941,6 +5086,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -4972,6 +5118,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -5004,6 +5151,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "acquisition_note",
@@ -5038,7 +5186,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "150",
@@ -5060,6 +5209,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-08",
     "notes": [
       {
@@ -5112,6 +5262,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-04",
     "notes": [
       {
@@ -5159,7 +5310,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "153",
@@ -5180,7 +5332,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 58
+    "price": 58,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "154",
@@ -5201,7 +5354,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 95
+    "price": 95,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "155",
@@ -5223,6 +5377,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -5274,6 +5429,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 6,
     "second_call_number": "YC8IE"
   },
   {
@@ -5296,6 +5452,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-10"
   },
   {
@@ -5318,6 +5475,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-21",
     "notes": [
       {
@@ -5346,6 +5504,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "provenance_note",
@@ -5389,6 +5548,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-27",
     "notes": [
       {
@@ -5426,6 +5586,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -5477,6 +5638,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 6,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "binding_note",
@@ -5528,6 +5690,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -5571,7 +5734,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 60
+    "price": 60,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "165",
@@ -5593,6 +5757,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -5648,6 +5813,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkin_note",
@@ -5687,6 +5853,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-18",
     "notes": [
       {
@@ -5727,6 +5894,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-11-03"
   },
   {
@@ -5749,6 +5917,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -5784,6 +5953,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "staff_note",
@@ -5811,6 +5981,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-01-05",
     "notes": [
       {
@@ -5867,6 +6038,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-02-05"
   },
   {
@@ -5889,6 +6061,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-11"
   },
   {
@@ -5911,6 +6084,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "condition_note",
@@ -5951,6 +6125,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "binding_note",
@@ -6010,6 +6185,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -6057,6 +6233,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 5,
     "second_call_number": "70OY6"
   },
   {
@@ -6079,6 +6256,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-29",
     "second_call_number": "ZHGHI"
   },
@@ -6101,7 +6279,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 77
+    "price": 77,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "180",
@@ -6123,6 +6302,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-05-29"
   },
   {
@@ -6145,6 +6325,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-03-15",
     "notes": [
       {
@@ -6189,6 +6370,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "binding_note",
@@ -6244,6 +6426,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-02-11",
     "notes": [
       {
@@ -6284,6 +6467,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 15,
     "second_call_number": "XNIZT"
   },
   {
@@ -6306,6 +6490,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "acquisition_note",
@@ -6361,6 +6546,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-03-09",
     "notes": [
       {
@@ -6402,6 +6588,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 33,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -6450,6 +6637,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-11-23",
     "notes": [
       {
@@ -6506,6 +6694,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -6533,6 +6722,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -6564,6 +6754,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-20",
     "notes": [
       {
@@ -6624,6 +6815,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-25",
     "notes": [
       {
@@ -6653,6 +6845,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 3,
     "second_call_number": "PIWBF"
   },
   {
@@ -6675,6 +6868,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 10,
     "second_call_number": "G41NS"
   },
   {
@@ -6697,6 +6891,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-25"
   },
   {
@@ -6719,6 +6914,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -6745,7 +6941,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 47
+    "price": 47,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "198",
@@ -6767,6 +6964,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-27"
   },
   {
@@ -6788,7 +6986,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 94
+    "price": 94,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "200",
@@ -6810,6 +7009,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-02-23",
     "notes": [
       {
@@ -6859,6 +7059,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-21"
   },
   {
@@ -6881,6 +7082,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-11",
     "notes": [
       {
@@ -6922,6 +7124,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-08-06",
     "notes": [
       {
@@ -6974,6 +7177,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-13",
     "notes": [
       {
@@ -7010,6 +7214,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-04-08",
     "notes": [
       {
@@ -7038,6 +7243,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 9,
     "second_call_number": "HO667"
   },
   {
@@ -7060,6 +7266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "checkin_note",
@@ -7100,6 +7307,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-03-08",
     "notes": [
       {
@@ -7148,6 +7356,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-05-14",
     "notes": [
       {
@@ -7204,6 +7413,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 10,
     "second_call_number": "QD0AR"
   },
   {
@@ -7226,6 +7436,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-07",
     "notes": [
       {
@@ -7255,6 +7466,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -7314,6 +7526,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-11-19",
     "notes": [
       {
@@ -7346,6 +7559,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-12"
   },
   {
@@ -7368,6 +7582,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-26",
     "notes": [
       {
@@ -7396,6 +7611,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-01-21",
     "notes": [
       {
@@ -7432,6 +7648,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-06-13",
     "second_call_number": "4ZMY0"
   },
@@ -7455,6 +7672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-18"
   },
   {
@@ -7477,6 +7695,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -7517,6 +7736,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-05-13"
   },
   {
@@ -7538,7 +7758,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 11
+    "price": 11,
+    "legacy_checkout_count": 12
   },
   {
     "pid": "222",
@@ -7560,6 +7781,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -7587,6 +7809,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-11-24"
   },
   {
@@ -7609,6 +7832,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-11-02"
   },
   {
@@ -7631,6 +7855,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-07-24"
   },
   {
@@ -7653,6 +7878,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-29",
     "notes": [
       {
@@ -7686,6 +7912,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "condition_note",
@@ -7726,6 +7953,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -7774,6 +8002,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-31",
     "notes": [
       {
@@ -7817,7 +8046,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 16
+    "price": 16,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "231",
@@ -7839,6 +8069,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-10-05",
     "second_call_number": "78X0B"
   },
@@ -7862,6 +8093,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-12-28",
     "notes": [
       {
@@ -7910,6 +8142,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-07",
     "notes": [
       {
@@ -7955,6 +8188,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-05-08",
     "notes": [
       {
@@ -7991,6 +8225,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-10-02",
     "notes": [
       {
@@ -8047,6 +8282,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-28"
   },
   {
@@ -8069,6 +8305,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-14"
   },
   {
@@ -8091,6 +8328,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "binding_note",
@@ -8130,6 +8368,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-03"
   },
   {
@@ -8151,7 +8390,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 58
+    "price": 58,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "241",
@@ -8173,6 +8413,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 15,
     "second_call_number": "M0JCG"
   },
   {
@@ -8195,6 +8436,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-25",
     "notes": [
       {
@@ -8236,6 +8478,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-04-06",
     "notes": [
       {
@@ -8285,6 +8528,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -8327,7 +8571,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 25
+    "price": 25,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "246",
@@ -8348,7 +8593,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 6
+    "price": 6,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "247",
@@ -8369,7 +8615,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 1
+    "price": 1,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "248",
@@ -8391,6 +8638,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-29",
     "notes": [
       {
@@ -8435,6 +8683,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-04-06",
     "notes": [
       {
@@ -8480,6 +8729,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -8532,6 +8782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -8590,7 +8841,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 10
+    "price": 10,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "253",
@@ -8612,6 +8864,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -8643,6 +8896,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 34,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-09-14"
   },
   {
@@ -8665,6 +8919,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-04-09",
     "notes": [
       {
@@ -8713,6 +8968,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -8760,7 +9016,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 3
+    "price": 3,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "258",
@@ -8782,6 +9039,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-01-31"
   },
   {
@@ -8804,6 +9062,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 82,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-28",
     "notes": [
       {
@@ -8848,6 +9107,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "staff_note",
@@ -8899,6 +9159,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-20"
   },
   {
@@ -8921,6 +9182,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "general_note",
@@ -8955,7 +9217,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 15
+    "price": 15,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "264",
@@ -8976,7 +9239,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 87
+    "price": 87,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "265",
@@ -8998,6 +9262,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-02-24",
     "notes": [
       {
@@ -9049,7 +9314,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "267",
@@ -9071,6 +9337,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -9110,7 +9377,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 15
   },
   {
     "pid": "269",
@@ -9132,6 +9400,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-25",
     "notes": [
       {
@@ -9184,6 +9453,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-18",
     "second_call_number": "XXU6E"
   },
@@ -9206,7 +9476,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 45
+    "price": 45,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "272",
@@ -9228,6 +9499,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -9267,6 +9539,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "general_note",
@@ -9310,6 +9583,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "staff_note",
@@ -9361,6 +9635,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "condition_note",
@@ -9412,6 +9687,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-04-01"
   },
   {
@@ -9434,6 +9710,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-03-11"
   },
   {
@@ -9456,6 +9733,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-08-25",
     "notes": [
       {
@@ -9488,6 +9766,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-12",
     "notes": [
       {
@@ -9529,6 +9808,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "acquisition_note",
@@ -9584,6 +9864,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 10,
     "second_call_number": "5X2WQ"
   },
   {
@@ -9605,7 +9886,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 2
+    "price": 2,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "283",
@@ -9627,6 +9909,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-17",
     "notes": [
       {
@@ -9683,6 +9966,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -9726,6 +10010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -9785,6 +10070,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-15",
     "notes": [
       {
@@ -9837,6 +10123,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-06"
   },
   {
@@ -9859,6 +10146,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkin_note",
@@ -9910,6 +10198,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-04",
     "notes": [
       {
@@ -9958,7 +10247,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 37
+    "price": 37,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "291",
@@ -9979,7 +10269,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 30
+    "price": 30,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "292",
@@ -10000,7 +10291,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 75
+    "price": 75,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "293",
@@ -10022,6 +10314,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-15",
     "notes": [
       {
@@ -10073,7 +10366,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 71
+    "price": 71,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "295",
@@ -10095,6 +10389,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-21",
     "second_call_number": "42Z1B"
   },
@@ -10118,6 +10413,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-11"
   },
   {
@@ -10140,6 +10436,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-09",
     "notes": [
       {
@@ -10168,6 +10465,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 1,
     "second_call_number": "YMJ44"
   },
   {
@@ -10190,6 +10488,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-11-15"
   },
   {
@@ -10212,6 +10511,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-27"
   },
   {
@@ -10234,6 +10534,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-03-23"
   },
   {
@@ -10256,6 +10557,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-07-22",
     "notes": [
       {
@@ -10300,6 +10602,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-05-24"
   },
   {
@@ -10322,6 +10625,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-03"
   },
   {
@@ -10343,7 +10647,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "306",
@@ -10365,6 +10670,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -10424,7 +10730,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 28
+    "price": 28,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "308",
@@ -10446,6 +10753,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkin_note",
@@ -10501,6 +10809,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "acquisition_note",
@@ -10560,6 +10869,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 88,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "binding_note",
@@ -10595,6 +10905,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -10639,6 +10950,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -10670,6 +10982,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-18",
     "notes": [
       {
@@ -10719,6 +11032,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -10751,6 +11065,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-12-24",
     "notes": [
       {
@@ -10806,7 +11121,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 15
+    "price": 15,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "317",
@@ -10828,6 +11144,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -10859,6 +11176,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "condition_note",
@@ -10885,7 +11203,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 89
+    "price": 89,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "320",
@@ -10907,6 +11226,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-26",
     "notes": [
       {
@@ -10946,7 +11266,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 84
+    "price": 84,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "322",
@@ -10968,6 +11289,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -11027,6 +11349,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-03-16",
     "notes": [
       {
@@ -11059,6 +11382,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "general_note",
@@ -11090,6 +11414,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-10-26",
     "notes": [
       {
@@ -11151,6 +11476,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-05",
     "notes": [
       {
@@ -11179,7 +11505,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 96
+    "price": 96,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "328",
@@ -11201,6 +11528,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -11256,6 +11584,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-04-14",
     "notes": [
       {
@@ -11297,6 +11626,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-02-01",
     "notes": [
       {
@@ -11333,6 +11663,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -11384,6 +11715,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-08-08"
   },
   {
@@ -11406,6 +11738,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-16",
     "notes": [
       {
@@ -11465,7 +11798,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 54
+    "price": 54,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "335",
@@ -11487,6 +11821,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-05-18",
     "notes": [
       {
@@ -11547,6 +11882,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-16",
     "notes": [
       {
@@ -11608,6 +11944,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-07-26",
     "notes": [
       {
@@ -11639,7 +11976,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 67
+    "price": 67,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "339",
@@ -11661,6 +11999,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -11692,6 +12031,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "checkin_note",
@@ -11739,6 +12079,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-05-24",
     "notes": [
       {
@@ -11779,7 +12120,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "343",
@@ -11801,6 +12143,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-26",
     "notes": [
       {
@@ -11857,6 +12200,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-23",
     "notes": [
       {
@@ -11886,6 +12230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-10",
     "notes": [
       {
@@ -11922,6 +12267,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-28"
   },
   {
@@ -11944,6 +12290,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "checkout_note",
@@ -11975,6 +12322,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -12006,6 +12354,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-15"
   },
   {
@@ -12028,6 +12377,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 6,
     "second_call_number": "DF24Z"
   },
   {
@@ -12050,6 +12400,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-21",
     "notes": [
       {
@@ -12098,7 +12449,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 96
+    "price": 96,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "353",
@@ -12120,6 +12472,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-09-17"
   },
   {
@@ -12142,6 +12495,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "acquisition_note",
@@ -12177,6 +12531,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -12208,6 +12563,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 11,
     "second_call_number": "6SJFG"
   },
   {
@@ -12230,6 +12586,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-28",
     "notes": [
       {
@@ -12290,7 +12647,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 27
+    "price": 27,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "359",
@@ -12312,6 +12670,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-03"
   },
   {
@@ -12334,6 +12693,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -12381,6 +12741,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "checkin_note",
@@ -12433,6 +12794,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-30",
     "second_call_number": "CFM8A"
   },
@@ -12456,6 +12818,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "provenance_note",
@@ -12516,6 +12879,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2021-04-02",
     "second_call_number": "ARYZ0"
   },
@@ -12539,6 +12903,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 4,
     "second_call_number": "QTRYH"
   },
   {
@@ -12561,6 +12926,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-09-08",
     "notes": [
       {
@@ -12593,6 +12959,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "staff_note",
@@ -12641,6 +13008,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-05-15",
     "second_call_number": "UJ3TX"
   },
@@ -12664,6 +13032,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 61,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-24"
   },
   {
@@ -12686,6 +13055,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "checkin_note",
@@ -12721,6 +13091,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-08",
     "notes": [
       {
@@ -12757,6 +13128,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -12804,6 +13176,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 54,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-12-20",
     "notes": [
       {
@@ -12857,6 +13230,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-26",
     "notes": [
       {
@@ -12885,6 +13259,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -12912,6 +13287,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 2,
     "second_call_number": "5PP8U"
   },
   {
@@ -12934,6 +13310,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-03-13",
     "notes": [
       {
@@ -12971,6 +13348,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-06-22"
   },
   {
@@ -12993,6 +13371,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-20",
     "second_call_number": "VNYRR"
   },
@@ -13016,6 +13395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-12"
   },
   {
@@ -13038,6 +13418,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-09"
   },
   {
@@ -13060,6 +13441,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 18,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -13087,6 +13469,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "condition_note",
@@ -13138,6 +13521,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-23",
     "notes": [
       {
@@ -13194,6 +13578,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "staff_note",
@@ -13245,6 +13630,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -13284,6 +13670,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkin_note",
@@ -13335,6 +13722,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-14",
     "notes": [
       {
@@ -13379,6 +13767,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-04-01",
     "notes": [
       {
@@ -13439,6 +13828,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "condition_note",
@@ -13466,6 +13856,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 40,
+    "legacy_checkout_count": 11,
     "second_call_number": "REWWW"
   },
   {
@@ -13488,6 +13879,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -13536,6 +13928,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-04-18",
     "notes": [
       {
@@ -13585,6 +13978,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-03-20",
     "notes": [
       {
@@ -13633,6 +14027,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-09-21"
   },
   {
@@ -13655,6 +14050,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -13682,6 +14078,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-02",
     "notes": [
       {
@@ -13718,6 +14115,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -13749,6 +14147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-04-03",
     "notes": [
       {
@@ -13789,6 +14188,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 28,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-16"
   },
   {
@@ -13811,6 +14211,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 5,
     "second_call_number": "RHGXN"
   },
   {
@@ -13833,6 +14234,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-13",
     "notes": [
       {
@@ -13866,6 +14268,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-12-01"
   },
   {
@@ -13888,6 +14291,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 79,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-15"
   },
   {
@@ -13910,6 +14314,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 51,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-09-17"
   },
   {
@@ -13932,6 +14337,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkout_note",
@@ -13991,6 +14397,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-15",
     "notes": [
       {
@@ -14051,6 +14458,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "staff_note",
@@ -14110,6 +14518,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -14136,7 +14545,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 100
+    "price": 100,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "411",
@@ -14158,6 +14568,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-03-18"
   },
   {
@@ -14180,6 +14591,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-22",
     "notes": [
       {
@@ -14220,6 +14632,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-08-01",
     "notes": [
       {
@@ -14252,6 +14665,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-14"
   },
   {
@@ -14274,6 +14688,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-06-28",
     "notes": [
       {
@@ -14318,6 +14733,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-21",
     "notes": [
       {
@@ -14358,6 +14774,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 3,
     "second_call_number": "RPS0Z"
   },
   {
@@ -14380,6 +14797,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-08-10",
     "notes": [
       {
@@ -14416,6 +14834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-19",
     "notes": [
       {
@@ -14476,6 +14895,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -14528,6 +14948,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-09-06",
     "second_call_number": "SNDZ2"
   },
@@ -14551,6 +14972,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-08"
   },
   {
@@ -14573,6 +14995,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "condition_note",
@@ -14616,6 +15039,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -14651,6 +15075,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkin_note",
@@ -14699,6 +15124,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-06-09",
     "notes": [
       {
@@ -14755,6 +15181,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "provenance_note",
@@ -14794,6 +15221,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-04-09"
   },
   {
@@ -14816,6 +15244,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -14847,6 +15276,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-05-07",
     "second_call_number": "BTDC6"
   },
@@ -14870,6 +15300,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-01-21",
     "notes": [
       {
@@ -14902,6 +15333,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-27",
     "notes": [
       {
@@ -14947,6 +15379,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-14",
     "notes": [
       {
@@ -14999,6 +15432,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -15031,6 +15465,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkout_note",
@@ -15059,6 +15494,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "staff_note",
@@ -15118,6 +15554,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 84,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-11-27",
     "notes": [
       {
@@ -15158,6 +15595,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "acquisition_note",
@@ -15193,6 +15631,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 65,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "general_note",
@@ -15224,6 +15663,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-05-18"
   },
   {
@@ -15245,7 +15685,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 33
+    "price": 33,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "442",
@@ -15267,6 +15708,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-10-13",
     "notes": [
       {
@@ -15327,6 +15769,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 50,
+    "legacy_checkout_count": 13,
     "second_call_number": "1P4EL"
   },
   {
@@ -15349,6 +15792,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -15384,6 +15828,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -15439,6 +15884,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-09",
     "second_call_number": "CVW64"
   },
@@ -15462,6 +15908,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-06-12",
     "notes": [
       {
@@ -15523,6 +15970,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 48,
+    "legacy_checkout_count": 15,
     "second_call_number": "KUWFF"
   },
   {
@@ -15545,6 +15993,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-05-02",
     "notes": [
       {
@@ -15589,6 +16038,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-03-25"
   },
   {
@@ -15611,6 +16061,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "checkout_note",
@@ -15654,6 +16105,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -15693,7 +16145,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 75
+    "price": 75,
+    "legacy_checkout_count": 3
   },
   {
     "pid": "454",
@@ -15715,6 +16168,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-24"
   },
   {
@@ -15736,7 +16190,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 68
+    "price": 68,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "456",
@@ -15757,7 +16212,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 71
+    "price": 71,
+    "legacy_checkout_count": 4
   },
   {
     "pid": "457",
@@ -15779,6 +16235,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-14",
     "notes": [
       {
@@ -15823,6 +16280,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-09-11",
     "second_call_number": "WDI3H"
   },
@@ -15846,6 +16304,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -15881,6 +16340,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "staff_note",
@@ -15908,6 +16368,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 46,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-24"
   },
   {
@@ -15930,6 +16391,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-16"
   },
   {
@@ -15952,6 +16414,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-03-14",
     "notes": [
       {
@@ -16001,6 +16464,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "checkin_note",
@@ -16028,6 +16492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 83,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "acquisition_note",
@@ -16074,7 +16539,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 53
+    "price": 53,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "467",
@@ -16096,6 +16562,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "staff_note",
@@ -16123,6 +16590,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 8,
     "second_call_number": "7BJB5"
   },
   {
@@ -16145,6 +16613,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-08-16",
     "notes": [
       {
@@ -16201,6 +16670,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 98,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkin_note",
@@ -16240,6 +16710,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-22",
     "notes": [
       {
@@ -16272,6 +16743,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -16311,6 +16783,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "binding_note",
@@ -16370,6 +16843,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 64,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "provenance_note",
@@ -16408,7 +16882,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "476",
@@ -16430,6 +16905,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-10-01"
   },
   {
@@ -16452,6 +16928,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-12-07"
   },
   {
@@ -16474,6 +16951,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "binding_note",
@@ -16521,6 +16999,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "staff_note",
@@ -16549,6 +17028,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-11",
     "notes": [
       {
@@ -16597,6 +17077,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-02-13",
     "notes": [
       {
@@ -16642,6 +17123,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -16702,6 +17184,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 77,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-30",
     "notes": [
       {
@@ -16738,6 +17221,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-08-01",
     "notes": [
       {
@@ -16791,6 +17275,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-07-06",
     "notes": [
       {
@@ -16830,7 +17315,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 39
+    "price": 39,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "487",
@@ -16852,6 +17338,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-04-20",
     "notes": [
       {
@@ -16908,6 +17395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -16935,6 +17423,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "checkout_note",
@@ -16974,6 +17463,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -17033,6 +17523,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -17068,6 +17559,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-12-20",
     "notes": [
       {
@@ -17108,7 +17600,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 95
+    "price": 95,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "494",
@@ -17130,6 +17623,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-07-06",
     "second_call_number": "0YX1H"
   },
@@ -17152,7 +17646,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 17
+    "price": 17,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "496",
@@ -17174,6 +17669,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-11",
     "second_call_number": "V4E3B"
   },
@@ -17196,7 +17692,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 2
+    "price": 2,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "498",
@@ -17218,6 +17715,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 21,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-02-05"
   },
   {
@@ -17240,6 +17738,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 5,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-04-08",
     "second_call_number": "JVDAN"
   },
@@ -17262,7 +17761,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 70
+    "price": 70,
+    "legacy_checkout_count": 10
   },
   {
     "pid": "501",
@@ -17284,6 +17784,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 45,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-22",
     "notes": [
       {
@@ -17324,6 +17825,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "provenance_note",
@@ -17356,6 +17858,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 99,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-11-02",
     "second_call_number": "K5QWE"
   },
@@ -17379,6 +17882,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 3,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkout_note",
@@ -17410,6 +17914,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-09-09",
     "notes": [
       {
@@ -17438,6 +17943,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 13,
     "second_call_number": "WOLCX"
   },
   {
@@ -17459,7 +17965,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 99
+    "price": 99,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "508",
@@ -17480,7 +17987,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 95
+    "price": 95,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "509",
@@ -17502,6 +18010,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-27",
     "notes": [
       {
@@ -17555,6 +18064,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-03-15",
     "notes": [
       {
@@ -17592,6 +18102,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-12-26",
     "notes": [
       {
@@ -17636,6 +18147,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-05-27"
   },
   {
@@ -17657,7 +18169,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 1
+    "price": 1,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "514",
@@ -17679,6 +18192,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-11-23",
     "notes": [
       {
@@ -17727,6 +18241,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2020-08-30",
     "notes": [
       {
@@ -17771,6 +18286,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -17810,6 +18326,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -17854,6 +18371,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 24,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-30",
     "notes": [
       {
@@ -17909,7 +18427,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "520",
@@ -17931,6 +18450,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2021-02-06",
     "second_call_number": "45TI7"
   },
@@ -17954,6 +18474,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-06-01",
     "second_call_number": "TRM58"
   },
@@ -17977,6 +18498,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-12-06"
   },
   {
@@ -17999,6 +18521,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-12-30"
   },
   {
@@ -18021,6 +18544,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 8,
     "second_call_number": "XCRP3"
   },
   {
@@ -18043,6 +18567,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 10,
     "second_call_number": "2LR8L"
   },
   {
@@ -18065,6 +18590,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-03-25"
   },
   {
@@ -18087,6 +18613,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-03-22"
   },
   {
@@ -18109,6 +18636,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 47,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-10-12",
     "notes": [
       {
@@ -18169,6 +18697,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 26,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "binding_note",
@@ -18227,7 +18756,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 57
+    "price": 57,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "531",
@@ -18249,6 +18779,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkout_note",
@@ -18308,7 +18839,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "533",
@@ -18330,6 +18862,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-04-05",
     "notes": [
       {
@@ -18366,6 +18899,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "staff_note",
@@ -18413,6 +18947,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 52,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-06-30"
   },
   {
@@ -18435,6 +18970,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "provenance_note",
@@ -18489,7 +19025,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 42
+    "price": 42,
+    "legacy_checkout_count": 8
   },
   {
     "pid": "538",
@@ -18511,6 +19048,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-06-08"
   },
   {
@@ -18532,7 +19070,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 19
+    "price": 19,
+    "legacy_checkout_count": 11
   },
   {
     "pid": "540",
@@ -18554,6 +19093,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-26"
   },
   {
@@ -18575,7 +19115,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 91
+    "price": 91,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "542",
@@ -18597,6 +19138,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 23,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -18636,6 +19178,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 10,
     "acquisition_date": "2021-03-06",
     "notes": [
       {
@@ -18681,6 +19224,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-11-25"
   },
   {
@@ -18703,6 +19247,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "condition_note",
@@ -18739,6 +19284,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 49,
+    "legacy_checkout_count": 2,
     "notes": [
       {
         "type": "general_note",
@@ -18770,6 +19316,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-12"
   },
   {
@@ -18792,6 +19339,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "binding_note",
@@ -18823,6 +19371,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 14,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-05-25",
     "second_call_number": "A58T5"
   },
@@ -18846,6 +19395,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "provenance_note",
@@ -18874,6 +19424,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 7,
     "notes": [
       {
         "type": "condition_note",
@@ -18934,6 +19485,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 53,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "condition_note",
@@ -18985,6 +19537,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "acquisition_note",
@@ -19032,6 +19585,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2021-03-22",
     "notes": [
       {
@@ -19067,7 +19621,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 58
+    "price": 58,
+    "legacy_checkout_count": 14
   },
   {
     "pid": "556",
@@ -19088,7 +19643,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 74
+    "price": 74,
+    "legacy_checkout_count": 5
   },
   {
     "pid": "557",
@@ -19110,6 +19666,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 71,
+    "legacy_checkout_count": 13,
     "second_call_number": "OAZHW"
   },
   {
@@ -19132,6 +19689,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2021-01-30"
   },
   {
@@ -19153,7 +19711,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 21
+    "price": 21,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "560",
@@ -19175,6 +19734,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 35,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-05-16",
     "notes": [
       {
@@ -19231,6 +19791,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -19286,6 +19847,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "checkout_note",
@@ -19318,6 +19880,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 87,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-08-01",
     "notes": [
       {
@@ -19378,6 +19941,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 31,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "provenance_note",
@@ -19438,6 +20002,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-03-23",
     "notes": [
       {
@@ -19478,6 +20043,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "binding_note",
@@ -19513,6 +20079,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 72,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-07-01"
   },
   {
@@ -19535,6 +20102,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 3,
     "second_call_number": "ERBNI"
   },
   {
@@ -19557,6 +20125,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-06-24",
     "notes": [
       {
@@ -19617,6 +20186,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 85,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-10-31",
     "notes": [
       {
@@ -19673,6 +20243,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2021-01-13"
   },
   {
@@ -19695,6 +20266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2021-04-09",
     "notes": [
       {
@@ -19728,6 +20300,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 93,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "staff_note",
@@ -19771,6 +20344,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 30,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-06-18",
     "notes": [
       {
@@ -19819,6 +20393,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-03-23",
     "second_call_number": "R50ZZ"
   },
@@ -19842,6 +20417,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 74,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-04-08",
     "notes": [
       {
@@ -19870,6 +20446,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 7,
     "second_call_number": "A88EQ"
   },
   {
@@ -19891,7 +20468,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 31
+    "price": 31,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "579",
@@ -19913,6 +20491,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 55,
+    "legacy_checkout_count": 14,
     "notes": [
       {
         "type": "general_note",
@@ -19940,6 +20519,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-14",
     "notes": [
       {
@@ -19996,6 +20576,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2020-06-14",
     "notes": [
       {
@@ -20045,6 +20626,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2021-02-07",
     "notes": [
       {
@@ -20090,6 +20672,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 60,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -20125,6 +20708,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "binding_note",
@@ -20161,6 +20745,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 37,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-02-22",
     "notes": [
       {
@@ -20193,6 +20778,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 57,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-09-18",
     "notes": [
       {
@@ -20220,7 +20806,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 93
+    "price": 93,
+    "legacy_checkout_count": 13
   },
   {
     "pid": "588",
@@ -20242,6 +20829,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-08-24"
   },
   {
@@ -20264,6 +20852,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 4,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-08-18",
     "notes": [
       {
@@ -20308,6 +20897,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "checkin_note",
@@ -20352,6 +20942,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 19,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "checkout_note",
@@ -20411,6 +21002,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -20463,6 +21055,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 70,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "binding_note",
@@ -20494,6 +21087,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2021-03-12",
     "notes": [
       {
@@ -20526,6 +21120,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 75,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "condition_note",
@@ -20585,6 +21180,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 8,
+    "legacy_checkout_count": 9,
     "second_call_number": "75FGK"
   },
   {
@@ -20606,7 +21202,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 88
+    "price": 88,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "598",
@@ -20628,6 +21225,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-07-06",
     "notes": [
       {
@@ -20661,6 +21259,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 89,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-12-16",
     "notes": [
       {
@@ -20701,6 +21300,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-08-09",
     "notes": [
       {
@@ -20753,6 +21353,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 13,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -20784,6 +21385,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 25,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-07-07"
   },
   {
@@ -20806,6 +21408,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 41,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-07-09",
     "notes": [
       {
@@ -20863,6 +21466,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-03-16",
     "notes": [
       {
@@ -20919,6 +21523,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 80,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "staff_note",
@@ -20946,6 +21551,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2021-01-20",
     "notes": [
       {
@@ -20999,6 +21605,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "checkin_note",
@@ -21043,6 +21650,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 22,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-29"
   },
   {
@@ -21065,6 +21673,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 44,
+    "legacy_checkout_count": 2,
     "acquisition_date": "2020-10-24"
   },
   {
@@ -21086,7 +21695,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 20
+    "price": 20,
+    "legacy_checkout_count": 9
   },
   {
     "pid": "611",
@@ -21108,6 +21718,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 38,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-10-09",
     "second_call_number": "Z6RLP"
   },
@@ -21131,6 +21742,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -21170,6 +21782,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "general_note",
@@ -21197,6 +21810,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 100,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-05-01",
     "second_call_number": "MUKMW"
   },
@@ -21220,6 +21834,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "staff_note",
@@ -21251,6 +21866,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 63,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-26",
     "notes": [
       {
@@ -21308,6 +21924,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 11,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-03-30",
     "notes": [
       {
@@ -21337,6 +21954,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 86,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-11-25",
     "notes": [
       {
@@ -21397,6 +22015,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-11-01",
     "notes": [
       {
@@ -21441,6 +22060,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 42,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "provenance_note",
@@ -21501,6 +22121,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 13,
+    "legacy_checkout_count": 15,
     "acquisition_date": "2021-02-22",
     "second_call_number": "KE8T9"
   },
@@ -21524,6 +22145,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 2,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "checkout_note",
@@ -21551,6 +22173,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "acquisition_note",
@@ -21602,7 +22225,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 13
+    "price": 13,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "625",
@@ -21624,6 +22248,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 67,
+    "legacy_checkout_count": 13,
     "acquisition_date": "2020-10-25"
   },
   {
@@ -21646,6 +22271,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 15,
     "notes": [
       {
         "type": "acquisition_note",
@@ -21681,6 +22307,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 90,
+    "legacy_checkout_count": 3,
     "acquisition_date": "2020-04-03",
     "notes": [
       {
@@ -21733,6 +22360,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-02-05"
   },
   {
@@ -21755,6 +22383,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 97,
+    "legacy_checkout_count": 6,
     "second_call_number": "FZYYZ"
   },
   {
@@ -21777,6 +22406,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 17,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2020-12-13",
     "notes": [
       {
@@ -21805,6 +22435,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 69,
+    "legacy_checkout_count": 4,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -21837,6 +22468,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 62,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-06-04",
     "second_call_number": "U3SRM"
   },
@@ -21860,6 +22492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "checkout_note",
@@ -21900,6 +22533,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 39,
+    "legacy_checkout_count": 8,
     "notes": [
       {
         "type": "provenance_note",
@@ -21927,6 +22561,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 76,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-09-06",
     "notes": [
       {
@@ -21966,7 +22601,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 6
+    "price": 6,
+    "legacy_checkout_count": 7
   },
   {
     "pid": "637",
@@ -21988,6 +22624,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 81,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-11-25",
     "notes": [
       {
@@ -22016,6 +22653,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 78,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "provenance_note",
@@ -22055,6 +22693,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 8,
     "acquisition_date": "2020-08-06",
     "notes": [
       {
@@ -22100,6 +22739,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 91,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2020-08-31"
   },
   {
@@ -22122,6 +22762,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 12,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2020-10-11",
     "notes": [
       {
@@ -22170,6 +22811,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 6,
     "acquisition_date": "2021-01-02",
     "notes": [
       {
@@ -22218,6 +22860,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 27,
+    "legacy_checkout_count": 4,
     "second_call_number": "3A56A"
   },
   {
@@ -22240,6 +22883,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 95,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-08-20",
     "notes": [
       {
@@ -22280,6 +22924,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 68,
+    "legacy_checkout_count": 1,
     "notes": [
       {
         "type": "general_note",
@@ -22319,6 +22964,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 96,
+    "legacy_checkout_count": 11,
     "acquisition_date": "2020-08-18"
   },
   {
@@ -22341,6 +22987,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 59,
+    "legacy_checkout_count": 11,
     "notes": [
       {
         "type": "acquisition_note",
@@ -22396,6 +23043,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 29,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "general_note",
@@ -22432,6 +23080,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 3,
     "notes": [
       {
         "type": "checkout_note",
@@ -22491,6 +23140,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 56,
+    "legacy_checkout_count": 14,
     "acquisition_date": "2020-05-01",
     "notes": [
       {
@@ -22547,6 +23197,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 58,
+    "legacy_checkout_count": 6,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -22582,6 +23233,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 92,
+    "legacy_checkout_count": 1,
     "acquisition_date": "2020-11-19",
     "notes": [
       {
@@ -22614,6 +23266,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 66,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "condition_note",
@@ -22665,6 +23318,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 16,
+    "legacy_checkout_count": 9,
     "notes": [
       {
         "type": "general_note",
@@ -22712,6 +23366,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 15,
+    "legacy_checkout_count": 5,
     "notes": [
       {
         "type": "binding_note",
@@ -22755,6 +23410,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 20,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2021-01-09",
     "notes": [
       {
@@ -22787,6 +23443,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 7,
+    "legacy_checkout_count": 7,
     "acquisition_date": "2020-07-16",
     "notes": [
       {
@@ -22835,6 +23492,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 10,
+    "legacy_checkout_count": 10,
     "notes": [
       {
         "type": "patrimonial_note",
@@ -22882,6 +23540,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 32,
+    "legacy_checkout_count": 9,
     "acquisition_date": "2021-01-19",
     "notes": [
       {
@@ -22914,6 +23573,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 73,
+    "legacy_checkout_count": 12,
     "acquisition_date": "2020-07-17",
     "notes": [
       {
@@ -22974,6 +23634,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 43,
+    "legacy_checkout_count": 4,
     "acquisition_date": "2020-09-18",
     "notes": [
       {
@@ -23035,6 +23696,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 36,
+    "legacy_checkout_count": 12,
     "notes": [
       {
         "type": "general_note",
@@ -23089,7 +23751,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 63
+    "price": 63,
+    "legacy_checkout_count": 1
   },
   {
     "pid": "664",
@@ -23110,7 +23773,8 @@
     },
     "type": "standard",
     "pac_code": "2_controlled_consumption",
-    "price": 38
+    "price": 38,
+    "legacy_checkout_count": 2
   },
   {
     "pid": "665",
@@ -23132,6 +23796,7 @@
     "type": "standard",
     "pac_code": "2_controlled_consumption",
     "price": 1,
+    "legacy_checkout_count": 5,
     "acquisition_date": "2021-02-08"
   }
 ]

--- a/rero_ils/modules/items/cli.py
+++ b/rero_ils/modules/items/cli.py
@@ -149,6 +149,7 @@ def create_items(count, itemscount, missing, items_f, holdings_f):
                         barcode = str(10000000000 + item_pid)
 
                     price = random.randint(1, 100)
+                    legacy_checkout_count = random.randint(1, 15)
 
                     missing, item = create_random_item(
                         item_pid=item_pid,
@@ -160,7 +161,8 @@ def create_items(count, itemscount, missing, items_f, holdings_f):
                         barcode=barcode,
                         status=status,
                         new_acquisition=new_acquisition,
-                        price=price
+                        price=price,
+                        legacy_checkout_count=legacy_checkout_count
                     )
                     item_pid += 1
                     yield item, new_holding
@@ -236,7 +238,7 @@ def get_item_types():
 
 def create_random_item(item_pid, location_pid, missing, item_type_pid,
                        document_pid, holding_pid, barcode, status,
-                       new_acquisition, price):
+                       new_acquisition, price, legacy_checkout_count):
     """Create items with randomised values."""
     if not status:
         status = ItemStatus.ON_SHELF
@@ -262,7 +264,8 @@ def create_random_item(item_pid, location_pid, missing, item_type_pid,
         },
         'type': 'standard',
         'pac_code': '2_controlled_consumption',
-        'price': price
+        'price': price,
+        'legacy_checkout_count': legacy_checkout_count
     }
     # ACQUISITION DATE
     #   add acquisition date if item is a new acquisition

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -786,6 +786,12 @@
         }
       }
     },
+    "legacy_checkout_count": {
+      "title": "Number of checkouts from previous system",
+      "type": "integer",
+      "minimum": 0,
+      "default": 0
+    },
     "_masked": {
       "title": "Masked",
       "type": "boolean",

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -309,6 +309,9 @@
       "_masked": {
         "type": "boolean"
       },
+      "legacy_checkout_count": {
+        "type": "integer"
+      },
       "_created": {
         "type": "date"
       },

--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -56,6 +56,7 @@ _csv = ItemCSVSerializer(
         'item_barcode',
         'item_call_number',
         'item_second_call_number',
+        'item_legacy_checkout_count',
         'item_type',
         'item_library_name',
         'item_location_name',

--- a/rero_ils/modules/items/serializers/collector.py
+++ b/rero_ils/modules/items/serializers/collector.py
@@ -207,6 +207,7 @@ class Collector():
             ('barcode', 'item_barcode'),
             ('call_number', 'item_call_number'),
             ('second_call_number', 'item_second_call_number'),
+            ('legacy_checkout_count', 'item_legacy_checkout_count'),
             ('pac_code', 'item_pac_code'),
             ('price', 'item_price'),
             ('type', 'item_item_type'),

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -570,6 +570,11 @@ def stats(item_pid):
     for result in results.aggregations.trigger.buckets:
         output['total'][result.key] = result.doc_count
         output['total_year'][result.key] = result.year.doc_count
+    # Add legacy checkout count
+    if item := Item.get_record_by_pid(item_pid):
+        legacy_count = item.get('legacy_checkout_count', 0)
+        output['total'].setdefault('checkout', 0)
+        output['total']['checkout'] += legacy_count
     return jsonify(output)
 
 

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -183,10 +183,11 @@ def test_item_stats(
         'execute',
         mock.MagicMock(return_value=es_response)
     ):
+        # We sum the Legacy_count field in the checkout field
         res = client.get(url_for('api_item.stats', item_pid='item1'))
         assert res.json == \
             {
-                'total': {'checkout': 1, 'extend': 2, 'checkin': 2},
+                'total': {'checkout': 5, 'extend': 2, 'checkin': 2},
                 'total_year': {'checkout': 1, 'extend': 1, 'checkin': 1}}
 
     with mock.patch.object(
@@ -195,10 +196,11 @@ def test_item_stats(
         mock.MagicMock(return_value=es_response_checkin)
     ):
         # item found
+        # We add the legacy_checkout_count field to the checkout field
         res = client.get(url_for('api_item.stats', item_pid='item1'))
         assert res.json == \
             {
-                'total': {'checkin': 2},
+                'total': {'checkout': 4, 'checkin': 2},
                 'total_year': {'checkin': 1}}
         # No item found
         res = client.get(url_for('api_item.stats', item_pid='foot'))

--- a/tests/api/items/test_items_serializer.py
+++ b/tests/api/items/test_items_serializer.py
@@ -91,7 +91,7 @@ def test_serializers(
         'document_local_field_7', 'document_local_field_8',
         'document_local_field_9', 'document_local_field_10',
         'item_acquisition_date', 'item_barcode', 'item_call_number',
-        'item_second_call_number',
+        'item_second_call_number', 'item_legacy_checkout_count',
         'item_type', 'item_library_name', 'item_location_name',
         'item_pac_code', 'item_holding_pid', 'item_price', 'item_status',
         'item_item_type', 'item_general_note', 'item_staff_note',

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -4098,7 +4098,8 @@
     "status": "on_shelf",
     "url": "https://lipda.mediatheque.ch/CH-000019-X:223156.file",
     "pac_code": "0_frozen_collection",
-    "price": 23.2
+    "price": 23.2,
+    "legacy_checkout_count": 4
   },
   "item2": {
     "$schema": "https://bib.rero.ch/schemas/items/item-v0.0.1.json",

--- a/tests/unit/test_items_jsonschema.py
+++ b/tests/unit/test_items_jsonschema.py
@@ -62,7 +62,8 @@ def test_item_all_jsonschema_keys_values(
         {'key': 'ur', 'value': 25},
         {'key': 'pac_code', 'value': 25},
         {'key': 'price', 'value': '25'},
-        {'key': '_masked', 'value': 25}
+        {'key': '_masked', 'value': 25},
+        {'key': 'legacy_checkout_count', 'value': '25'}
     ]
     for element in validator:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
* RERO+ clients still need this field.