### PR TITLE
fix(editor): seriesStatement becoming invalid if deleted and re-added

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json
@@ -46,7 +46,7 @@
         "subseriesStatement": {
           "title": "Subseries statement",
           "type": "array",
-          "minItems": 1,
+          "minItems": 0,
           "items": {
             "type": "object",
             "title": "Subseries",


### PR DESCRIPTION
* Workaround for default value problem in third level arrays. See: https://github.com/ngx-formly/ngx-formly/issues/3974.