### PR TITLE
docs: remove confusing indication in library emails

### DIFF
--- a/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
+++ b/rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json
@@ -36,7 +36,7 @@
         },
         "email": {
           "title": "E-mail",
-          "description": "The notifications for patrons without e-mail are sent to this address. No notification is sent if the field is empty.",
+          "description": "The notifications for patrons without e-mail are sent to this address.",
           "type": "string",
           "format": "email"
         }
@@ -58,7 +58,7 @@
         },
         "email": {
           "title": "E-mail",
-          "description": "The notifications for patrons without e-mail are sent to this address. No notification is sent if the field is empty.",
+          "description": "The notifications for patrons without e-mail are sent to this address.",
           "type": "string",
           "format": "email"
         },


### PR DESCRIPTION
* "No notification is sent if the field is empty." could make users believe that even patrons with email did not recieve notifications.