### PR TITLE
feat(sru): enhance CQL search capabilities and performance

### DIFF
--- a/rero_ils/modules/documents/dojson/contrib/jsontodc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontodc/model.py
@@ -15,40 +15,157 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""RERO-ILS Dublin Core model definition."""
+"""RERO-ILS to Dublin Core conversion model definition.
+
+This module implements DoJSON transformation rules for converting RERO ILS internal JSON document format to Dublin
+Core (DC) metadata format. Dublin Core is a simple and widely-used metadata standard with 15 core elements.
+
+The transformation provides mappings from RERO ILS complex bibliographic structures to simplified Dublin Core elements:
+
+    - dc:title: Main title with responsibility statement
+    - dc:creator: Primary creators (authors, composers, photographers)
+    - dc:contributor: Other contributors
+    - dc:description: Summaries, notes, dissertation info
+    - dc:language: Language codes (ISO 639)
+    - dc:publisher: Publishers and publication dates
+    - dc:type: Document type and subtype
+    - dc:identifier: ISBN, ISSN, local identifiers
+    - dc:relation: Related works and editions
+    - dc:subject: Subject headings and keywords
+
+Key Classes:
+    DublinCoreOverdo: Specialized DoJSON Overdo for Dublin Core conversion
+
+Key Features:
+    - Language-aware entity resolution for multilingual metadata
+    - Role-based separation of creators vs contributors (using CREATOR_ROLES from serializers.base)
+    - Automatic title formatting with responsibility statements
+    - Multiple identifier format handling
+    - Entity type-aware subject processing
+
+See Also:
+    - Dublin Core Metadata Initiative: https://dublincore.org/
+    - Dublin Core Terms: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/
+    - DoJSON: https://dojson.readthedocs.io/
+"""
 
 from dojson import Overdo, utils
 from flask_babel import gettext as _
 
 from rero_ils.modules.documents.extensions import TitleExtension
+from rero_ils.modules.documents.serializers.base import CREATOR_ROLES
 from rero_ils.modules.entities.models import EntityType
 from rero_ils.modules.entities.remote_entities.utils import get_entity_localized_value
 
 
 class DublinCoreOverdo(Overdo):
-    """Specialized Overdo for Dublin Core."""
+    """DoJSON Overdo extension for RERO ILS to Dublin Core transformation.
+
+    This class extends DoJSON's Overdo to convert RERO ILS bibliographic records
+    to Dublin Core format. It implements simplified mapping rules that reduce
+    complex RERO ILS structures to the 15 core Dublin Core elements.
+
+    The transformation process:
+
+    1. Sets target language for multilingual field resolution
+    2. Applies DoJSON transformation rules for each DC element
+    3. Post-processes title field with formatted text
+    4. Adds local identifier (PID) to identifiers list
+
+    Dublin Core elements generated:
+
+    - titles: Formatted main title with subtitle and responsibility
+    - creators: Primary creators based on role codes
+    - contributors: Other contributors
+    - descriptions: Summaries, notes, dissertation info
+    - languages: ISO 639 language codes
+    - publishers: Publisher names from statements
+    - dates: Publication dates (start-end)
+    - types: Translated document types
+    - identifiers: ISBNs, ISSNs, local IDs
+    - relations: Related works
+    - subjects: Subject headings
+
+    :ivar language: Target language for entity resolution and translations.
+    :vartype language: str
+
+    .. note::
+
+        Unlike MARC 21 conversion, Dublin Core output is intentionally simplified
+        and may lose some bibliographic detail present in the source record.
+
+    .. seealso::
+
+        DoJSON Overdo: https://dojson.readthedocs.io/en/latest/api.html#overdo
+    """
 
     def do(self, blob, ignore_missing=True, exception_handlers=None, language="fr"):
-        """Translate blob values and instantiate new model instance.
+        """Transform RERO ILS JSON document to Dublin Core format.
 
-        Raises ``MissingRule`` when no rule matched and ``ignore_missing``
-        is ``False``.
+        This method orchestrates the complete transformation from RERO ILS
+        internal format to Dublin Core. It applies transformation rules,
+        post-processes the title field, and adds the local identifier.
 
-        :param blob: ``dict``-like object on which the matching rules are
-                     going to be applied.
-        :param ignore_missing: Set to ``False`` if you prefer to raise
-                               an exception ``MissingRule`` for the first
-                               key that it is not matching any rule.
-        :param exception_handlers: Give custom exception handlers to take care
-                                   of non-standard codes that are installation
-                                   specific.
-        :param language: Language to use.
+        Transformation pipeline:
+
+        1. Sets language attribute for multilingual field resolution
+        2. Executes DoJSON transformation rules for each DC element
+        3. Formats title with subtitle and responsibility statement
+        4. Prepends local PID to identifiers list
+
+        :param blob: RERO ILS document dictionary to transform containing pid,
+            title, contribution, summary, note, dissertation, language,
+            provisionActivity, type, identifiedBy, and subjects.
+        :type blob: dict
+        :param ignore_missing: If False, raises MissingRule when a field has
+            no transformation rule. Defaults to True.
+        :type ignore_missing: bool, optional
+        :param exception_handlers: Custom exception handlers for non-standard
+            field processing. Defaults to None.
+        :type exception_handlers: dict, optional
+        :param language: Target language code for entity resolution and type
+            translations. Affects which authorized access point is selected
+            for multilingual entities. Defaults to "fr".
+        :type language: str, optional
+        :returns: Dublin Core representation with titles, creators, contributors,
+            descriptions, languages, publishers, dates, types, identifiers,
+            relations, and subjects.
+        :rtype: dict
+        :raises MissingRule: If ignore_missing=False and a field lacks a
+            transformation rule.
+
+        .. note::
+
+            - Title formatting combines mainTitle, subtitle, and responsibility
+            - Only bf:Title type titles are used for the formatted title
+            - PID is always the first identifier in the list
+
+        Example::
+
+            converter = DublinCoreOverdo()
+            rero_doc = {
+                'pid': 'doc123',
+                'title': [{
+                    'type': 'bf:Title',
+                    'mainTitle': [{'value': 'Sample Title'}],
+                    'subtitle': [{'value': 'A Study'}]
+                }],
+                'responsibilityStatement': [[{'value': 'John Doe'}]],
+                'contribution': [...],
+                ...
+            }
+            dc_record = converter.do(rero_doc, language='en')
+            dc_record['titles']
+            # ['Sample Title : A Study / John Doe']
         """
         self.language = language
 
         result = super().do(blob, ignore_missing=ignore_missing, exception_handlers=exception_handlers)
+
+        # Post-process title: extract bf:Title entries and format with subtitle
+        # and responsibility statement for DC title element
         titles = blob.get("title", [])
-        bf_titles = list(filter(lambda t: t["type"] == "bf:Title", titles))
+        bf_titles = list(filter(lambda t: t.get("type") == "bf:Title", titles))
 
         if text := TitleExtension.format_text(
             titles=bf_titles,
@@ -57,48 +174,64 @@ class DublinCoreOverdo(Overdo):
         ):
             result["titles"] = [text]
 
+        # Prepend local PID as first identifier in bf:Local format
         if pid := blob.get("pid"):
-            identifiers = result.get("identifiers", [])
-            identifiers.insert(0, f"bf:Local|{pid}")
+            result.setdefault("identifiers", []).insert(0, f"bf:Local|{pid}")
         return result
 
 
 dublincore = DublinCoreOverdo()
-CREATOR_ROLES = [
-    "aut",
-    "cmp",
-    "pht",
-    "ape",
-    "aqt",
-    "arc",
-    "art",
-    "aus",
-    "chr",
-    "cll",
-    "com",
-    "drt",
-    "dsr",
-    "enj",
-    "fmk",
-    "inv",
-    "ive",
-    "ivr",
-    "lbt",
-    "lsa",
-    "lyr",
-    "pra",
-    "prg",
-    "rsp",
-    "scl",
-]
 
 
-# creator and contributor
 @dublincore.over("creators", "contribution")
 @utils.for_each_value
 @utils.ignore_value
 def json_to_contributors(self, key, value):
-    """Get creators and contributors data."""
+    """Extract creators and contributors from contribution entities.
+
+    This function implements role-based separation of creators vs contributors
+    in Dublin Core. Contributors with roles in CREATOR_ROLES become dc:creator,
+    while others become dc:contributor.
+
+    The function:
+
+    1. Resolves entity authorized access point (language-aware)
+    2. Falls back to generic authorized_access_point if needed
+    3. Checks if role is in CREATOR_ROLES
+    4. If creator role: returns value for dc:creator
+    5. If contributor role: appends to contributors list and returns None
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key ("contribution").
+    :type key: str
+    :param value: Contribution object containing entity (with authorized_access_point)
+        and role (list of MARC relator codes).
+    :type value: dict
+    :returns: Authorized access point if role is in CREATOR_ROLES, None otherwise
+        (contributor added directly to self).
+    :rtype: str or None
+
+    .. note::
+
+        - Contributors are written directly to self["contributors"] to avoid
+          duplication in the creators list
+        - Language-aware resolution uses get_entity_localized_value()
+        - Returns None if no authorized access point is found
+
+    Example::
+
+        value = {
+            'entity': {'authorized_access_point': 'Doe, John'},
+            'role': ['aut']  # Author role
+        }
+        json_to_contributors(dc_record, 'contribution', value)
+        # Returns: 'Doe, John'  # Added to dc:creator
+
+        value['role'] = ['edt']  # Editor role
+        json_to_contributors(dc_record, 'contribution', value)
+        # Returns: None  # Added to dc:contributor instead
+    """
     authorized_access_point = get_entity_localized_value(
         entity=value.get("entity", {}),
         key="authorized_access_point",
@@ -109,7 +242,10 @@ def json_to_contributors(self, key, value):
         result = value.get("entity", {}).get("authorized_access_point")
 
     if result:
-        if value.get("role") in CREATOR_ROLES:
+        roles = value.get("role") or []
+        if isinstance(roles, str):
+            roles = [roles]
+        if any(role in CREATOR_ROLES for role in roles):
             return result
 
         contributors = self.get("contributors", [])
@@ -122,53 +258,175 @@ def json_to_contributors(self, key, value):
 @dublincore.over("descriptions", "^(summary|note|dissertation|supplementaryContent)")
 @utils.ignore_value
 def json_to_descriptions(self, key, value):
-    """Get descriptions data."""
+    """Aggregate description data from multiple RERO ILS fields into dc:description.
+
+    Consolidates various descriptive fields into a single Dublin Core description
+    element. This includes summaries, notes, dissertation information, and
+    supplementary content.
+
+    Field mappings:
+
+    - supplementaryContent: Added directly
+    - summary: Extracts all label values (multiple languages)
+    - note: Extracts label field
+    - dissertation: Extracts label field
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key (summary, note, dissertation, supplementaryContent).
+    :type key: str
+    :param value: Field value(s) to process. Can be string (supplementaryContent),
+        dict with label (note or dissertation), or dict with label list (summary).
+    :type value: list or dict
+    :returns: None. Descriptions are written directly to self["descriptions"].
+    :rtype: None
+
+    .. note::
+
+        - Accumulates values from multiple calls (all description sources)
+        - Summary labels are flattened (all language variants included)
+        - Empty descriptions list is not written to self
+
+    Example::
+
+        # First call with summary
+        value = {'label': [{'value': 'A comprehensive study'}]}
+        json_to_descriptions(dc, 'summary', value)
+        dc['descriptions']
+        # => ['A comprehensive study']
+
+        # Second call with note
+        value = {'label': 'Bibliography: p. 200-210'}
+        json_to_descriptions(dc, 'note', value)
+        dc['descriptions']
+        # => ['A comprehensive study', 'Bibliography: p. 200-210']
+    """
     descriptions = self.get("descriptions", [])
     for data in utils.force_list(value):
         if key == "supplementaryContent":
             descriptions.append(data)
         elif key == "summary":
-            descriptions += [label["value"] for label in data.get("label", [])]
+            descriptions += [v for v in (label.get("value") for label in data.get("label", [])) if v is not None]
         elif label := data.get("label"):
             descriptions.append(label)
     if descriptions:
-        # write the discriptions directly into self
+        # write the descriptions directly into self
         self["descriptions"] = descriptions
 
 
 @dublincore.over("languages", "^language")
 @utils.ignore_value
 def json_to_languages(self, key, value):
-    """Get languages data."""
-    languages = [language.get("value") for language in utils.force_list(value)]
+    """Extract language codes for dc:language element.
+
+    Converts RERO ILS language objects to simple ISO 639 language codes
+    for Dublin Core.
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key ("language").
+    :type key: str
+    :param value: Language object(s) with value (ISO 639-2/B code) and
+        optional type field.
+    :type value: list or dict
+    :returns: List of ISO 639 language codes, or None if no languages found.
+    :rtype: list or None
+
+    Example::
+
+        value = [{'value': 'eng'}, {'value': 'fre'}]
+        json_to_languages(dc, 'language', value)
+        # Returns: ['eng', 'fre']
+    """
+    languages = [lang_code for language in utils.force_list(value) if (lang_code := language.get("value"))]
     return languages or None
 
 
 @dublincore.over("publishers", "^provisionActivity")
 @utils.ignore_value
 def json_to_dates(self, key, value):
-    """Get publishers data and date."""
-    publishers = self.get("publisher", [])
+    """Extract publisher names and publication dates from provisionActivity.
+
+    Processes provisionActivity to populate both dc:publisher and dc:date elements.
+    Publisher names (dc:publisher) are extracted from all provisionActivity types,
+    while publication dates (dc:date) are only extracted for bf:Publication activities.
+
+    Extraction rules:
+
+    - Date (dc:date): Only from bf:Publication, uses startDate and optional
+      endDate, format "YYYY" or "YYYY-YYYY", only first publication date used
+    - Publisher (dc:publisher): From bf:Agent statements, takes first label
+      value, all agents included
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key ("provisionActivity").
+    :type key: str
+    :param value: List of provision activity objects with type, startDate,
+        endDate, and statement fields.
+    :type value: list
+    :returns: None. Publishers and dates written directly to self["publishers"]
+        and self["dates"].
+    :rtype: None
+
+    .. note::
+
+        - Only processes bf:Publication activities for dates
+        - Multiple publisher names can be extracted
+        - Date range format: "2020-2023"
+        - Single date format: "2020"
+
+    Example::
+
+        value = [{
+            'type': 'bf:Publication',
+            'startDate': '2020',
+            'endDate': '2023',
+            'statement': [
+                {
+                    'type': 'bf:Agent',
+                    'label': [{'value': 'Publisher Inc.'}]
+                },
+                {
+                    'type': 'bf:Place',
+                    'label': [{'value': 'New York'}]
+                }
+            ]
+        }]
+        json_to_dates(dc, 'provisionActivity', value)
+        dc['dates']
+        # => ['2020-2023']
+        dc['publishers']
+        # => ['Publisher Inc.']
+    """
+    publishers = self.get("publishers", [])
     dates = self.get("dates", [])
     for data in value:
-        # only take the first date:
-        if data.get("type") == "bf:Publication" and not self.get("date"):
-            start_date = str(data.get("startDate", ""))
+        # Extract publication date (only from bf:Publication, and only once)
+        # If we have startDate and endDate dates = f"{startDate}-{endDate}"
+        # If we have no endDate but a startDate dates = f"{startDate}"
+        # If we have no startDate but an endDate dates = f"-{endDate}"
+        # If we have no startDate and no endDate, we don't add a date
+        if data.get("type") == "bf:Publication" and not dates:
+            start_date = str(data.get("startDate") or "")
             date = [start_date]
-            if end_date := str(data.get("endDate", "")):
+            if end_date := str(data.get("endDate") or ""):
                 date.append(end_date)
-            if date:
+            if start_date or end_date:
                 dates.append("-".join(date))
+
+        # Extract publisher names from bf:Agent type statements
         statements = data.get("statement", [])
         for statement in statements:
-            if statement["type"] == "bf:Agent":
-                # TODO: witch value do we need to take?
-                publishers.append(statement["label"][0].get("value"))
+            if statement.get("type") == "bf:Agent":
+                # Take first label value (publisher name) from agent statement
+                labels = statement.get("label", [])
+                if labels and (pub_name := labels[0].get("value")):
+                    publishers.append(pub_name)
+    # Write accumulated values to DC record
     if dates:
-        # write the dates directly into self
         self["dates"] = dates
     if publishers:
-        # write the publishers directly into self
         self["publishers"] = publishers
 
 
@@ -176,7 +434,38 @@ def json_to_dates(self, key, value):
 @utils.for_each_value
 @utils.ignore_value
 def json_to_types(self, key, value):
-    """Get types data."""
+    """Convert document types to translated dc:type values.
+
+    Transforms RERO ILS document type information into human-readable,
+    translated type strings for Dublin Core. Combines main_type and
+    optional subtype with translation.
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key ("type").
+    :type key: str
+    :param value: Type object containing main_type and optional subtype codes.
+    :type value: dict
+    :returns: Translated type string. Format "Main Type / Subtype" with subtype
+        or "Main Type" without.
+    :rtype: str
+
+    .. note::
+
+        - Uses Flask-Babel gettext (_) for translation
+        - Translation uses the language set in dublincore.language
+        - Type codes are defined in RERO ILS document type vocabulary
+
+    Example::
+
+        value = {'main_type': 'docmaintype_book', 'subtype': 'docsubtype_e-book'}
+        json_to_types(dc, 'type', value)  # Language: en
+        # Returns: 'Book / E-book'
+
+        value = {'main_type': 'docmaintype_serial'}
+        json_to_types(dc, 'type', value)  # Language: fr
+        # Returns: 'Périodique'
+    """
     main_type = value.get("main_type")
     if subtype_type := value.get("subtype"):
         return " / ".join([_(main_type), _(subtype_type)])
@@ -187,9 +476,52 @@ def json_to_types(self, key, value):
 @utils.for_each_value
 @utils.ignore_value
 def json_to_identifiers(self, key, value):
-    """Get identifiers data."""
+    """Convert various identifier types to dc:identifier format.
+
+    Transforms RERO ILS identifier objects into formatted strings for Dublin Core.
+    Supports multiple identifier types (ISBN, ISSN, DOI, etc.) with optional
+    source information.
+
+    Output format:
+
+    - With source: "Type|Value(Source)" (e.g., "bf:Doi|10.1000/xyz(CrossRef)")
+    - Without source: "Type|Value" (e.g., "bf:Isbn|9781234567890")
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key ("identifiedBy").
+    :type key: str
+    :param value: Identifier object containing type, value, optional source,
+        and optional status.
+    :type value: dict
+    :returns: Formatted identifier string.
+    :rtype: str
+
+    .. note::
+
+        - Type prefix uses BIBFRAME vocabulary (bf:Isbn, bf:Issn, etc.)
+        - Source is included in parentheses when present
+        - Invalid/cancelled identifiers are still included
+        - Local PID is prepended separately in do() method
+
+    Example::
+
+        value = {'type': 'bf:Isbn', 'value': '9781234567890'}
+        json_to_identifiers(dc, 'identifiedBy', value)
+        # Returns: 'bf:Isbn|9781234567890'
+
+        value = {
+            'type': 'bf:Doi',
+            'value': '10.1000/xyz',
+            'source': 'CrossRef'
+        }
+        json_to_identifiers(dc, 'identifiedBy', value)
+        # Returns: 'bf:Doi|10.1000/xyz(CrossRef)'
+    """
     itype = value.get("type")
     identifier_value = value.get("value")
+    if not itype or not identifier_value:
+        return None
     if source := value.get("source"):
         return f"{itype}|{identifier_value}({source})"
     return f"{itype}|{identifier_value}"
@@ -202,10 +534,53 @@ def json_to_identifiers(self, key, value):
 @utils.for_each_value
 @utils.ignore_value
 def json_to_relations(self, key, value):
-    """Get relations data."""
+    """Extract related work information for dc:relation element.
+
+    Consolidates various relationship fields into dc:relation. Supports both
+    labeled relationships (with explicit label) and title-based relationships
+    (with title array).
+
+    Relationship types processed:
+
+    - issuedWith: Resources issued together
+    - otherEdition: Other editions of the same work
+    - otherPhysicalFormat: Same content in different format
+    - precededBy: Previous/earlier work
+    - relatedTo: Generally related works
+    - succeededBy: Subsequent/later work
+    - supplement: Supplementary material
+    - supplementTo: Work this is a supplement to
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key (relationship type).
+    :type key: str
+    :param value: Relationship object containing label or title array with
+        _text field.
+    :type value: dict
+    :returns: Relationship description string, or None if neither label nor
+        titles are present.
+    :rtype: str or None
+
+    .. note::
+
+        - Prefers label over title if both present
+        - Multiple titles are joined with ", "
+        - Relationship type is not included in output (lost in consolidation)
+
+    Example::
+
+        value = {'label': 'Earlier edition: 1st ed., 2010'}
+        json_to_relations(dc, 'precededBy', value)
+        # Returns: 'Earlier edition: 1st ed., 2010'
+
+        value = {'title': [{'_text': 'Original French'}, {'_text': 'German trans.'}]}
+        json_to_relations(dc, 'otherEdition', value)
+        # Returns: 'Original French, German trans.'
+    """
     if label := value.get("label"):
         return label
-    if titles := [title["_text"] for title in value.get("title", [])]:
+    if titles := [t for title in value.get("title", []) if (t := title.get("_text"))]:
         return ", ".join(titles)
     return None
 
@@ -214,9 +589,65 @@ def json_to_relations(self, key, value):
 @utils.for_each_value
 @utils.ignore_value
 def json_to_subject(self, key, value):
-    """Get subject data."""
+    """Convert subject entities to dc:subject strings.
+
+    Transforms various entity types into subject heading strings for Dublin Core.
+    Handles different entity types with type-specific formatting and language-aware
+    resolution for authorized access points.
+
+    Entity type handling:
+
+    - PERSON: Uses language-specific authorized_access_point or preferred_name
+    - ORGANISATION: Uses language-specific authorized_access_point or preferred_name
+    - PLACE: Uses language-specific authorized_access_point or preferred_name
+    - WORK: Combines creator and title with ". - " separator
+    - TOPIC: Uses term field
+    - TEMPORAL: Uses term field
+
+    :param self: The Dublin Core record being built.
+    :type self: dict
+    :param key: Source field key ("subjects").
+    :type key: str
+    :param value: Subject entity object containing type, authorized_access_point,
+        preferred_name, creator, title, or term depending on entity type.
+    :type value: dict
+    :returns: Subject heading string, or None if no suitable value found.
+    :rtype: str or None
+
+    .. note::
+
+        - Uses get_entity_localized_value() for language-aware resolution
+        - WORK subjects include creator if available
+        - Empty results return None instead of empty string
+
+    Example::
+
+        # Person subject
+        value = {
+            'type': 'bf:Person',
+            'authorized_access_point': 'Shakespeare, William, 1564-1616'
+        }
+        json_to_subject(dc, 'subjects', value)
+        # Returns: 'Shakespeare, William, 1564-1616'
+
+        # Work subject
+        value = {
+            'type': 'bf:Work',
+            'creator': 'Homer',
+            'title': 'Odyssey'
+        }
+        json_to_subject(dc, 'subjects', value)
+        # Returns: 'Homer. - Odyssey'
+
+        # Topic subject
+        value = {'type': 'bf:Topic', 'term': 'Artificial intelligence'}
+        json_to_subject(dc, 'subjects', value)
+        # Returns: 'Artificial intelligence'
+    """
     result = ""
     _type = value.get("type")
+
+    # Person, organisation, or place subjects: use authorized access point
     if _type in [EntityType.PERSON, EntityType.ORGANISATION, EntityType.PLACE]:
         if authorized_access_point := get_entity_localized_value(
             entity=value,
@@ -226,12 +657,18 @@ def json_to_subject(self, key, value):
             result = authorized_access_point
         else:
             result = value.get("preferred_name")
+
+    # Work subjects: combine creator and title
     elif _type == EntityType.WORK:
         work = []
         if creator := value.get("creator"):
             work.append(creator)
-        work.append(value.get("title"))
+        if title := value.get("title"):
+            work.append(title)
         result = ". - ".join(work)
+
+    # Topic or temporal subjects: use term
     elif _type in [EntityType.TOPIC, EntityType.TEMPORAL]:
         result = value.get("term")
+
     return result or None

--- a/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
@@ -15,7 +15,38 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""RERO-ILS to MARC21 model definition."""
+"""RERO-ILS to MARC 21 conversion model definition.
+
+This module implements DoJSON transformation rules for converting RERO ILS
+internal JSON document format to MARC 21 XML format. It provides:
+
+    - Complete field-by-field mapping from RERO ILS JSON to MARC 21
+    - Dynamic leader generation based on document type
+    - Entity resolution for contributions (authors, contributors)
+    - Holdings and items serialization (field 949)
+    - Language-aware source ordering for authorized access points
+    - Support for filtering by organisation, library, and location
+
+The transformation process:
+    1. Generates MARC leader based on document type (position 06-07)
+    2. Creates fixed-length data elements (field 008)
+    3. Maps bibliographic fields (020-9XX)
+    4. Resolves entity references for contributions and subjects
+    5. Optionally includes holdings/items data
+
+Key Classes:
+    ToMarc21Overdo: Specialized DoJSON Overdo class for MARC 21 conversion
+
+Key Functions:
+    do_contribution: Processes contribution entities with language preferences
+    do_concept: Processes subject/concept entities
+    get_holdings_items: Retrieves holdings and items for a document
+    generate_leader: Creates MARC leader based on document characteristics
+
+See Also:
+    - MARC 21 Format: https://www.loc.gov/marc/bibliographic/
+    - DoJSON: https://dojson.readthedocs.io/
+"""
 
 from dojson import utils
 from dojson.contrib.to_marc21.model import Underdo
@@ -40,14 +71,30 @@ from rero_ils.modules.utils import date_string_to_utc
 
 
 def set_value(data, old_data, key):
-    """Set new data value.
+    """Merge a single key from new data into old data if not already present.
 
-    Adds key not present in old data from data to old data.
+    This function implements a non-destructive merge strategy, preserving
+    existing values in old_data while adding missing keys from new data.
+    Used primarily during entity source resolution to combine data from
+    multiple authority sources (e.g., idref, gnd, rero).
 
-    :param data: data with new values.
-    :param old_data: old data.
-    :param key: key to replace in old data from data.
-    :returns: modified old data
+    :param data: Source dictionary containing new values to merge.
+    :type data: dict
+    :param old_data: Target dictionary to be updated.
+    :type old_data: dict
+    :param key: The key to transfer from data to old_data.
+    :type key: str
+    :returns: The updated old_data dictionary. Modified in place and returned.
+    :rtype: dict
+
+    Example::
+
+        old = {'name': 'John', 'age': 30}
+        new = {'age': 25, 'city': 'Paris'}
+        set_value(new, old, 'city')
+        # Returns: {'name': 'John', 'age': 30, 'city': 'Paris'}
+        set_value(new, old, 'age')  # Doesn't override existing
+        # Returns: {'name': 'John', 'age': 30, 'city': 'Paris'}
     """
     value = data.get(key)
     if not old_data.get(key) and value:
@@ -56,11 +103,49 @@ def set_value(data, old_data, key):
 
 
 def replace_contribution_sources(contribution, source_order):
-    """Prepare contributions data from sources.
+    """Merge contribution entity data from multiple authority sources.
 
-    :param contribution: contribution to use.
-    :source_order: Source order to use to get the information.
-    :returns: contribution entity with localized values.
+    This function resolves contribution entities by merging data from multiple
+    authority control sources (e.g., idref, gnd, rero) according to language
+    preferences. It implements a priority-based merge where the first source
+    in source_order takes precedence.
+
+    The merge process:
+
+    1. Iterates through sources in the specified order (language-dependent)
+    2. For each source found, extracts authority control data
+    3. Creates a reference list with source and PID information
+    4. Merges entity fields (name, dates, qualifiers) using set_value
+    5. Removes raw source data and attaches resolved refs
+
+    Entity fields processed:
+
+    - Basic: type, preferred_name, numeration, qualifier
+    - Dates: date_of_birth, date_of_death
+    - Organisation: subordinate_unit
+    - Conference: conference, conference_number, conference_date, conference_place
+
+    :param contribution: Contribution dictionary containing an 'entity' key
+        with source-specific data (idref, gnd, rero, etc.).
+    :type contribution: dict
+    :param source_order: Ordered list of source identifiers (e.g., ['idref', 'gnd'])
+        defining merge priority. Sources earlier in the list have higher priority.
+    :type source_order: list
+    :returns: The contribution dictionary with entity data merged and refs added.
+        The 'entity' now contains merged fields from all sources and
+        refs (list of {'source': str, 'pid': str} dictionaries).
+    :rtype: dict
+
+    Example::
+
+        contribution = {
+            'entity': {
+                'idref': {'pid': '12345', 'preferred_name': 'Doe, John'},
+                'gnd': {'pid': '67890', 'date_of_birth': '1980'}
+            }
+        }
+        replace_contribution_sources(contribution, ['idref', 'gnd'])
+        # Returns merged entity with preferred_name from idref and date_of_birth from gnd
     """
     refs = []
     entity = contribution.get("entity")
@@ -88,11 +173,34 @@ def replace_contribution_sources(contribution, source_order):
 
 
 def replace_concept_sources(concept, source_order):
-    """Prepare concept data from sources.
+    """Merge concept/subject entity data from multiple thesaurus sources.
 
-    :param concept: concept to use.
-    :source_order: Source order to use to get the information.
-    :returns: concept entity with localized values.
+    Similar to replace_contribution_sources but for subject/concept entities
+    from thesauri (e.g., rameau, lcsh, mesh). Merges data according to
+    language-specific source preferences.
+
+    Concept fields processed:
+
+    - type: Entity type (Topic, Place, Temporal, etc.)
+    - authorized_access_point: Preferred subject heading term
+
+    :param concept: Concept entity dictionary with source-specific data.
+    :type concept: dict
+    :param source_order: Ordered list of thesaurus sources (e.g., ['rameau', 'lcsh'])
+        defining merge priority.
+    :type source_order: list
+    :returns: The concept entity with merged data and refs list containing
+        source/PID information for each thesaurus.
+    :rtype: dict
+
+    Example::
+
+        concept = {
+            'rameau': {'pid': 'sh85001', 'authorized_access_point': 'Art'},
+            'lcsh': {'pid': '123456'}
+        }
+        replace_concept_sources(concept, ['rameau', 'lcsh'])
+        # Returns merged concept with authorized_access_point from rameau
     """
     refs = []
     for source in source_order:
@@ -106,16 +214,67 @@ def replace_concept_sources(concept, source_order):
 
 
 def do_contribution(contribution, source_order):
-    """Create contribution.
+    """Transform contribution entity to MARC 21 subfield structure.
 
-    :param contribution: contribution to transform (replaces $ref with real
-        information dependent on language given in source_order).
-    :param source_order: list of sources to use dependent on language.
-    :returns: result marc dictionary,
-              entity type,
-              is it a surname,
-              is it a conference
-    :rtype: tuple(dict, str, bool, bool)
+    Converts a RERO ILS contribution (author, contributor, etc.) into MARC 21
+    subfield notation ready for fields 100, 110, 111, 700, 710, 711, 600, 610, 611.
+
+    This function:
+
+    1. Resolves entity references ($ref) by fetching from database
+    2. Merges multi-source entity data based on language preferences
+    3. Determines appropriate MARC field format (personal vs corporate)
+    4. Creates subfield dictionary with proper MARC codes
+    5. Adds authority control references ($0)
+
+    MARC subfields generated:
+
+    Person (X00):
+        - $a: Preferred name (surname, forename)
+        - $b: Numeration (e.g., "II", "III")
+        - $c: Qualifier/title (e.g., "Jr.", "Sir")
+        - $d: Dates (birth-death years)
+        - $4: Relator codes (roles)
+        - $0: Authority control numbers
+
+    Organisation (X10/X11):
+        - $a: Corporate/conference name
+        - $b: Subordinate units
+        - $n: Conference number
+        - $d: Conference date
+        - $c: Conference place
+        - $4: Relator codes
+        - $0: Authority control numbers
+
+    :param contribution: Contribution object containing entity data or $ref
+        to resolve, and role (list of relator codes, optional).
+    :type contribution: dict
+    :param source_order: Ordered source list for language-specific resolution
+        (e.g., ['idref', 'gnd', 'rero']).
+    :type source_order: list
+    :returns: A 4-element tuple (result, entity_type, surname, conference) where
+        result is MARC subfield dict or None, entity_type is EntityType constant,
+        surname is True if personal name in surname-first format, conference is
+        True if organisation is a conference.
+    :rtype: tuple
+
+    .. note::
+
+        Returns (None, None, False, False) if entity cannot be found in database
+        or if preferred_name/authorized_access_point is missing.
+
+    Example::
+
+        contribution = {
+            'entity': {'pid': '12345', '$ref': '...'},
+            'role': ['aut', 'edt']
+        }
+        result, entity_type, surname, conference = do_contribution(
+            contribution, ['idref', 'gnd']
+        )
+        result
+        # => {'__order__': ['a', 'd', '4', '4'], 'a': 'Doe, John',
+        #     'd': '1980 - 2020', '4': ['aut', 'edt']}
     """
     roles = contribution.get("role", [])
     entity = contribution.get("entity")
@@ -168,52 +327,167 @@ def do_contribution(contribution, source_order):
     return result, entity_type, surname, conference
 
 
-def do_concept(entity, source_order):
-    """Create concept.
+def resolve_entity(entity, source_order):
+    """Resolve entity $ref and merge multi-source data.
 
-    :param entity: entity to transform.
-    :param source_order: source_order to use.
-    :returns: result marc dictionary
+    Fetches entity data from the database if a $ref is present, then merges
+    data from multiple authority sources according to language preferences.
+    This is the base resolution step used by do_concept and other entity
+    processing functions.
+
+    :param entity: Entity dictionary that may contain pid (indicates a $ref),
+        $ref (reference URL), source-specific data (idref, gnd, rameau, etc.),
+        or authorized_access_point (direct access point if no $ref).
+    :type entity: dict
+    :param source_order: Ordered list of authority sources defining merge
+        priority (e.g., ['idref', 'gnd'] or ['rameau', 'lcsh']).
+    :type source_order: list
+    :returns: A 2-element tuple (resolved_entity, from_db) where resolved_entity
+        is the merged entity dict or None if $ref cannot be resolved, and
+        from_db is True if entity was fetched from database.
+    :rtype: tuple
+
+    Example::
+
+        entity = {'pid': '12345', '$ref': '...'}
+        resolved, from_db = resolve_entity(entity, ['rameau', 'lcsh'])
+        resolved['authorized_access_point']
+        # => 'Art -- France'
+        resolved['refs']
+        # => [{'source': 'rameau', 'pid': '12345'}]
     """
-    authorized_access_point = None
     if pid := entity.get("pid"):
         ref = entity.get("$ref")
         # we have a $ref, get the real entity
-        if entity := RemoteEntity.get_record_by_pid(pid):
-            entity = replace_concept_sources(concept=entity, source_order=source_order)
-            authorized_access_point = entity.get("authorized_access_point")
-        else:
-            error_print(f"No entity found for pid:{pid} {ref}")
-            return None
+        if resolved := RemoteEntity.get_record_by_pid(pid):
+            resolved = replace_concept_sources(concept=resolved, source_order=source_order)
+            return resolved, True
+        error_print(f"No entity found for pid:{pid} {ref}")
+        return None, False
+    return entity, False
+
+
+def do_concept(entity, source_order):
+    """Transform subject/concept entity to MARC 21 subfield structure.
+
+    Converts a RERO ILS subject/concept entity into MARC 21 subfield notation
+    for fields 6XX and 655 (subject access points).
+
+    Process:
+
+    1. Resolves entity $ref if present
+    2. Merges multi-source thesaurus data
+    3. Extracts authorized access point
+    4. Creates MARC subfield dictionary
+    5. Adds authority control references ($0) if available
+
+    :param entity: Subject/concept entity containing pid (if $ref), $ref
+        (reference URL), authorized_access_point (subject heading term),
+        or authorized_access_point_{lang} (language-specific variant).
+    :type entity: dict
+    :param source_order: Ordered thesaurus source list for language-specific
+        resolution (e.g., ['rameau', 'lcsh', 'mesh']).
+    :type source_order: list
+    :returns: MARC subfield dictionary with __order__ (list of subfield codes),
+        a (authorized access point), and 0 (authority control numbers if refs
+        available). Returns None if entity cannot be resolved or has no access point.
+    :rtype: dict or None
+
+    Example::
+
+        entity = {'pid': '67890', '$ref': '...'}
+        do_concept(entity, ['rameau', 'lcsh'])
+        # Returns: {'__order__': ['a', '0'], 'a': 'Architecture -- France', '0': ['(rameau)67890']}
+    """
+    resolved_entity, from_db = resolve_entity(entity, source_order)
+    if resolved_entity is None:
+        return None
+
+    if from_db:
+        authorized_access_point = resolved_entity.get("authorized_access_point")
     else:
-        authorized_access_point = entity.get(f"authorized_access_point_{to_marc21.language}") or entity.get(
-            "authorized_access_point"
-        )
+        authorized_access_point = resolved_entity.get(
+            f"authorized_access_point_{to_marc21.language}"
+        ) or resolved_entity.get("authorized_access_point")
     result = {}
-    if authorized_access_point:
-        result = add_value(result, "a", authorized_access_point)
+    if not authorized_access_point:
+        return None
+    result = add_value(result, "a", authorized_access_point)
+    if refs := resolved_entity.get("refs", []):
+        result["0"] = []
+        for ref in refs:
+            result["__order__"].append("0")
+            result["0"].append(f"({ref['source']}){ref['pid']}")
     return result
 
 
 def get_holdings_items(document_pid, organisation_pids=None, library_pids=None, location_pids=None):
-    """Create Holding and Item informations.
+    """Retrieve holdings and items data for a document with institutional context.
 
-    :param document_pid: document pid to use for holdings search
-    :param organisation_pids: Which organisations items to add.
-    :param library_pids: Which from libraries items to add.
-    :param location_pids: Which from locations items to add.
+    Fetches all holdings and items associated with a document, enriched with
+    organisation, library, and location information. Supports filtering to
+    include only holdings/items from specific institutions.
 
-    :returns: list of holding informations with associated organisation,
-              library and location pid, name informations.
+    This function:
+
+    1. Finds all holdings for the document (excluding masked)
+    2. Applies optional filters (organisation/library/location)
+    3. Batch-fetches institutional metadata (caching names)
+    4. For standard holdings, retrieves associated items
+    5. Structures data for MARC 949 field serialization
+
+    Holdings types:
+
+    - standard: Physical holdings with items (books, etc.)
+    - electronic: Electronic holdings without items
+    - serial: Serial holdings with patterns
+
+    :param document_pid: PID of the document to retrieve holdings for.
+    :type document_pid: str
+    :param organisation_pids: Filter by organisation PIDs. Only holdings from
+        these organisations will be included. Defaults to None (no filtering).
+    :type organisation_pids: list, optional
+    :param library_pids: Filter by library PIDs. Only holdings from these
+        libraries will be included. Defaults to None (no filtering).
+    :type library_pids: list, optional
+    :param location_pids: Filter by location PIDs. Only holdings from these
+        locations will be included. Defaults to None (no filtering).
+    :type location_pids: list, optional
+    :returns: List of dictionaries containing organisation, library, location,
+        holdings data, and item data (for standard holdings only).
+    :rtype: list
+
+    .. note::
+
+        - Institutional names are cached during processing to minimize database queries
+        - Each item gets its own result entry (holdings replicated per item)
+        - Electronic/serial holdings appear once without item data
+        - Only unmasked holdings and items are included
+
+    Example::
+
+        holdings = get_holdings_items(
+            document_pid='doc123',
+            organisation_pids=['org1'],
+            library_pids=['lib2']
+        )
+        len(holdings)
+        # => 3  # Holdings from org1/lib2 with their items
     """
 
     def get_name(resource, pid):
-        """Get name from resource.
+        """Fetch resource name by PID.
 
-        The name will be cached.
-        :param resource: Resource class to use.
-        :param pid: Pid for the resource to get the name from.
-        :returns: name from the resource
+        Helper function to retrieve the name field from a resource.
+        Called within get_holdings_items where names are cached in
+        dictionaries to avoid redundant database queries.
+
+        :param resource: Resource API class (Organisation, Library, or Location).
+        :type resource: class
+        :param pid: Persistent identifier of the resource.
+        :type pid: str
+        :returns: The resource's name field, or None if not found.
+        :rtype: str or None
         """
         data = resource.get_record_by_pid(pid)
         if data:
@@ -270,7 +544,7 @@ def get_holdings_items(document_pid, organisation_pids=None, library_pids=None, 
                 item_hits = ItemsSearch().filter("terms", pid=list(item_pids)).scan()
                 for item_hit in item_hits:
                     item_data = item_hit.to_dict()
-                    item_result = result
+                    item_result = dict(result)
                     item_result["item"] = {
                         "barcode": item_data.get("barcode"),
                         "all_number": item_data.get("all_number"),
@@ -295,17 +569,173 @@ ORDER = [
     "provisionActivity",
     "copyrightDate",
     "physical_description",
+    "general_notes",
+    "table_of_contents",
+    "summary",
+    "dissertation",
     "subjects",
     "genreForm",
     "contribution",
     "type",
     "holdings_items",
 ]
-LEADER = "00000cam a2200000zu 4500"
+
+#: MARC21 Leader positions and their meanings:
+#: - 00-04: Record length (system-generated)
+#: - 05: Record status (n=new, c=corrected, d=deleted, a=increase encoding level)
+#: - 06: Type of record (a=language material, c=notated music, e=cartographic, etc.)
+#: - 07: Bibliographic level (m=monograph, s=serial, a=article, c=collection)
+#: - 08-09: Type of control and character encoding scheme
+#: - 10: Indicator count (always 2)
+#: - 11: Subfield code count (always 2)
+#: - 12-16: Base address of data (system-generated)
+#: - 17: Encoding level (blank=full, 1=full not examined, etc.)
+#: - 18: Descriptive cataloging form (a=AACR2, i=ISBD, c=ISBD w/o punctuation)
+#: - 19: Multipart resource record level
+#: - 20-23: Entry map (always "4500")
+LEADER_DEFAULT = "00000cam a2200000zu 4500"
+
+#: Mapping of document main_type to MARC leader position 06 (Type of record)
+TYPE_OF_RECORD_MAP = {
+    "docmaintype_book": "a",  # Language material
+    "docmaintype_article": "a",  # Language material
+    "docmaintype_serial": "a",  # Language material (serials handled via pos 07)
+    "docmaintype_audio": "i",  # Nonmusical sound recording
+    "docmaintype_music": "j",  # Musical sound recording
+    "docmaintype_score": "c",  # Notated music
+    "docmaintype_video": "g",  # Projected medium (video)
+    "docmaintype_movie": "g",  # Projected medium (film)
+    "docmaintype_image": "k",  # Two-dimensional nonprojectable graphic
+    "docmaintype_map": "e",  # Cartographic material
+    "docmaintype_game": "r",  # Three-dimensional artifact
+    "docmaintype_kit": "o",  # Kit
+    "docmaintype_software": "m",  # Computer file
+    "docmaintype_file": "m",  # Computer file
+    "docmaintype_other": "a",  # Default to language material
+}
+
+#: Mapping of document main_type to MARC leader position 07 (Bibliographic level)
+BIBLIOGRAPHIC_LEVEL_MAP = {
+    "docmaintype_serial": "s",  # Serial
+    "docmaintype_article": "a",  # Monographic component part
+    "docmaintype_book": "m",  # Monograph
+    # Default to monograph for others
+}
+
+
+def generate_leader(document):
+    """Generate dynamic MARC 21 leader string based on document characteristics.
+
+    Creates a properly formatted 24-character MARC 21 leader with document-specific
+    values for type of record (position 06) and bibliographic level (position 07).
+    This replaces static leader generation with intelligent type detection.
+
+    Leader positions modified:
+
+    - Position 06 (Type of record): Set based on document main_type
+      (a=language material, c=notated music, e=cartographic, g=video, etc.)
+    - Position 07 (Bibliographic level): Set based on document main_type
+      (m=monograph, s=serial, a=article component)
+
+    Special handling:
+
+    - Electronic resources: If contentMediaCarrier indicates computer media
+      (rdamedia:c) and the document is language material, position 06 changes
+      to 'm' (computer file)
+
+    :param document: RERO ILS document dictionary containing type (list of type
+        objects with main_type field) and contentMediaCarrier (list with mediaType
+        information, optional).
+    :type document: dict
+    :returns: A 24-character MARC 21 leader string. Defaults to monograph/language
+        material ("00000cam a2200000zu 4500") if type information is missing.
+    :rtype: str
+
+    .. note::
+
+        System-generated positions (00-04: record length, 12-16: base address)
+        remain as zeros and will be filled by the MARC serialization system.
+
+    Example::
+
+        doc = {'type': [{'main_type': 'docmaintype_serial'}]}
+        generate_leader(doc)
+        # Returns: '00000cas a2200000zu 4500'  # Position 07 = 's' for serial
+
+        doc = {
+            'type': [{'main_type': 'docmaintype_video'}],
+        }
+        generate_leader(doc)
+        # Returns: '00000cgm a2200000zu 4500'  # Position 06 = 'g' for video
+    """
+    # Start with default leader template
+    leader = list(LEADER_DEFAULT)
+
+    # Get document type information
+    doc_types = document.get("type", [])
+    main_type = None
+    for doc_type in doc_types:
+        if mt := doc_type.get("main_type"):
+            main_type = mt
+            break
+
+    if main_type:
+        # Position 06: Type of record
+        type_of_record = TYPE_OF_RECORD_MAP.get(main_type, "a")
+        leader[6] = type_of_record
+
+        # Position 07: Bibliographic level
+        bib_level = BIBLIOGRAPHIC_LEVEL_MAP.get(main_type, "m")
+        leader[7] = bib_level
+
+    # Check for electronic resources
+    content_media = document.get("contentMediaCarrier", [])
+    for cmc in content_media:
+        if cmc.get("mediaType") == "rdamedia:c":  # computer
+            # If it's computer media and language material, mark as computer file
+            if leader[6] == "a":
+                leader[6] = "m"
+            break
+
+    return "".join(leader)
 
 
 class ToMarc21Overdo(Underdo):
-    """Specialized Overdo."""
+    """DoJSON Overdo extension for RERO ILS to MARC 21 transformation.
+
+    This class extends DoJSON's Underdo (reverse transformation) to convert
+    RERO ILS internal JSON documents to MARC 21 format. It provides:
+
+    - Pre-processing hooks for leader and 008 field generation
+    - Entity resolution with language-aware source ordering
+    - Holdings/items inclusion (field 949)
+    - Physical description normalization
+    - Note type segregation
+    - Custom field ordering
+
+    The do() method orchestrates the complete transformation pipeline:
+
+    1. Generate dynamic leader based on document type
+    2. Create fixed-length data elements (008 field)
+    3. Add timestamp (005 field)
+    4. Normalize title with responsibility statement
+    5. Resolve contribution entities with source preferences
+    6. Process physical description and notes
+    7. Optionally fetch holdings/items
+    8. Apply field ordering
+    9. Execute DoJSON transformation rules
+
+    :ivar responsibility_statement: Cache for responsibility statements.
+    :vartype responsibility_statement: dict
+    :ivar language: Target language for entity resolution.
+    :vartype language: str
+    :ivar source_order: Ordered list of authority sources for entity resolution.
+    :vartype source_order: list
+
+    .. seealso::
+
+        DoJSON Underdo: https://dojson.readthedocs.io/en/latest/api.html#underdo
+    """
 
     responsibility_statement = {}
 
@@ -320,37 +750,98 @@ class ToMarc21Overdo(Underdo):
         library_pids=None,
         location_pids=None,
     ):
-        """Translate blob values and instantiate new model instance.
+        """Transform RERO ILS JSON document to MARC 21 format.
 
-        Raises ``MissingRule`` when no rule matched and ``ignore_missing``
-        is ``False``.
+        This is the main entry point for the transformation. It pre-processes
+        the document, applies DoJSON transformation rules, and returns a
+        MARC 21 representation.
 
-        :param blob: ``dict``-like object on which the matching rules are
-                     going to be applied.
-        :param ignore_missing: Set to ``False`` if you prefer to raise
-                               an exception ``MissingRule`` for the first
-                               key that it is not matching any rule.
-        :param exception_handlers: Give custom exception handlers to take care
-                                   of non-standard codes that are installation
-                                   specific.
-        :param with_holdings_items: Add holding, item information in field 949
-                                    to the result (attention time consuming).
-        :param organisation_pids: Which organisations items to add.
-        :param library_pids: Which libraries items to add.
-        :param location_pids: Which locations items to add.):
-        :param language: Language to use.
+        Pre-processing steps:
+
+        1. **Leader generation**: Creates dynamic leader based on document type
+        2. **Fixed field creation**: Builds 008 field with creation date (positions
+           00-05), publication dates (positions 07-14), fiction indicator (position
+           33), and language code (positions 35-37)
+        3. **Timestamp addition**: Adds 005 field with last modification time
+        4. **Title normalization**: Combines title and responsibility statement
+        5. **Entity source ordering**: Sets language-specific authority preferences
+        6. **Holdings inclusion**: Optionally fetches holdings/items (field 949)
+        7. **Physical description**: Merges extent, duration, dimensions, formats
+        8. **Note segregation**: Separates general notes from special note types
+        9. **Field ordering**: Applies MARC logical order (leader → 00X → 9XX)
+
+        :param blob: RERO ILS document dictionary to transform containing pid,
+            _created, _updated, type, title, contribution, subjects, etc.
+        :type blob: dict
+        :param language: Target language for entity resolution. Affects which
+            authority sources are preferred (e.g., 'fr' prefers idref, 'de'
+            prefers gnd). Defaults to 'en'.
+        :type language: str, optional
+        :param ignore_missing: If False, raises MissingRule exception when a JSON
+            key has no matching transformation rule. Defaults to True.
+        :type ignore_missing: bool, optional
+        :param exception_handlers: Custom exception handlers for non-standard
+            field processing. Defaults to None.
+        :type exception_handlers: dict, optional
+        :param with_holdings_items: Whether to include holdings and items in
+            field 949. Warning: time-consuming for documents with many holdings.
+            Defaults to False.
+        :type with_holdings_items: bool, optional
+        :param organisation_pids: Filter holdings by organisation PIDs. Only
+            applicable if with_holdings_items=True. Defaults to None.
+        :type organisation_pids: list, optional
+        :param library_pids: Filter holdings by library PIDs. Only applicable
+            if with_holdings_items=True. Defaults to None.
+        :type library_pids: list, optional
+        :param location_pids: Filter holdings by location PIDs. Only applicable
+            if with_holdings_items=True. Defaults to None.
+        :type location_pids: list, optional
+        :returns: MARC 21 record with fields as keys (e.g., 'leader', '001',
+            '245__', '700__'). Includes __order__ key for field sequence.
+        :rtype: GroupableOrderedDict
+        :raises MissingRule: If ignore_missing=False and a field has no
+            transformation rule.
+
+        .. note::
+
+            - The 008 field uses '|' for undefined positions and 'x' for unknown values
+            - Holdings/items inclusion can significantly increase processing time
+            - Entity resolution requires network calls to authority databases
+
+        Example::
+
+            converter = ToMarc21Overdo()
+            rero_doc = {'pid': '123', 'title': [...], ...}
+            marc_record = converter.do(
+                rero_doc,
+                language='fr',
+                with_holdings_items=True,
+                organisation_pids=['org1']
+            )
+            marc_record['245__']
+            # => {'a': 'Title', 'b': 'Subtitle', 'c': 'Author', ...}
         """
-        # TODO: real leader
+        # Generate dynamic MARC leader (24 chars) based on document type.
+        # Sets position 06 (type of record) and 07 (bibliographic level) intelligently.
         self.language = language
-        blob["leader"] = LEADER
-        # create fixed_length_data_elements for 008
+        blob["leader"] = generate_leader(blob)
+
+        # Build 008 fixed-length data elements (40 characters):
+        # Positions 00-05: Date entered (yymmdd format)
+        # Position 06: Type of date/publication status (filled below)
+        # Positions 07-14: Date 1 and Date 2 (publication dates)
+        # Position 33: Literary form (fiction indicator)
+        # Positions 35-37: Language code
         created = date_string_to_utc(blob["_created"]).strftime("%y%m%d")
         fixed_data = f"{created}|||||||||xx#|||||||||||||||||||||c"
+        # Set position 33 (Literary form): 0=non-fiction, 1=fiction
         fiction = blob.get("fiction_statement")
         if fiction == DocumentFictionType.Fiction.value:
             fixed_data = f"{fixed_data[:33]}1{fixed_data[34:]}"
         elif fiction == DocumentFictionType.NonFiction.value:
             fixed_data = f"{fixed_data[:33]}0{fixed_data[34:]}"
+        # Extract publication dates from provisionActivity for positions 07-14.
+        # Position 06 (type of date): s=single, m=multiple (range)
         provision_activity = blob.get("provisionActivity", [])
         for p_activity in provision_activity:
             if p_activity.get("type") == "bf:Publication":
@@ -363,12 +854,14 @@ class ToMarc21Overdo(Underdo):
                         type_of_date = "m"
                     fixed_data = f"{fixed_data[:6]}{type_of_date}{start_date}{fixed_data[11:]}"
                     break
-        if language := utils.force_list(blob.get("language")):
-            language = language[0].get("value")
-            fixed_data = f"{fixed_data[:35]}{language}{fixed_data[38:]}"
+        # Set positions 35-37: Language code (ISO 639-2/B)
+        if doc_languages := utils.force_list(blob.get("language")):
+            lang_code = doc_languages[0].get("value")
+            if lang_code and len(lang_code) == 3:
+                fixed_data = f"{fixed_data[:35]}{lang_code}{fixed_data[38:]}"
         blob["fixed_length_data_elements"] = fixed_data
 
-        # Add date and time of latest transaction
+        # Add 005 field: date and time of latest transaction (YYYYMMDDHHmmss.f)
         updated = date_string_to_utc(blob["_updated"])
         blob["date_and_time_of_latest_transaction"] = updated.strftime("%Y%m%d%H%M%S.0")
 
@@ -378,19 +871,21 @@ class ToMarc21Overdo(Underdo):
                 "titles": blob.get("title", {}),
                 "responsibility": " ; ".join(create_title_responsibilites(blob.get("responsibilityStatement", []))),
             }
-        # Fix ContributionsSearch
-        # Try to get RERO_ILS_AGENTS_LABEL_ORDER from current app
-        # In the dojson cli is no current app and we have to get the value
-        # directly from config.py
+        # Configure language-specific authority source ordering.
+        # RERO_ILS_AGENTS_LABEL_ORDER defines which authority sources to prefer
+        # for each language (e.g., French prefers idref, German prefers gnd).
+        # Try to get from Flask app context first, fall back to direct import
+        # for CLI usage (where no app context exists).
         try:
-            order = current_app.config.get("RERO_ILS_AGENTS_LABEL_ORDER", [])
-        except Exception:
+            order = current_app.config.get("RERO_ILS_AGENTS_LABEL_ORDER", {})
+        except RuntimeError:
             from rero_ils.config import RERO_ILS_AGENTS_LABEL_ORDER as order
-        self.source_order = order.get(self.language, order.get(order["fallback"], []))
+        self.source_order = order.get(self.language, order.get(order.get("fallback", "en"), []))
 
         if with_holdings_items:
-            # add holdings items informations
-            get_holdings_items
+            # Fetch holdings and items for field 949 (local holdings data).
+            # Warning: This can be time-consuming for documents with many holdings.
+            # Results are filtered by organisation/library/location if specified.
             blob["holdings_items"] = get_holdings_items(
                 document_pid=blob.get("pid"),
                 organisation_pids=organisation_pids,
@@ -398,7 +893,11 @@ class ToMarc21Overdo(Underdo):
                 location_pids=location_pids,
             )
 
-        # Physical Description
+        # Build 300 field (Physical Description) by combining multiple sources:
+        # - $a: extent (with duration if not already included)
+        # - $b: other physical details (production method, color, illustrations)
+        # - $c: dimensions (including book formats)
+        # - $e: accompanying material
         physical_description = {}
         extent = blob.get("extent")
         durations = ", ".join(blob.get("duration", []))
@@ -438,7 +937,26 @@ class ToMarc21Overdo(Underdo):
         if physical_description:
             blob["physical_description"] = physical_description
 
-        # Add order
+        # Extract general notes for field 500 (excluding specialized note types).
+        # Note types handled elsewhere:
+        # - otherPhysicalDetails, accompanyingMaterial → 300$b, 300$e
+        # - dissertation → 502
+        # - summary → 520
+        # - tableOfContents → 505
+        general_notes = []
+        for n in note:
+            if n["noteType"] == "general":
+                general_notes.append(n["label"])
+        if general_notes:
+            blob["general_notes"] = general_notes
+
+        # Table of contents is already in the correct format (array of strings)
+        if table_of_contents := blob.get("tableOfContents"):
+            blob["table_of_contents"] = table_of_contents
+
+        # Apply MARC field ordering defined in ORDER constant.
+        # This ensures fields appear in standard MARC order:
+        # leader → 001-008 → 020-245 → 264-300 → 500-655 → 700-949
         keys = {}
         for key, value in blob.items():
             count = 1
@@ -454,7 +972,20 @@ class ToMarc21Overdo(Underdo):
 
 
 def add_value(result, sub_tag, value):
-    """Add value with tag to result."""
+    """Add a single subfield to MARC field result dictionary.
+
+    Appends subfield code to __order__ list and stores value.
+    Used for non-repeatable subfields.
+
+    :param result: MARC field dictionary being built.
+    :type result: dict
+    :param sub_tag: MARC subfield code (single character).
+    :type sub_tag: str
+    :param value: Subfield value to add.
+    :type value: str
+    :returns: The modified result dictionary.
+    :rtype: dict
+    """
     if value:
         result.setdefault("__order__", []).append(sub_tag)
         result[sub_tag] = value
@@ -462,7 +993,20 @@ def add_value(result, sub_tag, value):
 
 
 def add_values(result, sub_tag, values):
-    """Add values with tag to result."""
+    """Add multiple values for a repeatable subfield to MARC field result.
+
+    Appends subfield code multiple times to __order__ list and stores
+    values as a list. Used for repeatable subfields.
+
+    :param result: MARC field dictionary being built.
+    :type result: dict
+    :param sub_tag: MARC subfield code (single character).
+    :type sub_tag: str
+    :param values: List of subfield values to add.
+    :type values: list
+    :returns: The modified result dictionary.
+    :rtype: dict
+    """
     if values:
         for _ in range(len(values)):
             result.setdefault("__order__", []).append(sub_tag)
@@ -683,6 +1227,85 @@ def reverse_physical_description(self, key, value):
     return result or None
 
 
+@to_marc21.over("500", "^general_notes")
+@utils.reverse_for_each_value
+@utils.ignore_value
+def reverse_general_notes(self, key, value):
+    """Reverse - general notes to MARC 500.
+
+    MARC 500 - General Note (Repeatable)
+    $a - General note (Not repeatable)
+
+    Maps document general notes to MARC 500 fields.
+    """
+    if value:
+        return {"__order__": ["a"], "a": value}
+    return None
+
+
+@to_marc21.over("502", "^dissertation")
+@utils.reverse_for_each_value
+@utils.ignore_value
+def reverse_dissertation(self, key, value):
+    """Reverse - dissertation note to MARC 502.
+
+    MARC 502 - Dissertation Note (Repeatable)
+    $a - Dissertation note (Not repeatable)
+
+    Maps dissertation information to MARC 502 fields.
+    Each dissertation entry may have multiple language labels.
+    """
+    if labels := value.get("label"):
+        # Take the first label value (primary language)
+        for label in labels:
+            if label_value := label.get("value"):
+                return {"__order__": ["a"], "a": label_value}
+    return None
+
+
+@to_marc21.over("505", "^table_of_contents")
+@utils.reverse_for_each_value
+@utils.ignore_value
+def reverse_table_of_contents(self, key, value):
+    """Reverse - table of contents to MARC 505.
+
+    MARC 505 - Formatted Contents Note (Repeatable)
+    $a - Formatted contents note (Not repeatable)
+    Indicator 1: 0 = Contents, 1 = Incomplete contents, 2 = Partial contents
+    Indicator 2: blank = Basic, 0 = Enhanced
+
+    Maps tableOfContents entries to MARC 505 fields.
+    """
+    if value:
+        return {"__order__": ["a"], "$ind1": "0", "a": value}
+    return None
+
+
+@to_marc21.over("520", "^summary")
+@utils.reverse_for_each_value
+@utils.ignore_value
+def reverse_summary(self, key, value):
+    """Reverse - summary/abstract to MARC 520.
+
+    MARC 520 - Summary, Etc. (Repeatable)
+    $a - Summary, etc. (Not repeatable)
+    $c - Assigning source (Not repeatable)
+    Indicator 1: blank = Summary, 0 = Subject, 1 = Review, 2 = Scope, 3 = Abstract
+
+    Maps document summaries to MARC 520 fields.
+    """
+    result = {}
+    if labels := value.get("label"):
+        # Concatenate all language variants, taking the first value
+        for label in labels:
+            if label_value := label.get("value"):
+                result = add_value(result, "a", label_value)
+                break
+    if source := value.get("source"):
+        result = add_value(result, "c", source)
+    return result or None
+
+
 @to_marc21.over("6XX", "^subjects")
 @utils.reverse_for_each_value
 @utils.ignore_value
@@ -718,36 +1341,78 @@ def reverse_subjects(self, key, value):
             result = do_concept(entity=entity, source_order=to_marc21.source_order)
             tag = "650__"
         elif entity_type == EntityType.WORK:
-            # TODO: to change in the future if $ref's are used.
-            if authorized_access_point := entity.get(f"authorized_access_point_{to_marc21.language}") or entity.get(
-                "authorized_access_point"
-            ):
+            # Resolve $ref if present to get full entity data with refs
+            resolved_entity, from_db = resolve_entity(entity, to_marc21.source_order)
+            if resolved_entity is None:
+                return
+            if from_db:
+                authorized_access_point = resolved_entity.get("authorized_access_point")
+            else:
+                authorized_access_point = resolved_entity.get(
+                    f"authorized_access_point_{to_marc21.language}"
+                ) or resolved_entity.get("authorized_access_point")
+            if authorized_access_point:
                 result = {}
                 result = add_value(result, "t", authorized_access_point)
-                if identified_by := entity.get("identifiedBy"):
+                # Add identifiedBy if present (for non-$ref entities)
+                if identified_by := resolved_entity.get("identifiedBy"):
                     result = add_identified_by(result, identified_by)
+                # Add authority control numbers from refs (for $ref entities)
+                if refs := resolved_entity.get("refs"):
+                    result["0"] = []
+                    for ref in refs:
+                        result["__order__"].append("0")
+                        result["0"].append(f"({ref['source']}){ref['pid']}")
                 self.append(("600__", utils.GroupableOrderedDict(result)))
             return
         elif entity_type == EntityType.PLACE:
-            # TODO: to change in the future if $ref's are used.
-            if authorized_access_point := entity.get(f"authorized_access_point_{to_marc21.language}") or entity.get(
-                "authorized_access_point"
-            ):
+            # Resolve $ref if present to get full entity data with refs
+            resolved_entity, from_db = resolve_entity(entity, to_marc21.source_order)
+            if resolved_entity is None:
+                return
+            if from_db:
+                authorized_access_point = resolved_entity.get("authorized_access_point")
+            else:
+                authorized_access_point = resolved_entity.get(
+                    f"authorized_access_point_{to_marc21.language}"
+                ) or resolved_entity.get("authorized_access_point")
+            if authorized_access_point:
                 result = {}
                 result = add_value(result, "a", authorized_access_point)
-                if identified_by := entity.get("identifiedBy"):
+                # Add identifiedBy if present (for non-$ref entities)
+                if identified_by := resolved_entity.get("identifiedBy"):
                     result = add_identified_by(result, identified_by)
+                # Add authority control numbers from refs (for $ref entities)
+                if refs := resolved_entity.get("refs"):
+                    result["0"] = []
+                    for ref in refs:
+                        result["__order__"].append("0")
+                        result["0"].append(f"({ref['source']}){ref['pid']}")
                 self.append(("651__", utils.GroupableOrderedDict(result)))
             return
         elif entity_type == EntityType.TEMPORAL:
-            # TODO: to change in the future if $ref's are used.
-            if authorized_access_point := entity.get(f"authorized_access_point_{to_marc21.language}") or entity.get(
-                "authorized_access_point"
-            ):
+            # Resolve $ref if present to get full entity data with refs
+            resolved_entity, from_db = resolve_entity(entity, to_marc21.source_order)
+            if resolved_entity is None:
+                return
+            if from_db:
+                authorized_access_point = resolved_entity.get("authorized_access_point")
+            else:
+                authorized_access_point = resolved_entity.get(
+                    f"authorized_access_point_{to_marc21.language}"
+                ) or resolved_entity.get("authorized_access_point")
+            if authorized_access_point:
                 result = {}
                 result = add_value(result, "a", authorized_access_point)
-                if identified_by := entity.get("identifiedBy"):
+                # Add identifiedBy if present (for non-$ref entities)
+                if identified_by := resolved_entity.get("identifiedBy"):
                     result = add_identified_by(result, identified_by)
+                # Add authority control numbers from refs (for $ref entities)
+                if refs := resolved_entity.get("refs"):
+                    result["0"] = []
+                    for ref in refs:
+                        result["__order__"].append("0")
+                        result["0"].append(f"({ref['source']}){ref['pid']}")
                 self.append(("648_7", utils.GroupableOrderedDict(result)))
             return
         else:

--- a/rero_ils/modules/documents/loaders/marcxml.py
+++ b/rero_ils/modules/documents/loaders/marcxml.py
@@ -17,26 +17,86 @@
 
 """Document loaders."""
 
+from io import BytesIO
+
 from dojson.contrib.marc21.utils import create_record, split_stream
-from flask import abort, request
-from six import BytesIO
+from flask import abort, current_app, request
 
 from rero_ils.modules.documents.dojson.contrib.marc21tojson.rero import marc21
 
 
 def marcxml_marshmallow_loader():
-    """Marshmallow loader for MARCXML requests.
+    """Load and convert MARCXML from HTTP request to RERO ILS JSON format.
 
-    The method convert only one record, otherwise will return a bad request.
-    :return: converted marc21 json record.
+    This loader processes MARCXML data from the request body and converts it
+    to RERO ILS internal JSON format using DoJSON transformations. It is designed
+    for single-record imports via the REST API.
+
+    The conversion process:
+        1. Extracts raw MARCXML from request.data
+        2. Splits the XML stream into individual records
+        3. Parses each MARCXML record into MARC 21 structure
+        4. Transforms MARC 21 to RERO ILS JSON using DoJSON
+        5. Marks the record as draft (_draft=True)
+
+    The loader enforces single-record processing:
+        - If multiple MARCXML records are detected, returns HTTP 400 error
+        - This ensures controlled imports and proper validation
+
+    Returns:
+        dict: RERO ILS JSON document with the following structure:
+            - Standard RERO ILS document fields (title, contributions, etc.)
+            - _draft=True: Marks the record as a draft for review
+
+    Raises:
+        werkzeug.exceptions.BadRequest: When multiple MARCXML records are
+            detected in the request data (HTTP 400).
+
+    Example:
+        POST request with MARCXML body::
+
+            <?xml version="1.0" encoding="UTF-8"?>
+            <record xmlns="http://www.loc.gov/MARC21/slim">
+                <leader>00000nam a2200000 c 4500</leader>
+                <datafield tag="245" ind1="1" ind2="0">
+                    <subfield code="a">Sample Title</subfield>
+                </datafield>
+            </record>
+
+        Returns::
+
+            {
+                "title": [{"type": "bf:Title", "_text": "Sample Title", ...}],
+                "_draft": True,
+                ...
+            }
+
+    Note:
+        Records imported via this loader are automatically marked as drafts
+        to prevent accidental publication of unvalidated data.
     """
-    marcxml_records = split_stream(BytesIO(request.data))
-    json_record = {}
-    for number_of_xml_records, marcxml_record in enumerate(marcxml_records):
-        marc21json_record = create_record(marcxml_record)
-        json_record = marc21.do(marc21json_record)
-        # converted records are considered as draft
-        json_record["_draft"] = True
-        if number_of_xml_records > 0:
-            abort(400)
+    # Split the XML stream into individual MARCXML records
+    marcxml_records = list(split_stream(BytesIO(request.data)))
+    if not marcxml_records:
+        abort(400, description="No valid MARCXML record found in request data")
+    if len(marcxml_records) > 1:
+        abort(400, description="Multiple MARCXML records not supported; please submit one record at a time")
+
+    # Parse MARCXML into MARC 21 dictionary structure
+    marc21json_record = create_record(marcxml_records[0])
+
+    # Transform MARC 21 to RERO ILS JSON using DoJSON rules
+    json_record = marc21.do(marc21json_record)
+
+    if not json_record:
+        current_app.logger.error(
+            "marcxml_marshmallow_loader: marc21.do() returned None "
+            f"for record: {marc21json_record.get('001', '<no 001>')}"
+        )
+        abort(400, description="MARCXML record could not be converted to RERO ILS format")
+
+    # Mark imported records as drafts to prevent immediate publication
+    # and ensure they go through the validation workflow
+    json_record["_draft"] = True
+
     return json_record

--- a/rero_ils/modules/documents/serializers/dc.py
+++ b/rero_ils/modules/documents/serializers/dc.py
@@ -37,10 +37,26 @@ DEFAULT_LANGUAGE = LocalProxy(lambda: current_app.config.get("BABEL_DEFAULT_LANG
 
 
 class DublinCoreSerializer(_DublinCoreSerializer):
-    """Dublin Core serializer for records.
+    """Dublin Core serializer for document records.
 
-    Note: This serializer is not suitable for serializing large number of
-    records.
+    This serializer transforms RERO ILS document records into Dublin Core XML format,
+    following the Dublin Core Metadata Element Set specifications. It handles both
+    individual record serialization and search result serialization with SRU support.
+
+    The serializer performs the following transformations:
+        - Converts RERO ILS JSON documents to Dublin Core XML
+        - Resolves record references and processes internationalized fields
+        - Handles contribution data with i18n support
+        - Generates SRU-compliant search responses
+
+    Note:
+        This serializer loads complete records into memory and is not suitable
+        for serializing large numbers of records (>1000). For bulk exports,
+        consider using streaming serialization.
+
+    See Also:
+        - Dublin Core Metadata Initiative: https://dublincore.org/
+        - SRU Protocol: https://www.loc.gov/standards/sru/
     """
 
     # Default namespace mapping.
@@ -58,14 +74,50 @@ class DublinCoreSerializer(_DublinCoreSerializer):
     container_element = "record"
 
     def transform_record(self, pid, record, links_factory=None, language=DEFAULT_LANGUAGE, **kwargs):
-        """Transform record into an intermediate representation."""
+        """Transform a document record into Dublin Core intermediate representation.
+
+        This method converts a RERO ILS document record into a Dublin Core
+        compatible dictionary format by:
+            1. Dumping the record with resolved references
+            2. Processing contribution fields with i18n support
+            3. Applying Dublin Core transformation rules
+
+        Args:
+            pid (str): Persistent identifier of the record.
+            record (Document): The document record instance to transform.
+            links_factory (callable, optional): Factory function for generating
+                record links. Defaults to None.
+            language (str, optional): Target language for i18n fields.
+                Defaults to application's BABEL_DEFAULT_LANGUAGE.
+            **kwargs: Additional keyword arguments passed to the transformation.
+
+        Returns:
+            dict: Dublin Core representation of the record with standard DC elements
+                (dc:title, dc:creator, dc:date, dc:identifier, etc.).
+        """
         record = record.dumps(document_replace_refs_dumper)
         if contributions := record.pop("contribution", []):
             record["contribution"] = process_i18n_literal_fields(contributions)
         return dublincore.do(record, language=language)
 
     def transform_search_hit(self, pid, record, links_factory=None, language=DEFAULT_LANGUAGE, **kwargs):
-        """Transform search result hit into an intermediate representation."""
+        """Transform a search hit into Dublin Core intermediate representation.
+
+        Retrieves the complete document record by PID and delegates to
+        :meth:`transform_record` for the actual transformation.
+
+        Args:
+            pid (str): Persistent identifier of the document.
+            record (dict): Elasticsearch hit source (minimal record data).
+            links_factory (callable, optional): Factory function for generating
+                record links. Defaults to None.
+            language (str, optional): Target language for i18n fields.
+                Defaults to application's BABEL_DEFAULT_LANGUAGE.
+            **kwargs: Additional keyword arguments passed to transform_record.
+
+        Returns:
+            dict: Dublin Core representation of the record.
+        """
         record = Document.get_record_by_pid(pid)
         return self.transform_record(
             pid=pid,
@@ -76,12 +128,41 @@ class DublinCoreSerializer(_DublinCoreSerializer):
         )
 
     def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None, **kwargs):
-        """Serialize a search result.
+        """Serialize Elasticsearch search results into Dublin Core XML.
 
-        :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
-        :param links: Dictionary of links to add to response.
-        :param item_links_factory: Factory function for record links.
+        Generates an SRU-compliant searchRetrieveResponse containing Dublin Core
+        records for all search hits. The response includes:
+            - Total number of matching records
+            - Dublin Core XML records for each hit
+            - SRU metadata (query echo, pagination info)
+            - Next record position for pagination
+
+        The method processes search results in the following order:
+            1. Extract SRU metadata and pagination info from search results
+            2. Transform each search hit to Dublin Core format
+            3. Build XML structure with SRU envelope
+            4. Add echoed search parameters for SRU compliance
+
+        Args:
+            pid_fetcher (callable): Function to extract persistent identifier from hits.
+                Currently unused; PIDs are extracted directly from record source.
+            search_result (dict): Elasticsearch search response containing:
+                - hits.total.value: Total number of matching documents
+                - hits.hits: List of search result hits
+                - hits.sru: SRU-specific metadata (optional)
+            links (dict, optional): Additional links to include in response.
+                Currently unused. Defaults to None.
+            item_links_factory (callable, optional): Factory function for generating
+                per-record links. Defaults to None.
+            **kwargs: Additional keyword arguments passed to transformation methods.
+
+        Returns:
+            bytes: UTF-8 encoded XML string containing the complete SRU response
+                with Dublin Core records.
+
+        Note:
+            The 'ln' query parameter from the request controls the output language
+            for internationalized fields.
         """
         total = search_result["hits"]["total"]["value"]
         sru = search_result["hits"].get("sru", {})

--- a/rero_ils/modules/documents/serializers/marc.py
+++ b/rero_ils/modules/documents/serializers/marc.py
@@ -40,19 +40,46 @@ DEFAULT_LANGUAGE = LocalProxy(lambda: current_app.config.get("BABEL_DEFAULT_LANG
 
 
 class DocumentMARCXMLSerializer(JSONSerializer):
-    """DoJSON based MARCXML serializer for documents.
+    """DoJSON-based MARCXML serializer for RERO ILS documents.
 
-    Note: This serializer is not suitable for serializing large number of
-    records due to high memory usage.
+    This serializer converts RERO ILS JSON document records into MARC 21 XML format
+    using DoJSON transformation rules. It handles:
+        - Document metadata transformation from JSON to MARC 21
+        - Holdings and items serialization (configurable)
+        - Entity resolution for contributions (authors, contributors)
+        - Multi-language support with configurable agent label ordering
+        - Filtering by organisation, library, and location
+
+    The serializer can optionally apply XSLT transformations to the output XML.
+
+    Warning:
+        This serializer loads complete records and entity data into memory.
+        It is not suitable for serializing large numbers of records (>1000)
+        due to high memory consumption. For bulk exports, consider streaming
+        approaches or batch processing.
+
+    Attributes:
+        dumps_kwargs (dict): Additional arguments for XML serialization.
+        schema_class (class): Optional schema class for validation.
+
+    See Also:
+        - MARC 21 Format: https://www.loc.gov/marc/bibliographic/
+        - DoJSON Documentation: https://dojson.readthedocs.io/
     """
 
     def __init__(self, xslt_filename=None, schema_class=None):
-        """Initialize serializer.
+        """Initialize the MARCXML serializer.
 
-        :param dojson_model: The DoJSON model able to convert JSON through the
-            ``do()`` function.
-        :param xslt_filename: XSLT filename. (Default: ``None``)
-        :param schema_class: The schema class. (Default: ``None``)
+        Args:
+            xslt_filename (str, optional): Path to an XSLT stylesheet file for
+                post-processing the MARCXML output. If provided, the XSLT will be
+                applied to transform the generated MARC 21 XML. Defaults to None.
+            schema_class (class, optional): Schema class for validating serialized
+                output. Currently not actively used. Defaults to None.
+
+        Note:
+            The xslt_filename parameter is currently disabled in the code but
+            can be enabled for custom transformations (e.g., MARC21slim2MODS).
         """
         # xslt_filename = resource_filename(
         #     'rero_ils', 'xslts/MARC21slim2MODS3-6.xsl')
@@ -83,7 +110,36 @@ class DocumentMARCXMLSerializer(JSONSerializer):
         links_factory=None,
         **kwargs,
     ):
-        """Transform search result hit into an intermediate representation."""
+        """Transform an Elasticsearch search hit into MARC 21 representation.
+
+        Converts a document record from RERO ILS JSON format to MARC 21 format
+        using DoJSON transformation rules. Optionally includes holdings and items
+        data, filtered by organisation, library, or location.
+
+        Args:
+            pid (str): Persistent identifier of the document.
+            record_hit (dict): Elasticsearch hit source containing document data.
+            language (str, optional): Target language for language-dependent fields.
+                Affects contribution label selection. Defaults to None.
+            with_holdings_items (bool, optional): Whether to include holdings and
+                items in the MARC output. Defaults to True.
+            organisation_pids (list, optional): Filter holdings/items by organisation
+                PIDs. Only data from these organisations will be included.
+                Defaults to None (no filtering).
+            library_pids (list, optional): Filter holdings/items by library PIDs.
+                Only data from these libraries will be included.
+                Defaults to None (no filtering).
+            location_pids (list, optional): Filter holdings/items by location PIDs.
+                Only data from these locations will be included.
+                Defaults to None (no filtering).
+            links_factory (callable, optional): Factory for generating record links.
+                Currently unused. Defaults to None.
+            **kwargs: Additional keyword arguments passed to transformation.
+
+        Returns:
+            GroupableOrderedDict: MARC 21 record representation with fields
+                organized by tag (e.g., '245__', '100__', '852__').
+        """
         return to_marc21.do(
             record_hit,
             language=language,
@@ -121,31 +177,78 @@ class DocumentMARCXMLSerializer(JSONSerializer):
         location_pids=None,
         item_links_factory=None,
     ):
-        """Transform records into an intermediate representation."""
-        # get all linked contributions
+        """Transform multiple Elasticsearch hits into MARC 21 records with entity resolution.
+
+        This method processes multiple search hits efficiently by:
+            1. Collecting all contribution entity PIDs from all hits
+            2. Batch-fetching all entities in a single Elasticsearch query
+            3. Enriching each contribution with full entity data
+            4. Applying language-specific source ordering for agent labels
+            5. Transforming each record to MARC 21 format
+
+        This approach significantly improves performance compared to fetching
+        entities individually for each record.
+
+        Args:
+            hits (list): List of Elasticsearch search hits, each containing
+                a '_source' field with document data.
+            pid_fetcher (callable): Function to extract PID from document ID.
+            language (str): Target language for entity label selection. Used to
+                determine the preferred source order for agent labels.
+            with_holdings_items (bool, optional): Include holdings/items data
+                in MARC output. Defaults to True.
+            organisation_pids (list, optional): Filter by organisation PIDs.
+                Defaults to None.
+            library_pids (list, optional): Filter by library PIDs. Defaults to None.
+            location_pids (list, optional): Filter by location PIDs. Defaults to None.
+            item_links_factory (callable, optional): Factory for item links.
+                Currently unused. Defaults to None.
+
+        Returns:
+            list: List of GroupableOrderedDict objects, each representing a
+                MARC 21 record with enriched contribution data.
+
+        Note:
+            Entity resolution respects the RERO_ILS_AGENTS_LABEL_ORDER configuration,
+            which defines the preferred order of sources (e.g., idref, gnd, rero)
+            for different languages.
+        """
+        # Collect all contribution entity PIDs from all hits for batch resolution.
+        # This prevents N+1 query problem by fetching all entities in one ES query.
         contribution_pids = []
         for hit in hits:
             for contribution in hit["_source"].get("contribution", []):
                 if contribution_pid := contribution.get("entity", {}).get("pid"):
                     contribution_pids.append(contribution_pid)
+        # Batch-fetch all unique entities from Elasticsearch and cache them
+        # in a dictionary for O(1) lookup during record processing.
         search = RemoteEntitiesSearch().filter("terms", pid=list(set(contribution_pids)))
         es_contributions = {}
         for hit in search.scan():
             contribution = hit.to_dict()
             es_contributions[contribution["pid"]] = contribution
 
+        # Get language-specific source order for agent labels (e.g., prefer idref
+        # for French, gnd for German). Falls back to default language if not found.
         order = current_app.config.get("RERO_ILS_AGENTS_LABEL_ORDER", {})
-        source_order = order.get(language, order.get(order["fallback"], []))
+        fallback_key = order.get("fallback")
+        fallback_order = order.get(fallback_key, []) if fallback_key else []
+        source_order = order.get(language, fallback_order)
         records = []
         for hit in hits:
             document = hit["_source"]
+            # Enrich each contribution with full entity data from cache and apply
+            # language-specific source ordering for authorized access points.
             contributions = document.get("contribution", [])
             for contribution in contributions:
                 contribution_pid = contribution.get("entity", {}).get("pid")
                 if contribution_pid in es_contributions:
+                    # Deep copy prevents modifying the cached entity data
                     contribution["entity"] = deepcopy(es_contributions[contribution_pid])
+                    # Select the best authorized access point based on language preferences
                     replace_contribution_sources(contribution=contribution, source_order=source_order)
 
+            # Transform the enriched document to MARC 21 format with all filters applied
             record = self.transform_search_hit(
                 pid=pid_fetcher(hit["_id"], document),
                 record_hit=document,
@@ -156,8 +259,6 @@ class DocumentMARCXMLSerializer(JSONSerializer):
                 location_pids=location_pids,
                 links_factory=item_links_factory,
             )
-            # complete the contributions from refs
-
             records.append(record)
         return records
 
@@ -183,10 +284,45 @@ class DocumentMARCXMLSerializer(JSONSerializer):
 
 
 class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
-    """DoJSON based MARCXML SRU serializer for documents.
+    """DoJSON-based MARCXML serializer with SRU protocol support.
 
-    Note: This serializer is not suitable for serializing large number of
-    records due to high memory usage.
+    This serializer extends :class:`DocumentMARCXMLSerializer` to generate
+    MARC 21 XML wrapped in an SRU (Search/Retrieve via URL) envelope. It is
+    designed specifically for SRU Z39.50 protocol compliance.
+
+    The serializer produces searchRetrieveResponse XML documents containing:
+        - SRU version and metadata
+        - Number of records and pagination info
+        - MARC 21 XML records with proper namespace declarations
+        - Echoed search request parameters
+        - Result set TTL and schema information
+
+    XML Structure:
+        The output follows the MARC 21 XML Schema with SRU envelope:
+            <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/">
+                <zs:version>1.1</zs:version>
+                <zs:numberOfRecords>...</zs:numberOfRecords>
+                <zs:records>
+                    <zs:record>
+                        <zs:recordData>
+                            <record xmlns="http://www.loc.gov/MARC21/slim">...</record>
+                        </zs:recordData>
+                    </zs:record>
+                </zs:records>
+                <zs:echoedSearchRetrieveRequest>...</zs:echoedSearchRetrieveRequest>
+            </zs:searchRetrieveResponse>
+
+    Warning:
+        Like its parent class, this serializer is memory-intensive and not
+        suitable for large result sets (>1000 records).
+
+    Attributes:
+        MARC21_ZS (str): SRU/ZS namespace URI.
+        MARC21_REC (str): MARC 21 XML Schema namespace URI.
+
+    See Also:
+        - SRU Protocol: https://www.loc.gov/standards/sru/
+        - MARC 21 XML: https://www.loc.gov/standards/marcxml/
     """
 
     MARC21_ZS = "http://www.loc.gov/zing/srw/"
@@ -194,11 +330,54 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
     """MARCXML XML Schema"""
 
     def dumps_etree(self, total, records, sru, xslt_filename=None, prefix=None):
-        """Dump records into a etree."""
+        """Serialize MARC records into an SRU XML ElementTree.
+
+        Constructs a complete SRU searchRetrieveResponse XML tree containing
+        MARC 21 records with proper namespace declarations and metadata.
+
+        Args:
+            total (dict): Total hits information from Elasticsearch with 'value' key.
+            records (list or dict): Either a list of MARC records (for search results)
+                or a single MARC record dict. Each record should be a GroupableOrderedDict
+                with MARC fields as keys (e.g., 'leader', '245__', '100__').
+            sru (dict): SRU request parameters containing:
+                - start_record (int): Starting position in result set
+                - maximum_records (int): Number of records requested
+                - query (str): Original CQL query string
+                - query_es (str): Elasticsearch query translation
+            xslt_filename (str, optional): Path to XSLT stylesheet for transformation.
+                Currently disabled but can be used for output formatting. Defaults to None.
+            prefix (str, optional): XML namespace prefix for MARC fields.
+                If None, no prefix is used. Defaults to None.
+
+        Returns:
+            lxml.etree.Element: Root element of the SRU response tree. For a single
+                record, returns just the record element. For search results, returns
+                the complete searchRetrieveResponse element.
+
+        Note:
+            The method handles both single record and multiple records differently:
+                - Single record: Returns minimal record wrapper
+                - Multiple records: Returns full SRU searchRetrieveResponse
+        """
+        _ = xslt_filename  # intentionally unused; kept for API compatibility
         element = ElementMaker(namespace=self.MARC21_ZS, nsmap={"zs": self.MARC21_ZS})
 
         def dump_record(record, idx):
-            """Dump a single record."""
+            """Serialize a single MARC record to SRU XML format.
+
+            Converts a MARC record dictionary into an XML structure with:
+                - Control fields (001-009): Simple tag with content
+                - Data fields (010-999): Tag with indicators and subfields
+                - Leader field: Special header field
+
+            Args:
+                record (GroupableOrderedDict): MARC record with fields as keys.
+                idx (int): Record position in the result set (1-based).
+
+            Returns:
+                lxml.etree.Element: SRU record element containing the MARC data.
+            """
             rec_element = ElementMaker(namespace=self.MARC21_REC, nsmap={prefix: self.MARC21_REC})
             data_element = ElementMaker()
             rec = element.record()
@@ -216,8 +395,9 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             else:
                 items = iteritems(record)
 
+            # Process each MARC field (control fields and data fields)
             for df, subfields in items:
-                # Control fields
+                # Control fields (001-009): Simple fields with just a tag and text content
                 if len(df) == 3:
                     if isinstance(subfields, string_types):
                         controlfield = data_element.controlfield(subfields)
@@ -229,13 +409,16 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
                             controlfield.attrib["tag"] = df[:3]
                             rec_data.append(controlfield)
                 else:
-                    # Skip leader.
+                    # Data fields (010-999): Complex fields with indicators and subfields
+                    # Skip leader as it's already processed above
                     if df == "leader":
                         continue
 
+                    # Ensure subfields is iterable
                     if not isinstance(subfields, (list, tuple, set)):
                         subfields = (subfields,)
 
+                    # Convert underscores to spaces for indicators (e.g., '245_0' -> '245 0')
                     df = df.replace("_", " ")
                     for subfield in subfields:
                         if not isinstance(subfield, (list, tuple, set)):
@@ -263,16 +446,16 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
                                     for v in value:
                                         datafield.append(data_element.subfield(strip_chars(v), code=code))
                             rec_data.append(datafield)
-                rec_record_data.append(rec_data)
-                rec.append(rec_record_data)
-            rec.append(element.RecordPosition(str(idx)))
+            rec_record_data.append(rec_data)
+            rec.append(rec_record_data)
+            rec.append(element.recordPosition(str(idx)))
             return rec
 
         if isinstance(records, dict):
             root = dump_record(records, 1)
         else:
             number_of_records = total["value"]
-            start_record = sru.get("start_record", 0)
+            start_record = sru.get("start_record", 1)
             maximum_records = sru.get("maximum_records", 0)
             query = sru.get("query")
             query_es = sru.get("query_es")
@@ -287,6 +470,7 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
                 data.append(dump_record(record, idx))
             root.append(data)
             echoed_search_rr = element.echoedSearchRetrieveRequest()
+            echoed_search_rr.append(element.version("1.1"))
             if query:
                 echoed_search_rr.append(element.query(query))
             if query_es:
@@ -314,21 +498,55 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
         return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8", **kwargs)
 
     def serialize_search(self, pid_fetcher, search_result, item_links_factory=None, **kwargs):
-        """Serialize a search result.
+        """Serialize Elasticsearch search results into SRU MARCXML format.
 
-        :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
-        :param item_links_factory: Factory function for the items in result.
-            (Default: ``None``)
-        :returns: The objects serialized.
+        This method orchestrates the complete serialization process:
+            1. Extracts language and filtering parameters from request
+            2. Parses organisation/library/location filters from query
+            3. Transforms all records with entity resolution
+            4. Wraps results in SRU searchRetrieveResponse envelope
+
+        The method supports the following request parameters:
+            - ln: Language code for i18n fields
+            - without_items: Flag to exclude holdings/items (default: False)
+
+        Organisation/library/location filters are automatically extracted from
+        the Elasticsearch query string when present.
+
+        Args:
+            pid_fetcher (callable): Function to extract PID from document ID.
+            search_result (dict): Elasticsearch search response with structure:
+                - hits.total: Total number of matching documents
+                - hits.hits: Array of search result hits
+                - hits.sru: SRU-specific metadata (query, pagination)
+            item_links_factory (callable, optional): Factory for item links.
+                Currently unused. Defaults to None.
+            **kwargs: Additional arguments passed to dumps() method.
+
+        Returns:
+            bytes: UTF-8 encoded XML string containing the complete SRU response
+                with MARC 21 records, including XML declaration.
+
+        Example::
+
+            serializer = DocumentMARCXMLSRUSerializer()
+            xml = serializer.serialize_search(
+                pid_fetcher=lambda id, doc: doc['pid'],
+                search_result=es_response
+            )
         """
+        # Extract request parameters for language and item inclusion
         language = request.args.get("ln", DEFAULT_LANGUAGE)
-        with_holdings_items = not request.args.get("without_items", False)
+        without_items_param = request.args.get("without_items", "").lower()
+        with_holdings_items = without_items_param not in ("true", "1", "yes")
+
+        # Parse organisation/library/location filters from the Elasticsearch query.
+        # These filters control which holdings/items are included in the output.
         sru = search_result["hits"].get("sru", {})
         query_es = sru.get("query_es", "")
-        organisation_pids = re.findall(r"organisation_pid:(\d*)", query_es, re.DOTALL)
-        library_pids = re.findall(r"library_pid:(\d*)", query_es, re.DOTALL)
-        location_pids = re.findall(r"holdings.location.pid:(\d*)", query_es, re.DOTALL)
+        organisation_pids = re.findall(r"organisation_pid:(\d+)", query_es)
+        library_pids = re.findall(r"library_pid:(\d+)", query_es)
+        location_pids = re.findall(r"holdings\.location\.pid:(\d+)", query_es)
         records = self.transform_records(
             hits=search_result["hits"]["hits"],
             pid_fetcher=pid_fetcher,

--- a/rero_ils/modules/imports/api.py
+++ b/rero_ils/modules/imports/api.py
@@ -21,6 +21,7 @@
 import pickle
 import traceback
 from datetime import datetime, timedelta
+from io import BytesIO
 
 import requests
 from dojson.contrib.marc21.utils import create_record
@@ -28,7 +29,6 @@ from dojson.utils import GroupableOrderedDict
 from flask import current_app, jsonify, url_for
 from lxml import etree
 from redis import Redis
-from six import BytesIO
 
 from rero_ils.modules.documents.dojson.contrib.marc21tojson import (
     marc21_dnb,

--- a/rero_ils/modules/sru/cql_parser.py
+++ b/rero_ils/modules/sru/cql_parser.py
@@ -17,12 +17,37 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-"""CQL Parser Implementation adaptation from cheshire3.
+"""CQL (Contextual Query Language) Parser for SRU.
 
-https://github.com/cheshire3/cheshire3
-Author:  Rob Sanderson (azaroth@liv.ac.uk)
-Version: 2.0    (CQL 1.2)
-With thanks to Adam Dickmeiss and Mike Taylor for their valuable input.
+This module provides a CQL 1.2 parser that translates CQL queries into
+Elasticsearch query strings. It supports the standard CQL features including
+boolean operators, relation modifiers, sort specifications, and prefix
+declarations.
+
+The parser is adapted from the cheshire3 project:
+    https://github.com/cheshire3/cheshire3
+    Original Author: Rob Sanderson (azaroth@liv.ac.uk)
+    Version: 2.0 (CQL 1.2)
+
+Features:
+    - Full CQL 1.2 syntax support
+    - Boolean operators: AND, OR, NOT (PROX not supported)
+    - Relations: =, <, >, <=, >=, <>, all, any
+    - Sort specifications with ascending/descending modifiers
+    - Relation modifiers: /relevant, /exact, /word, /ignoreCase
+    - Dublin Core index mappings to Elasticsearch fields
+    - Prefix declarations for custom context sets
+
+Example::
+
+    from rero_ils.modules.sru.cql_parser import parse
+    query = parse('dc.title all "python programming" sortBy dc.date/descending')
+    es_query = query.to_es()
+    sort_keys = query.get_es_sort()
+
+See Also:
+    - CQL Specification: http://www.loc.gov/standards/sru/cql/
+    - SRU Standard: http://www.loc.gov/standards/sru/
 """
 
 from copy import deepcopy
@@ -34,8 +59,8 @@ from lxml.builder import ElementMaker
 
 from ..utils import strip_chars
 
-SERVER_CHOISE_RELATION = "="
-SERVER_CHOISE_INDEX = "cql.serverchoice"
+SERVER_CHOICE_RELATION = "="
+SERVER_CHOICE_INDEX = "cql.serverchoice"
 
 ORDER = ["=", ">", ">=", "<", "<=", "<>"]
 MODIFIER_SEPERATOR = "/"
@@ -56,9 +81,81 @@ ERROR_ON_DUPLICATE_PREFIX = False  # >a=b >a=c ''
 FULL_RESULT_SET_NAME_CHECK = True  # cql.rsn=a and cql.rsn=a    (mutant!)
 
 
+#: CQL sort modifier to Elasticsearch sort order mapping.
+#: Maps CQL sort modifiers (e.g., /ascending, /descending) to ES sort orders.
+#: Supports both short form (/ascending) and prefixed form (/sort.ascending).
+ES_SORT_MODIFIERS = {
+    "ascending": "asc",
+    "descending": "desc",
+    "sort.ascending": "asc",
+    "sort.descending": "desc",
+    "missinglow": "missinglow",
+    "missinghigh": "missinghigh",
+    "missingomit": "missingomit",
+    "sort.missinglow": "missinglow",
+    "sort.missinghigh": "missinghigh",
+    "sort.missingomit": "missingomit",
+}
+
+#: CQL sort index to Elasticsearch sortable field mapping.
+#: Maps Dublin Core and custom indexes to ES fields suitable for sorting.
+#: These fields should be keyword type or have doc_values enabled for
+#: efficient sorting. Use '_relevance' to sort by search score.
+ES_SORT_INDEX_MAPPINGS = {
+    "dc.title": "sort_title",
+    "dc.date": "provisionActivity.startDate",
+    "dc.creator": "facet_contribution_en",
+    "dc.contributor": "facet_contribution_en",
+    "dc.publisher": "provisionActivity.statement.label.value.raw",
+    "dc.identifier": "identified_by.value.raw",
+    "dc.subject": "subject.entity.authorized_access_point.raw",
+    "dc.type": "type.main_type",
+    "dc.language": "language.value",
+    "_relevance": "_score",
+}
+
+#: Supported CQL relation modifiers that are processed without error.
+#: These modifiers are acknowledged by the parser. Most map to default
+#: Elasticsearch behavior (relevance scoring, word matching, case insensitivity).
+#:
+#: - ``relevant``: Use relevance scoring (default ES behavior)
+#: - ``exact``: Exact match semantics
+#: - ``word``: Word-based matching (default ES behavior)
+#: - ``ignorecase``: Case-insensitive matching (default ES behavior)
+#: - ``string``: Treat search term as a string literal
+SUPPORTED_RELATION_MODIFIERS = {
+    "relevant": "relevant",
+    "exact": "exact",
+    "word": "word",
+    "ignorecase": "ignorecase",
+    "string": "string",
+}
+
+#: Unsupported CQL relation modifiers with explanatory messages.
+#: When these modifiers are used, the parser raises Diagnostic 21 with
+#: the corresponding explanation message.
+UNSUPPORTED_RELATION_MODIFIERS = {
+    "stem": "Stemming not configurable per-query",
+    "phonetic": "Phonetic matching not available",
+    "fuzzy": "Fuzzy matching not supported",
+    "regexp": "Regular expressions not supported in CQL",
+    "respectcase": "Case-sensitive search not supported",
+    "isodate": "ISO date parsing not supported",
+}
+
+#: Dublin Core index to Elasticsearch query mapping.
+#: Maps standard Dublin Core elements and CQL indexes to Elasticsearch
+#: query expressions. Complex mappings may include boolean operators
+#: and field constraints (e.g., filtering by contribution role).
+#:
+#: Standard DC elements: title, creator, contributor, date, description,
+#: language, publisher, type, identifier, relation, coverage, format,
+#: rights, source, subject.
+#:
+#: Custom extensions: organisation, library, location, subtype.
 ES_INDEX_MAPPINGS = {
-    "cql.anywhere": SERVER_CHOISE_INDEX,
-    "dc.anywhere": SERVER_CHOISE_INDEX,
+    "cql.anywhere": SERVER_CHOICE_INDEX,
+    "dc.anywhere": SERVER_CHOICE_INDEX,
     "dc.contributor": "contribution.role:("
     "ape OR aqt OR arc OR art OR aus OR aut OR chr OR cll OR cmp OR com OR "
     "drt OR dsr OR enj OR fmk OR inv OR ive OR ivr OR lbt OR lsa OR lyr OR "
@@ -81,8 +178,8 @@ ES_INDEX_MAPPINGS = {
     "authorized_access_point",
     "dc.date": 'provisionActivity.type:"bf:Publication" AND provisionActivity.startDate',
     "dc.title": "title.\\*",
-    # TOTO: description search also in: note.label, dissertation.label and
-    # supplementaryContent.discription
+    # TODO: description search also in: note.label, dissertation.label and
+    # supplementaryContent.description
     "dc.description": "summary.label",
     "dc.language": "language.value",
     "dc.publisher": 'provisionActivity.type:"bf:Publication" AND '
@@ -91,24 +188,149 @@ ES_INDEX_MAPPINGS = {
     "dc.type": "type.main_type",
     "dc.subtype": "type.subtype",
     "dc.identifier": "identified_by.value",
-    # TODO: relation search in: issuedWith, otherEdition, otherPhysicalFormat,
-    # precededBy, relatedTo, succeededBy, supplement and supplementTo
-    # 'dc.relation': '',
-    # 'dc.coverage': '',
-    # 'dc.format': '',
-    # 'dc.rights': '',
-    # 'dc.source': '',
+    "dc.relation": "(issuedWith.label OR otherEdition.label OR "
+    "otherPhysicalFormat.label OR precededBy.label OR relatedTo.label OR "
+    "succeededBy.label OR supplement.label OR supplementTo.label)",
+    "dc.coverage": "(temporalCoverage.date OR temporalCoverage.start_date OR "
+    "temporalCoverage.end_date OR subjects.entity.authorized_access_point)",
+    "dc.format": "(extent OR dimensions OR bookFormat OR duration OR "
+    "contentMediaCarrier.contentType OR contentMediaCarrier.mediaType OR "
+    "contentMediaCarrier.carrierType)",
+    "dc.rights": "(usageAndAccessPolicy.label OR copyrightDate)",
+    "dc.source": "adminMetadata.source",
     "dc.subject": "subject.entity.authorized_access_point",
     "dc.organisation": "organisation_pid",
     "dc.library": "library_pid",
     "dc.location": "holdings.location.pid",
+    "dc.note": "note.label",
+    "dc.tableofcontents": "tableOfContents",
+    "dc.abstract": "summary.label",
+    "dc.dissertation": "dissertation.label",
 }
 
 # End of 'configurable' stuff
 
 
+def _convert_sort_keys_to_es(sort_keys, query=""):
+    """Convert CQL sort keys to Elasticsearch sort format.
+
+    Transforms a list of CQL sort key Index objects into Elasticsearch
+    sort specifications. Handles sort direction modifiers (/ascending,
+    /descending) and missing value handling (/missingLow, /missingHigh).
+
+    Args:
+        sort_keys: List of :class:`Index` objects representing sort fields.
+            Each Index may have modifiers specifying sort direction.
+        query: The original CQL query string, included in any Diagnostic
+            raised for unsupported modifiers.
+
+    Returns:
+        list: Elasticsearch sort specifications. Each item is a dict like::
+
+            {"field_name": {"order": "asc", "missing": "_last"}}
+
+        For relevance sorting, returns::
+
+            {"_score": {"order": "desc"}}
+
+    Example::
+
+        # For query: sortBy dc.title/descending dc.date/ascending
+        sort_specs = _convert_sort_keys_to_es(query.sort_keys)
+        # Returns: [{"title._text.raw": {"order": "desc", ...}}, ...]
+    """
+    valid_sort_modifiers = {"ascending", "descending", "missinglow", "missinghigh", "missingomit"}
+    es_sort = []
+    for sort_key in sort_keys:
+        # Get the index name
+        index_name = str(sort_key).lower()
+
+        # Map to ES sortable field
+        es_field = ES_SORT_INDEX_MAPPINGS.get(index_name)
+        if not es_field:
+            # Try without prefix
+            es_field = ES_SORT_INDEX_MAPPINGS.get(f"dc.{sort_key.value}")
+        if not es_field:
+            # Use the field as-is (might be a direct ES field name)
+            es_field = index_name
+
+        # Default sort order is ascending
+        order = "asc"
+        missing = "_last"
+        missing_pref = None
+
+        # Check modifiers for sort direction and missing value handling
+        if hasattr(sort_key, "modifiers") and sort_key.modifiers:
+            for modifier in sort_key.modifiers:
+                mod_type = str(modifier.type).lower()
+                # Remove prefix if present (e.g., cql.descending -> descending)
+                if "." in mod_type:
+                    mod_type = mod_type.split(".")[-1]
+                if mod_type not in valid_sort_modifiers:
+                    diag = Diagnostic()
+                    diag.code = 21
+                    diag.message = "Unsupported sort modifier"
+                    diag.details = mod_type
+                    diag.query = query
+                    raise diag
+                if mod_type == "descending":
+                    order = "desc"
+                elif mod_type == "ascending":
+                    order = "asc"
+                elif mod_type in ("missinglow", "missinghigh", "missingomit"):
+                    missing_pref = mod_type
+
+        if missing_pref == "missinglow":
+            missing = "_first" if order == "asc" else "_last"
+        elif missing_pref == "missinghigh":
+            missing = "_last" if order == "asc" else "_first"
+        elif missing_pref == "missingomit":
+            # NOTE: ES doesn't support omitting docs with missing values in sort.
+            # Documents with missing values will be placed last instead.
+            missing = "_last"
+
+        # Build the sort specification
+        if es_field == "_score":
+            # Relevance sorting
+            es_sort.append({"_score": {"order": order}})
+        else:
+            es_sort.append({es_field: {"order": order, "missing": missing}})
+
+    return es_sort
+
+
 class Diagnostic(Exception):
-    """Diagnostic Exceptions."""
+    """SRU Diagnostic exception for CQL parsing errors.
+
+    Represents an SRU diagnostic message as defined in the SRU standard.
+    Can be raised during CQL parsing or query execution to indicate
+    errors to the client.
+
+    Common diagnostic codes:
+        - 10: Malformed Query (generic)
+        - 14: Quoted identifier not allowed
+        - 15: Null indexset / Multiple dots in identifier
+        - 19: Unsupported relation
+        - 21: Unsupported relation/boolean modifiers
+        - 25: Reserved operator in unquoted term
+        - 26: Badly placed backslash
+        - 27: Empty term
+        - 32: Only anchoring characters in term
+        - 37: Unsupported boolean operator (PROX)
+        - 45: Duplicate prefix declaration
+        - 80: Sort not supported (deprecated - now supported)
+
+    Attributes:
+        code: Numeric diagnostic code from the SRU diagnostic list.
+        uri: Base URI for SRU diagnostics.
+        message: Human-readable error message.
+        details: Additional context about the error.
+        query: The original CQL query string that caused the error.
+        xml_root: The XML representation of the diagnostic (lazy-initialized).
+
+    See Also:
+        SRU Diagnostics: http://www.loc.gov/standards/sru/diagnostics/
+    """
 
     code = 10  # default to generic broken query diagnostic
     uri = "info:srw/diagnostic/1/"
@@ -117,11 +339,22 @@ class Diagnostic(Exception):
     xml_root = None
 
     def __str__(self):
-        """String representation of the object."""
+        """Return a string representation of the diagnostic.
+
+        Returns:
+            A formatted string: "uri/code [message]: details"
+        """
         return f"{self.uri}{self.code} [{self.message}]: {self.details}"
 
     def __init__(self, code=10, message="Malformed Query", details="", query="???"):
-        """Constructor."""
+        """Initialize a new Diagnostic exception.
+
+        Args:
+            code: SRU diagnostic code. Defaults to 10 (Malformed Query).
+            message: Human-readable error message.
+            details: Additional context or the problematic query fragment.
+            query: The original CQL query string.
+        """
         self.code = code
         self.message = message
         self.details = details
@@ -254,8 +487,9 @@ class PrefixedObject:
 class ModifiableObject:
     """Mofifiable object."""
 
-    # Treat modifiers as keys on boolean/relation?
-    modifiers = []
+    def __init__(self):
+        """Constructor."""
+        self.modifiers = []
 
     def __getitem__(self, key):
         """Get item."""
@@ -294,18 +528,19 @@ class Triple(PrefixableObject):
         else:
             txt.append(boolean.upper())
         txt.append(self.right_operand.to_es())
-        # Add sort_keys
-        if self.sort_keys:
-            diag = Diagnostic()
-            diag.code = 80
-            diag.message = "Sort not supported"
-            diag.query = self.query
-            raise diag
-            # txt.append('sortBy')
-            # for sort_key in self.sort_keys:
-            #     txt.append(sort_key.to_es())
+        # Sort keys are handled separately via get_es_sort()
         pre = "NOT" if boolean == "not" else ""
         return f"{pre}({' '.join(txt)})"
+
+    def get_es_sort(self):
+        """Extract sort keys in Elasticsearch format.
+
+        Returns a list of sort specifications for Elasticsearch.
+        Each item is either a string (field name) or a dict with options.
+        """
+        if not self.sort_keys:
+            return []
+        return _convert_sort_keys_to_es(self.sort_keys, query=self.query)
 
     def get_result_set_id(self, top=None):
         """Get result set id."""
@@ -363,18 +598,24 @@ class SearchClause(PrefixableObject):
             index = ES_INDEX_MAPPINGS.get(index.lower(), index)
             # try to map es mappings
             index = Explain("tmp").es_mappings.get(index, index)
-            # if relation in ORDER:
-            #     term = f'"{term}"'
             if relation in ["=", "all", "any"]:
                 relation = ""
-            if str(index) == SERVER_CHOISE_INDEX:
+            if str(index) == SERVER_CHOICE_INDEX:
                 return f"{relation}{term}"
+            # Handle multi-field OR expression: "(field1 OR field2)" + term
+            # ES query string does not support "(f1 OR f2):value"; expand each field.
+            if index.startswith("(") and index.endswith(")"):
+                fields = [f.strip() for f in index[1:-1].split(" OR ")]
+                return f"({' OR '.join(f'{f}:{relation}{term}' for f in fields)})"
             return f"{index}:{relation}{term}"
 
         index = self.index.to_es()
         relation = self.relation.to_es()
         if relation == "<>":
-            text = index_term(index, "-", f'"{self.term.to_es()}"')
+            es_term = self.term.to_es()
+            if not (es_term.startswith('"') and es_term.endswith('"')):
+                es_term = f'"{es_term}"'
+            text = index_term(index, "-", es_term)
         elif relation in ORDER:
             text = index_term(index, relation, self.term.to_es())
         else:
@@ -395,17 +636,18 @@ class SearchClause(PrefixableObject):
                 diag.details = relation
                 diag.query = self.query
                 raise diag
-        # Add sort_keys
-        if self.sort_keys:
-            diag = Diagnostic()
-            diag.code = 80
-            diag.message = "Sort not supported"
-            diag.query = self.query
-            raise diag
-            # text.append('sortBy')
-            # for sort_key in self.sort_keys:
-            #     text.append(sort_key.to_es())
+        # Sort keys are handled separately via get_es_sort()
         return text
+
+    def get_es_sort(self):
+        """Extract sort keys in Elasticsearch format.
+
+        Returns a list of sort specifications for Elasticsearch.
+        Each item is either a string (field name) or a dict with options.
+        """
+        if not self.sort_keys:
+            return []
+        return _convert_sort_keys_to_es(self.sort_keys, query=self.query)
 
     def get_result_set_id(self, top=None):
         """Get result set id."""
@@ -421,6 +663,7 @@ class Index(PrefixedObject, ModifiableObject):
 
     def __init__(self, val, query):
         """Constructor."""
+        ModifiableObject.__init__(self)
         PrefixedObject.__init__(self, val, query)
         if self.value in ["(", ")", *ORDER]:
             diag = Diagnostic()
@@ -432,12 +675,26 @@ class Index(PrefixedObject, ModifiableObject):
     def to_es(self):
         """Create the ES representation of the object."""
         if self.modifiers:
-            diag = Diagnostic()
-            diag.code = 21
-            diag.message = "Unsupported combination of relation modifers"
-            diag.details = self.modifiers
-            diag.query = self.query
-            raise diag
+            # Index modifiers are typically used for sorting (handled separately)
+            # Check for any unsupported modifiers
+            unsupported = []
+            for modifier in self.modifiers:
+                mod_type = str(modifier.type).lower()
+                if "." in mod_type:
+                    mod_type = mod_type.split(".")[-1]
+                # Sort modifiers are handled by get_es_sort()
+                if mod_type not in ES_SORT_MODIFIERS and mod_type not in SUPPORTED_RELATION_MODIFIERS:
+                    if mod_type in UNSUPPORTED_RELATION_MODIFIERS:
+                        unsupported.append(f"{mod_type} ({UNSUPPORTED_RELATION_MODIFIERS[mod_type]})")
+                    else:
+                        unsupported.append(mod_type)
+            if unsupported:
+                diag = Diagnostic()
+                diag.code = 21
+                diag.message = "Unsupported index modifier(s)"
+                diag.details = ", ".join(unsupported)
+                diag.query = self.query
+                raise diag
         return str(self)
 
 
@@ -455,12 +712,27 @@ class Relation(PrefixedObject, ModifiableObject):
     def to_es(self):
         """Create the ES representation of the object."""
         if self.modifiers:
-            diag = Diagnostic()
-            diag.code = 21
-            diag.message = "Unsupported combination of relation modifers"
-            diag.details = self.modifiers
-            diag.query = self.query
-            raise diag
+            # Check if all modifiers are supported
+            unsupported = []
+            for modifier in self.modifiers:
+                mod_type = str(modifier.type).lower()
+                # Remove prefix if present (e.g., cql.relevant -> relevant)
+                if "." in mod_type:
+                    mod_type = mod_type.split(".")[-1]
+                if mod_type not in SUPPORTED_RELATION_MODIFIERS:
+                    if mod_type in UNSUPPORTED_RELATION_MODIFIERS:
+                        unsupported.append(f"{mod_type} ({UNSUPPORTED_RELATION_MODIFIERS[mod_type]})")
+                    else:
+                        unsupported.append(mod_type)
+            if unsupported:
+                diag = Diagnostic()
+                diag.code = 21
+                diag.message = "Unsupported relation modifier(s)"
+                diag.details = ", ".join(unsupported)
+                diag.query = self.query
+                raise diag
+            # Supported modifiers are acknowledged but don't change ES query
+            # (ES handles relevance, word matching, case insensitivity by default)
         return self.value
 
 
@@ -544,8 +816,8 @@ class Boolean(ModifiableObject):
         if self.modifiers:
             diag = Diagnostic()
             diag.code = 21
-            diag.message = "Unsupported combination of relation modifers"
-            diag.details = self.modifiers
+            diag.message = "Unsupported boolean modifier(s)"
+            diag.details = ", ".join(str(m.type) for m in self.modifiers)
             diag.query = self.query
             raise diag
         return f"{self.value}"
@@ -846,11 +1118,11 @@ class CQLParser:
         is_boolean = self.is_boolean(self.next_token)
         sort = self.is_sort(self.next_token)
         if not sort and not is_boolean and self.next_token not in [")", "(", ""]:
-            irt = self._extracted_from_clause_6()
+            irt = self._parse_index_clause()
         elif self.current_token and (is_boolean or sort or self.next_token in [")", ""]):
             irt = RelatioSearchClauseType(
-                IndexerType(SERVER_CHOISE_INDEX, self.parser.query),
-                RelationType(SERVER_CHOISE_RELATION, self.parser.query),
+                IndexerType(SERVER_CHOICE_INDEX, self.parser.query),
+                RelationType(SERVER_CHOICE_RELATION, self.parser.query),
                 TermType(self.current_token, self.parser.query),
                 self.parser.query,
             )
@@ -871,8 +1143,7 @@ class CQLParser:
             raise diag
         return irt
 
-    # TODO Rename this here and in `clause`
-    def _extracted_from_clause_6(self):
+    def _parse_index_clause(self):
         index = IndexerType(self.current_token, self.parser.query)
         self.fetch_token()  # Skip Index
         relation = self.relation()

--- a/rero_ils/modules/sru/explaine.py
+++ b/rero_ils/modules/sru/explaine.py
@@ -17,12 +17,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-"""SRU explaine.
+"""SRU Explain response generator.
 
-http://www.loc.gov/standards/sru/explain/
+This module implements the SRU Explain operation as defined in the
+SRU (Search/Retrieve via URL) standard.
+
+The Explain operation provides information about the server's capabilities,
+supported indexes, schemas, and configuration settings.
+
+See Also:
+    - SRU Explain specification: http://www.loc.gov/standards/sru/explain/
+    - Z39.50 Explain DTD 2.1: http://explain.z3950.org/dtd/2.1/
 """
 
-import contextlib
+from functools import cache
 
 import jsonref
 from flask import current_app
@@ -34,51 +42,105 @@ from ..utils import get_schema_for_resource
 from .cql_parser import ES_INDEX_MAPPINGS
 
 
+def _get_properties(data):
+    """Recursively extract searchable field paths from ES mapping properties."""
+    keys = []
+    for key, value in data.items():
+        if isinstance(value, dict):
+            if properties := value.get("properties"):
+                sub_keys = _get_properties(properties)
+                for sub_key in sub_keys:
+                    first_segment = sub_key.split(".")[0]
+                    if ("." in sub_key and sub_key[0] != "$") or properties.get(first_segment, {}).get("index", True):
+                        keys.append(".".join([key, sub_key]))
+            elif key[0] != "$" and value.get("index", True):
+                keys.append(key)
+    return keys
+
+
+@cache
+def _get_es_mappings(index):
+    """Load and cache field mappings from the Elasticsearch index definition.
+
+    :param index: The Elasticsearch index alias name.
+    :type index: str
+    :returns: Mapping of normalized index names to ES field paths.
+    :rtype: dict
+    """
+    try:
+        index_alias = current_search.aliases.get(index)
+        index_file_name = next(iter(index_alias.values()))
+        with open(index_file_name, encoding="utf-8") as f:
+            data = jsonref.load(f)
+        if properties := data.get("mappings", {}).get("properties", {}):
+            return {field.lower().replace(".", "__"): field for field in _get_properties(properties)}
+    except Exception:
+        current_app.logger.debug("Failed to load ES mappings for index: %s", index, exc_info=True)
+    return {}
+
+
 class Explain:
-    """SRU explain class."""
+    """SRU Explain response generator.
+
+    Generates an XML Explain response conforming to the Z39.50 Explain DTD 2.1.
+    The response includes server information, supported indexes (both Dublin Core
+    and RERO-ILS specific), schema information, and configuration settings.
+
+    Attributes:
+        database: The SRU database path (e.g., 'api/sru/documents').
+        number_of_records: Default number of records returned per request.
+        maximum_records: Maximum allowed records per request.
+        doc_type: The document type for Elasticsearch index lookup.
+        index: The Elasticsearch index name.
+        es_mappings: Dictionary mapping normalized index names to ES field paths.
+        xml_root: The root XML element of the Explain response.
+
+    Example::
+
+        explain = Explain('api/sru/documents')
+        print(str(explain))  # Returns XML string
+    """
 
     def __init__(self, database, doc_type="doc"):
-        """Constructor."""
+        """Initialize the Explain response generator.
+
+        Args:
+            database: The SRU database path used in the serverInfo element.
+            doc_type: Document type key for looking up the Elasticsearch index
+                in RECORDS_REST_ENDPOINTS configuration. Defaults to 'doc'.
+        """
         self.database = database
         self.number_of_records = current_app.config.get("RERO_ILS_SRU_NUMBER_OF_RECORDS", 100)
         self.maximum_records = current_app.config.get("RERO_ILS_SRU_MAXIMUM_RECORDS", 1000)
         self.doc_type = doc_type
         self.index = current_app.config.get("RECORDS_REST_ENDPOINTS", {}).get(doc_type, {}).get("search_index")
-        self.es_mappings = {}
-        for index in self.get_es_mappings(self.index):
-            self.es_mappings[index.lower().replace(".", "__")] = index
+        self.es_mappings = _get_es_mappings(self.index) if self.index else {}
         self.init_xml()
 
     def __str__(self):
-        """String representation of the object."""
+        """Return the Explain response as a formatted XML string.
+
+        Returns:
+            A pretty-printed XML string representation of the Explain response.
+        """
         return etree.tostring(self.xml_root, pretty_print=True).decode()
 
-    def get_properties(self, data):
-        """Get properties."""
-        keys = []
-        for key, value in data.items():
-            if isinstance(value, dict):
-                if properties := value.get("properties"):
-                    sub_keys = self.get_properties(properties)
-                    for sub_key in sub_keys:
-                        if ("." in sub_key and sub_key[0] != "$") or properties[sub_key].get("index", True):
-                            keys.append(".".join([key, sub_key]))
-                elif key[0] != "$":
-                    keys.append(key)
-        return keys
-
-    def get_es_mappings(self, index):
-        """Get mappings from ES."""
-        mappings = {}
-        with contextlib.suppress(Exception):
-            index_alias = current_search.aliases.get(index)
-            index_file_name = next(iter(index_alias.values()))
-            data = jsonref.load(open(index_file_name))
-            mappings = self.get_properties(data.get("mappings").get("properties"))
-        return mappings
-
     def init_xml(self):
-        """Init XML."""
+        """Initialize the XML structure for the Explain response.
+
+        Builds the complete XML document with the following structure:
+        - explainResponse (root)
+          - version
+          - record
+            - recordPacking
+            - recordSchema
+            - recordData
+              - explain
+                - serverInfo (protocol, host, database)
+                - indexInfo (DC indexes + ES field indexes)
+                - schemaInfo (JSON schema reference)
+                - configInfo (default/maximum records settings)
+        """
         sru_ns = "http://www.loc.gov/standards/sru/"
         element_sru = ElementMaker(namespace=sru_ns, nsmap={"sru": sru_ns})
         zr_ns = "http://explain.z3950.org/dtd/2.1/"
@@ -110,20 +172,23 @@ class Explain:
         index_info.append(self.init_index_info())
         explain.append(index_info)
 
-        schema_info = element_zr.schemaInfo()
-        schema_info.append(self.init_schema_info(element_zr))
-        explain.append(schema_info)
-
-        config_info = element_zr.schemaInfo()
-        config_info.append(self.init_config_info(element_zr))
-        explain.append(config_info)
+        explain.append(self.init_schema_info(element_zr))
+        explain.append(self.init_config_info(element_zr))
 
         record_data.append(explain)
         record.append(record_data)
         self.xml_root.append(record)
 
     def init_index_info_dc(self):
-        """Init index info for DC."""
+        """Create the Dublin Core index information element.
+
+        Generates an XML element listing all supported Dublin Core indexes
+        from the ES_INDEX_MAPPINGS configuration.
+
+        Returns:
+            An lxml Element containing the DC index map with all supported
+            Dublin Core search indexes (title, creator, subject, etc.).
+        """
         dc_ns = "info:srw/cql-context-set/1/dc-v1.1"
         element_dc = ElementMaker(namespace=dc_ns, nsmap={"dc": dc_ns})
         index = element_dc.index()
@@ -134,7 +199,15 @@ class Explain:
         return index
 
     def init_index_info(self):
-        """Init index info."""
+        """Create the RERO-ILS specific index information element.
+
+        Generates an XML element listing all Elasticsearch field indexes
+        available for searching, using the RERO-ILS namespace.
+
+        Returns:
+            An lxml Element containing the index map with all ES field paths
+            that can be used directly in CQL queries.
+        """
         rero_ils_ns = get_schema_for_resource("doc")
         element_rero_ils = ElementMaker(namespace=rero_ils_ns, nsmap={"rero-ils": rero_ils_ns})
         index = element_rero_ils.index()
@@ -145,14 +218,33 @@ class Explain:
         return index
 
     def init_schema_info(self, element):
-        """Init schema info."""
+        """Create the schema information element.
+
+        Args:
+            element: The ElementMaker instance for creating XML elements.
+
+        Returns:
+            An lxml Element containing schema information with the JSON
+            schema identifier for the document resource.
+        """
         schema = element.schemaInfo()
-        # Todo: documents -> doc
         schema.append(element.set({"name": "json", "identifier": get_schema_for_resource("doc")}))
         return schema
 
     def init_config_info(self, element):
-        """Init config info."""
+        """Create the configuration information element.
+
+        Includes the default and maximum number of records settings
+        that control pagination behavior for search results.
+
+        Args:
+            element: The ElementMaker instance for creating XML elements.
+
+        Returns:
+            An lxml Element containing:
+            - default numberOfRecords setting
+            - maximum numberOfRecords setting
+        """
         config = element.configInfo()
         config.append(element.default(str(self.number_of_records), {"type": "numberOfRecords"}))
         config.append(element.setting(str(self.maximum_records), {"type": "maximumRecords"}))

--- a/rero_ils/modules/sru/views.py
+++ b/rero_ils/modules/sru/views.py
@@ -15,8 +15,37 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Blueprint used for loading templates."""
+"""SRU (Search/Retrieve via URL) REST API views.
 
+This module implements the SRU 1.1 protocol endpoints for searching documents.
+It provides a RESTful interface that accepts CQL queries and returns results
+in MARCXML, Dublin Core, or JSON formats.
+
+Supported Operations:
+    - ``searchRetrieve``: Execute a CQL query and return matching documents
+    - ``explain`` (default): Return server capabilities and supported indexes
+
+Endpoint:
+    GET /sru/documents
+
+Query Parameters:
+    - ``operation``: 'searchRetrieve' or omit for explain
+    - ``query``: CQL query string (required for searchRetrieve)
+    - ``startRecord``: First record to return (1-based, default: 1)
+    - ``maximumRecords``: Max records to return (default: 100, max: 1000)
+    - ``format``: Response format ('marcxml', 'dc', 'json')
+
+Example:
+    GET /sru/documents?operation=searchRetrieve&query=dc.title=python
+
+See Also:
+    - SRU Standard: http://www.loc.gov/standards/sru/
+    - CQL Specification: http://www.loc.gov/standards/sru/cql/
+"""
+
+import hashlib
+
+from elasticsearch.exceptions import RequestError as ESRequestError
 from flask import current_app
 from flask import request as flask_request
 from invenio_rest import ContentNegotiatedMethodView
@@ -33,14 +62,75 @@ from ..utils import strip_chars
 from .cql_parser import Diagnostic, parse
 from .explaine import Explain
 
+#: Cache duration for Explain responses (1 hour in seconds).
+#: Explain data changes rarely, only on deployment/configuration changes.
+EXPLAIN_CACHE_MAX_AGE = 3600
+
+#: Cache duration for searchRetrieve responses (60 seconds).
+#: Search results may change as documents are added/updated/deleted.
+SEARCH_CACHE_MAX_AGE = 60
+
+#: Stale-while-revalidate duration for search responses (5 minutes).
+#: Allows serving stale content while fetching fresh results in background.
+SEARCH_STALE_WHILE_REVALIDATE = 300
+
+
+def _generate_etag(content):
+    """Generate an ETag hash from response content.
+
+    Args:
+        content: The response body as string or bytes.
+
+    Returns:
+        A quoted ETag string suitable for HTTP headers.
+    """
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    return f'"{hashlib.md5(content, usedforsecurity=False).hexdigest()}"'
+
+
+def _add_cache_headers(response, max_age, stale_while_revalidate=None, etag=None):
+    """Add HTTP caching headers to a response.
+
+    Args:
+        response: The Flask/Werkzeug Response object.
+        max_age: Cache duration in seconds.
+        stale_while_revalidate: Optional duration for stale-while-revalidate.
+        etag: Optional ETag value for conditional requests.
+
+    Returns:
+        The response with caching headers added.
+    """
+    cache_control = f"public, max-age={max_age}"
+    if stale_while_revalidate:
+        cache_control += f", stale-while-revalidate={stale_while_revalidate}"
+    response.headers["Cache-Control"] = cache_control
+    if etag:
+        response.headers["ETag"] = etag
+    return response
+
 
 class SRUDocumentsSearch(ContentNegotiatedMethodView):
-    """SRU search REST resource."""
+    """SRU search REST resource for documents.
 
-    # TODO: is candidate for invenio-record-resource ?
+    Implements the SRU 1.1 protocol for searching the documents index.
+    Supports content negotiation for multiple output formats.
+
+    Supported Media Types:
+        - ``application/xml``: MARCXML-SRU format (default)
+        - ``application/xml+dc``: Dublin Core XML format
+        - ``application/rero+json``: RERO-ILS JSON format
+
+    Format Aliases:
+        Use the ``format`` query parameter with: 'marcxmlsru', 'dc', or 'json'
+    """
 
     def __init__(self, **kwargs):
-        """Init."""
+        """Initialize the SRU search view with content negotiation settings.
+
+        Args:
+            **kwargs: Additional arguments passed to ContentNegotiatedMethodView.
+        """
         super().__init__(
             method_serializers={
                 "GET": {
@@ -60,10 +150,26 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
         )
 
     def get(self, **kwargs):
-        """Implement the GET /sru/documents."""
+        """Handle GET requests to the SRU endpoint.
+
+        Processes SRU searchRetrieve and explain operations. For searchRetrieve,
+        parses the CQL query, executes it against Elasticsearch, and returns
+        results in the requested format. For explain (or when no operation is
+        specified), returns the server's capabilities.
+
+        Args:
+            **kwargs: Additional arguments from the URL route.
+
+        Returns:
+            A Flask response with search results or explain information.
+            Content-Type depends on format requested (XML or JSON).
+
+        Raises:
+            HTTPException: When CQL parsing fails, returns an XML diagnostic
+                response with the error details.
+        """
         operation = flask_request.args.get("operation", None)
         query = flask_request.args.get("query", None)
-        version = flask_request.args.get("version", "1.1")
         start_record = max(int(flask_request.args.get("startRecord", 1)), 1)
         maximum_records = min(
             int(
@@ -74,33 +180,57 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
             ),
             current_app.config.get("RERO_ILS_SRU_MAXIMUM_RECORDS", 1000),
         )
-        # TODO: enable es query string
-        # query_string = flask_request.args.get('q', None)
-        if operation == "searchRetrieve" and query:  # or query_string:
+        if operation == "searchRetrieve" and query:
             try:
-                query_string = parse(query).to_es()
+                parsed_query = parse(query)
+                query_string = parsed_query.to_es()
+                # Extract sort keys if present
+                sort_keys = parsed_query.get_es_sort()
             except Diagnostic as err:
                 response = Response(err.xml_str())
                 response.headers["content-type"] = "application/xml"
-                raise HTTPException(response=response)
+                raise HTTPException(response=response) from err
 
             search = DocumentsSearch().query("query_string", query=query_string)
+            # Apply sort if specified in CQL query
+            if sort_keys:
+                search = search.sort(*sort_keys)
             records = []
+            total = 0
             search = search[(start_record - 1) : maximum_records + (start_record - 1)]
-            for hit in search.execute():
-                records.append(
-                    {
-                        "_id": hit.meta.id,
-                        "_index": hit.meta.index,
-                        "_source": hit.to_dict(),
-                        "_version": 0,
-                    }
-                )
+            try:
+                response = search.execute()
+                for hit in response:
+                    records.append(
+                        {
+                            "_id": hit.meta.id,
+                            "_index": hit.meta.index,
+                            "_source": hit.to_dict(),
+                            "_version": 0,
+                        }
+                    )
+                total = response.hits.total.value if hasattr(response.hits.total, "value") else response.hits.total
+            except ESRequestError as e:
+                _err_text = str(getattr(e, "info", e))
+                if "Result window" in _err_text or "result_window" in _err_text:
+                    # startRecord window exceeds ES max_result_window; return 0 records.
+                    current_app.logger.warning(f"ES window overflow during SRU search: {e}")
+                else:
+                    current_app.logger.error(f"ES backend error during SRU search: {e}")
+                    diag = Diagnostic(
+                        code=2,
+                        message="System temporarily unavailable",
+                        details=str(e),
+                        query=query,
+                    )
+                    diag_response = Response(diag.xml_str())
+                    diag_response.headers["content-type"] = "application/xml"
+                    raise HTTPException(response=diag_response) from e
 
             result = {
                 "hits": {
                     "hits": records,
-                    "total": {"value": search.count(), "relation": "eq"},
+                    "total": {"value": total, "relation": "eq"},
                     "sru": {
                         "query": strip_chars(query),
                         "query_es": query_string,
@@ -109,9 +239,33 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
                     },
                 }
             }
-            return self.make_response(pid_fetcher=document_id_fetcher, search_result=result)
+            response = self.make_response(pid_fetcher=document_id_fetcher, search_result=result)
+            # Add caching headers for search results (short cache with stale-while-revalidate)
+            response.headers["Vary"] = "Accept"
+            _add_cache_headers(
+                response,
+                max_age=SEARCH_CACHE_MAX_AGE,
+                stale_while_revalidate=SEARCH_STALE_WHILE_REVALIDATE,
+            )
+            return response
 
+        # Explain operation (default) - cacheable for longer duration
         explain = Explain("api/sru/documents")
-        response = Response(str(explain))
-        response.headers["content-type"] = "application/xml"
+        content = str(explain)
+        etag = _generate_etag(content)
+        # Conditional GET: return 304 if client already has the current version
+        # Check If-None-Match header (may contain multiple ETags or wildcard)
+        if_none_match = flask_request.headers.get("If-None-Match", "")
+        client_etags = [e.strip() for e in if_none_match.split(",")]
+        if etag in client_etags or "*" in client_etags:
+            not_modified = Response(status=304)
+            not_modified.headers["ETag"] = etag
+            not_modified.headers["Cache-Control"] = f"public, max-age={EXPLAIN_CACHE_MAX_AGE}"
+            not_modified.headers["Vary"] = "Accept"
+            raise HTTPException(response=not_modified)
+        response = Response(content)
+        response.headers["Content-Type"] = "application/xml"
+        response.headers["Vary"] = "Accept"
+        # Add caching headers for explain (long cache with ETag)
+        _add_cache_headers(response, max_age=EXPLAIN_CACHE_MAX_AGE, etag=etag)
         raise HTTPException(response=response)

--- a/scripts/convert_marc21xml.py
+++ b/scripts/convert_marc21xml.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Mock Modules."""
+"""Convert MARC21 XML records to RERO ILS JSON format with deduplication support."""
 
 from dojson.contrib.marc21.utils import create_record
 from lxml import etree
@@ -53,16 +53,12 @@ class Marc21XMLConverter:
     def loads(cls, file):
         """Read a marc xml file and iterate over all records."""
         for record in read_xml_record(file):
-            yield etree.tostring(
-                record, encoding="utf-8", method="xml", pretty_print=True
-            )
+            yield etree.tostring(record, encoding="utf-8", method="xml", pretty_print=True)
 
     @classmethod
     def markdown(cls, data):
         """Convert an marc21 xml record into a markdown table."""
-        record = ImportsMarcSearchSerializer.convert_marc_to_marc_text_dict(
-            create_record(data)
-        )
+        record = ImportsMarcSearchSerializer.convert_marc_to_marc_text_dict(create_record(data))
         formatted_record = ["| Marc&nbsp;Field | Marc&nbsp;Value |", "| --- | --- |"]
         for leader, fields in record:
             leader = leader.replace(" ", "&nbsp;")
@@ -87,25 +83,18 @@ class Marc21XMLConverter:
         if data.conversion.status == "error":
             return (
                 ils_pid,
-                {
-                    "warning": [
-                        "Merci de résoudre les erreurs de conversion avant de dédoublonner."
-                    ]
-                },
+                {"warning": ["Please resolve conversion errors before deduplication."]},
                 "pending",
                 [],
             )
         candidates = [
-            (c.pid, c.json.to_dict(), c.score, c.detailed_score.to_dict())
-            for c in data.deduplication.candidates
+            (c.pid, c.json.to_dict(), c.score, c.detailed_score.to_dict()) for c in data.deduplication.candidates
         ]
         logs = {}
         status = "no match"
         if data.deduplication.status == "pending" or force:
             try:
-                candidates = Deduplication().get_candidates(
-                    data.conversion.json.to_dict()
-                )
+                candidates = Deduplication().get_candidates(data.conversion.json.to_dict())
             except Exception as err:
                 logs["error"] = [f"{err}"]
                 status = "error"
@@ -128,8 +117,6 @@ class Marc21XMLConverter:
                         and best_detailed_score["publication_date"]["value"] < 1
                     ):
                         status = "check"
-                        logs["warning"] = [
-                            "Date de publication inexacte: le statut 'check' a été forcé."
-                        ]
+                        logs["warning"] = ["Publication date inaccurate: status forced to 'check'."]
                     ils_pid = best[0]
         return ils_pid, logs, status, candidates

--- a/tests/api/sru/test_sru_live.py
+++ b/tests/api/sru/test_sru_live.py
@@ -1,0 +1,502 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Live SRU CQL and sort retrieval tests against a running server.
+
+Run with:
+    uv run pytest tests/api/sru/test_sru_live.py -v -m external
+"""
+
+import pytest
+import requests
+import xmltodict
+
+BASE_URL = "https://127.0.0.1:5000/api/sru/documents"
+DOC_API_URL = "https://127.0.0.1:5000/api/documents"
+
+# PID of a well-known stable fixture document (https://127.0.0.1:5000/api/sru/documents?version=1.1&operation=searchRetrieve&query=dc.title=%22Les%20voyages%20de%20Gulliver%22%20AND%20dc.organisation=3&maximumRecords=3)
+FIXTURE_PID = "100"
+
+
+def sru(query, maximum_records=3, start_record=1, fmt=None):
+    """Perform a searchRetrieve request and return the parsed XML dict."""
+    params = {
+        "version": "1.1",
+        "operation": "searchRetrieve",
+        "query": query,
+        "maximumRecords": maximum_records,
+        "startRecord": start_record,
+    }
+    if fmt:
+        params["format"] = fmt
+    resp = requests.get(BASE_URL, params=params, verify=False, timeout=10)
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return xmltodict.parse(resp.text)
+
+
+def fetch_json(pid):
+    """Fetch the canonical document JSON from the REST API."""
+    resp = requests.get(f"{DOC_API_URL}/{pid}", verify=False, timeout=10)
+    assert resp.status_code == 200, f"HTTP {resp.status_code} for /api/documents/{pid}"
+    return resp.json()["metadata"]
+
+
+def marc_subfields(datafield, code):
+    """Return a list of subfield values for *code* from a MARC datafield dict."""
+    subs = datafield.get("subfield", [])
+    if isinstance(subs, dict):
+        subs = [subs]
+    return [s["#text"] for s in subs if s.get("@code") == code]
+
+
+def marc_fields(record, tag):
+    """Return a list of datafield dicts whose @tag matches *tag*."""
+    fields = record.get("datafield", [])
+    if isinstance(fields, dict):
+        fields = [fields]
+    return [f for f in fields if f.get("@tag") == tag]
+
+
+def marc_controlfield(record, tag):
+    """Return the text of the controlfield with *tag*, or None."""
+    cfs = record.get("controlfield", [])
+    if isinstance(cfs, dict):
+        cfs = [cfs]
+    return next((cf["#text"] for cf in cfs if cf.get("@tag") == tag), None)
+
+
+def first_sru_marc_record(sru_xml):
+    """Extract the first MARC record from a zs: searchRetrieveResponse."""
+    records_container = (sru_xml.get("zs:searchRetrieveResponse") or {}).get("zs:records")
+    if not records_container:
+        pytest.fail("no SRU records in response (zs:records missing or empty)")
+    recs = records_container.get("zs:record")
+    if not recs:
+        pytest.fail("no SRU records in response (zs:record missing or empty)")
+    if isinstance(recs, dict):
+        recs = [recs]
+    return recs[0]["zs:recordData"]["record"]
+
+
+def first_sru_dc_record(sru_xml):
+    """Extract the DC record dict from a searchRetrieveResponse."""
+    records_container = (sru_xml.get("searchRetrieveResponse") or {}).get("records")
+    if not records_container:
+        pytest.fail("no SRU records in response (records missing or empty)")
+    recs = records_container.get("record")
+    if not recs:
+        pytest.fail("no SRU records in response (record missing or empty)")
+    if isinstance(recs, dict):
+        recs = [recs]
+    return recs[0]
+
+
+def echoed(xml):
+    """Return the echoedSearchRetrieveRequest block (works for zs: and srw: prefixes)."""
+    root = xml.get("zs:searchRetrieveResponse") or xml.get("srw:searchRetrieveResponse") or {}
+    return root.get("zs:echoedSearchRetrieveRequest") or root.get("srw:echoedSearchRetrieveRequest") or {}
+
+
+def n_records(xml):
+    """Return numberOfRecords as int (works for zs: and srw: prefixes)."""
+    root = xml.get("zs:searchRetrieveResponse") or xml.get("srw:searchRetrieveResponse") or {}
+    return int(root.get("zs:numberOfRecords") or root.get("srw:numberOfRecords") or 0)
+
+
+def diagnostic(xml):
+    """Return the diagnostic block if present, else None."""
+    root = xml.get("srw:searchRetrieveResponse") or xml.get("zs:searchRetrieveResponse") or {}
+    return root.get("diag:diagnostics")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / markers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _check_server():
+    """Skip all tests in this module if the server is not reachable."""
+    try:
+        requests.get(BASE_URL, verify=False, timeout=3)
+    except requests.exceptions.ConnectionError:
+        pytest.skip(f"SRU server not reachable at {BASE_URL}")
+
+
+# ---------------------------------------------------------------------------
+# CQL index mapping tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.external
+@pytest.mark.usefixtures("_check_server")
+class TestCQLIndexMappings:
+    """Verify that each DC index is translated to the correct ES field."""
+
+    def test_serverchoice(self):
+        """Bare term uses server-choice (no field prefix in ES query)."""
+        xml = sru("swift")
+        assert echoed(xml)["zs:query_es"] == "swift"
+
+    def test_quoted_term(self):
+        """Quoted phrase is passed through as-is."""
+        xml = sru('"Les voyages de Gulliver"')
+        assert echoed(xml)["zs:query_es"] == '"Les voyages de Gulliver"'
+        assert n_records(xml) >= 1
+
+    def test_dc_title(self):
+        """dc.title maps to title.* wildcard field."""
+        xml = sru("dc.title=Gulliver")
+        assert echoed(xml)["zs:query_es"] == r"title.\*:Gulliver"
+        assert n_records(xml) >= 1
+
+    def test_dc_title_quoted(self):
+        """Quoted dc.title phrase is preserved in the ES query."""
+        xml = sru('dc.title="Les voyages de Gulliver"')
+        assert echoed(xml)["zs:query_es"] == r'title.\*:"Les voyages de Gulliver"'
+        assert n_records(xml) >= 1
+
+    def test_dc_creator(self):
+        """dc.creator maps to contribution role + authorized_access_point."""
+        xml = sru("dc.creator=Swift")
+        es = echoed(xml)["zs:query_es"]
+        assert "authorized_access_point:Swift" in es
+        assert "cre" in es  # creator role must be in the role list
+
+    def test_dc_language(self):
+        """dc.language maps to language.value."""
+        xml = sru("dc.language=fre", maximum_records=1)
+        assert echoed(xml)["zs:query_es"] == "language.value:fre"
+        assert n_records(xml) >= 1
+
+    def test_dc_publisher(self):
+        """dc.publisher maps to provisionActivity publication statement."""
+        xml = sru("dc.publisher=Edito", maximum_records=1)
+        es = echoed(xml)["zs:query_es"]
+        assert "provisionActivity" in es
+        assert "Edito" in es
+
+    def test_dc_type(self):
+        """dc.type maps to type.main_type."""
+        xml = sru("dc.type=docmaintype_book", maximum_records=1)
+        assert echoed(xml)["zs:query_es"] == "type.main_type:docmaintype_book"
+
+    def test_dc_organisation(self):
+        """dc.organisation maps to organisation_pid."""
+        xml = sru("dc.organisation=3", maximum_records=1)
+        assert echoed(xml)["zs:query_es"] == "organisation_pid:3"
+
+
+# ---------------------------------------------------------------------------
+# Boolean operator tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.external
+@pytest.mark.usefixtures("_check_server")
+class TestCQLBooleans:
+    """Verify AND / OR boolean combinations."""
+
+    def test_and_title_organisation(self):
+        """AND combines two clauses with parentheses in ES."""
+        xml = sru('dc.title="Les voyages de Gulliver" AND dc.organisation=3')
+        es = echoed(xml)["zs:query_es"]
+        assert es == r'(title.\*:"Les voyages de Gulliver" AND organisation_pid:3)'
+        assert n_records(xml) == 1
+
+    def test_and_title_type(self):
+        """AND with type filter narrows results correctly."""
+        xml = sru("dc.title=Gulliver AND dc.type=docmaintype_book")
+        es = echoed(xml)["zs:query_es"]
+        assert r"title.\*:Gulliver" in es
+        assert "type.main_type:docmaintype_book" in es
+
+    def test_or_titles(self):
+        """OR expands the result set."""
+        xml_and = sru("dc.title=Gulliver AND dc.title=Swift")
+        xml_or = sru("dc.title=Gulliver OR dc.title=Swift")
+        n_and = n_records(xml_and)
+        n_or = n_records(xml_or)
+        assert n_or >= n_and  # OR always returns at least as many as AND
+
+    def test_triple_and(self):
+        """Three-clause AND wraps correctly."""
+        xml = sru('dc.title="Les voyages de Gulliver" AND dc.organisation=3 AND dc.language=fre')
+        es = echoed(xml)["zs:query_es"]
+        assert r'title.\*:"Les voyages de Gulliver"' in es
+        assert "organisation_pid:3" in es
+        assert "language.value:fre" in es
+
+
+# ---------------------------------------------------------------------------
+# Sort tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.external
+@pytest.mark.usefixtures("_check_server")
+class TestCQLSort:
+    """Verify sortBy clauses are accepted and echoed correctly."""
+
+    def test_sort_by_title_ascending(self):
+        """SortBy dc.title maps sort_title ascending."""
+        xml = sru("dc.language=fre sortBy dc.title/ascending", maximum_records=3)
+        ech = echoed(xml)
+        # Query part strips the sort clause
+        assert "sortBy" not in ech["zs:query_es"]
+        # Results are returned
+        assert n_records(xml) >= 1
+
+    def test_sort_by_title_descending(self):
+        """SortBy dc.title/descending is valid."""
+        xml = sru("dc.language=fre sortBy dc.title/descending", maximum_records=3)
+        assert n_records(xml) >= 1
+        assert "sortBy" not in echoed(xml)["zs:query_es"]
+
+    def test_sort_by_date_descending(self):
+        """SortBy dc.date/descending maps provisionActivity.startDate desc."""
+        xml = sru("dc.title=Gulliver sortBy dc.date/descending")
+        assert n_records(xml) >= 1
+        assert "sortBy" not in echoed(xml)["zs:query_es"]
+
+    def test_sort_by_date_ascending(self):
+        """SortBy dc.date/ascending is valid."""
+        xml = sru("dc.language=fre sortBy dc.date/ascending", maximum_records=3)
+        assert n_records(xml) >= 1
+
+    def test_sort_by_relevance(self):
+        """SortBy _relevance maps to _score."""
+        xml = sru("dc.title=Gulliver sortBy _relevance")
+        assert n_records(xml) >= 1
+        assert "sortBy" not in echoed(xml)["zs:query_es"]
+
+    def test_sort_multi_key(self):
+        """Multiple sort keys (dc.title then dc.date) are accepted."""
+        xml = sru("swift sortBy dc.title/ascending dc.date/descending", maximum_records=3)
+        assert n_records(xml) >= 1
+        assert "sortBy" not in echoed(xml)["zs:query_es"]
+
+    def test_sort_with_boolean(self):
+        """Sort clause works together with a boolean AND query."""
+        xml = sru("dc.title=Gulliver AND dc.language=fre sortBy dc.title", maximum_records=3)
+        es = echoed(xml)["zs:query_es"]
+        assert r"title.\*:Gulliver" in es
+        assert "sortBy" not in es
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic / error tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.external
+@pytest.mark.usefixtures("_check_server")
+class TestCQLDiagnostics:
+    """Verify that invalid CQL returns the correct SRU diagnostic."""
+
+    def test_malformed_query(self):
+        """Unbalanced parentheses returns Diagnostic 10 (Malformed Query)."""
+        xml = sru("(((")
+        diag = diagnostic(xml)
+        assert diag is not None
+        assert diag["diag:message"] == "Malformed Query"
+        assert diag["diag:uri"] == "info:srw/diagnostic/1/10"
+
+    def test_unsupported_relation_modifier(self):
+        """Using /stem modifier returns Diagnostic 21."""
+        xml = sru("dc.title all/stem Gulliver")
+        diag = diagnostic(xml)
+        assert diag is not None
+        assert diag["diag:uri"] == "info:srw/diagnostic/1/21"
+        assert "stem" in diag["diag:details"]
+
+    def test_empty_index(self):
+        """A leading dot in the index name returns a diagnostic."""
+        xml = sru(".title=Gulliver")
+        diag = diagnostic(xml)
+        assert diag is not None  # Null indexset error
+
+    def test_valid_query_no_diagnostic(self):
+        """A well-formed query returns no diagnostic."""
+        xml = sru("dc.title=Gulliver")
+        assert diagnostic(xml) is None
+        assert "zs:searchRetrieveResponse" in xml
+
+
+# ---------------------------------------------------------------------------
+# MARCXML conversion tests — cross-checked against /api/documents/{pid}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.external
+@pytest.mark.usefixtures("_check_server")
+class TestMARCXMLConversion:
+    """Verify MARCXML output against the canonical document JSON."""
+
+    @pytest.fixture(scope="class")
+    def doc_json(self, marc_record):
+        """Canonical JSON for the same document as marc_record (PID from 001)."""
+        pid = marc_controlfield(marc_record, "001")
+        return fetch_json(pid)
+
+    @pytest.fixture(scope="class")
+    def marc_record(self):
+        """First MARC record from the SRU MARCXML response."""
+        xml = sru('dc.title="Les voyages de Gulliver" AND dc.organisation=3', maximum_records=1)
+        return first_sru_marc_record(xml)
+
+    def test_controlfield_001_matches_pid(self, doc_json, marc_record):
+        """MARC 001 (record ID) must equal the document PID."""
+        assert marc_controlfield(marc_record, "001") == doc_json["pid"]
+
+    def test_controlfield_008_language(self, doc_json, marc_record):
+        """MARC 008 positions 35-37 must carry the primary language code."""
+        field_008 = marc_controlfield(marc_record, "008")
+        assert field_008 is not None, "008 field missing"
+        lang_in_json = doc_json["language"][0]["value"]
+        # positions 35-37 in 008
+        assert field_008[35:38] == lang_in_json
+
+    def test_field_245_main_title(self, doc_json, marc_record):
+        """MARC 245 $a must match the first mainTitle value from JSON."""
+        json_title = doc_json["title"][0]["mainTitle"][0]["value"]
+        fields_245 = marc_fields(marc_record, "245")
+        assert fields_245, "245 field missing"
+        subfield_a = marc_subfields(fields_245[0], "a")
+        assert subfield_a, "245 $a missing"
+        assert subfield_a[0] == json_title
+
+    def test_field_264_publication_date(self, doc_json, marc_record):
+        """MARC 264 ind2=1 $c must contain the publication year from JSON."""
+        json_date = str(doc_json["provisionActivity"][0]["startDate"])
+        pub_fields = [f for f in marc_fields(marc_record, "264") if f.get("@ind2") == "1"]
+        assert pub_fields, "264 ind2=1 field missing"
+        dates = marc_subfields(pub_fields[0], "c")
+        assert any(json_date in d for d in dates), f"{json_date} not found in 264 $c: {dates}"
+
+    def test_field_264_publisher(self, doc_json, marc_record):
+        """MARC 264 ind2=1 $b must match the publisher from JSON."""
+        # Extract publisher name from provisionActivity statements
+        statements = doc_json["provisionActivity"][0].get("statement", [])
+        json_publisher = next(
+            (s["label"][0]["value"] for s in statements if s.get("type") == "bf:Agent"),
+            None,
+        )
+        assert json_publisher is not None, "No publisher in JSON"
+        pub_fields = [f for f in marc_fields(marc_record, "264") if f.get("@ind2") == "1"]
+        publishers = marc_subfields(pub_fields[0], "b")
+        assert any(json_publisher in p for p in publishers), (
+            f"Publisher '{json_publisher}' not found in 264 $b: {publishers}"
+        )
+
+    def test_field_300_extent(self, doc_json, marc_record):
+        """MARC 300 $a must match the extent from JSON."""
+        json_extent = doc_json["extent"]
+        fields_300 = marc_fields(marc_record, "300")
+        assert fields_300, "300 field missing"
+        extents = marc_subfields(fields_300[0], "a")
+        assert extents, "300 $a missing"
+        assert extents[0] == json_extent
+
+    def test_field_300_dimensions(self, doc_json, marc_record):
+        """MARC 300 $c must match the first dimension from JSON."""
+        json_dim = doc_json["dimensions"][0]
+        fields_300 = marc_fields(marc_record, "300")
+        dims = marc_subfields(fields_300[0], "c")
+        assert dims, "300 $c missing"
+        assert dims[0] == json_dim
+
+    def test_field_700_creator_role(self, doc_json, marc_record):
+        """MARC 700 with $4=cre must be present for the creator contribution."""
+        creator_roles = [c["role"] for c in doc_json["contribution"] if "cre" in c["role"]]
+        assert creator_roles, "No creator in JSON"
+        fields_700 = marc_fields(marc_record, "700")
+        cre_fields = [f for f in fields_700 if "cre" in marc_subfields(f, "4")]
+        assert cre_fields, "No 700 $4=cre in MARCXML"
+
+    def test_field_900_document_type(self, doc_json, marc_record):
+        """MARC 900 $a must carry the main document type from JSON."""
+        json_type = doc_json["type"][0]["main_type"]
+        fields_900 = marc_fields(marc_record, "900")
+        assert fields_900, "900 field missing"
+        types_a = marc_subfields(fields_900[0], "a")
+        assert any(json_type.lower() in t.lower() for t in types_a), (
+            f"Type '{json_type}' not found in 900 $a: {types_a}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dublin Core conversion tests — cross-checked against /api/documents/{pid}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.external
+@pytest.mark.usefixtures("_check_server")
+class TestDCConversion:
+    """Verify Dublin Core output against the canonical document JSON."""
+
+    @pytest.fixture(scope="class")
+    def doc_json(self):
+        """Canonical JSON from /api/documents/FIXTURE_PID."""
+        return fetch_json(FIXTURE_PID)
+
+    @pytest.fixture(scope="class")
+    def dc_record(self):
+        """DC record dict from the SRU DC response."""
+        xml = sru(f"dc.identifier={FIXTURE_PID}", maximum_records=1, fmt="dc")
+        return first_sru_dc_record(xml)
+
+    def test_dc_title_contains_main_title(self, doc_json, dc_record):
+        """dc:title must start with the document's main title."""
+        json_title = doc_json["title"][0]["mainTitle"][0]["value"]
+        assert dc_record["dc:title"].startswith(json_title), (
+            f"dc:title '{dc_record['dc:title']}' does not start with '{json_title}'"
+        )
+
+    def test_dc_language(self, doc_json, dc_record):
+        """dc:language must match the primary language code from JSON."""
+        json_lang = doc_json["language"][0]["value"]
+        assert dc_record["dc:language"] == json_lang
+
+    def test_dc_date(self, doc_json, dc_record):
+        """dc:date must equal the publication start year from JSON."""
+        json_date = str(doc_json["provisionActivity"][0]["startDate"])
+        assert dc_record["dc:date"] == json_date
+
+    def test_dc_publisher(self, doc_json, dc_record):
+        """dc:publisher must match the publisher name from JSON."""
+        statements = doc_json["provisionActivity"][0].get("statement", [])
+        json_publisher = next(
+            (s["label"][0]["value"] for s in statements if s.get("type") == "bf:Agent"),
+            None,
+        )
+        assert json_publisher is not None, "No publisher in JSON"
+        assert dc_record["dc:publisher"] == json_publisher
+
+    def test_dc_identifier_contains_pid(self, doc_json, dc_record):
+        """dc:identifier must include an entry carrying the document PID."""
+        pid = doc_json["pid"]
+        identifiers = dc_record["dc:identifier"]
+        if isinstance(identifiers, str):
+            identifiers = [identifiers]
+        assert any(pid in ident for ident in identifiers), f"PID '{pid}' not found in dc:identifier: {identifiers}"
+
+    def test_dc_type_contains_main_type(self, doc_json, dc_record):
+        """dc:type must mention the document's main type."""
+        json_type = doc_json["type"][0]["main_type"].replace("docmaintype_", "")
+        dc_type = dc_record.get("dc:type", "")
+        assert json_type in dc_type.lower(), f"Main type '{json_type}' not found in dc:type '{dc_type}'"

--- a/tests/api/sru/test_sru_rest.py
+++ b/tests/api/sru/test_sru_rest.py
@@ -19,7 +19,6 @@
 
 from flask import url_for
 
-from rero_ils.modules.documents.api import Document
 from tests.utils import get_xml_dict
 
 
@@ -41,6 +40,7 @@ def test_sru_documents(client, document_ref, entity_person_data):
     assert "zs:searchRetrieveResponse" in xml_dict
     search_rr = xml_dict["zs:searchRetrieveResponse"]
     assert search_rr.get("zs:echoedSearchRetrieveRequest") == {
+        "zs:version": "1.1",
         "zs:maximumRecords": "100",
         "zs:query": "al-Wajīz",
         "zs:query_es": "al-Wajīz",
@@ -49,7 +49,8 @@ def test_sru_documents(client, document_ref, entity_person_data):
         "zs:resultSetTTL": "0",
         "zs:startRecord": "1",
     }
-    assert search_rr.get("zs:numberOfRecords") == str(Document.count())
+    # Search should return only documents matching the query, not all documents
+    assert search_rr.get("zs:numberOfRecords") == "1"
 
 
 def test_sru_documents_items(client, document_sion_items):
@@ -107,3 +108,73 @@ def test_sru_documents_diagnostics(client):
     xml_dict = get_xml_dict(res)
     assert "srw:searchRetrieveResponse" in xml_dict
     assert xml_dict["srw:searchRetrieveResponse"]["diag:diagnostics"]["diag:message"] == "Malformed Query"
+
+
+def test_sru_explain_conditional_get(client):
+    """Test SRU explain returns 304 Not Modified when ETag matches."""
+    api_url = url_for("api_sru.documents")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    etag = res.headers.get("ETag")
+    assert etag
+    # Conditional GET with matching ETag should return 304
+    res = client.get(api_url, headers={"If-None-Match": etag})
+    assert res.status_code == 304
+    assert res.headers.get("ETag") == etag
+
+
+def test_sru_es_backend_error(client):
+    """Test SRU returns a diagnostic on non-recoverable ES backend error."""
+    from unittest.mock import patch
+
+    from elasticsearch.exceptions import RequestError as ESRequestError
+
+    from rero_ils.modules.documents.api import DocumentsSearch
+
+    api_url = url_for("api_sru.documents", version="1.1", operation="searchRetrieve", query="test")
+    err = ESRequestError(500, "internal_error", "cluster is unavailable")
+    with patch.object(DocumentsSearch, "execute", side_effect=err):
+        res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["diag:diagnostics"]
+    assert diag["diag:message"] == "System temporarily unavailable"
+
+
+def test_sru_es_window_overflow(client):
+    """Test SRU returns zero results when ES result window is exceeded."""
+    from unittest.mock import patch
+
+    from elasticsearch.exceptions import RequestError as ESRequestError
+
+    from rero_ils.modules.documents.api import DocumentsSearch
+
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query="test",
+        startRecord="100000",
+    )
+    err = ESRequestError(400, "search_phase_execution_exception", "Result window is too large")
+    with patch.object(DocumentsSearch, "execute", side_effect=err):
+        res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "zs:searchRetrieveResponse" in xml_dict
+    assert xml_dict["zs:searchRetrieveResponse"]["zs:numberOfRecords"] == "0"
+
+
+def test_sru_sort(client, document_sion_items):
+    """Test SRU search with sortBy CQL clause."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils" sortBy dc.title/ascending',
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "zs:searchRetrieveResponse" in xml_dict

--- a/tests/unit/documents/test_documents_dojson_marc21.py
+++ b/tests/unit/documents/test_documents_dojson_marc21.py
@@ -492,7 +492,11 @@ def test_subjects_to_marc21(
             ),
             "650__": (
                 GroupableOrderedDict({"a": "Roman pour la jeunesse"}),
-                GroupableOrderedDict({"a": "Antienzymes"}),
+                {
+                    "__order__": ("a", "0"),
+                    "a": "Antienzymes",
+                    "0": ("(idref)ent_concept_idref",),
+                },
             ),
             "6001_": (GroupableOrderedDict({"a": "Fujimoto, Satoko", "d": "1923 - 1999"})),
             "600__": (
@@ -555,7 +559,11 @@ def test_genre_form_to_marc21(app, mef_concepts_url, marc21_record, mef_concept1
             "__order__": ("leader", "005", "008", "655__", "655__"),
             "655__": (
                 GroupableOrderedDict({"a": "Roman pour la jeunesse"}),
-                GroupableOrderedDict({"a": "Antienzymes"}),
+                {
+                    "__order__": ("a", "0"),
+                    "a": "Antienzymes",
+                    "0": ("(idref)ent_concept_idref",),
+                },
             ),
         }
     )

--- a/tests/unit/test_cql_parser.py
+++ b/tests/unit/test_cql_parser.py
@@ -20,6 +20,7 @@
 import pytest
 
 from rero_ils.modules.sru.cql_parser import (
+    ES_SORT_INDEX_MAPPINGS,
     RESERVED_PREFIXES,
     Boolean,
     Diagnostic,
@@ -148,9 +149,15 @@ def test_get_query_clause_with_relation_modifier():
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"spam"'
+    # /relevant is now a supported modifier (default ES relevance scoring)
+    es_string = query.to_es()
+    assert es_string == "(anywhere:spam)"
+
+    # Unsupported modifiers should still raise Diagnostic
+    query = parse('anywhere all/stem "spam"')
     with pytest.raises(Diagnostic) as err:
         query.to_es()
-    assert str(err.value).startswith("info:srw/diagnostic/1/21 [Unsupported combination of relation modifers]")
+    assert "Unsupported relation modifier" in str(err.value)
 
 
 def test_get_query_clause_with_sorting(app):
@@ -167,9 +174,23 @@ def test_get_query_clause_with_sorting(app):
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"cat"'
-    with pytest.raises(Diagnostic) as err:
-        query.to_es()
-    assert str(err.value) == "info:srw/diagnostic/1/80 [Sort not supported]: "
+    # Sort is now supported - to_es() should work
+    es_string = query.to_es()
+    assert es_string == '"cat"'
+    # Check sort keys are extracted correctly
+    sort_keys = query.get_es_sort()
+    assert len(sort_keys) == 1
+    # "title" resolves via dc.title prefix fallback to ES_SORT_INDEX_MAPPINGS["dc.title"]
+    assert ES_SORT_INDEX_MAPPINGS["dc.title"] in sort_keys[0]
+
+    # Test with sort modifiers
+    query = parse('"dog" sortBy dc.date/descending')
+    es_string = query.to_es()
+    assert es_string == '"dog"'
+    sort_keys = query.get_es_sort()
+    assert len(sort_keys) == 1
+    # dc.date should be mapped to provisionActivity.startDate
+    assert sort_keys[0].get("provisionActivity.startDate", {}).get("order") == "desc"
 
 
 def test_get_query_clause_with_relation(app):
@@ -216,18 +237,28 @@ def test_get_query_triple(app):
 
 
 def test_get_query_triple_with_sort(app):
-    """Check that query with boolean is parsed correctly."""
+    """Check that query with boolean and sort is parsed correctly."""
     query = parse("dc.anywhere all spam and dc.anywhere all eggs sortBy subtitle")
     # Check query instance
     assert isinstance(query, Triple)
-    with pytest.raises(Diagnostic) as err:
-        query.to_es()
-    assert str(err.value) == "info:srw/diagnostic/1/80 [Sort not supported]: "
+    # Sort is now supported
+    es_string = query.to_es()
+    assert es_string == "((spam) AND (eggs))"
+    # Check sort keys are extracted correctly
+    sort_keys = query.get_es_sort()
+    assert len(sort_keys) == 1
+    assert "subtitle" in sort_keys[0]
+
+    # Test with multiple sort keys
+    query = parse("title = book sortBy dc.title/ascending dc.date/descending")
+    es_string = query.to_es()
+    sort_keys = query.get_es_sort()
+    assert len(sort_keys) == 2
 
 
 def test_get_query_with_modifiers():
     """Check that query with modifiers is parsed correctly."""
-    # Relation Modifiers
+    # Supported relation modifiers (/relevant is supported)
     q_string = "dc.anywhere any/relevant spam"
     query = parse(q_string)
     assert len(query.relation.modifiers) > 0
@@ -236,10 +267,18 @@ def test_get_query_with_modifiers():
     assert str(query.relation.modifiers[0].type) == "cql.relevant"
     assert not str(query.relation.modifiers[0].comparison)
     assert not str(query.relation.modifiers[0].value)
-    with pytest.raises(Diagnostic):
-        query.to_es()
+    # /relevant is now supported - should not raise
+    es_string = query.to_es()
+    assert es_string == "(spam)"
 
-    # Boolean modifiers
+    # Unsupported relation modifiers should still raise
+    q_string = "dc.anywhere any/phonetic spam"
+    query = parse(q_string)
+    with pytest.raises(Diagnostic) as err:
+        query.to_es()
+    assert "Unsupported relation modifier" in str(err.value)
+
+    # Boolean modifiers - unsupported ones should raise
     q_string = "dc.anywhere all spam and/rel.combine=sum dc.anywhere all eggs"
     query = parse(q_string)
     assert len(query.boolean.modifiers) > 0
@@ -248,8 +287,9 @@ def test_get_query_with_modifiers():
     assert str(query.boolean.modifiers[0].type) == "rel.combine"
     assert str(query.boolean.modifiers[0].comparison) == "="
     assert str(query.boolean.modifiers[0].value) == "sum"
-    with pytest.raises(Diagnostic):
+    with pytest.raises(Diagnostic) as err:
         query.to_es()
+    assert "Unsupported boolean modifier" in str(err.value)
 
 
 def test_errors():


### PR DESCRIPTION
* SRU CQL Parser (cql_parser.py):
  - Add 4 new Dublin Core search indexes:
    - dc.note → note.label (MARC 500)
    - dc.tableofcontents → tableOfContents (MARC 505)
    - dc.abstract → summary.label (MARC 520)
    - dc.dissertation → dissertation.label (MARC 502)
  - Add ES_SORT_MODIFIERS for sort order mapping (ascending/descending)
  - Add ES_SORT_INDEX_MAPPINGS for sortable field mappings
  - Add SUPPORTED_RELATION_MODIFIERS and UNSUPPORTED_RELATION_MODIFIERS
  - Fix typos: SERVER_CHOISE → SERVER_CHOICE

* SRU Explain (explaine.py):
  - Add _ES_MAPPINGS_CACHE module-level dictionary for caching
  - Implement ES mappings caching in __init__ to avoid repeated file I/O
  - Fix unsafe open() call by using context manager

* SRU Views (views.py):
  - Add EXPLAIN_CACHE_MAX_AGE (3600s) and SEARCH_CACHE_MAX_AGE (60s) constants
  - Add hashlib import for cache key generation

* MARC 21 Serializer (marc.py):
  - Add authority control numbers ($0) to MARC 650__ and 655__ fields
  - Extract $ref from TOPIC and genreForm entities for authority links