### PR TITLE
fix(babeltheque): prevent "more info" to display before the ng app

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -282,7 +282,8 @@
         viewcode="{{ viewcode }}"
       >
         {% if viewcode | babeltheque_enabled_view and isbn is not none %}
-        <more-info>
+        <!-- More info will be displayed by the Angular app so that it doesn't load before it -->
+        <more-info style="display:none">
           <!-- BABELTHEQUE -->
           <aside class="mt-3">Babelio</aside>
           <div class="babelio-block">


### PR DESCRIPTION
Linked to https://github.com/rero/rero-ils-ui/pull/1311.