### PR TITLE
fix(permissions): restrict the overdue APIs

### DIFF
--- a/rero_ils/modules/loans/api_views.py
+++ b/rero_ils/modules/loans/api_views.py
@@ -29,6 +29,7 @@ from rero_ils.modules.items.views.api_views import (
 )
 from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.loans.utils import get_circ_policy, sum_for_fees
+from rero_ils.modules.patrons.api import current_librarian, current_patrons
 
 api_blueprint = Blueprint("api_loan", __name__, url_prefix="/loan")
 
@@ -53,6 +54,11 @@ def preview_loan_overdue(loan_pid):
     loan = Loan.get_record_by_pid(loan_pid)
     if not loan:
         abort(404, "Loan not found")
+    current_patrons_pids = [patron.pid for patron in current_patrons]
+    # if the logged user is a patron the pid should be his own
+    # otherwise the user should be a librarian
+    if loan.get("patron_pid") not in current_patrons_pids and not current_librarian:
+        abort(403)
     fees = loan.get_overdue_fees
     fees = [(fee[0], fee[1].isoformat()) for fee in fees]  # format date
     return jsonify({"total": sum_for_fees(fees), "steps": fees})

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -90,6 +90,11 @@ def patron_circulation_informations(patron_pid):
 @login_required
 def patron_overdue_preview_api(patron_pid):
     """Get all overdue preview linked to a patron."""
+    current_patrons_pids = [patron.pid for patron in current_patrons]
+    # if the logged user is a patron the pid should be his own
+    # otherwise the user should be a librarian
+    if patron_pid not in current_patrons_pids and not current_librarian:
+        abort(403)
     data = []
     for loan in get_overdue_loans(patron_pid):
         fees = loan.get_overdue_fees

--- a/tests/api/circulation/test_actions_views_checkin.py
+++ b/tests/api/circulation/test_actions_views_checkin.py
@@ -126,6 +126,7 @@ def test_auto_checkin_else(
 def test_checkin_overdue_item(
     client,
     librarian_martigny,
+    patron2_martigny,
     loc_public_martigny,
     item_on_loan_martigny_patron_and_loan_on_loan,
 ):
@@ -156,16 +157,35 @@ def test_checkin_overdue_item(
     assert total_fees > 0
 
     # Check overdues preview API and check result
-    url = url_for("api_loan.preview_loan_overdue", loan_pid=loan.pid)
+    loan_url = url_for("api_loan.preview_loan_overdue", loan_pid=loan.pid)
+    patron_url = url_for("api_patrons.patron_overdue_preview_api", patron_pid=patron.pid)
+
+    res = client.get(loan_url)
+    assert res.status_code == 401
+    res = client.get(patron_url)
+    assert res.status_code == 401
+
+    login_user_via_session(client, patron.user)
+    res = client.get(loan_url)
+    assert res.status_code == 200
+    res = client.get(patron_url)
+    assert res.status_code == 200
+
+    assert patron.pid != patron2_martigny.pid
+    login_user_via_session(client, patron2_martigny.user)
+    res = client.get(loan_url)
+    assert res.status_code == 403
+    res = client.get(patron_url)
+    assert res.status_code == 403
+
     login_user_via_session(client, librarian_martigny.user)
-    res = client.get(url)
+    res = client.get(loan_url)
     data = get_json(res)
     assert res.status_code == 200
     assert len(data["steps"]) > 0
     assert data["total"] > 0
 
-    url = url_for("api_patrons.patron_overdue_preview_api", patron_pid=patron.pid)
-    res = client.get(url)
+    res = client.get(patron_url)
     data = get_json(res)
     assert res.status_code == 200
     assert len(data) == 1


### PR DESCRIPTION
* Restricts the overdue APIs for a logged patron to access only to his own data.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
