### PR TITLE
fix(item_types): prevent deletion when linked to serial/electronic holdings

### DIFF
--- a/rero_ils/modules/item_types/api.py
+++ b/rero_ils/modules/item_types/api.py
@@ -122,6 +122,7 @@ class ItemType(IlsRecord):
         :param get_pids: if True list of linked pids
                          if False count of linked records
         """
+        from ..holdings.api import HoldingsSearch
         from ..items.api import ItemsSearch
 
         links = {}
@@ -137,16 +138,26 @@ class ItemType(IlsRecord):
             path="settings",
             query=Q("bool", must=[Q("match", settings__item_type__pid=self.pid)]),
         )
+        holdings_query = (
+            HoldingsSearch()
+            # Standard holdings are entirely dependent on their items, so they don't need to be checked
+            .exclude("term", holdings_type="standard")
+            .filter("term", circulation_category__pid=self.pid)
+        )
         if get_pids:
             items = sorted_pids(items_query)
             circ_policies = sorted_pids(cipo_query)
+            holdings = sorted_pids(holdings_query)
         else:
             items = items_query.count()
             circ_policies = cipo_query.count()
+            holdings = holdings_query.count()
         if items:
             links["items"] = items
         if circ_policies:
             links["circ_policies"] = circ_policies
+        if holdings:
+            links["holdings"] = holdings
         return links
 
     def reasons_not_to_delete(self):

--- a/tests/api/item_types/test_item_types_rest.py
+++ b/tests/api/item_types/test_item_types_rest.py
@@ -163,12 +163,15 @@ def test_item_types_name_validate(client):
         assert get_json(res) == {"name": None}
 
 
-def test_item_types_can_delete(client, item_type_standard_martigny, item_lib_martigny, circulation_policies):
+def test_item_types_can_delete(
+    item_type_standard_martigny, holding_lib_martigny_w_patterns, item_lib_martigny, circulation_policies
+):
     """Test can delete an item type."""
     can, reasons = item_type_standard_martigny.can_delete
     assert not can
     assert reasons["links"]["circ_policies"]
     assert reasons["links"]["items"]
+    assert reasons["links"]["holdings"]
 
 
 def test_filtered_item_types_get(


### PR DESCRIPTION
Standard holdings depend entirely on their items, so the link check was not necessary. However, serial and electronic holdings have their own circulation category that must be preserved.