### PR TITLE
sip2: fix patron language

### DIFF
--- a/rero_ils/modules/selfcheck/api.py
+++ b/rero_ils/modules/selfcheck/api.py
@@ -133,8 +133,8 @@ def enable_patron(barcode, **kwargs):
         if patron:
             return SelfcheckEnablePatron(
                 patron_status=get_patron_status(patron),
-                language=patron.get('communication_language', 'und'),
-                institution_id=patron.library_pid,
+                language=patron.patron.get('communication_language', 'und'),
+                institution_id=patron.organisation_pid,
                 patron_id=patron.patron.get('barcode'),
                 patron_name=patron.formatted_name
             )
@@ -460,7 +460,6 @@ def selfcheck_checkin(transaction_user_pid, item_barcode, **kwargs):
     :return: The SelfcheckCheckin object.
     """
     if check_sip2_module():
-        from invenio_sip2.errors import SelfcheckCirculationError
         from invenio_sip2.models import SelfcheckCheckin
 
         language = kwargs.get('language', current_app.config
@@ -520,10 +519,9 @@ def selfcheck_checkin(transaction_user_pid, item_barcode, **kwargs):
                 checkin.get('screen_messages', []).append(
                     _(circ_err.description))
             except Exception:
+                current_app.logger.error('self checkin failed')
                 checkin.get('screen_messages', []).append(
                     _('Error encountered: please contact a librarian'))
-                raise SelfcheckCirculationError('self checkin failed',
-                                                checkin)
         return checkin
 
 

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -129,10 +129,12 @@ def test_enable_patron(selfcheck_patron_martigny):
     """Test enable patron."""
     response = enable_patron(
         selfcheck_patron_martigny.get('patron', {}).get('barcode')[0])
-    assert response.get('institution_id') == selfcheck_patron_martigny\
-        .library_pid
-    assert response.get('patron_id')
-    assert response.get('patron_name')
+    ptrn = selfcheck_patron_martigny
+    assert response.get('institution_id') == ptrn.organisation_pid
+    assert response.get('patron_id') == ptrn.patron['barcode']
+    assert response.get('patron_name') == ptrn.formatted_name
+    assert response.get('language') == \
+        ptrn.patron['communication_language']
 
     # test with wrong patron
     response = enable_patron('wrong_patron_barcode')


### PR DESCRIPTION
* Fixes the language patron preference for sip2 messages.
* Fixes missing sip2 error message for circulation error.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Laurent Dubois <laurent.dubois@itld-solutions.be>
Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
