### PR TITLE
chore(permissions): add details for acquisition permissions

### DIFF
--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -302,6 +302,8 @@ class AcqOrderLine(AcquisitionIlsRecord):
 
     def reasons_not_to_delete(self):
         """Get reasons not to delete record."""
+        from rero_ils.modules.acquisition.acq_orders.api import AcqOrder, AcqOrderStatus
+
         cannot_delete = {}
         # Note: not possible to delete records attached to rolled_over budget.
         if not self.is_active:
@@ -309,6 +311,9 @@ class AcqOrderLine(AcquisitionIlsRecord):
             return cannot_delete
         if links := self.get_links_to_me():
             cannot_delete["links"] = links
+        order_status = AcqOrder.get_status_by_pid(self.order_pid)
+        if order_status not in [AcqOrderStatus.CANCELLED, AcqOrderStatus.PENDING]:
+            cannot_delete["others"] = {_("Order status is %s") % _(order_status): True}
         return cannot_delete
 
 

--- a/rero_ils/modules/acquisition/acq_order_lines/permissions.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/permissions.py
@@ -65,6 +65,7 @@ class AcqOrderLinePermissionPolicy(RecordPermissionPolicy):
         AllowedByActionRestrictByManageableLibrary(delete_action),
         DisallowedIfRollovered(AcqOrderLine),
         DisallowedByOrderStatus(
-            AcqOrderLine, [AcqOrderStatus.CANCELLED, AcqOrderStatus.PENDING]
+            record_cls=AcqOrderLine,
+            allowed_statuses=[AcqOrderStatus.CANCELLED, AcqOrderStatus.PENDING],
         ),
     ]

--- a/rero_ils/modules/acquisition/acq_receipt_lines/permissions.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/permissions.py
@@ -51,12 +51,18 @@ class AcqReceiptLinePermissionPolicy(RecordPermissionPolicy):
     can_update = [
         AllowedByActionRestrictByManageableLibrary(update_action),
         DisallowedIfRollovered(AcqReceiptLine),
-        DisallowedByOrderStatus(AcqReceiptLine, [AcqOrderStatus.PARTIALLY_RECEIVED]),
+        DisallowedByOrderStatus(
+            AcqReceiptLine, [AcqOrderStatus.PARTIALLY_RECEIVED, AcqOrderStatus.RECEIVED]
+        ),
     ]
     can_delete = [
         AllowedByActionRestrictByManageableLibrary(delete_action),
         DisallowedIfRollovered(AcqReceiptLine),
         DisallowedByOrderStatus(
-            AcqReceiptLine, [AcqOrderStatus.PARTIALLY_RECEIVED, AcqOrderStatus.RECEIVED]
+            record_cls=AcqReceiptLine,
+            allowed_statuses=[
+                AcqOrderStatus.PARTIALLY_RECEIVED,
+                AcqOrderStatus.RECEIVED,
+            ],
         ),
     ]

--- a/rero_ils/modules/acquisition/acq_receipts/permissions.py
+++ b/rero_ils/modules/acquisition/acq_receipts/permissions.py
@@ -52,13 +52,22 @@ class AcqReceiptPermissionPolicy(RecordPermissionPolicy):
         AllowedByActionRestrictByManageableLibrary(update_action),
         DisallowedIfRollovered(AcqReceipt),
         DisallowedByOrderStatus(
-            AcqReceipt, [AcqOrderStatus.PARTIALLY_RECEIVED, AcqOrderStatus.RECEIVED]
+            AcqReceipt,
+            [
+                AcqOrderStatus.PARTIALLY_RECEIVED,
+                AcqOrderStatus.RECEIVED,
+                AcqOrderStatus.ORDERED,
+            ],
         ),
     ]
     can_delete = [
         AllowedByActionRestrictByManageableLibrary(delete_action),
         DisallowedIfRollovered(AcqReceipt),
         DisallowedByOrderStatus(
-            AcqReceipt, [AcqOrderStatus.PARTIALLY_RECEIVED, AcqOrderStatus.RECEIVED]
+            record_cls=AcqReceipt,
+            allowed_statuses=[
+                AcqOrderStatus.PARTIALLY_RECEIVED,
+                AcqOrderStatus.RECEIVED,
+            ],
         ),
     ]

--- a/scripts/test
+++ b/scripts/test
@@ -97,6 +97,10 @@ function pretests () {
   add_exceptions "GHSA-f9vj-2wh5-fj8j"
   # werkzeug     2.2.3   GHSA-q34m-jh98-gwm2 3.0.6
   add_exceptions "GHSA-q34m-jh98-gwm2"
+  # urllib3 1.26.20 GHSA-48p4-8xcf-vxj5 2.5.0
+  add_exceptions "GHSA-48p4-8xcf-vxj5"
+  # urllib3 1.26.20 GHSA-pq67-6m6q-mj2v 2.5.0
+  add_exceptions "GHSA-pq67-6m6q-mj2v"
   PIPAPI_PYTHON_LOCATION=`which python` pip-audit ${pip_audit_exceptions}
 
   info_msg "Check json:"

--- a/tests/api/acq_receipts/test_acq_receipts_permissions.py
+++ b/tests/api/acq_receipts/test_acq_receipts_permissions.py
@@ -199,7 +199,7 @@ def test_receipts_permissions(
                 "search": True,
                 "read": True,
                 "create": True,
-                "update": False,
+                "update": True,
                 "delete": False,
             },
             acq_receipt_fiction_martigny,

--- a/tests/api/acq_receipts/test_acq_receipts_rest.py
+++ b/tests/api/acq_receipts/test_acq_receipts_rest.py
@@ -72,6 +72,10 @@ def test_acq_receipt_get(
     "invenio_records_rest.views.verify_record_permission",
     mock.MagicMock(return_value=VerifyRecordPermissionPatch),
 )
+@mock.patch(
+    "rero_ils.modules.acquisition.acq_receipts.api.AcqReceipt.reasons_not_to_delete",
+    mock.MagicMock(return_value={}),
+)
 def test_acq_receipts_post_put_delete(
     client, org_martigny, vendor2_martigny, acq_receipt_fiction_saxon, json_header
 ):

--- a/tests/ui/acq_receipts/test_acq_receipts_jsonresolver.py
+++ b/tests/ui/acq_receipts/test_acq_receipts_jsonresolver.py
@@ -18,10 +18,12 @@
 
 """Acq receipt JSONResolver tests."""
 
+import mock
 import pytest
 from invenio_records.api import Record
 from jsonref import JsonRefError
 
+from rero_ils.modules.acquisition.acq_orders.models import AcqOrderStatus
 from rero_ils.modules.utils import extracted_data_from_ref
 
 
@@ -31,7 +33,11 @@ def test_acq_receipts_jsonresolver(acq_receipt_fiction_martigny):
     rec = Record.create({"acq_receipt": data})
     assert extracted_data_from_ref(rec.get("acq_receipt")) == "acre1"
     # deleted record
-    acq_receipt_fiction_martigny.delete()
+    with mock.patch(
+        "rero_ils.modules.acquisition.acq_orders.api.AcqOrder.get_status_by_pid",
+        mock.MagicMock(return_value=AcqOrderStatus.PARTIALLY_RECEIVED),
+    ):
+        acq_receipt_fiction_martigny.delete()
     with pytest.raises(JsonRefError):
         type(rec)(rec.replace_refs()).dumps()
 


### PR DESCRIPTION
* Adds a message when a receipt, receipt line, order cannot be deleted due to the order status.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
