### PR TITLE
fix(translations): remove f-strings from gettext

### DIFF
--- a/rero_ils/filter.py
+++ b/rero_ils/filter.py
@@ -208,7 +208,9 @@ def translate(data, prefix="", separator=", "):
     """
     if data:
         if isinstance(data, list):
-            translated = [_(f"{prefix}{item}") for item in data]
+            translated = [
+                _("{prefix}{item}").format(prefix=prefix, item=item) for item in data
+            ]
             return separator.join(translated)
         elif isinstance(data, str):
-            return _(f"{prefix}{data}")
+            return _("{prefix}{item}").format(prefix=prefix, item=item)

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -163,7 +163,9 @@ class Holding(IlsRecord):
         document_pid = extracted_data_from_ref(self.get("document").get("$ref"))
         document = Document.get_record_by_pid(document_pid)
         if not document:
-            return _(f"Document does not exist {document_pid}.")
+            return _("Document {document_pid} does not exist.").format(
+                document_pid=document_pid
+            )
 
         if self.is_serial:
             patterns = self.get("patterns", {})
@@ -192,7 +194,9 @@ class Holding(IlsRecord):
             ]
             for field in fields:
                 if self.get(field):
-                    return _(f"{field} is allowed only for serial holdings")
+                    return _("{field} is allowed only for serial holdings").format(
+                        field=field
+                    )
         # No multiple notes with same type
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -91,14 +91,16 @@ class ItemRecord(IlsRecord):
                 .source("pid")
                 .count()
             ):
-                return _(f"Barcode {barcode} is already taken.")
+                return _("Barcode {barcode} is already taken.").format(barcode=barcode)
 
         from ...holdings.api import Holding
 
         holding_pid = extracted_data_from_ref(self.get("holding").get("$ref"))
         holding = Holding.get_record_by_pid(holding_pid)
         if not holding:
-            return _(f"Holding does not exist: {holding_pid}")
+            return _("Holding {holding_pid} does not exist.").format(
+                holding_pid=holding_pid
+            )
 
         if self.get("issue") and self.get("type") == TypeOfItem.STANDARD:
             return _("Standard item can not have a issue field.")

--- a/rero_ils/modules/patron_transactions/utils.py
+++ b/rero_ils/modules/patron_transactions/utils.py
@@ -185,7 +185,9 @@ def create_subscription_for_patron(
             "creation_date": datetime.now(timezone.utc).isoformat(),
             "type": "subscription",
             "status": "open",
-            "note": _(f"Subscription for '{name}' from {start} to {end}"),
+            "note": _("Subscription for '{name}' from {start} to {end}").format(
+                name=name, start=start, end=end
+            ),
         }
         record = PatronTransaction.create(
             data, dbcommit=dbcommit, reindex=reindex, delete_pid=delete_pid


### PR DESCRIPTION
"Python f-strings cannot be used directly with gettext functions because f-string expressions are evaluated before they reach gettext." See: https://docs.astral.sh/ruff/rules/f-string-in-get-text-func-call/