### PR TITLE
acquisition: add logging file to rollover cli

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -3482,7 +3482,7 @@ ROLLOVER_LOGGING_CONFIG = {
         "console": {"class": "logging.StreamHandler", "formatter": "standard"},
         "file": {
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": "logs/rollover_log",
+            "filename": "logs/rollover",
             "backupCount": 10,
             "formatter": "standard",
         },

--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -255,6 +255,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
             if self.order_date
             else AcqOrderLineStatus.APPROVED
         )
+
         received_quantity = self.received_quantity
         # not use the property to prevent an extra ES call
         unreceived_quantity = self.quantity - received_quantity

--- a/rero_ils/modules/acquisition/cli.py
+++ b/rero_ils/modules/acquisition/cli.py
@@ -57,6 +57,7 @@ def acquisition():
     "--budget-start-date", "budget_start_date", help="The new budget start-date"
 )
 @click.option("--budget-end-date", "budget_end_date", help="The new budget end-date")
+@click.option("--logging_file", "logging_file", help="Logging file name", default=None)
 @with_appcontext
 def rollover(
     origin_budget_pid,
@@ -66,6 +67,7 @@ def rollover(
     budget_name,
     budget_start_date,
     budget_end_date,
+    logging_file,
 ):
     """CLI to run rollover process between two acquisition budgets."""
     # Check parameters
@@ -92,6 +94,9 @@ def rollover(
 
     destination_budget = Budget.get_record_by_pid(dest_budget_pid)
     rollover_runner = AcqRollover(
-        original_budget, destination_budget, is_interactive=interactive
+        original_budget=original_budget,
+        destination_budget=destination_budget,
+        is_interactive=interactive,
+        logging_file=logging_file,
     )
     rollover_runner.run()

--- a/tests/api/acquisition/test_acquisition_rollover.py
+++ b/tests/api/acquisition/test_acquisition_rollover.py
@@ -64,6 +64,8 @@ def test_rollover_cli(client, acq_full_structure_a, org_martigny):
                 "2022-01-01",
                 "--budget-end-date",
                 "2022-12-31",
+                "--logging_file",
+                "logs/rollover_log",
             ],
         )
         assert result.exit_code == 0  # all works fine !


### PR DESCRIPTION
* Adds logging file parameter to rollover cli.
* Adds time stamp to log file if no file parameter is given.
* Closes #3560.