### PR TITLE
refact(permissions): add codes to can request api

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -113,7 +113,6 @@ from .modules.loans.utils import (
     can_be_requested,
     get_default_loan_duration,
     get_extension_params,
-    is_item_available_for_checkout,
     loan_build_document_ref,
     loan_build_item_ref,
     loan_build_patron_ref,
@@ -3773,7 +3772,8 @@ CIRCULATION_POLICIES = dict(
     checkout=dict(
         duration_default=get_default_loan_duration,
         duration_validate=validate_loan_duration,
-        item_can_circulate=is_item_available_for_checkout,
+        # managed by *_CIRCULATION_ACTIONS_VALIDATION
+        item_can_circulate=lambda _: True,
     ),
     extension=dict(
         from_end_date=False,
@@ -3785,7 +3785,7 @@ CIRCULATION_POLICIES = dict(
     request=dict(can_be_requested=can_be_requested),
 )
 
-CIRCULATION_ACTIONS_VALIDATION = {
+ITEM_CIRCULATION_ACTIONS_VALIDATION = {
     ItemCirculationAction.REQUEST: [
         Location.can_request,
         Item.can_request,

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -404,11 +404,11 @@ class CircPolicy(IlsRecord):
         if not patron:
             # none patron get be load from kwargs argument. This check can't
             # be relevant --> return True by default
-            return True, []
+            return True, {}
         if "patron" not in patron.get("roles", []):
             # without 'patron' role, we can't find any patron_type and so we
             # can't find any corresponding cipo --> return False
-            return False, [_("Patron doesn't have the correct role")]
+            return False, {"circulation_policy_no_patron_role": _("Patron doesn't have the correct role")}
         library_pid = kwargs["library"].pid if kwargs.get("library") else record.library_pid
 
         if isinstance(record, Item):
@@ -428,8 +428,8 @@ class CircPolicy(IlsRecord):
             record_circulation_category_pid,
         )
         if not cipo.get("allow_requests", False):
-            return False, [_("Circulation policy disallows the operation.")]
-        return True, []
+            return False, {"circulation_policy_disallows": _("Circulation policy disallows the operation.")}
+        return True, {}
 
     @classmethod
     def allow_checkout(cls, item, **kwargs):
@@ -444,11 +444,11 @@ class CircPolicy(IlsRecord):
         if not patron:
             # none patron get be load from kwargs argument. This check can't
             # be relevant --> return True by default
-            return True, []
+            return True, {}
         if "patron" not in patron.get("roles", []):
             # without 'patron' role, we can't find any patron_type and so we
             # can't find any corresponding cipo --> return False
-            return False, [_("Patron doesn't have the correct role")]
+            return False, {"circulation_policy_no_patron_role": _("Patron doesn't have the correct role")}
         library_pid = kwargs["library"].pid if kwargs.get("library") else item.library_pid
         cipo = cls.provide_circ_policy(
             item.organisation_pid,
@@ -457,8 +457,8 @@ class CircPolicy(IlsRecord):
             item.item_type_circulation_category_pid,
         )
         if not cipo.can_checkout:
-            return False, [_("Circulation policy disallows the operation.")]
-        return True, []
+            return False, {"circulation_policy_disallows": _("Circulation policy disallows the operation.")}
+        return True, {}
 
 
 class CircPoliciesIndexer(IlsRecordsIndexer):

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -494,13 +494,12 @@ class Holding(IlsRecord):
         :return a tuple with True|False to know if the action is possible and
                 a list of reasons to disallow if False.
         """
-        can, reasons = True, []
+        can, reasons = True, {}
         actions = current_app.config.get("HOLDING_CIRCULATION_ACTIONS_VALIDATION", {})
         for func_name in actions["request"]:
-            class_name = func_name.__self__.__name__
             func_callback = obj_or_import_string(func_name)
             func_can, func_reasons = func_callback(self, **kwargs)
-            reasons += func_reasons
+            reasons.update(func_reasons)
             can = can and func_can
         return can, reasons
 
@@ -513,8 +512,8 @@ class Holding(IlsRecord):
         :return a tuple with True|False and reasons to disallow if False.
         """
         if holding and not holding.is_serial:
-            return False, [_("Only serial holdings can be requested.")]
-        return True, []
+            return False, {"holding_not_serial": _("Only serial holdings can be requested.")}
+        return True, {}
 
     @classmethod
     def _get_next_issue_display_text(cls, patterns):

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -979,12 +979,12 @@ class ItemCirculation(ItemRecord):
         :return a tuple with True|False to know if the action is possible and
                 a list of reasons to disallow if False.
         """
-        can, reasons = True, []
-        actions = current_app.config.get("CIRCULATION_ACTIONS_VALIDATION", {})
+        can, reasons = True, {}
+        actions = current_app.config.get("ITEM_CIRCULATION_ACTIONS_VALIDATION", {})
         for func_name in actions.get(action, []):
             func_callback = obj_or_import_string(func_name)
             func_can, func_reasons = func_callback(self, **kwargs)
-            reasons += func_reasons
+            reasons.update(func_reasons)
             can = can and func_can
         return can, reasons
 
@@ -996,15 +996,19 @@ class ItemCirculation(ItemRecord):
         :param kwargs : other arguments.
         :return a tuple with True|False and reasons to disallow if False.
         """
-        reasons = []
+        reasons = {}
         if item.status in [ItemStatus.MISSING, ItemStatus.EXCLUDED]:
-            reasons.append(_("Item status disallows the operation."))
-        if "patron" in kwargs:
-            patron = kwargs["patron"]
+            reasons["item_status"] = _("Item status disallows the operation.")
+        patron = kwargs.get("patron")
+        if not patron and "patron_pid" in kwargs:
+            patron = Patron.get_record_by_pid(kwargs["patron_pid"])
+        if patron:
             if patron.organisation_pid != item.organisation_pid:
-                reasons.append(_("Item and patron are not in the same organisation."))
+                reasons["item_patron_organisation"] = _("Item and patron are not in the same organisation.")
             if patron.patron.get("barcode") and item.patron_has_an_active_loan_on_item(patron):
-                reasons.append(_("Item is already checked-out or requested by patron."))
+                reasons["item_already_checked_out_or_requested"] = _(
+                    "Item is already checked-out or requested by patron."
+                )
         return not reasons, reasons
 
     def action_filter(self, action, organisation_pid, library_pid, loan, patron_pid, patron_type_pid):

--- a/rero_ils/modules/items/decorators.py
+++ b/rero_ils/modules/items/decorators.py
@@ -71,10 +71,10 @@ def check_operation_allowed(action):
 
     Check if an 'override_blocking' parameter is present. If this param is
     present and set to True (or corresponding True values [1, 'true', ...])
-    then no CIRCULATION_ACTIONS_VALIDATION should be tested.
+    then no ITEM_CIRCULATION_ACTIONS_VALIDATION should be tested.
     Remove this parameter from the data arguments.
 
-    Check the CIRCULATION_ACTIONS_VALIDATION configuration file and execute
+    Check the ITEM_CIRCULATION_ACTIONS_VALIDATION configuration file and execute
     function corresponding to the action specified. All function are execute
     until one return False (action denied) or all actions are successful.
 
@@ -88,12 +88,12 @@ def check_operation_allowed(action):
             override_blocking = kwargs.pop("override_blocking", False)
             override_blocking = bool(override_blocking)
             if not override_blocking:
-                actions = current_app.config.get("CIRCULATION_ACTIONS_VALIDATION", {})
+                actions = current_app.config.get("ITEM_CIRCULATION_ACTIONS_VALIDATION", {})
                 for func_name in actions.get(action, []):
                     func_callback = obj_or_import_string(func_name)
                     can, reasons = func_callback(args[0], **kwargs)
                     if not can:
-                        raise CirculationException(description=reasons[0])
+                        raise CirculationException(description="; ".join(reasons.values()))
             return func(*args, **kwargs)
 
         return decorated_view

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -126,9 +126,9 @@ class Loan(IlsRecord):
         if loan is None:  # try to load the loan from kwargs
             loan, _unused_data = item.prior_extend_loan_actions(**kwargs)
         if loan is None:  # not relevant method :: return True
-            return True, []
+            return True, {}
         if loan.get("state") != LoanState.ITEM_ON_LOAN:
-            return False, [_("The loan cannot be extended")]
+            return False, {"loan_bad_state": _("The loan cannot be extended")}
         # The parameters for the renewal is calculated based on the transaction
         # library and not the owning library.
         transaction_library_pid = Location.get_record_by_pid(loan["transaction_location_pid"]).get_library().get("pid")
@@ -148,10 +148,10 @@ class Loan(IlsRecord):
             library_pid=transaction_library_pid,
         )
         if not (extension_count < number_renewals > 0 and loan_data_is_valid):
-            return False, [_("Circulation policies disallows the operation.")]
+            return False, {"loan_policy_disallows": _("Circulation policies disallows the operation.")}
         if item.number_of_requests():
-            return False, [_("A pending request exists on this item.")]
-        return True, []
+            return False, {"loan_pending_request": _("A pending request exists on this item.")}
+        return True, {}
 
     @staticmethod
     def check_required_params(action, **kwargs):
@@ -1033,22 +1033,6 @@ def get_request_by_item_pid_by_patron_pid(item_pid, patron_pid):
         LoanState.ITEM_AT_DESK,
         LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
         LoanState.ITEM_IN_TRANSIT_TO_HOUSE,
-    ]
-    return get_loans_by_item_pid_by_patron_pid(item_pid, patron_pid, filter_states)
-
-
-def get_any_loans_by_item_pid_by_patron_pid(item_pid, patron_pid):
-    """Get loans not ITEM_IN_TRANSIT_TO_HOUSE, CREATED for item, patron.
-
-    :param item_pid: The item pid.
-    :param patron_pid: The patron pid.
-    :return: loans for given item and patron.
-    """
-    filter_states = [
-        LoanState.PENDING,
-        LoanState.ITEM_AT_DESK,
-        LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
-        LoanState.ITEM_ON_LOAN,
     ]
     return get_loans_by_item_pid_by_patron_pid(item_pid, patron_pid, filter_states)
 

--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -23,16 +23,17 @@ from datetime import datetime, timedelta, timezone
 
 import ciso8601
 from flask import current_app
+from invenio_base.utils import obj_or_import_string
 
 from rero_ils.modules.circ_policies.api import CircPolicy
 from rero_ils.modules.items.api import Item
+from rero_ils.modules.items.models import ItemCirculationAction
 from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.libraries.exceptions import LibraryNeverOpen
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.utils import get_ref_for_pid
 
-from .api import get_any_loans_by_item_pid_by_patron_pid
 from .models import LoanAction
 
 
@@ -170,12 +171,6 @@ def validate_loan_duration(loan):
     return loan["end_date"] > loan["start_date"]
 
 
-def is_item_available_for_checkout(item_pid):
-    """Item is available for action CHECKOUT."""
-    # TODO: implement item level restrictions not related to cipo here
-    return True
-
-
 def can_be_requested(loan):
     """Check if record can be requested."""
     # TODO : Should use
@@ -187,26 +182,13 @@ def can_be_requested(loan):
     #  it seems this function only answer the question "Is the item potentially
     #  requestable" and not "Is the item is really requestable".
 
-    if not loan.item_pid:
-        raise Exception("Transaction on document is not implemented.")
+    config = current_app.config.get("ITEM_CIRCULATION_ACTIONS_VALIDATION", {})
+    can = True
+    for func_name in config.get(ItemCirculationAction.REQUEST, []):
+        func_callback = obj_or_import_string(func_name)
+        can = can and func_callback(loan.item, loan=loan)[0]
 
-    # 1) Check patron is not blocked
-    patron = Patron.get_record_by_pid(loan.patron_pid)
-    if patron.patron.get("blocked", False):
-        return False
-
-    # 2) Check if owning location allows request
-    location = Item.get_record_by_pid(loan.item_pid).get_circulation_location()
-    if not location or not location.get("allow_request"):
-        return False
-
-    # 3) Check if there is already a loan for same patron+item
-    if get_any_loans_by_item_pid_by_patron_pid(loan.get("item_pid", {}).get("value"), loan.get("patron_pid")):
-        return False
-
-    # 4) Check if circulation_policy allows request
-    policy = get_circ_policy(loan)
-    return bool(policy.get("allow_requests"))
+    return can
 
 
 def loan_build_item_ref(loan_pid, loan):

--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -216,21 +216,21 @@ class Location(IlsRecord):
         return self["pickup_name"] if "pickup_name" in self else f"{self.library['code']}: {self['name']}"
 
     @classmethod
-    def can_request(cls, record, **kwargs):
+    def can_request(cls, item, **kwargs):
         """Check if a record can be requested regarding its location.
 
         :param record : the `Item` record to check
         :param kwargs : addition arguments
         :return a tuple with True|False and reasons to disallow if False.
         """
-        if record:
+        if item:
             location_method = "get_location"
-            if hasattr(record, "get_circulation_location"):
+            if hasattr(item, "get_circulation_location"):
                 location_method = "get_circulation_location"
-            location = getattr(record, location_method)()
+            location = getattr(item, location_method)()
             if not location.get("allow_request", False):
-                return False, [_("Record location disallows request.")]
-        return True, []
+                return False, {"location_disallows": _("Record location disallows request.")}
+        return True, {}
 
     def transaction_location_validator(self, location_pid):
         """Validate that the given transaction location PID is valid.

--- a/rero_ils/modules/patron_types/api.py
+++ b/rero_ils/modules/patron_types/api.py
@@ -162,23 +162,16 @@ class PatronType(IlsRecord):
         if not patron:
             # 'patron' argument are present into kwargs. This check can't
             # be relevant --> return True by default
-            return True, []
+            return True, {}
 
         # check overdue items limits
         patron_type = PatronType.get_record_by_pid(patron.patron_type_pid)
-        if not patron_type.check_overdue_items_limit(patron):
-            return False, [_("Checkout denied: maximum number of late items reached")]
+        reasons = cls.can_extend(item, **kwargs)[1]
         # check checkout count limit
         valid, message = patron_type.check_checkout_count_limit(patron, item)
         if not valid:
-            return False, [message]
-        # check fee amount limit
-        if not patron_type.check_fee_amount_limit(patron):
-            return False, [_("Checkout denied: maximum amount of overdue fees reached")]
-        # check unpaid subscription
-        if not patron_type.check_unpaid_subscription(patron):
-            return False, [_("Checkout denied: patron has unpaid subscription")]
-        return True, []
+            reasons.update({"patron_type_checkout_count_limit": message})
+        return not reasons, reasons
 
     @classmethod
     def can_request(cls, item, **kwargs):
@@ -193,23 +186,15 @@ class PatronType(IlsRecord):
         if not patron:
             # 'patron' argument are present into kwargs. This check can't
             # be relevant --> return True by default
-            return True, []
-        # check overdue items limits
+            return True, {}
         patron_type = PatronType.get_record_by_pid(patron.patron_type_pid)
-        if not patron_type.check_overdue_items_limit(patron):
-            return False, [_("Maximum number of late items is reached")]
-        # check checkout count limit
+        reasons = cls.can_extend(item, **kwargs)[1]
+        # check request limits
         valid, message = patron_type.check_request_limits(patron, item)
         if not valid:
-            return False, [message]
-        # check fee amount limit
-        if not patron_type.check_fee_amount_limit(patron):
-            return False, [_("Maximum amount of overdue fees reached")]
-        # check unpaid subscription
-        if not patron_type.check_unpaid_subscription(patron):
-            return False, [_("Patron has unpaid subscription")]
+            reasons.update({"patron_type_request_limits": message})
 
-        return True, []
+        return not reasons, reasons
 
     @classmethod
     def can_extend(cls, item, **kwargs):
@@ -224,18 +209,19 @@ class PatronType(IlsRecord):
         if not patron:
             # 'patron' argument are present into kwargs. This check can't
             # be relevant --> return True by default
-            return True, []
+            return True, {}
         # check overdue items limit
         patron_type = PatronType.get_record_by_pid(patron.patron_type_pid)
+        reasons = {}
         if not patron_type.check_overdue_items_limit(patron):
-            return False, [_("Renewal denied: maximum number of overdue items reached")]
+            reasons.update({"patron_type_overdue_items_limit": _("Maximum number of overdue items reached")})
         # check fee amount limit
         if not patron_type.check_fee_amount_limit(patron):
-            return False, [_("Renewal denied: maximum amount of overdue fees reached")]
+            reasons.update({"patron_type_fee_amount_limit": _("Maximum amount of overdue fees reached")})
         # check unpaid subscription
         if not patron_type.check_unpaid_subscription(patron):
-            return False, [_("Renewal denied: patron has unpaid subscription")]
-        return True, []
+            reasons.update({"patron_type_unpaid_subscription": _("Patron has unpaid subscription")})
+        return not reasons, reasons
 
     def get_linked_patron(self):
         """Get patron linked to this patron type."""

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -585,17 +585,17 @@ class Patron(IlsRecord):
         if not patron:
             # 'patron' argument are present into kwargs. This check can't
             # be relevant --> return True by default
-            return True, []
+            return True, {}
 
-        messages = []
+        reasons = {}
         # 1) a blocked patron can't request any item
         # 2) a patron with obsolete expiration_date can't request any item
         if patron.is_blocked:
-            messages.append(patron.get_blocked_message())
+            reasons.update({"patron_blocked": patron.get_blocked_message()})
         if patron.is_expired:
-            messages.append(_("Patron account expired."))
+            reasons.update({"patron_expired": _("Patron account expired.")})
 
-        return not messages, messages
+        return not reasons, reasons
 
     @classmethod
     def can_checkout(cls, item, **kwargs):

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -353,7 +353,7 @@ def test_overdue_limit(
         },
     )
     assert res.status_code == 403
-    assert "Checkout denied" in data["message"]
+    assert "Maximum number of overdue items reached" in data["message"]
     # Try a request - limit should be reached
     res, data = postdata(
         client,
@@ -367,7 +367,7 @@ def test_overdue_limit(
         },
     )
     assert res.status_code == 403
-    assert "Maximum number of late items is reached" in data["message"]
+    assert "Maximum number of overdue items reached" in data["message"]
     # Try to extend - limit should be reached
     res, _ = postdata(
         client,
@@ -379,7 +379,7 @@ def test_overdue_limit(
         },
     )
     assert res.status_code == 403
-    assert "Maximum number of late items is reached" in data["message"]
+    assert "Maximum number of overdue items reached" in data["message"]
 
     # reset the patron_type with default value
     del patron_type["limits"]
@@ -404,7 +404,7 @@ def test_overdue_limit(
         },
     )
     assert res.status_code == 403
-    assert "Checkout denied" in data["message"]
+    assert "Maximum amount of overdue fees reached" in data["message"]
 
     # [2.2] test fee amount limit when we try to request another item
     res, data = postdata(
@@ -505,7 +505,7 @@ def test_unpaid_subscription(
         },
     )
     assert res.status_code == 403
-    assert "Checkout denied" in data["message"] and "unpaid" in data["message"]
+    assert "Patron has unpaid subscription" in data["message"]
     # STEP#3 :: Pay the subscription and retry a circulation operation
     #   As the subscription will be paid the checkout operation must be granted
     data = {

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -897,7 +897,7 @@ def test_requested_loans_to_validate(
     item2_lib_martigny,
     json_header,
     item_type_missing_martigny,
-    patron_sion,
+    patron_martigny,
     circulation_policies,
 ):
     """Test requested loans to validate."""
@@ -928,13 +928,13 @@ def test_requested_loans_to_validate(
         "api_item.librarian_request",
         {
             "item_pid": item2_lib_martigny.pid,
-            "patron_pid": patron_sion.pid,
+            "patron_pid": patron_martigny.pid,
             "pickup_location_pid": loc_public_martigny.pid,
             "transaction_user_pid": librarian_martigny.pid,
             "transaction_location_pid": loc_public_martigny.pid,
         },
     )
-
+    assert res.status_code == 200
     res = client.get(url_for("api_item.requested_loans", library_pid=library_pid))
     assert res.status_code == 200
     data = get_json(res)
@@ -943,7 +943,7 @@ def test_requested_loans_to_validate(
     assert item2_lib_martigny.pid == requested_loan["item"]["pid"]
     assert item2_lib_martigny.pid == requested_loan["loan"]["item_pid"]["value"]
     assert requested_loan["loan"]["state"] == LoanState.PENDING
-    assert patron_sion.pid == requested_loan["loan"]["patron_pid"]
+    assert patron_martigny.pid == requested_loan["loan"]["patron_pid"]
 
     assert requested_loan["item"]["temporary_location"]["name"]
 

--- a/tests/api/loans/test_loans_rest_views.py
+++ b/tests/api/loans/test_loans_rest_views.py
@@ -55,7 +55,7 @@ def test_loan_can_extend(
     assert response.status_code == 200
     assert get_json(response) == {
         "can": False,
-        "reasons": ["Circulation policies disallows the operation."],
+        "reasons": {"loan_policy_disallows": "Circulation policies disallows the operation."},
     }
 
 

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -291,10 +291,8 @@ def test_notifications_post_put_delete(client, dummy_notification, loan_validate
 def test_recall_notification(
     client,
     patron_sion,
+    patron_sion_without_email1,
     lib_sion,
-    json_header,
-    patron2_martigny,
-    patron_martigny,
     item_lib_sion,
     librarian_sion,
     circulation_policies,
@@ -326,11 +324,12 @@ def test_recall_notification(
         {
             "item_pid": item_lib_sion.pid,
             "pickup_location_pid": loc_public_sion.pid,
-            "patron_pid": patron2_martigny.pid,
+            "patron_pid": patron_sion_without_email1.pid,
             "transaction_library_pid": lib_sion.pid,
             "transaction_user_pid": librarian_sion.pid,
         },
     )
+    print(res.json)
     assert res.status_code == 200
 
     request_loan_pid = data.get("action_applied")[LoanAction.REQUEST].get("pid")
@@ -370,7 +369,7 @@ def test_recall_notification(
         {
             "item_pid": item_lib_sion.pid,
             "pickup_location_pid": loc_public_sion.pid,
-            "patron_pid": patron2_martigny.pid,
+            "patron_pid": patron_sion_without_email1.pid,
             "transaction_library_pid": lib_sion.pid,
             "transaction_user_pid": librarian_sion.pid,
         },

--- a/tests/ui/circulation/test_actions_add_request.py
+++ b/tests/ui/circulation/test_actions_add_request.py
@@ -18,7 +18,7 @@
 """Test item circulation request actions."""
 
 import pytest
-from invenio_circulation.errors import RecordCannotBeRequestedError
+from invenio_circulation.errors import CirculationException
 
 from rero_ils.modules.loans.models import LoanState
 from tests.utils import item_record_to_a_specific_loan_state
@@ -46,7 +46,7 @@ def test_add_request_on_item_on_shelf(
         "transaction_user_pid": librarian_martigny.pid,
         "pickup_location_pid": loc_public_martigny.pid,
     }
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False
         )
@@ -79,7 +79,7 @@ def test_add_request_on_item_at_desk(
         "transaction_user_pid": librarian_martigny.pid,
         "pickup_location_pid": loc_public_martigny.pid,
     }
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False
         )
@@ -113,7 +113,7 @@ def test_add_request_on_item_on_loan(
         "transaction_user_pid": librarian_martigny.pid,
         "pickup_location_pid": loc_public_martigny.pid,
     }
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False
         )
@@ -132,7 +132,7 @@ def test_add_request_on_item_on_loan(
     # when an item on_loan has pending requests, the patron who owns the
     # pending loan may not add a new pending loan
     params["patron_pid"] = patron2_martigny.pid
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, requested_loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False
         )
@@ -166,7 +166,7 @@ def test_add_request_on_item_in_transit_for_pickup(
         "transaction_user_pid": librarian_martigny.pid,
         "pickup_location_pid": loc_public_fully.pid,
     }
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False
         )
@@ -212,7 +212,7 @@ def test_add_request_on_item_in_transit_to_house(
     # the following tests the circulation action ADD_REQUEST_5_2_1
     # when a pending loan exist on an item with loan ITEM_IN_TRANSIT_TO_HOUSE
     # the patron who owns the pending loan cannot add a new pending loan
-    with pytest.raises(RecordCannotBeRequestedError):
+    with pytest.raises(CirculationException):
         item, requested_loan = item_record_to_a_specific_loan_state(
             item=item, loan_state=LoanState.PENDING, params=params, copy_item=False
         )

--- a/tests/ui/circulation/test_loan_utils.py
+++ b/tests/ui/circulation/test_loan_utils.py
@@ -17,8 +17,6 @@
 
 """Tests loan utils methods."""
 
-from copy import deepcopy
-
 import pytest
 from invenio_circulation.errors import CirculationException
 
@@ -85,13 +83,6 @@ def test_loan_utils(
     # test required parameters for get_last_transaction_loc_for_item
     with pytest.raises(TypeError):
         assert get_last_transaction_loc_for_item()
-
-    # test the organisation of the loan is based on the item
-    new_loan = deepcopy(loan_pending_martigny)
-    assert new_loan.organisation_pid == "org1"
-    del new_loan["item_pid"]
-    assert new_loan.organisation_pid == "org1"
-    assert not can_be_requested(loan_pending_martigny)
 
     # test the allow request at the location level
     loc_public_martigny["allow_request"] = False


### PR DESCRIPTION
* Renames CIRCULATION_ACTIONS_VALIDATION into ITEM_CIRCULATION_ACTIONS_VALIDATION.
* All circulation validation actions returns a reasons dictionaries.
* Fixes dependencies.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
