### PR TITLE
refactor(import): route GND subjects to subjects

### DIFF
--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -519,10 +519,11 @@ def marc21_to_notes_and_original_title_504(self, key, value):
 def marc21_to_subjects_6XX(self, key, value):
     """Get subjects.
 
-    - create an object :
-        genreForm : for the field 655
-        subjects :  for 6xx with $2 rero
-        subjects_imported : for 6xx having indicator 2 '0' or '2'
+    Route 6XX fields to the appropriate key based on tag and $2 subfield:
+        - genreForm: field 655 (regardless of $2)
+        - subjects: other 6xx with $2 gnd
+        - subjects_imported: other 6xx with $2 rero or idref,
+          or with indicator 2 = '0' (LCSH) or '2' (MeSH)
     """
     type_per_tag = {
         "600": EntityType.PERSON,
@@ -560,7 +561,13 @@ def marc21_to_subjects_6XX(self, key, value):
     subfield_2 = subfields_2[0].replace("gnd-content", "gnd") if subfields_2 else None
     subfields_a = utils.force_list(value.get("a", []))
 
-    field_key = "genreForm" if tag_key == "655" else "subjects_imported"
+    if tag_key == "655":
+        field_key = "genreForm"
+    elif subfield_2 == "gnd":
+        field_key = "subjects"
+    else:
+        field_key = "subjects_imported"
+
     if subfield_2 in ["rero", "gnd", "idref"]:
         if tag_key in ["600", "610", "611"] and value.get("t"):
             tag_key += "t"
@@ -602,8 +609,6 @@ def marc21_to_subjects_6XX(self, key, value):
             ids=utils.force_list(value.get("0")),
             key=key,
         ):
-            if field_key == "subjects_imported":
-                field_key = "subjects"
             subject = {"$ref": ref}
         else:
             if field_key == "genreForm":

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
@@ -352,8 +352,8 @@ def marc21_to_subjects_6XX(self, key, value):
 
     - create an object :
         genreForm : for the field 655
-        subjects :  for 6xx with $2 rero
-        subjects_imported : for 6xx having indicator 2 '0' or '2'
+        subjects : for 6xx with $2 gnd
+        subjects_imported : for 6xx with $2 rero or idref, or indicator 2 '0' or '2'
     """
     type_per_tag = {
         "600": EntityType.PERSON,
@@ -376,7 +376,13 @@ def marc21_to_subjects_6XX(self, key, value):
     subfield_2 = subfields_2[0].replace("gnd-content", "gnd") if subfields_2 else None
     subfields_a = utils.force_list(value.get("a", []))
 
-    field_key = "genreForm" if tag_key == "655" else "subjects_imported"
+    if tag_key == "655":
+        field_key = "genreForm"
+    elif subfield_2 == "gnd":
+        field_key = "subjects"
+    else:
+        field_key = "subjects_imported"
+
     if subfield_2 in ["rero", "gnd", "idref"]:
         if tag_key in ["600", "610", "611"] and value.get("t"):
             tag_key += "t"
@@ -429,8 +435,6 @@ def marc21_to_subjects_6XX(self, key, value):
             ids=utils.force_list(value.get("0")),
             key=key,
         ):
-            if field_key == "subjects_imported":
-                field_key = "subjects"
             subject = {"$ref": ref}
         else:
             if field_key == "genreForm":

--- a/tests/unit/documents/test_documents_dojson_loc.py
+++ b/tests/unit/documents/test_documents_dojson_loc.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""DOJSON LOC model tests."""
+
+from unittest import mock
+
+from dojson.contrib.marc21.utils import create_record
+
+from rero_ils.modules.documents.dojson.contrib.marc21tojson.loc import marc21
+
+
+@mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.loc.model.get_mef_link")
+def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
+    """Test that GND subjects always go to subjects field, not subjects_imported."""
+
+    # Test 1: GND subject WITHOUT MEF link should go to subjects
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Computer science</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Computer science",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") is None
+
+    # Test 2: GND subject WITH MEF link should go to subjects
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Mathematics</subfield>
+        <subfield code="0">(DE-588)123456789</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://test.rero.ch/api/concepts/gnd/123456789"
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [{"entity": {"$ref": "https://test.rero.ch/api/concepts/gnd/123456789"}}]
+    assert data.get("subjects_imported") is None
+
+    # Test 3: RERO subject should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Physics</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Physics",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 4: IDREF subject should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Chemistry</subfield>
+        <subfield code="2">idref</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Chemistry",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 5: LCSH subject (indicator 2=0) should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Astronomy</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Astronomy",
+                "source": "LCSH",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 6: MeSH subject (indicator 2=2) should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="2">
+        <subfield code="a">Neurology</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Neurology",
+                "source": "MeSH",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 7: Mixed GND and non-GND subjects should be routed correctly
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Biology</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Geology</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Ecology</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Biology",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Geology",
+            }
+        },
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Ecology",
+                "source": "LCSH",
+            }
+        },
+    ]
+
+    # Test 8: gnd-content should be treated as gnd and go to subjects
+    marc21xml = """
+    <record>
+      <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Documentary</subfield>
+        <subfield code="2">gnd-content</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("genreForm") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Documentary",
+            }
+        }
+    ]
+
+    # Test 9: GND Person subject WITHOUT MEF link
+    marc21xml = """
+    <record>
+      <datafield tag="600" ind1=" " ind2="7">
+        <subfield code="a">Einstein, Albert</subfield>
+        <subfield code="d">1879-1955</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Person",
+                "authorized_access_point": "Einstein, Albert 1879-1955",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") is None
+
+    # Test 10: GND Place subject WITH MEF link
+    marc21xml = """
+    <record>
+      <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Berlin</subfield>
+        <subfield code="0">(DE-588)4005728-8</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://test.rero.ch/api/places/gnd/4005728-8"
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [{"entity": {"$ref": "https://test.rero.ch/api/places/gnd/4005728-8"}}]
+    assert data.get("subjects_imported") is None

--- a/tests/unit/documents/test_documents_dojson_slsp.py
+++ b/tests/unit/documents/test_documents_dojson_slsp.py
@@ -368,3 +368,238 @@ def test_marc21_to_subjects(mock_get_mef_link):
     assert data.get("genreForm") == [
         {"entity": {"$ref": "https://test.rero.ch/api/concepts/TOPIC"}},
     ]
+
+
+@mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.slsp.model.get_mef_link")
+def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
+    """Test that GND subjects always go to subjects field, not subjects_imported."""
+
+    # Test 1: GND subject WITHOUT MEF link should go to subjects
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Computer science</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Computer science",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") is None
+
+    # Test 2: GND subject WITH MEF link should go to subjects
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Mathematics</subfield>
+        <subfield code="0">(DE-588)123456789</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://test.rero.ch/api/concepts/gnd/123456789"
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [{"entity": {"$ref": "https://test.rero.ch/api/concepts/gnd/123456789"}}]
+    assert data.get("subjects_imported") is None
+
+    # Test 3: RERO subject should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Physics</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Physics",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 4: IDREF subject should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Chemistry</subfield>
+        <subfield code="2">idref</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Chemistry",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 5: Mixed GND and non-GND subjects should be routed correctly
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Biology</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Geology</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Astronomy</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Biology",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Geology",
+            }
+        },
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Astronomy",
+                "source": "LCSH",
+            }
+        },
+    ]
+
+    # Test 6: gnd-content should be treated as gnd and go to subjects
+    marc21xml = """
+    <record>
+      <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Documentary</subfield>
+        <subfield code="2">gnd-content</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("genreForm") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Documentary",
+            }
+        }
+    ]
+    # genreForm uses different field_key logic, but gnd-content should still work
+
+    # Test 7: LCSH subject (indicator 2=0) should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Astronomy</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Astronomy",
+                "source": "LCSH",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 8: MeSH subject (indicator 2=2) should go to subjects_imported
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="2">
+        <subfield code="a">Neurology</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Neurology",
+                "source": "MeSH",
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 9: GND Person subject WITHOUT MEF link
+    marc21xml = """
+    <record>
+      <datafield tag="600" ind1=" " ind2="7">
+        <subfield code="a">Einstein, Albert</subfield>
+        <subfield code="d">1879-1955</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Person",
+                "authorized_access_point": "Einstein, Albert 1879-1955",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") is None
+
+    # Test 10: GND Place subject WITH MEF link
+    marc21xml = """
+    <record>
+      <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Berlin</subfield>
+        <subfield code="0">(DE-588)4005728-8</subfield>
+        <subfield code="2">gnd</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://test.rero.ch/api/places/gnd/4005728-8"
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [{"entity": {"$ref": "https://test.rero.ch/api/places/gnd/4005728-8"}}]
+    assert data.get("subjects_imported") is None


### PR DESCRIPTION
* Change the dojson transformation logic to route GND subjects directly to the `subjects`. RERO and IDREF subjects are routed to `subjects_imported`. This change affects the SLSP, LOC, DNB, and KUL marc21tojson models.
* Closes rero/rero-ils#4010