### PR TITLE
fix: enhance the structure and format of the RIS export

### DIFF
--- a/rero_ils/modules/documents/serializers/ris.py
+++ b/rero_ils/modules/documents/serializers/ris.py
@@ -29,6 +29,7 @@ from rero_ils.utils import get_i18n_supported_languages
 
 from ..dumpers import document_replace_refs_dumper
 from ..utils import process_i18n_literal_fields
+from ..views import doc_entity_label
 from .base import BaseDocumentFormatterMixin
 
 
@@ -110,23 +111,23 @@ class RISFormatter(BaseDocumentFormatterMixin):
         if "type" not in self.record:
             return ["GEN"]
 
+        # Only take the first document type
+        doc_type = self.record["type"][0]
+        return self._doctype_mapper(doc_type.get("main_type"), doc_type.get("subtype"))
+
+    def _get_subjects_text(self):
+        """Return document subjects as a list of strings."""
         return [
-            self._doctype_mapper(doc_type.get("main_type"), doc_type.get("subtype")) for doc_type in self.record["type"]
+            doc_entity_label(subject.get("entity", {}), language=self._language)[2] for subject in self._get_subjects()
         ]
-
-    def _get_city(self):
-        """Return publication place."""
-        return self._get_publication_places()
-
-    def _get_date(self):
-        return self._get_publication_year()
-
-    def _get_primary_year(self):
-        """Return primary year."""
-        return self._get_publication_year()
 
     def _fetch_fields(self):
         """Return formatted output based on export fields."""
+
+        def get_first_value(values):
+            """Return only the first value of a list for RIS tags that are not repeatable."""
+            return next(iter(values), None)
+
         available_fields = {
             "TY": self._get_document_types(),
             "ID": self._get_pid(),
@@ -136,18 +137,20 @@ class RISFormatter(BaseDocumentFormatterMixin):
             "A2": self._get_secondary_authors(),
             "DA": self._get_publication_year(),
             "ET": self._get_editions(),
-            "SP": self._get_start_pages(),
-            "EP": self._get_end_pages(),
-            "CY": self._get_publication_places(),
-            "LA": self._get_languages(),
-            "PB": self._get_publisher(),
-            "SN": self._get_identifiers([IdentifierType.ISBN, IdentifierType.ISSN, IdentifierType.L_ISSN]),
+            "SP": get_first_value(self._get_start_pages()),
+            "EP": get_first_value(self._get_end_pages()),
+            "CY": get_first_value(self._get_publication_places()),
+            "LA": get_first_value(self._get_languages()),
+            "PB": get_first_value(self._get_publisher()),
+            "SN": get_first_value(
+                self._get_identifiers([IdentifierType.ISBN, IdentifierType.ISSN, IdentifierType.L_ISSN])
+            ),
             "UR": [*self._get_electronic_locators(), self._get_permalink()],
-            "KW": self._get_subjects(),
-            "DO": self._get_identifiers([IdentifierType.DOI]),
-            "VL": self._get_volume_numbers(),
-            "IS": self._get_issue_numbers(),
-            "PP": self._get_publication_places(),
+            "KW": self._get_subjects_text(),
+            "DO": get_first_value(self._get_identifiers([IdentifierType.DOI])),
+            "VL": get_first_value(self._get_volume_numbers()),
+            "IS": get_first_value(self._get_issue_numbers()),
+            "PP": get_first_value(self._get_publication_places()),
             "Y1": self._get_publication_year(),
             "PY": self._get_publication_year(),
         }

--- a/tests/api/documents/test_export_serializers.py
+++ b/tests/api/documents/test_export_serializers.py
@@ -84,3 +84,8 @@ def test_ris_serializer(client, ris_header, document, export_document):
     assert response.status_code == 200
     ris_data = response.get_data(as_text=True)
     assert all(tag in ris_data for tag in ris_tag)
+    ris_list_tags = ["A1  -", "A2  -", "A3  -", "A4  -", "AU  -", "KW  -", "N1  -", "UR  -"]
+    # check that there is only one of each RIS tag that is not repeatable
+    for tag in ris_tag:
+        if tag not in ris_list_tags:
+            assert ris_data.count(tag) == 1

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3496,6 +3496,12 @@
             "value": "A001234567"
           }
         }
+      },
+      {
+        "entity": {
+          "$ref": "https://mef.rero.ch/api/concepts/idref/050394460",
+          "pid": "14650374"
+        }
       }
     ]
   },


### PR DESCRIPTION
* Ensures that only the standard repeatable fields are repeated (e.g. only one TY tag per document). 
* Formats the subjects as strings (authorized_access_points) instead of dict structures.
* Removes unused class methods.
* Closes #3978.