### PR TITLE
fix(jsonschemas): fix minItems

### DIFF
--- a/rero_ils/modules/acquisition/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -101,7 +101,7 @@
     "notes": {
       "title": "Notes",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "maxItems": 2,
       "items": {
         "type": "object",

--- a/rero_ils/modules/acquisition/acq_receipt_lines/jsonschemas/acq_receipt_lines/acq_receipt_line-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/jsonschemas/acq_receipt_lines/acq_receipt_line-v0.0.1.json
@@ -137,7 +137,7 @@
     "notes": {
       "title": "Notes",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "maxItems": 2,
       "items": {
         "type": "object",

--- a/rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json
+++ b/rero_ils/modules/acquisition/acq_receipts/jsonschemas/acq_receipts/acq_receipt-v0.0.1.json
@@ -142,7 +142,7 @@
     "notes": {
       "title": "Notes",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "maxItems": 1,
       "items": {
         "type": "object",

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -424,7 +424,7 @@
       "title": "List of libraries",
       "uniqueItems": true,
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "type": "object",
         "title": "Library",


### PR DESCRIPTION
* minItems: 0 prevents some fields to be displayed in edit mode, especially the notes field in acquisition receipts and orders.
* Closes #3709.