### PR TITLE
fix(items): restore collections in item `get_links_to_me`

### DIFF
--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -120,8 +120,9 @@ class Item(ItemCirculation, ItemIssue):
         """Get reasons not to delete record."""
         cannot_delete = {}
         links = self.get_links_to_me()
-        # local_fields aren't a reason to block suppression
+        # local_fields and collections aren't a reason to block suppression
         links.pop("local_fields", None)
+        links.pop("collections", None)
         if links:
             cannot_delete["links"] = links
         return cannot_delete

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -1041,6 +1041,7 @@ class ItemCirculation(ItemRecord):
                          if False count of linked records
         """
         # avoid circular import
+        from rero_ils.modules.collections.api import CollectionsSearch
         from rero_ils.modules.local_fields.api import LocalFieldsSearch
 
         query_loans = search_by_pid(
@@ -1057,19 +1058,23 @@ class ItemCirculation(ItemRecord):
             .filter("term", status="open")
             .filter("range", total_amount={"gt": 0})
         )
+        query_collections = CollectionsSearch().filter("term", items__pid=self.pid)
         query_local_fields = LocalFieldsSearch().get_local_fields(self.provider.pid_type, self.pid)
 
         if get_pids:
             loans = sorted_pids(query_loans)
             fees = sorted_pids(query_fees)
+            collections = sorted_pids(query_collections)
             local_fields = sorted_pids(query_local_fields)
         else:
             loans = query_loans.count()
             fees = query_fees.count()
+            collections = query_collections.count()
             local_fields = query_local_fields.count()
         links = {
             "loans": loans,
             "fees": fees,
+            "collections": collections,
             "local_fields": local_fields,
         }
         return {k: v for k, v in links.items() if v}

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -151,9 +151,9 @@ def test_receive_regular_issue(holding_lib_martigny_w_patterns, tomorrow):
         assert holding.reasons_not_to_delete() == {"links": {"items_with_loans_or_fees": 3}}
     with mock.patch(
         "rero_ils.modules.items.api.Item.get_links_to_me",
-        return_value={"loans": 2},
+        return_value={"collections": 2},
     ):
-        assert holding.reasons_not_to_delete() == {"links": {"items_with_loans_or_fees": 3}}
+        assert holding.reasons_not_to_delete() == {}
 
 
 def test_patterns_yearly_one_level(holding_lib_martigny_w_patterns, pattern_yearly_one_level_data):

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -280,6 +280,13 @@ def test_get_links_to_me_with_fees(patron_transaction_overdue_saxon):
     assert item.get_links_to_me(get_pids=True) == {"loans": ["1"]}
 
 
+def test_get_links_to_me_with_collection(coll_martigny_1, item_lib_martigny):
+    """Test item deletion used by a collection."""
+    assert item_lib_martigny.get_links_to_me() == {"collections": 1}
+    assert item_lib_martigny.get_links_to_me(get_pids=True) == {"collections": [coll_martigny_1.pid]}
+    assert item_lib_martigny.can_delete
+
+
 def test_items_properties(item_lib_martigny):
     """Test some properties about item class."""
     item = item_lib_martigny


### PR DESCRIPTION
* The implementation of https://github.com/rero/rero-ils/pull/3954 was incorrect. The collections linked to an item should still be links for `get_links_to_me()`, they should simply not be a `reason_not_to_delete`.