### PR TITLE
fix(entities): wrong date in public view

### DIFF
--- a/rero_ils/modules/entities/templates/rero_ils/_remote_person.html
+++ b/rero_ils/modules/entities/templates/rero_ils/_remote_person.html
@@ -20,11 +20,11 @@
 
 <!-- DATE OF BIRTH -->
 {% if data.date_of_birth %}
-  {{ dl(_('Birth date'), data.date_of_birth | format_date(date_format='short', time_format=None)) }}
+  {{ dl(_('Birth date'), data.date_of_birth) }}
 {% endif %}
 <!-- DATE OF DEATH -->
 {% if data.date_of_death %}
-  {{ dl(_('Death date'), data.date_of_death | format_date(date_format='short', time_format=None)) }}
+  {{ dl(_('Death date'), data.date_of_death) }}
 {% endif %}
 <!-- LANGUAGE -->
 {% if data.language %}


### PR DESCRIPTION
* Entities' dates are string fields, they should not be formatted by the interface, otherwise they display wrong data. E.g. if "date of birth" is only a year (very frequent), the formatting will add a day/month.