### PR TITLE
fix: not all locations displayed in the library facet

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2100,28 +2100,35 @@ RECORDS_REST_FACETS = dict(
                 terms=dict(field="language.value", size=DOCUMENTS_AGGREGATION_SIZE)
             ),
             organisation=dict(
-                terms=dict(
-                    field="organisation_pid",
-                    size=DOCUMENTS_AGGREGATION_SIZE,
-                    min_doc_count=0,
+                nested=dict(
+                    path="nested_holdings"
                 ),
                 aggs=dict(
-                    library=dict(
+                    organisation=dict(
                         terms=dict(
-                            field="library_pid",
+                            field="nested_holdings.organisation.organisation_pid",
                             size=DOCUMENTS_AGGREGATION_SIZE,
                             min_doc_count=0,
                         ),
                         aggs=dict(
-                            location=dict(
+                            library=dict(
                                 terms=dict(
-                                    field="location_pid",
-                                    size=DOCUMENTS_AGGREGATION_SIZE,
+                                    field="nested_holdings.organisation.library_pid",
+                                    size=50,
                                     min_doc_count=0,
-                                )
+                                ),
+                                aggs=dict(
+                                    location=dict(
+                                        terms=dict(
+                                            field="nested_holdings.location.pid",
+                                            size=100,
+                                            min_doc_count=0,
+                                        )
+                                    )
+                                ),
                             )
                         ),
-                    )
+                    ),
                 ),
             ),
             status=dict(

--- a/rero_ils/modules/documents/dumpers/indexer.py
+++ b/rero_ils/modules/documents/dumpers/indexer.py
@@ -114,6 +114,7 @@ class IndexerDumper(Dumper):
 
         if holdings:
             data["holdings"] = holdings
+            data["nested_holdings"] = holdings
 
     @staticmethod
     def _process_identifiers(record, data):

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -1329,6 +1329,210 @@
           }
         }
       },
+      "nested_holdings": {
+        "type": "nested",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "pid": {
+                "type": "keyword",
+                "copy_to": "location_pid"
+              }
+            }
+          },
+          "circulation_category": {
+            "type": "object",
+            "properties": {
+              "pid": {
+                "type": "keyword"
+              },
+              "type": {
+                "type": "keyword"
+              }
+            }
+          },
+          "organisation": {
+            "type": "object",
+            "properties": {
+              "organisation_pid": {
+                "type": "keyword",
+                "copy_to": "organisation_pid"
+              },
+              "library_pid": {
+                "type": "keyword",
+                "copy_to": "library_pid"
+              }
+            }
+          },
+          "holdings_type": {
+            "type": "keyword"
+          },
+          "local_fields": {
+            "properties": {
+              "organisation_pid": {
+                "type": "keyword"
+              },
+              "fields": {
+                "type": "object",
+                "properties": {
+                  "field_1": {
+                    "type": "text"
+                  },
+                  "field_2": {
+                    "type": "text"
+                  },
+                  "field_3": {
+                    "type": "text"
+                  },
+                  "field_4": {
+                    "type": "text"
+                  },
+                  "field_5": {
+                    "type": "text"
+                  },
+                  "field_6": {
+                    "type": "text"
+                  },
+                  "field_7": {
+                    "type": "text"
+                  },
+                  "field_8": {
+                    "type": "text"
+                  },
+                  "field_9": {
+                    "type": "text"
+                  },
+                  "field_10": {
+                    "type": "text"
+                  }
+                }
+              }
+            }
+          },
+          "call_number": {
+            "type": "text",
+            "copy_to": "call_numbers"
+          },
+          "second_call_number": {
+            "type": "text",
+            "copy_to": "call_numbers"
+          },
+          "index": {
+            "type": "text"
+          },
+          "enumerationAndChronology": {
+            "type": "text"
+          },
+          "supplementaryContent": {
+            "type": "text"
+          },
+          "notes": {
+            "type": "text"
+          },
+          "items": {
+            "type": "object",
+            "properties": {
+              "pid": {
+                "type": "keyword"
+              },
+              "barcode": {
+                "type": "keyword"
+              },
+              "call_number": {
+                "type": "text",
+                "copy_to": "call_numbers"
+              },
+              "second_call_number": {
+                "type": "text",
+                "copy_to": "call_numbers"
+              },
+              "status": {
+                "type": "keyword"
+              },
+              "acquisition": {
+                "type": "nested",
+                "properties": {
+                  "organisation_pid": {
+                    "type": "keyword"
+                  },
+                  "library_pid": {
+                    "type": "keyword"
+                  },
+                  "location_pid": {
+                    "type": "keyword"
+                  },
+                  "date": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd"
+                  }
+                }
+              },
+              "notes": {
+                "type": "text"
+              },
+              "local_fields": {
+                "properties": {
+                  "organisation_pid": {
+                    "type": "keyword"
+                  },
+                  "fields": {
+                    "type": "object",
+                    "properties": {
+                      "field_1": {
+                        "type": "text"
+                      },
+                      "field_2": {
+                        "type": "text"
+                      },
+                      "field_3": {
+                        "type": "text"
+                      },
+                      "field_4": {
+                        "type": "text"
+                      },
+                      "field_5": {
+                        "type": "text"
+                      },
+                      "field_6": {
+                        "type": "text"
+                      },
+                      "field_7": {
+                        "type": "text"
+                      },
+                      "field_8": {
+                        "type": "text"
+                      },
+                      "field_9": {
+                        "type": "text"
+                      },
+                      "field_10": {
+                        "type": "text"
+                      }
+                    }
+                  }
+                }
+              },
+              "temporary_item_type": {
+                "properties": {
+                  "type": {
+                    "type": "keyword"
+                  },
+                  "pid": {
+                    "type": "keyword"
+                  },
+                  "end_date": {
+                    "type": "date"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "local_fields": {
         "type": "object",
         "properties": {

--- a/rero_ils/modules/documents/serializers/json.py
+++ b/rero_ils/modules/documents/serializers/json.py
@@ -33,6 +33,7 @@ from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.organisations.api import OrganisationsSearch
 from rero_ils.modules.serializers import JSONSerializer
+from rero_ils.modules.serializers.mixins import CachedDataSerializerMixin
 
 from ..dumpers import document_replace_refs_dumper
 from ..dumpers.indexer import IndexerDumper
@@ -41,7 +42,7 @@ from ..extensions import TitleExtension
 GLOBAL_VIEW_CODE = LocalProxy(lambda: current_app.config.get("RERO_ILS_SEARCH_GLOBAL_VIEW_CODE"))
 
 
-class DocumentJSONSerializer(JSONSerializer):
+class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
     """Serializer for RERO-ILS `Document` records as JSON."""
 
     @staticmethod
@@ -157,47 +158,42 @@ class DocumentJSONSerializer(JSONSerializer):
                     "max": extract_acquisition_date("date_max", datetime.now().strftime("%Y-%m-%d")),
                 },
             }
+        # organisation aggregation is a nested aggregation, we need to
+        # remove this useless level.
+        if aggr_by_org := aggregations.pop("organisation", None):
+            aggregations["organisation"] = aggr_by_org["organisation"]
 
         if aggr_org := aggregations.get("organisation", {}).get("buckets", []):
+            # nested aggregation, we need to filter empty buckets
+            aggr_org = filter(lambda agg: agg["doc_count"] > 0, aggr_org)
+            # load all organisations, libraries and locations in cache
+            # to avoid multiple queries
+            self.load_all(
+                OrganisationsSearch().source(["name", "pid"]),
+                LibrariesSearch().source(["name", "pid"]),
+                LocationsSearch().source(["name", "pid"]),
+            )
             # For a "local view", we only need the facet on the location
             # organisation. We can filter the organisation aggregation to keep
             # only this value
             if view_code != GLOBAL_VIEW_CODE:
+                # nested aggregation, we need to filter empty buckets
                 aggr_org = list(filter(lambda term: term["key"] == view_id, aggr_org))
                 aggregations["organisation"]["buckets"] = aggr_org
-
             for org in aggr_org:
-                # filter libraries by organisation
-                #   Keep only libraries for the current selected organisation.
-                query = LibrariesSearch().filter("term", organisation__pid=org["key"]).source(["pid", "name"])
-                org_libraries = {hit.pid: hit.name for hit in query.scan()}
-                org["library"]["buckets"] = list(
-                    filter(
-                        lambda lib: lib["key"] in org_libraries,
-                        org["library"]["buckets"],
+                # add aggregation name
+                org["name"] = self.get_resource(OrganisationsSearch(), org["key"])["name"]
+                org["library"]["buckets"] = list(filter(lambda agg: agg["doc_count"] > 0, org["library"]["buckets"]))
+                for lib_term in org["library"].get("buckets", []):
+                    # add aggregation name
+                    lib_term["name"] = self.get_resource(LibrariesSearch(), lib_term["key"])["name"]
+                    # nested aggregation, we need to filter empty buckets
+                    lib_term["location"]["buckets"] = list(
+                        filter(lambda agg: agg["doc_count"] > 0, lib_term["location"]["buckets"])
                     )
-                )
-                for term in org["library"]["buckets"]:
-                    if term["key"] in org_libraries:
-                        term["name"] = org_libraries[term["key"]]
-
-                # filter locations by library
-                for library in org["library"]["buckets"]:
-                    query = LocationsSearch().filter("term", library__pid=library["key"]).source(["pid", "name"])
-                    lib_locations = {hit.pid: hit.name for hit in query.scan()}
-                    library["location"]["buckets"] = list(
-                        filter(
-                            lambda lib: lib["key"] in lib_locations,
-                            library["location"]["buckets"],
-                        )
-                    )
-                    for term in library["location"]["buckets"]:
-                        if term["key"] in lib_locations:
-                            term["name"] = lib_locations[term["key"]]
-
-            # Complete Organisation aggregation information
-            # with corresponding resource name
-            JSONSerializer.enrich_bucket_with_data(aggr_org, OrganisationsSearch, "name")
+                    for loc_term in lib_term["location"].get("buckets", []):
+                        # add aggregation name
+                        loc_term["name"] = self.get_resource(LocationsSearch(), loc_term["key"])["name"]
 
             # For a "local view", we replace the organisation aggregation by
             # a library aggregation containing only for the local organisation

--- a/tests/api/documents/test_documents_files_rest.py
+++ b/tests/api/documents/test_documents_files_rest.py
@@ -34,14 +34,9 @@ def test_document_files(
 ):
     """Test document files."""
 
-    list_url = url_for(
-        "invenio_records_rest.doc_list",
-        q="_exists_:files",
-    )
+    list_url = url_for("invenio_records_rest.doc_list", q="_exists_:files")
     res = client.get(list_url)
     hits = get_json(res)["hits"]
-    aggregations = get_json(res)["aggregations"]["organisation"]
-    assert aggregations["buckets"][0]["doc_count"] == 1
     assert hits["total"]["value"] == 1
 
     # check for collections

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -337,7 +337,7 @@ def test_documents_facets(
     "invenio_records_rest.views.verify_record_permission",
     mock.MagicMock(return_value=VerifyRecordPermissionPatch),
 )
-def test_documents_organisation_facets(client, document, item_lib_martigny, rero_json_header):
+def test_documents_organisation_facets(client, document, item_lib_martigny, item_lib_saxon, rero_json_header):
     """Test record retrieval."""
     list_url = url_for("invenio_records_rest.doc_list", view="global")
 
@@ -345,7 +345,39 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, rero
     data = get_json(res)
     aggs = data["aggregations"]
 
-    assert "organisation" in aggs
+    assert aggs["organisation"]["buckets"] == [
+        {
+            "doc_count": 2,
+            "key": "org1",
+            "library": {
+                "buckets": [
+                    {
+                        "doc_count": 1,
+                        "key": "lib1",
+                        "location": {
+                            "buckets": [{"doc_count": 1, "key": "loc1", "name": "Martigny Library Public Space"}],
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                        },
+                        "name": "Library of Martigny-ville",
+                    },
+                    {
+                        "doc_count": 1,
+                        "key": "lib2",
+                        "location": {
+                            "buckets": [{"doc_count": 1, "key": "loc3", "name": "Saxon Library Public Space"}],
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                        },
+                        "name": "Library of Saxon",
+                    },
+                ],
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+            },
+            "name": "The district of Martigny Libraries",
+        }
+    ]
 
 
 @mock.patch(


### PR DESCRIPTION
* Creates an holdings nested field.
* Changes the facet configuration for the document organisation facets.
* Closes https://github.com/rero/rero-ils/issues/2658.
