### PR TITLE
fix(circulation): extend with no open date

### DIFF
--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Loans utils."""
+
 import math
 from datetime import datetime, timedelta, timezone
 
@@ -138,7 +139,11 @@ def get_extension_params(loan=None, initial_loan=None, parameter_name=None):
         + timedelta(days=policy.get("renewal_duration"))
         - timedelta(days=1)
     )
-    next_open_date = library.next_open(date=due_date_eve)
+    try:
+        next_open_date = library.next_open(date=due_date_eve)
+    except LibraryNeverOpen:
+        # if the library has no open day, use standard loan duration from cipo
+        next_open_date = due_date_eve + timedelta(days=1)
 
     if next_open_date.date() < end_date.date():
         params["max_count"] = 0

--- a/tests/api/circulation/test_library_with_no_circulation.py
+++ b/tests/api/circulation/test_library_with_no_circulation.py
@@ -225,3 +225,9 @@ def test_requesting_item_from_non_circulating_library(
     assert pickup_lib_pid == lib_martigny.pid
 
     assert loan.get("state") == LoanState.ITEM_ON_LOAN
+
+    # Test extend loan for library with no open days
+    loan["end_date"] = loan["start_date"]
+    loan.update(loan, dbcommit=True, reindex=True)
+    res, data = postdata(client, "api_item.extend_loan", params)
+    assert res.status_code == 200


### PR DESCRIPTION
* Allows loan extension even for libraries with no open dates.
* Addresses SENTRY-RERO-ILS-672.