### PR TITLE
fix(holdings): remove irregular frequency in the pattern

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -161,10 +161,6 @@ class Holding(IlsRecord):
         if not document:
             return f"Document {document_pid} does not exist."
 
-        if self.is_serial:
-            patterns = self.get("patterns", {})
-            if patterns and patterns.get("frequency") != "rdafr:1016" and not patterns.get("next_expected_date"):
-                return _("Must have next expected date for regular frequencies.")
         # the enumeration and chronology optional fields are only allowed for
         # serial or electronic holdings
         if not self.is_serial ^ self.is_electronic:
@@ -673,7 +669,7 @@ class Holding(IlsRecord):
         """Receive the next expected regular issue for the holdings record."""
         # receive is allowed only on holdings of type serials with a regular
         # frequency
-        if self.holdings_type != HoldingTypes.SERIAL or self.get("patterns", {}).get("frequency") == "rdafr:1016":
+        if self.holdings_type != HoldingTypes.SERIAL:
             raise RegularReceiveNotAllowed()
 
         issue_display, expected_date = self._get_next_issue_display_text(self.get("patterns"))

--- a/rero_ils/modules/holdings/api_views.py
+++ b/rero_ils/modules/holdings/api_views.py
@@ -109,8 +109,6 @@ def pattern_preview():
     patterns_data = flask_request.get_json()
     pattern = patterns_data.get("data", {})
     size = patterns_data.get("size", 10)
-    if pattern and pattern.get("frequency") == "rdafr:1016":
-        return jsonify({"status": "error: irregular frequency"}), 400
     issues = Holding.prediction_issues_preview_for_pattern(pattern, number_of_predictions=size)
     return jsonify({"issues": issues})
 

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -211,7 +211,8 @@
       "required": [
         "values",
         "template",
-        "frequency"
+        "frequency",
+        "next_expected_date"
       ],
       "propertiesOrder": [
         "language",
@@ -259,8 +260,7 @@
             "rdafr:1012",
             "rdafr:1013",
             "rdafr:1014",
-            "rdafr:1015",
-            "rdafr:1016"
+            "rdafr:1015"
           ],
           "widget": {
             "formlyConfig": {
@@ -287,10 +287,6 @@
                   {
                     "label": "rdafr:1001",
                     "value": "rdafr:1001"
-                  },
-                  {
-                    "label": "rdafr:1016",
-                    "value": "rdafr:1016"
                   },
                   {
                     "label": "rdafr:1008",

--- a/rero_ils/modules/holdings/utils.py
+++ b/rero_ils/modules/holdings/utils.py
@@ -45,7 +45,6 @@ def get_late_serial_holdings():
         .filter("term", holdings_type="serial")
         .filter("term", acquisition_status="currently_received")
         .filter("range", patterns__next_expected_date={"lte": yesterday})
-        .exclude("term", patterns__frequency="rdafr:1016")
         .source(False)
     )
     for id_ in [hit.meta.id for hit in query.scan()]:

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -202,7 +202,6 @@ class ItemRecord(IlsRecord):
             and item.get("issue", {}).get("regular")
             and holding.holdings_type == "serial"
             and holding.get("patterns")
-            and holding.get("patterns", {}).get("frequency") != "rdafr:1016"
         ):
             updated_holding = holding.increment_next_prediction()
             return holding.update(data=updated_holding, dbcommit=dbcommit, reindex=reindex)


### PR DESCRIPTION
* The pattern allows to automatically know when to recieve the next issue of a serial. An irregular frequency prevents this, and so this value is not relevant in that field.
* Closes #3850.
* :warning: Requires a data migration script (remove pattern field when the frequency is irregular).