### PR TITLE
primeng: fix patron editor

### DIFF
--- a/rero_ils/jsonschemas/common/cantons-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/cantons-v0.0.1.json
@@ -37,7 +37,9 @@
         },
         "props": {
           "sort": true,
-          "itemCssClass": "col-lg-4",
+          "placeholder": "Select an option…",
+          "sortOrder": "asc",
+          "filter": true,
           "options": [
             {
               "label": "canton_ag",

--- a/rero_ils/jsonschemas/common/countries-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/countries-v0.0.1.json
@@ -385,7 +385,6 @@
           "placeholder": "Select an option…",
           "sortOrder": "asc",
           "filter": true,
-          "itemCssClass": "col-lg-4",
           "options": [
             {
               "label": "country_aa",

--- a/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json
@@ -16,9 +16,12 @@
       "pattern": "^(https://mef.rero.ch/api/concepts/(gnd|idref|rero)/.*|https://bib.rero.ch/api/local_entities/.*?)$",
       "widget": {
         "formlyConfig": {
-          "type": "entityTypeahead",
+          "type": "entity-autocomplete",
           "props": {
+            "scrollHeight": "600px",
+            "group": true,
             "filters": {
+              "selected": "concepts_genreForm",
               "options": [
                 {
                   "label": "Genre, form",
@@ -26,7 +29,9 @@
                 }
               ]
             },
-            "itemCssClass": "col-12"
+            "queryOptions": {
+              "type": "mef"
+            }
           }
         }
       }
@@ -35,13 +40,6 @@
       "title": "MEF ID",
       "type": "string",
       "minLength": 1
-    }
-  },
-  "widget": {
-    "formlyConfig": {
-      "props": {
-        "containerCssClass": "row"
-      }
     }
   }
 }

--- a/rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json
@@ -17,10 +17,12 @@
       "pattern": "^(https://mef.rero.ch/api/(agents|concepts|places)/(gnd|idref|rero)/.*|https://bib.rero.ch/api/local_entities/.*?)$",
       "widget": {
         "formlyConfig": {
-          "type": "entityTypeahead",
+          "type": "entity-autocomplete",
           "props": {
+            "scrollHeight": "600px",
+            "group": true,
             "filters": {
-              "default": "bf:Topic",
+              "selected": "bf:Topic",
               "options": [
                 {
                   "label": "Topic",
@@ -48,7 +50,9 @@
                 }
               ]
             },
-            "itemCssClass": "col-12"
+            "queryOptions": {
+              "type": "mef"
+            }
           }
         }
       }
@@ -57,13 +61,6 @@
       "title": "MEF ID",
       "type": "string",
       "minLength": 1
-    }
-  },
-  "widget": {
-    "formlyConfig": {
-      "props": {
-        "containerCssClass": "row"
-      }
     }
   }
 }

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -47,7 +47,14 @@
       "items": {
         "title": "Local code",
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "widget": {
+          "formlyConfig": {
+            "props": {
+              "hideLabel": true
+            }
+          }
+        }
       }
     },
     "user_id": {
@@ -57,7 +64,6 @@
       "widget": {
         "formlyConfig": {
           "wrappers": [
-            "form-field",
             "user-id"
           ]
         }
@@ -200,6 +206,7 @@
             "widget": {
               "formlyConfig": {
                 "props": {
+                  "hideLabel": true,
                   "doNotSubmitOnEnter": true,
                   "validation": {
                     "validators": {

--- a/rero_ils/theme/templates/rero_ils/frontpage.html
+++ b/rero_ils/theme/templates/rero_ils/frontpage.html
@@ -43,7 +43,6 @@
           language="{{ current_i18n.locale.language[:2] }}"
           inputstyleclass="md:text-xl w-full"
           class="rero-ils-ui"
-          admin="false"
         />
       </div>
     </div>

--- a/rero_ils/theme/templates/rero_ils/header.html
+++ b/rero_ils/theme/templates/rero_ils/header.html
@@ -35,7 +35,6 @@
         {%- block navbar_search %}
           <main-search-bar
             class="flex-grow-1 rero-ils-ui"
-            admin="false"
             inputstyleclass="text-sm py-1 w-full"
             placeholder="{{ _('Search') }}"
             viewcode="{{ viewcode or config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE }}"

--- a/rero_ils/theme/templates/rero_ils/professional.html
+++ b/rero_ils/theme/templates/rero_ils/professional.html
@@ -31,7 +31,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body>
-    <admin-root class="rero-ils-ui" />
+    <admin-root />
     {{ node_assets('@rero/rero-ils-ui/dist/admin', tags='type="module"') }}
 </body>
 


### PR DESCRIPTION
* Removes css class for the professional view.
* Adapts the main search component to the new ui version.
* Fixes several details in the patron editor.