### PR TITLE
fix(permissions): fix patron roles management restrictions

### DIFF
--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -497,6 +497,7 @@
         "formlyConfig": {
           "type": "multi-checkbox",
           "props": {
+            "fieldMap": "roles",
             "options": [
               {
                 "label": "patron",

--- a/rero_ils/modules/patrons/permissions.py
+++ b/rero_ils/modules/patrons/permissions.py
@@ -18,7 +18,7 @@
 
 """Permissions for patrons."""
 
-from flask import g
+from flask import current_app, g
 from flask_login import current_user
 from invenio_access import action_factory, any_user
 from invenio_records_permissions.generators import Generator
@@ -112,9 +112,10 @@ def get_allowed_roles_management():
 
     :return An array of allowed role management.
     """
-    allowed_roles = []
-    if current_librarian:
-        allowed_roles += [UserRole.PATRON, *UserRole.LIBRARIAN_ROLES]
-        if current_librarian.has_full_permissions:
-            allowed_roles += [UserRole.FULL_PERMISSIONS]
-    return allowed_roles
+    if not current_librarian:
+        return {}
+    config_roles = current_app.config.get("RERO_ILS_PATRON_ROLES_MANAGEMENT_RESTRICTIONS", {})
+    manageable_roles = set()
+    for role in current_librarian.user.roles:
+        manageable_roles = manageable_roles.union(config_roles.get(role.name, {}))
+    return manageable_roles

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -162,7 +162,7 @@ def profile(viewcode, path):
 @check_logged_as_librarian
 def get_roles_management_permissions():
     """Get the roles that current logged user could manage."""
-    return jsonify({"allowed_roles": get_allowed_roles_management()})
+    return jsonify({"allowed_roles": list(get_allowed_roles_management())})
 
 
 @api_blueprint.route("/<string:patron_pid>/messages", methods=["GET"])

--- a/scripts/test
+++ b/scripts/test
@@ -77,6 +77,8 @@ function pretests () {
   add_exceptions " PYSEC-2022-42969"
   # urllib3 1.26.20 GHSA-pq67-6m6q-mj2v 2.5.0
   add_exceptions "GHSA-pq67-6m6q-mj2v"
+  # future  1.0.0   GHSA-xqrq-4mgf-ff32
+  add_exceptions "GHSA-xqrq-4mgf-ff32"
   PIPAPI_PYTHON_LOCATION=`which python` pip-audit ${pip_audit_exceptions}
 
   info_msg "Check json:"

--- a/tests/api/test_commons_api.py
+++ b/tests/api/test_commons_api.py
@@ -42,24 +42,30 @@ def test_librarian_delete_permission_factory(client, librarian_fully, org_martig
     assert librarian_delete_permission_factory(org_martigny) is not None
 
 
-def test_system_librarian_permissions(
-    client,
-    json_header,
-    system_librarian_martigny,
-    patron_martigny,
-    patron_type_adults_martigny,
-    librarian_fully,
-):
+def test_get_roles_management_permissions(client, system_librarian_martigny, patron_martigny, librarian_fully, app):
     """Test system_librarian permissions."""
+    role_url = url_for("api_patrons.get_roles_management_permissions")
+    res = client.get(role_url)
+    assert res.status_code == 401
+
+    login_user_via_session(client, patron_martigny.user)
+    res = client.get(role_url)
+    assert res.status_code == 403
+
     # Login as system_librarian
     login_user_via_session(client, system_librarian_martigny.user)
-
     # can manage all types of patron roles
-    role_url = url_for("api_patrons.get_roles_management_permissions")
     res = client.get(role_url)
     assert res.status_code == 200
     data = get_json(res)
-    assert UserRole.FULL_PERMISSIONS in data["allowed_roles"]
+    assert set(data["allowed_roles"]) == set(UserRole.ALL_ROLES)
+
+    # Login as user manager
+    login_user_via_session(client, librarian_fully.user)
+    res = client.get(role_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert set(data["allowed_roles"]) == {UserRole.PATRON}
 
 
 def test_permission_exposition(app, db, client, system_librarian_martigny):


### PR DESCRIPTION
* Adds a fieldMap widget configuration in the patron jsonschema.
* Tests the HTTP view with several users.
* Gets the values from the corresponding configuration.
* Closes #3733.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
