### PR TITLE
fix(circulation policies): improve data consistency

### DIFF
--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -107,7 +107,7 @@ class CircPolicy(IlsRecord):
         for library in self.get('libraries', []):
             library_pid = extracted_data_from_ref(library)
             if not Library.get_record_by_pid(library_pid):
-                return f"CircPolicy: no library:  {library.get('pid')}"
+                return f"CircPolicy: no library: {library.get('pid')}"
 
         # check all patron_types & item_types from settings belongs to the
         # same organisation than the cipo
@@ -160,6 +160,11 @@ class CircPolicy(IlsRecord):
                        f':: [{lower_limit}-{upper_limit}]'
             last_lower_limit = lower_limit
             last_upper_limit = upper_limit
+
+        # Check renewal duration
+        # If renewals are enabled, a renewal duration is required.
+        if self.get('number_renewals') and not self.get('renewal_duration'):
+            return 'A renewal duration is required if renewals are enabled.'
 
         return True
 

--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -16,13 +16,13 @@
   "propertiesOrder": [
     "name",
     "description",
+    "allow_requests",
+    "pickup_hold_duration",
     "checkout_duration",
     "number_renewals",
     "renewal_duration",
     "automatic_renewal",
     "is_default",
-    "allow_requests",
-    "pickup_hold_duration",
     "policy_library_level",
     "libraries",
     "reminders",
@@ -84,18 +84,10 @@
       "minimum": 0,
       "widget": {
         "formlyConfig": {
-          "wrappers": [
-            "toggle-switch",
-            "card"
-          ],
           "props": {
             "addonRight": [
               "day(s)"
             ],
-            "toggle-switch": {
-              "label": "Allow checkout",
-              "description": "Checkouts are allowed or not."
-            },
             "navigation": {
               "essential": true
             }
@@ -366,7 +358,7 @@
       "widget": {
         "formlyConfig": {
           "expressions": {
-            "hide": "model && model.checkout_duration <= 0"
+            "hide": "!model.checkout_duration && model.checkout_duration !== 0"
           }
         }
       }
@@ -378,7 +370,8 @@
       "widget": {
         "formlyConfig": {
           "expressions": {
-            "hide": "model && (!model.hasOwnProperty('number_renewals') || model.number_renewals <= 0)"
+            "props.required": "model.number_renewals",
+            "hide": "!model.number_renewals"
           },
           "props": {
             "addonRight": [
@@ -395,10 +388,7 @@
       "widget": {
         "formlyConfig": {
           "expressions": {
-            "hide": "model.number_renewals <= 0"
-          },
-          "navigation": {
-            "essential": true
+            "hide": "!model.number_renewals"
           }
         }
       }

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -139,7 +139,8 @@ def test_circ_policy_can_delete(app, circ_policy_martigny_data_tmp):
 def test_circ_policy_extended_validation(
     app,
     circ_policy_short_martigny,
-    circ_policy_short_martigny_data
+    circ_policy_short_martigny_data,
+    circ_policy_default_sion_data
 ):
     """Test extended validation for circ policy"""
     cipo_data = deepcopy(circ_policy_short_martigny_data)
@@ -152,3 +153,14 @@ def test_circ_policy_extended_validation(
     assert 'pickup_hold_duration' not in cipo
 
     cipo.delete()
+
+    # Check that I cannot save a CiPo without a renewal duration if
+    # renewals are enabled.
+    cipo_sion_data = deepcopy(circ_policy_default_sion_data)
+    assert cipo_sion_data['number_renewals'] > 0
+
+    cipo_sion_data.pop('renewal_duration')
+
+    with pytest.raises(ValidationError) as err:
+        CircPolicy.create(cipo_sion_data, delete_pid=True)
+    assert 'renewal duration is required' in str(err.value)


### PR DESCRIPTION
* Reorders jsonschema to be more coherent.
* Adds hide and required expressions for the cipo editor so that checkouts and renewals settings are consistent with one another.
* Adds an extended validation to prevent circulation policies with renewals enabled but no renewal_duration, which would lead to an error when trying to renew.