### PR TITLE
chore(fixtures): remove auto_renewal in some circulation_policies

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -35,7 +35,6 @@
     ],
     "number_renewals": 3,
     "renewal_duration": 30,
-    "automatic_renewal": true,
     "policy_library_level": false,
     "is_default": true
   },
@@ -105,7 +104,6 @@
     ],
     "number_renewals": 1,
     "renewal_duration": 7,
-    "automatic_renewal": true,
     "policy_library_level": true,
     "is_default": false,
     "libraries": [
@@ -160,7 +158,6 @@
     ],
     "number_renewals": 1,
     "renewal_duration": 14,
-    "automatic_renewal": true,
     "policy_library_level": false,
     "is_default": false,
     "settings": [
@@ -218,7 +215,6 @@
     ],
     "number_renewals": 3,
     "renewal_duration": 28,
-    "automatic_renewal": true,
     "policy_library_level": false,
     "is_default": false,
     "settings": [


### PR DESCRIPTION
* This allows us to have "predicted" fees after the setup script in Aoste organisation.