### PR TITLE
feat: add the reminder number in the operation logs of overdue notifications

### DIFF
--- a/rero_ils/modules/notifications/logs/api.py
+++ b/rero_ils/modules/notifications/logs/api.py
@@ -77,5 +77,9 @@ class NotificationOperationLog(OperationLog, SpecificOperationLog):
                 "recipients": recipients,
             },
         }
+        reminder_counter = data.get("context", {}).get("reminder_counter")
+        # if the reminder_counter == 0, we need to take it as well
+        if reminder_counter is not None:
+            log["notification"]["reminder_counter"] = reminder_counter
 
         return super().create(log, index_refresh=index_refresh)

--- a/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
+++ b/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
@@ -66,6 +66,9 @@
           "sender_library_pid": {
             "type": "keyword"
           },
+          "reminder_counter": {
+            "type": "integer"
+          },
           "recipients": {
             "type": "text"
           }

--- a/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
+++ b/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
@@ -135,6 +135,10 @@
           "type": "string",
           "minLength": 1
         },
+        "reminder_counter": {
+          "title": "Current reminder count",
+          "type": "number"
+        },
         "recipients": {
           "title": "Recipients",
           "type": "array",

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -345,7 +345,9 @@ def test_overdue_loans(
     OperationLogsSearch.flush_and_refresh()
     assert number_of_notifications_sent(loan) == 1
     # Check notification is created on operation logs
-    assert len(list(OperationLogsSearch().get_logs_by_notification_pid(notification.get("pid")))) == 1
+    notif_operation_logs = list(OperationLogsSearch().get_logs_by_notification_pid(notification.get("pid")))
+    assert len(notif_operation_logs) == 1
+    assert notif_operation_logs[0]["notification"].get("reminder_counter") == 0
 
     # Try a checkout for a blocked user :: It should be blocked
     res, data = postdata(


### PR DESCRIPTION
* Closes #3971.
* :warning: Requires a migration script to update existing data (please see and review [here](https://github.com/rero/rero-ils/wiki/Migration-workflow#add-reminder_counter-to-existing-notif-operation_logs)).