### PR TITLE
feat(permissions): change update receipts permissions

### DIFF
--- a/rero_ils/modules/acquisition/acq_receipts/api.py
+++ b/rero_ils/modules/acquisition/acq_receipts/api.py
@@ -155,6 +155,7 @@ class AcqReceipt(AcquisitionIlsRecord):
         if order_status not in [
             AcqOrderStatus.ORDERED,
             AcqOrderStatus.PARTIALLY_RECEIVED,
+            AcqOrderStatus.RECEIVED,
         ]:
             return _(
                 f"Can not create a receipt with an order with a wrong status {order_status}."

--- a/rero_ils/modules/acquisition/acq_receipts/permissions.py
+++ b/rero_ils/modules/acquisition/acq_receipts/permissions.py
@@ -51,7 +51,9 @@ class AcqReceiptPermissionPolicy(RecordPermissionPolicy):
     can_update = [
         AllowedByActionRestrictByManageableLibrary(update_action),
         DisallowedIfRollovered(AcqReceipt),
-        DisallowedByOrderStatus(AcqReceipt, [AcqOrderStatus.PARTIALLY_RECEIVED]),
+        DisallowedByOrderStatus(
+            AcqReceipt, [AcqOrderStatus.PARTIALLY_RECEIVED, AcqOrderStatus.RECEIVED]
+        ),
     ]
     can_delete = [
         AllowedByActionRestrictByManageableLibrary(delete_action),

--- a/tests/api/acq_receipts/test_acq_receipts_permissions.py
+++ b/tests/api/acq_receipts/test_acq_receipts_permissions.py
@@ -229,7 +229,7 @@ def test_receipts_permissions(
                 "search": True,
                 "read": True,
                 "create": True,
-                "update": False,
+                "update": True,
                 "delete": True,
             },
             acq_receipt_fiction_martigny,


### PR DESCRIPTION
- Allows an update of a recepts if the order is fully received.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
