### PR TITLE
fix(translations): disable interpolation for translated strings

### DIFF
--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -86,7 +86,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
         # NOTES fields testing
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):
-            return _("Can not have multiple notes of the same type.")
+            return _("Cannot have multiple notes of the same type.")
         from rero_ils.modules.acquisition.acq_orders.api import AcqOrder
         from rero_ils.modules.acquisition.acq_orders.models import AcqOrderStatus
 
@@ -101,7 +101,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
                 AcqOrderStatus.PARTIALLY_RECEIVED,
             ]
         if order_status not in valid_statuses:
-            return _(f"Can not create an order line with an order with a wrong status {order_status}.")
+            return _("Cannot create an order line with an order with a wrong status.")
         return True
 
     @classmethod
@@ -299,7 +299,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
             cannot_delete["links"] = links
         order_status = AcqOrder.get_status_by_pid(self.order_pid)
         if order_status not in [AcqOrderStatus.CANCELLED, AcqOrderStatus.PENDING]:
-            cannot_delete["others"] = {_("Order status is %s") % _(order_status): True}
+            cannot_delete["others"] = {"order_has_active_status": True}
         return cannot_delete
 
 

--- a/rero_ils/modules/acquisition/acq_orders/api.py
+++ b/rero_ils/modules/acquisition/acq_orders/api.py
@@ -99,7 +99,7 @@ class AcqOrder(AcquisitionIlsRecord):
         # NOTES fields testing
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):
-            return _("Can not have multiple notes of the same type.")
+            return _("Cannot have multiple notes of the same type.")
 
         return True
 
@@ -436,7 +436,7 @@ class AcqOrder(AcquisitionIlsRecord):
         # ``pre_delete`` hook.
         links.pop("acq_order_lines", None)
         if self.status != AcqOrderStatus.PENDING:
-            cannot_delete["others"] = {_("Order status is %s") % _(self.status): True}
+            cannot_delete["others"] = {"order_already_sent": True}
         if links:
             cannot_delete["links"] = links
         return cannot_delete

--- a/rero_ils/modules/acquisition/acq_receipt_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/api.py
@@ -99,7 +99,7 @@ class AcqReceiptLine(AcquisitionIlsRecord):
             AcqOrderStatus.PARTIALLY_RECEIVED,
             AcqOrderStatus.RECEIVED,
         ]:
-            return _(f"Can not create a receipt with an order with a wrong status {order_status}.")
+            return _("Cannot create a receipt with an order with a wrong status.")
         return True
 
     def update(self, data, commit=True, dbcommit=True, reindex=True):
@@ -214,7 +214,7 @@ class AcqReceiptLine(AcquisitionIlsRecord):
             AcqOrderStatus.PARTIALLY_RECEIVED,
             AcqOrderStatus.RECEIVED,
         ]:
-            cannot_delete["others"] = {_("Order status is %s") % _(order_status): True}
+            cannot_delete["others"] = {"order_not_in_reception": True}
         return cannot_delete
 
 

--- a/rero_ils/modules/acquisition/acq_receipts/api.py
+++ b/rero_ils/modules/acquisition/acq_receipts/api.py
@@ -151,7 +151,7 @@ class AcqReceipt(AcquisitionIlsRecord):
             AcqOrderStatus.PARTIALLY_RECEIVED,
             AcqOrderStatus.RECEIVED,
         ]:
-            return _(f"Can not create a receipt with an order with a wrong status {order_status}.")
+            return _("Cannot create a receipt with an order with a wrong status.")
         return True
 
     @classmethod
@@ -222,7 +222,7 @@ class AcqReceipt(AcquisitionIlsRecord):
             AcqOrderStatus.RECEIVED,
             AcqOrderStatus.PARTIALLY_RECEIVED,
         ]:
-            cannot_delete["others"] = {_("Order status is %s") % _(order_status): True}
+            cannot_delete["others"] = {"order_not_in_reception": True}
         # Note : linked receipt lines aren't yet a reason to keep the record.
         #        These lines will be deleted with the record.
         # TODO :: add a reason if order is concluded (rollovered or invoiced)

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -481,9 +481,9 @@ class IlsRecord(Record):
         try:
             indexer().delete(self)
         except NotFoundError:
-            current_app.logger.warning(f"Can not delete from index {self.__class__.__name__}: {self.pid}")
+            current_app.logger.warning(f"Cannot delete from index {self.__class__.__name__}: {self.pid}")
         except ValueError:
-            current_app.logger.warning(f"Can not delete from index {self.__class__.__name__}")
+            current_app.logger.warning(f"Cannot delete from index {self.__class__.__name__}")
 
     @property
     def pid(self):

--- a/rero_ils/modules/cli/index.py
+++ b/rero_ils/modules/cli/index.py
@@ -200,7 +200,7 @@ def reindex(pid_types, from_date, until_date, direct, queue):
                     indxer = IlsRecordsIndexer(queue=simple_queue, routing_key=queue)
                     indxer.bulk_index((x[0] for x in query), doc_type=pid_type)
             else:
-                click.echo("Can not index by date.")
+                click.echo("Cannot index by date.")
         else:
             click.secho(f"ERROR type does not exist: {pid_type}", fg="red")
         if not direct:

--- a/rero_ils/modules/cli/utils.py
+++ b/rero_ils/modules/cli/utils.py
@@ -1503,7 +1503,7 @@ def export(verbose, pid_type, outfile_name, pidfile, indent, schema):
             outfile.write(rec)
         except Exception as err:
             click.echo(err)
-            click.echo(f"ERROR: Can not export pid:{pid}")
+            click.echo(f"ERROR: Cannot export pid:{pid}")
 
 
 def create_personal(name, user_id, scopes=None, is_internal=False, access_token=None):

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -159,7 +159,7 @@ class Holding(IlsRecord):
         document_pid = extracted_data_from_ref(self.get("document").get("$ref"))
         document = Document.get_record_by_pid(document_pid)
         if not document:
-            return _(f"Document does not exist {document_pid}.")
+            return f"Document {document_pid} does not exist."
 
         if self.is_serial:
             patterns = self.get("patterns", {})
@@ -184,11 +184,11 @@ class Holding(IlsRecord):
             ]
             for field in fields:
                 if self.get(field):
-                    return _(f"{field} is allowed only for serial holdings")
+                    return f"{field} only allowed for serial holdings."
         # No multiple notes with same type
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):
-            return _("Can not have multiple notes of the same type.")
+            return _("Cannot have multiple notes of the same type.")
         return True
 
     def delete(self, force=False, dbcommit=False, delindex=False):
@@ -438,18 +438,9 @@ class Holding(IlsRecord):
         cannot_delete = {}
         if self.is_serial:
             counts = {}
-            for item in self.get_all_items():
-                reasons_not_to_delete = item.reasons_not_to_delete().get("links", {})
-                issue_status = item.issue_status
-                for reason in reasons_not_to_delete:
-                    counts.setdefault(reason, 0)
-                    # Add reason count for received loans and all other reasons.
-                    if (reason == "loans" and issue_status == ItemIssueStatus.RECEIVED) or reason != "loans":
-                        counts[reason] += 1
-                if cannot_delete_msgs := {
-                    _(f"has {value} items with {name} attached"): value for name, value in counts.items() if value > 0
-                }:
-                    cannot_delete["others"] = cannot_delete_msgs
+            if not_deletable_items := [item for item in self.get_all_items() if item.reasons_not_to_delete()]:
+                count = len(not_deletable_items)
+                cannot_delete["links"] = {"items_with_loans_or_fees": count}
         else:
             links = self.get_links_to_me()
             # local_fields isn't a reason to block holding suppression

--- a/rero_ils/modules/holdings/tasks.py
+++ b/rero_ils/modules/holdings/tasks.py
@@ -41,7 +41,7 @@ def delete_standard_holdings_having_no_items():
             except Exception as err:
                 errors += 1
                 reasons = record.reasons_not_to_delete()
-                current_app.logger.error(f"Can not delete standard holding: {hit.pid} {reasons} {err}")
+                current_app.logger.error(f"Cannot delete standard holding: {hit.pid} {reasons} {err}")
         else:
             # delete holding from index
             HoldingsIndexer().client.delete(id=hit.meta.id, index="holdings", doc_type="_doc")

--- a/rero_ils/modules/ill_requests/api.py
+++ b/rero_ils/modules/ill_requests/api.py
@@ -100,7 +100,7 @@ class ILLRequest(IlsRecord):
 
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):
-            return _("Can not have multiple notes of the same type.")
+            return _("Cannot have multiple notes of the same type.")
 
         return True
 

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -99,7 +99,7 @@ class Item(ItemCirculation, ItemIssue):
         "required": {"loc": "location", "doc": "document", "itty": "item_type"},
         "not_required": {
             "org": "organisation",
-            # We can not make the holding required because it is created later
+            # We cannot make the holding required because it is created later
             "hold": "holding",
         },
     }

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -86,17 +86,17 @@ class ItemRecord(IlsRecord):
 
         if barcode := self.get("barcode"):
             if ItemsSearch().exclude("term", pid=self.pid).filter("term", barcode=barcode).source("pid").count():
-                return _(f"Barcode {barcode} is already taken.")
+                return _("Barcode is already taken.")
 
         from ...holdings.api import Holding
 
         holding_pid = extracted_data_from_ref(self.get("holding").get("$ref"))
         holding = Holding.get_record_by_pid(holding_pid)
         if not holding:
-            return _(f"Holding does not exist: {holding_pid}")
+            return f"Holdings {holding_pid} does not exist."
 
         if self.get("issue") and self.get("type") == TypeOfItem.STANDARD:
-            return _("Standard item can not have a issue field.")
+            return _("Standard item cannot have a issue field.")
         if self.get("type") == TypeOfItem.ISSUE:
             if not self.get("issue", {}):
                 return _("Issue item must have an issue field.")
@@ -104,7 +104,7 @@ class ItemRecord(IlsRecord):
                 return _("enumerationAndChronology field is required for an issue item")
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):
-            return _("Can not have multiple notes of the same type.")
+            return _("Cannot have multiple notes of the same type.")
 
         # check temporary item type data
         if tmp_itty := self.get("temporary_item_type"):

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -243,7 +243,7 @@ class Loan(IlsRecord):
             # Anonymize loan operation logs
             LoanOperationLog.anonymize_logs(self.pid)
         except Exception as err:
-            current_app.logger.error(f"Can not anonymize loan: {self.get('pid')} {err}")
+            current_app.logger.error(f"Cannot anonymize loan: {self.get('pid')} {err}")
         return self
 
     def date_fields2datetime(self):
@@ -992,7 +992,7 @@ class Loan(IlsRecord):
         if patron:
             keep_history = patron.user.user_profile.get("keep_history", True)
         else:
-            msg = f"Can not anonymize loan: {loan_data.get('pid')} no patron: {loan_data.get('patron_pid')}"
+            msg = f"Cannot anonymize loan: {loan_data.get('pid')} no patron: {loan_data.get('patron_pid')}"
             current_app.logger.warning(msg)
         return not keep_history
 

--- a/rero_ils/modules/patron_transactions/utils.py
+++ b/rero_ils/modules/patron_transactions/utils.py
@@ -164,7 +164,6 @@ def create_subscription_for_patron(
     """
     record = {}
     if patron_type.is_subscription_required:
-        name = (patron_type.get("name"),)
         start = (start_date.strftime("%Y-%m-%d"),)
         end = end_date.strftime("%Y-%m-%d")
         data = {
@@ -174,7 +173,7 @@ def create_subscription_for_patron(
             "creation_date": datetime.now(timezone.utc).isoformat(),
             "type": "subscription",
             "status": "open",
-            "note": _(f"Subscription for '{name}' from {start} to {end}"),
+            "note": f"{start}-{end}",
         }
         record = PatronTransaction.create(data, dbcommit=dbcommit, reindex=reindex, delete_pid=delete_pid)
     return record

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -577,7 +577,7 @@ def set_timestamp(name, **kwargs):
     utc_now = datetime.now(timezone.utc)
     time_stamps[name] = kwargs | {"time": utc_now, "name": name}
     if not current_cache.set(key="timestamps", value=time_stamps, timeout=0):
-        current_app.logger.warning(f"Can not set time stamp for: {name}")
+        current_app.logger.warning(f"Cannot set time stamp for: {name}")
     return utc_now
 
 
@@ -1051,7 +1051,7 @@ def sorted_pids(query):
     try:
         return sorted(pids, key=int)
     except Exception as err:
-        current_app.logger.info(f"Can not sort pids from query: {err}")
+        current_app.logger.info(f"Cannot sort pids from query: {err}")
     return pids
 
 

--- a/rero_ils/modules/vendors/api.py
+++ b/rero_ils/modules/vendors/api.py
@@ -71,11 +71,11 @@ class Vendor(IlsRecord):
         # CONTACTS field
         types = [contact.get("type") for contact in self.get("contacts", [])]
         if len(types) != len(set(types)):
-            return _("Can not have multiple contacts with the same type.")
+            return _("Cannot have multiple contacts with the same type.")
         # NOTES field
         types = [note.get("type") for note in self.get("notes", [])]
         if len(types) != len(set(types)):
-            return _("Can not have multiple notes with the same type.")
+            return _("Cannot have multiple notes with the same type.")
 
         return True
 

--- a/tests/api/holdings/test_holdings_rest.py
+++ b/tests/api/holdings/test_holdings_rest.py
@@ -137,7 +137,7 @@ def test_holdings_post_put_delete(
     list_url = url_for("invenio_records_rest.hold_list", q="pid:2")
     holding_data = holding_lib_martigny_data_tmp
     # Create record / POST
-    # We can not use pid=1 here. It is already used!
+    # We cannot use pid=1 here. It is already used!
     holding_data["pid"] = "2"
     res, data = postdata(client, "invenio_records_rest.hold_list", holding_data)
     assert res.status_code == 201

--- a/tests/api/holdings/test_provisional_items.py
+++ b/tests/api/holdings/test_provisional_items.py
@@ -58,7 +58,7 @@ def test_provisional_items_creation(
     assert item_es.status == ItemStatus.ON_SHELF
     assert item_es.holding_pid == holding.pid
 
-    # TEST: logged patrons can not have the provisional items in the results.
+    # TEST: logged patrons cannot have the provisional items in the results.
     # for both global and insitutional view.
     login_user_via_session(client, patron_martigny.user)
 

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -875,7 +875,7 @@ def test_items_notes(client, librarian_martigny, item_lib_martigny, json_header)
     )
     assert get_json(res) == {
         "status": 400,
-        "message": "Validation error: Can not have multiple notes of the same type..",
+        "message": "Validation error: Cannot have multiple notes of the same type..",
     }
     item["notes"] = item.notes[:-1]
 

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -1244,7 +1244,7 @@ def test_delete_pickup_location(loan2_validated_martigny, loc_restricted_martign
     loan = loan2_validated_martigny
     notification = get_notification(loan, NotificationType.AVAILABILITY)
     assert notification.pickup_location.pid == loc_restricted_martigny.pid
-    # We can not delete location used as transaction or pickup location
+    # We cannot delete location used as transaction or pickup location
     # # any more.
     reasons_not_to_delete = loc_restricted_martigny.reasons_not_to_delete()
     assert reasons_not_to_delete == {"links": {"loans": 1}}

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -154,7 +154,7 @@ def test_item_holding_document_availability(
     del item["_masked"]
     item.update(item, dbcommit=True, reindex=True)
 
-    # test can not request item already checked out to patron
+    # test cannot request item already checked out to patron
     res = client.get(
         url_for(
             "api_item.can_request",

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -107,7 +107,7 @@ def test_circ_policy_exist_name_and_organisation_pid(circ_policy_short_martigny)
 
 
 def test_circ_policy_can_not_delete(circ_policy_short_martigny):
-    """Test can not delete a policy."""
+    """Test cannot delete a policy."""
     org_pid = circ_policy_short_martigny.organisation_pid
     defaut_cipo = CircPolicy.get_default_circ_policy(org_pid)
     can, reasons = defaut_cipo.can_delete

--- a/tests/ui/circulation/test_actions_add_request.py
+++ b/tests/ui/circulation/test_actions_add_request.py
@@ -39,7 +39,7 @@ def test_add_request_on_item_on_shelf(
 
     # the following tests the circulation action ADD_REQUEST_1_2_1
     # for an item on_shelf with a pending loan, the patron that owns the
-    # pending loan can not add a new pending loan on same item.
+    # pending loan cannot add a new pending loan on same item.
     params = {
         "patron_pid": patron.pid,
         "transaction_location_pid": loc_public_martigny.pid,
@@ -159,7 +159,7 @@ def test_add_request_on_item_in_transit_for_pickup(
     item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
 
     # the following tests the circulation action ADD_REQUEST_4_1
-    # the owner of the IN_TRANSIT_FOR_PICKUP loan can not add a pending loan
+    # the owner of the IN_TRANSIT_FOR_PICKUP loan cannot add a pending loan
     params = {
         "patron_pid": patron.pid,
         "transaction_location_pid": loc_public_martigny.pid,
@@ -211,7 +211,7 @@ def test_add_request_on_item_in_transit_to_house(
 
     # the following tests the circulation action ADD_REQUEST_5_2_1
     # when a pending loan exist on an item with loan ITEM_IN_TRANSIT_TO_HOUSE
-    # the patron who owns the pending loan can not add a new pending loan
+    # the patron who owns the pending loan cannot add a new pending loan
     with pytest.raises(RecordCannotBeRequestedError):
         item, requested_loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -197,14 +197,14 @@ def test_document_add_cover_url(db, document):
 
 
 def test_document_with_item_can_not_delete(document, item_lib_martigny):
-    """Test can not delete."""
+    """Test cannot delete."""
     can, reasons = document.can_delete
     assert not can
     assert reasons["links"]["items"]
 
 
 def test_document_with_files_can_not_delete(document_with_files):
-    """Test can not delete."""
+    """Test cannot delete."""
     links_to_me = document_with_files.get_links_to_me(True)
     assert len(links_to_me["files"]) > 0
     can, reasons = document_with_files.can_delete

--- a/tests/ui/entities/remote_entities/test_remote_entities_api.py
+++ b/tests/ui/entities/remote_entities/test_remote_entities_api.py
@@ -60,7 +60,7 @@ def test_remote_entity_create(app, entity_person_data_tmp, caplog):
     assert caplog.record_tuples[1] == (
         "invenio",
         30,
-        "Can not delete from index RemoteEntity: 2",
+        "Cannot delete from index RemoteEntity: 2",
     )
 
 

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -112,7 +112,7 @@ def test_holding_extended_validation(
     record.get("notes").append({"type": "general_note", "content": "note"})
     with pytest.raises(ValidationError) as err:
         record.validate()
-    assert "Can not have multiple notes of the same type" in str(err)
+    assert "Cannot have multiple notes of the same type" in str(err)
     del record["notes"]
 
     with (
@@ -120,13 +120,13 @@ def test_holding_extended_validation(
         pytest.raises(ValidationError) as err,
     ):
         record.validate()
-    assert "Document does not exist" in str(err)
+    assert "Document doc4 does not exist" in str(err)
 
     record["holdings_type"] = HoldingTypes.STANDARD
     assert record["enumerationAndChronology"]
     with pytest.raises(ValidationError) as err:
         record.validate()
-    assert "is allowed only for serial holdings" in str(err)
+    assert "only allowed for serial holdings" in str(err)
 
     # TESTING ELECTRONIC HOLDING
     #   1. instantiate electronic holding

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -148,12 +148,12 @@ def test_receive_regular_issue(holding_lib_martigny_w_patterns, tomorrow):
         "rero_ils.modules.items.api.Item.get_links_to_me",
         return_value={"fees": 1},
     ):
-        assert holding.reasons_not_to_delete() == {"others": {"has 3 items with fees attached": 3}}
+        assert holding.reasons_not_to_delete() == {"links": {"items_with_loans_or_fees": 3}}
     with mock.patch(
         "rero_ils.modules.items.api.Item.get_links_to_me",
-        return_value={"collections": 1},
+        return_value={"loans": 2},
     ):
-        assert holding.reasons_not_to_delete() == {"others": {"has 3 items with collections attached": 3}}
+        assert holding.reasons_not_to_delete() == {"links": {"items_with_loans_or_fees": 3}}
 
 
 def test_patterns_yearly_one_level(holding_lib_martigny_w_patterns, pattern_yearly_one_level_data):

--- a/tests/ui/item_types/test_item_types_api.py
+++ b/tests/ui/item_types/test_item_types_api.py
@@ -63,7 +63,7 @@ def test_item_type_get_pid_by_name(item_type_standard_martigny):
 
 
 def test_item_type_can_not_delete(item_type_standard_martigny, item_lib_martigny):
-    """Test item type can not delete"""
+    """Test item type cannot delete"""
     can, reasons = item_type_standard_martigny.can_delete
     assert not can
     assert reasons["links"]["items"]

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -113,13 +113,13 @@ def test_item_extended_validation(client, holding_lib_martigny_w_patterns):
     Item.create(data, dbcommit=True, reindex=True, delete_pid=True)
 
     # TODO: check why system is not raising validation error here
-    # # can not have a standard item with issues on a serial holdings
+    # # cannot have a standard item with issues on a serial holdings
     # data['type'] = 'standard'
     # with pytest.raises(ValidationError):
     #     Item.create(data, dbcommit=True, reindex=True, delete_pid=True)
     # data['type'] == 'issue'
     # data.pop('issue')
-    # # can not create an issue item without issues on a serial holdings
+    # # cannot create an issue item without issues on a serial holdings
     # with pytest.raises(ValidationError):
     #     Item.create(data, dbcommit=True, reindex=True, delete_pid=True)
 

--- a/tests/unit/test_vendors_jsonschema.py
+++ b/tests/unit/test_vendors_jsonschema.py
@@ -35,10 +35,10 @@ def test_vendors_special_rero_validation(app, vendor_martigny_data, vendors_sche
     record["contacts"].append(record["contacts"][0])
     with pytest.raises(ValidationError) as err:
         Vendor.validate(Vendor(record))
-    assert "Can not have multiple contacts with the same type" in str(err)
+    assert "Cannot have multiple contacts with the same type" in str(err)
 
     record["contacts"] = vendor_martigny_data["contacts"]
     record["notes"].append(record["notes"][0])
     with pytest.raises(ValidationError) as err:
         Vendor.validate(Vendor(record))
-    assert "Can not have multiple notes with the same type" in str(err)
+    assert "Cannot have multiple notes with the same type" in str(err)


### PR DESCRIPTION
- The backend should never translate a formatted string with variable interpolation, because it has no notion of language and the frontend will not be able to translate the string with dynamic values.
- Closes #3920.