### PR TITLE
fix(documents): fix subject imports routing condition

### DIFF
--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -602,12 +602,14 @@ def marc21_to_subjects_6XX(self, key, value):
             ):
                 subject["authorized_access_point"] = f"{creator}. {subject['authorized_access_point']}"
 
-        if ref := get_mef_link(
-            bibid=marc21.bib_id,
-            reroid=marc21.bib_id,
-            entity_type=data_type,
-            ids=utils.force_list(value.get("0")),
-            key=key,
+        if field_key != "subjects_imported" and (
+            ref := get_mef_link(
+                bibid=marc21.bib_id,
+                reroid=marc21.bib_id,
+                entity_type=data_type,
+                ids=utils.force_list(value.get("0")),
+                key=key,
+            )
         ):
             subject = {"$ref": ref}
         else:

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/slsp/model.py
@@ -428,12 +428,14 @@ def marc21_to_subjects_6XX(self, key, value):
                 ".",
             ):
                 subject["authorized_access_point"] = f"{creator}. {subject['authorized_access_point']}"
-        if ref := get_mef_link(
-            bibid=marc21.bib_id,
-            reroid=marc21.rero_id,
-            entity_type=data_type,
-            ids=utils.force_list(value.get("0")),
-            key=key,
+        if field_key != "subjects_imported" and (
+            ref := get_mef_link(
+                bibid=marc21.bib_id,
+                reroid=marc21.rero_id,
+                entity_type=data_type,
+                ids=utils.force_list(value.get("0")),
+                key=key,
+            )
         ):
             subject = {"$ref": ref}
         else:

--- a/tests/unit/documents/test_documents_dojson_loc.py
+++ b/tests/unit/documents/test_documents_dojson_loc.py
@@ -256,3 +256,53 @@ def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
     data = marc21.do(marc21json)
     assert data.get("subjects") == [{"entity": {"$ref": "https://test.rero.ch/api/places/gnd/4005728-8"}}]
     assert data.get("subjects_imported") is None
+
+    # Test 11: RERO subject with $0 should NOT use $ref, should use
+    # authorized_access_point + identifiedBy
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Physics</subfield>
+        <subfield code="0">(RERO)A012345678</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://mef.rero.ch/api/concepts/rero/A012345678"
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Physics",
+                "identifiedBy": {"type": "RERO", "value": "A012345678"},
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 12: IDREF subject with $0 should NOT use $ref, should use
+    # authorized_access_point + identifiedBy
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Chemistry</subfield>
+        <subfield code="0">(IDREF)027390548</subfield>
+        <subfield code="2">idref</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://mef.rero.ch/api/concepts/idref/027390548"
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Chemistry",
+                "identifiedBy": {"type": "IdRef", "value": "027390548"},
+            }
+        }
+    ]
+    assert data.get("subjects") is None

--- a/tests/unit/documents/test_documents_dojson_slsp.py
+++ b/tests/unit/documents/test_documents_dojson_slsp.py
@@ -603,3 +603,53 @@ def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
     data = marc21.do(marc21json)
     assert data.get("subjects") == [{"entity": {"$ref": "https://test.rero.ch/api/places/gnd/4005728-8"}}]
     assert data.get("subjects_imported") is None
+
+    # Test 11: RERO subject with $0 should NOT use $ref, should use
+    # authorized_access_point + identifiedBy
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Physics</subfield>
+        <subfield code="0">(RERO)A012345678</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://mef.rero.ch/api/concepts/rero/A012345678"
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Physics",
+                "identifiedBy": {"type": "RERO", "value": "A012345678"},
+            }
+        }
+    ]
+    assert data.get("subjects") is None
+
+    # Test 12: IDREF subject with $0 should NOT use $ref, should use
+    # authorized_access_point + identifiedBy
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Chemistry</subfield>
+        <subfield code="0">(IDREF)027390548</subfield>
+        <subfield code="2">idref</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://mef.rero.ch/api/concepts/idref/027390548"
+    data = marc21.do(marc21json)
+    assert data.get("subjects_imported") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "authorized_access_point": "Chemistry",
+                "identifiedBy": {"type": "IdRef", "value": "027390548"},
+            }
+        }
+    ]
+    assert data.get("subjects") is None


### PR DESCRIPTION
* Add field_key condition check before get_mef_link() call in both LOC and SLSP models to ensure the check is applied only for non-imported subjects
* Ensures GND subjects are always routed to subjects field
* Add comprehensive tests for subject field routing with various sources (GND, RERO, IDREF, LCSH, MeSH)

Fixes subject routing for GND subjects in MARC21 to JSON conversion.