### PR TITLE
fix(circ_policy): fix patron_setting not translated

### DIFF
--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -207,11 +207,11 @@
                 "props": {
                   "options": [
                     {
-                      "label": "According to the patron's settings",
+                      "label": "patron_setting",
                       "value": "patron_setting"
                     },
                     {
-                      "label": "Always per mail",
+                      "label": "mail",
                       "value": "mail"
                     }
                   ]


### PR DESCRIPTION
Harmonise the label and value for the
`circ_policy.reminders.communication_channel` to avoid different strings being displayed by different views.