### PR TITLE
loan tasks: ignore auto extend non extendable item

### DIFF
--- a/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
+++ b/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
@@ -2,6 +2,11 @@
   "index_patterns": [
     "operation_logs*"
   ],
+  "settings": {
+    "number_of_shards": "8",
+    "number_of_replicas": "1",
+    "max_result_window": "100000"
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,


### PR DESCRIPTION
* Ignores auto extend non extendable item based on circulation action configuration.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
