### PR TITLE
refactor(items): split issue sort_date display from ES sort key

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2967,7 +2967,7 @@ RECORDS_REST_SORT_OPTIONS["items"]["issue_expected_date"] = dict(
     fields=["issue.expected_date"], title="Issue expected date", default_order="asc"
 )
 RECORDS_REST_SORT_OPTIONS["items"]["issue_sort_date"] = dict(
-    fields=["issue.sort_date"], title="Issue chronology date", default_order="asc"
+    fields=["issue.sort_key"], title="Issue chronology date", default_order="asc"
 )
 RECORDS_REST_SORT_OPTIONS["items"]["enumeration_chronology"] = dict(
     fields=["enumerationAndChronology.sort"],

--- a/rero_ils/modules/items/listener.py
+++ b/rero_ils/modules/items/listener.py
@@ -59,10 +59,8 @@ def enrich_item_data(
         json["local_fields"] = local_fields
 
     if record.is_issue:
-        # Issue `sort_date` is an optional field but value is used to sort
-        # issues from one another ; if this field is empty, use the issue
-        # `expected_date` as value
-        json["issue"]["sort_date"] = record.sort_date or record.expected_date
+        # `sort_key` used exclusively for ES sorting.
+        json["issue"]["sort_key"] = record.sort_date or record.expected_date
         # inherited_first_call_number to issue
         if call_number := record.issue_inherited_first_call_number:
             json["issue"]["inherited_first_call_number"] = call_number

--- a/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/mappings/v7/items/item-v0.0.1.json
@@ -217,6 +217,9 @@
           "sort_date": {
             "type": "date"
           },
+          "sort_key": {
+            "type": "date"
+          },
           "regular": {
             "type": "boolean"
           },

--- a/tests/api/items/test_items_issue.py
+++ b/tests/api/items/test_items_issue.py
@@ -272,3 +272,42 @@ def test_issue_claims_counter_indexed_without_claims(
         # Clean up: delete the created issue to restore fixtures
         issue_item.delete(dbcommit=True, delindex=True)
         ItemsSearch.flush_and_refresh()
+
+
+def test_issue_sort_key_indexed(
+    client,
+    holding_lib_martigny_w_patterns,
+    librarian_martigny,
+):
+    """Test that ES sort_key reflects expected_date or sort_date correctly.
+
+    The listener computes `sort_key` as `sort_date or expected_date`:
+    - when the record has no sort_date, sort_key must equal expected_date
+    - when sort_date is set on the record, sort_key must equal sort_date
+    """
+    from rero_ils.modules.items.api import ItemsSearch
+
+    holding = Holding.get_record_by_pid(holding_lib_martigny_w_patterns.pid)
+    login_user_via_session(client, librarian_martigny.user)
+    issue_item = _receive_regular_issue(client, holding)
+
+    try:
+        ItemsSearch.flush_and_refresh()
+        es_issue = ItemsSearch().get_record_by_pid(issue_item.pid)
+
+        # no sort_date on the record → sort_key falls back to expected_date
+        assert not issue_item.sort_date
+        assert es_issue["issue"]["sort_key"] == issue_item.expected_date
+
+        # set sort_date explicitly and reindex
+        issue_item.sort_date = issue_item.expected_date
+        issue_item = issue_item.update(issue_item, dbcommit=True, reindex=True)
+        ItemsSearch.flush_and_refresh()
+        es_issue = ItemsSearch().get_record_by_pid(issue_item.pid)
+
+        # sort_date is now set → sort_key must use sort_date
+        assert es_issue["issue"]["sort_key"] == issue_item.sort_date
+        assert es_issue["issue"]["sort_date"] == issue_item.sort_date
+    finally:
+        issue_item.delete(dbcommit=True, delindex=True)
+        ItemsSearch.flush_and_refresh()

--- a/tests/ui/holdings/test_serial_claims.py
+++ b/tests/ui/holdings/test_serial_claims.py
@@ -71,13 +71,13 @@ def test_late_expected(holding_lib_martigny_w_patterns, holding_lib_sion_w_patte
     assert len(late_issues) == 2  # no new late issue than before
 
     # Get a late issues and update it's expected date : this will be set the
-    # `sort_date` field
+    # `sort_key` field
     issue = late_issues[0]
     assert issue.issue_status == ItemIssueStatus.LATE
     original_expected_date = issue.expected_date
     es_issue = ItemsSearch().get_record_by_pid(issue.pid)
     assert not issue.sort_date
-    assert es_issue["issue"]["sort_date"] == original_expected_date
+    assert es_issue["issue"]["sort_key"] == original_expected_date
 
     issue.expected_date = tomorrow.strftime("%Y-%m-%d")
     issue = issue.update(issue, dbcommit=True, reindex=True)


### PR DESCRIPTION
`issue.sort_date` was always overwritten during ES indexing with `expected_date` as fallback, making it impossible for the UI to distinguish a user-defined sort_date from a computed one without an extra DB call.

Introduce a dedicated `sort_key` field in ES (always populated with `sort_date or expected_date`) used exclusively for sorting. The `sort_date` field is now indexed as-is from the DB record, so its presence in ES reliably signals a user/system-defined override.

:warning: A reindex of all items of type `issue` is required after deployment.