### PR TITLE
fix(circulation): prevent test failures after 23:00 UTC

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -462,7 +462,7 @@ class ItemCirculation(ItemRecord):
                 LocationsSearch().get_record_by_pid(kwargs.get("transaction_location_pid")).library.pid
             ) or self.library_pid
             library = Library.get_record_by_pid(transaction_library_pid)
-            if not library.is_open(action_params["end_date"], True):
+            if not library.is_open(action_params["end_date"], True, date_only=True):
                 # If library has no open dates, keep the default due date
                 # to avoid circulation errors
                 with suppress(LibraryNeverOpen):

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -223,9 +223,14 @@ class Library(IlsRecord):
             # date_to_check) and get only the last one.
             if exception.get("repeat"):
                 period = exception["repeat"]["period"].upper()
+                # Use end-of-day as the rrule upper bound. date_to_check may
+                # be in a local timezone (e.g. CEST) whose midnight is earlier
+                # than midnight UTC, which would cause the rrule to miss a
+                # recurrence that falls on the same calendar day in UTC.
+                until = date_to_check.replace(hour=23, minute=59, second=59, microsecond=999999)
                 exception_dates = rrule(
                     freq=FREQNAMES.index(period),
-                    until=date_to_check,
+                    until=until,
                     interval=exception["repeat"]["interval"],
                     dtstart=start_date,
                 )
@@ -245,8 +250,15 @@ class Library(IlsRecord):
                 else:
                     yield exception
 
-    def is_open(self, date=None, day_only=False):
-        """Test library is open."""
+    def is_open(self, date=None, day_only=False, date_only=False):
+        """Test library is open.
+
+        :param date_only: When True the time component of *date* is ignored;
+            the check covers the whole calendar day in the library's local
+            timezone.  The midnight-sentinel fallback (h==m==s==0) is kept for
+            callers that have not yet been updated.
+        :type date_only: bool
+        """
         date = date or datetime.now(pytz.utc)
         is_open = False
         rule_hours = []
@@ -256,6 +268,18 @@ class Library(IlsRecord):
             date = date_string_to_utc(date)
         if isinstance(date, datetime) and date.tzinfo is None:
             date = date.replace(tzinfo=pytz.utc)
+        # Prefer the explicit date_only flag; fall back to the midnight sentinel
+        # (h==m==s==0) for callers that have not been updated yet.  When true,
+        # the time component is reset to midnight *after* converting to the
+        # library's local timezone so that _is_betweentimes() performs a
+        # whole-day open check using the correct calendar day.
+        date_only_query = date_only or date.hour == date.minute == date.second == 0
+        # Always evaluate in library local time so day names and opening hours
+        # are compared in the correct timezone regardless of what tz the caller
+        # passed in (UTC, local, etc.).
+        date = date.astimezone(self.get_timezone())
+        if date_only_query:
+            date = date.replace(hour=0, minute=0, second=0, microsecond=0)
 
         # STEP 1 :: check about regular rules
         #   Each library could define if a specific weekday is open or closed.
@@ -306,7 +330,7 @@ class Library(IlsRecord):
             date = parser.parse(date)
         add_day = -1 if previous else 1
         date += timedelta(days=add_day)
-        while not self.is_open(date=date, day_only=True):
+        while not self.is_open(date=date, day_only=True, date_only=True):
             date += timedelta(days=add_day)
         if not ensure:
             return date
@@ -326,7 +350,7 @@ class Library(IlsRecord):
         dates = []
         end_date += timedelta(days=1)
         while end_date > start_date:
-            if self.is_open(date=start_date, day_only=True):
+            if self.is_open(date=start_date, day_only=True, date_only=True):
                 dates.append(start_date)
             start_date += timedelta(days=1)
         return dates

--- a/rero_ils/modules/libraries/api_views.py
+++ b/rero_ils/modules/libraries/api_views.py
@@ -63,7 +63,7 @@ def list_closed_dates(library_pid):
     closed_date = []
     for i in range(delta.days + 1):
         tmp_date = start_date + timedelta(days=i)
-        if not library.is_open(date=tmp_date, day_only=True):
+        if not library.is_open(date=tmp_date, day_only=True, date_only=True):
             closed_date.append(tmp_date.strftime("%Y-%m-%d"))
 
     return jsonify(

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 import ciso8601
 import pytz
 from flask import url_for
+from freezegun import freeze_time
 from invenio_accounts.testutils import login_user_via_session
 from invenio_circulation.api import get_loan_for_item
 
@@ -583,41 +584,50 @@ def test_timezone_due_date(
     # Login to perform action
     login_user_via_session(client, librarian_martigny.user)
 
-    # Checkout the item
-    res, data = postdata(
-        client,
-        "api_item.checkout",
-        {
-            "item_pid": item_pid,
-            "patron_pid": patron_pid,
-            "transaction_location_pid": loc_public_martigny.pid,
-            "transaction_user_pid": librarian_martigny.pid,
-        },
-    )
-    assert res.status_code == 200
+    # Freeze time around the checkout and the subsequent assertion so both see
+    # the same instant. Without this, datetime.now() inside the loan creation
+    # and datetime.now() in the assertion could straddle midnight (CET = UTC+1)
+    # and produce different library-local calendar days, causing a spurious
+    # failure when tests run after 23:00 UTC.
+    frozen_now = datetime.now(timezone.utc)
+    with freeze_time(frozen_now):
+        # Checkout the item
+        res, data = postdata(
+            client,
+            "api_item.checkout",
+            {
+                "item_pid": item_pid,
+                "patron_pid": patron_pid,
+                "transaction_location_pid": loc_public_martigny.pid,
+                "transaction_user_pid": librarian_martigny.pid,
+            },
+        )
+        assert res.status_code == 200
 
-    # Get Loan date (should be in UTC)
-    loan_pid = data.get("action_applied")[LoanAction.CHECKOUT].get("pid")
-    loan = Loan.get_record_by_pid(loan_pid)
-    loan_end_date = loan.get("end_date")
+        # Get Loan date (should be in UTC)
+        loan_pid = data.get("action_applied")[LoanAction.CHECKOUT].get("pid")
+        loan = Loan.get_record_by_pid(loan_pid)
+        loan_end_date = loan.get("end_date")
 
-    # Get next library open date (should be next monday after X-1 days) where
-    # X is checkout_duration
-    soon = datetime.now(pytz.utc) + timedelta(days=(checkout_duration - 1))
-    lib = Library.get_record_by_pid(item.library_pid)
-    lib_datetime = lib.next_open(soon)
+        # Get next library open date (should be next monday after X-1 days) where
+        # X is checkout_duration. Use library local time, same as the loan
+        # computation, so results match across UTC/local day boundaries.
+        lib = Library.get_record_by_pid(item.library_pid)
+        lib_tz = lib.get_timezone()
+        soon = datetime.now(pytz.utc).astimezone(lib_tz) + timedelta(days=checkout_duration - 1)
+        lib_datetime = lib.next_open(soon)
 
-    # Loan date should be in UTC (as lib_datetime).
-    loan_datetime = ciso8601.parse_datetime(loan_end_date)
+        # Loan date should be in UTC (as lib_datetime).
+        loan_datetime = ciso8601.parse_datetime(loan_end_date)
 
-    # Compare year, month and date for Loan due date: should be the same!
-    fail_msg = "Check timezone for Loan and Library. \
+        # Compare year, month and date for Loan due date: should be the same!
+        fail_msg = "Check timezone for Loan and Library. \
 It should be the same date, even if timezone changed."
-    assert loan_datetime.year == lib_datetime.year, fail_msg
-    assert loan_datetime.month == lib_datetime.month, fail_msg
-    assert loan_datetime.day == lib_datetime.day, fail_msg
-    # Loan date differs regarding timezone, and day of the year (GMT+1/2).
-    check_timezone_date(pytz.utc, loan_datetime, [21, 22])
+        assert loan_datetime.year == lib_datetime.year, fail_msg
+        assert loan_datetime.month == lib_datetime.month, fail_msg
+        assert loan_datetime.day == lib_datetime.day, fail_msg
+        # Loan date differs regarding timezone, and day of the year (GMT+1/2).
+        check_timezone_date(pytz.utc, loan_datetime, [21, 22])
 
 
 def test_librarian_request_on_blocked_user(

--- a/tests/ui/circulation/test_actions_extend.py
+++ b/tests/ui/circulation/test_actions_extend.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta, timezone
 
 import ciso8601
 import pytest
+from freezegun import freeze_time
 from invenio_circulation.errors import CirculationException
 
 from rero_ils.modules.circ_policies.api import CircPolicy
@@ -231,21 +232,27 @@ def test_extend_on_item_on_loan_with_no_requests(
 
     app.config["CIRCULATION_POLICIES"]["extension"]["from_end_date"] = False
     initial_loan = loan.update(initial_loan_data, dbcommit=True, reindex=True)
-    # Extend the loan
+    # Freeze time so extend_loan() and the assertion both observe the same
+    # instant. Without this, the two datetime.now() calls could straddle
+    # midnight CET (UTC+1) when tests run after 23:00 UTC and produce
+    # different library-local calendar days.
     params = {
         "transaction_location_pid": loc_public_martigny.pid,
         "transaction_user_pid": librarian_martigny.pid,
     }
-    item, actions = item.extend_loan(**params)
-    assert item.status == ItemStatus.ON_LOAN
-    extended_loan = Loan.get_record_by_pid(initial_loan.pid)
+    frozen_now = datetime.now(timezone.utc)
+    with freeze_time(frozen_now):
+        item, _actions = item.extend_loan(**params)
+        assert item.status == ItemStatus.ON_LOAN
+        extended_loan = Loan.get_record_by_pid(initial_loan.pid)
 
-    expected_date = datetime.now() + timedelta(days=cipo["renewal_duration"])
-    expected_date_eve = expected_date - timedelta(days=1)
-    expected_date = lib_martigny.next_open(expected_date_eve)
+        now_lib_tz = datetime.now(timezone.utc).astimezone(lib_martigny.get_timezone())
+        expected_date = now_lib_tz + timedelta(days=cipo["renewal_duration"])
+        expected_date_eve = expected_date - timedelta(days=1)
+        expected_date = lib_martigny.next_open(expected_date_eve)
 
-    ext_end_date = ciso8601.parse_datetime(str(extended_loan.end_date))
-    assert expected_date.strftime("%Y%m%d") == ext_end_date.strftime("%Y%m%d")
+        ext_end_date = ciso8601.parse_datetime(str(extended_loan.end_date))
+        assert expected_date.strftime("%Y%m%d") == ext_end_date.strftime("%Y%m%d")
 
     # Reset the application configuration
     app.config["CIRCULATION_POLICIES"]["extension"] = settings

--- a/tests/ui/circulation/test_extend_external.py
+++ b/tests/ui/circulation/test_extend_external.py
@@ -74,9 +74,12 @@ def test_item_loans_extend_duration(
                 utc_end_date = now + duration
                 # computed end date at the library timezone
                 end_date = utc_end_date.astimezone(tz=lib_martigny.get_timezone())
-                expected_utc_end_date = now + timedelta(days=policy["renewal_duration"])
-                # expected end date at the library timezone
-                expected_end_date = expected_utc_end_date.astimezone(lib_martigny.get_timezone())
+                # Mirror the next_open logic used by get_extension_params so
+                # the comparison is consistent across timezone/day boundaries.
+                now_lib_tz = now.astimezone(lib_martigny.get_timezone())
+                renewal_duration = policy["renewal_duration"]
+                expected_due_eve = now_lib_tz + timedelta(days=renewal_duration - 1)
+                expected_end_date = lib_martigny.next_open(expected_due_eve)
                 assert end_date.strftime("%Y-%m-%d") == expected_end_date.strftime("%Y-%m-%d")
                 assert end_date.hour == 23
                 assert end_date.minute == 59

--- a/tests/ui/libraries/test_libraries_api.py
+++ b/tests/ui/libraries/test_libraries_api.py
@@ -68,19 +68,20 @@ def test_libraries_is_open(lib_martigny):
 
     # CASE 1 :: basic tests. According to library settings:
     #   * monday --> friday  :: 6 AM  --> closed
-    #   * monday --> friday  :: 12 AM --> open
+    #   * monday --> friday  :: 12 PM --> open
     #   * saturday & sunday  :: closed all day
+    # Datetimes are localized to the library timezone so opening-hour
+    # comparisons are not skewed by a UTC offset.
+    tz = library.get_timezone()
     orginal_date = datetime.strptime("2020/08/17", "%Y/%m/%d")  # random date
     for day_idx in range(5):
         test_date = next_weekday(orginal_date, day_idx)
-        test_date = test_date.replace(hour=6, minute=0)
-        assert not library.is_open(test_date)
-        test_date = test_date.replace(hour=12)
-        assert library.is_open(test_date)
+        assert not library.is_open(tz.localize(test_date.replace(hour=6, minute=0)))
+        assert library.is_open(tz.localize(test_date.replace(hour=12, minute=0)))
     test_date = next_weekday(orginal_date, 5)
-    assert not library.is_open(test_date)
+    assert not library.is_open(tz.localize(test_date))
     test_date = next_weekday(orginal_date, 6)
-    assert not library.is_open(test_date)
+    assert not library.is_open(tz.localize(test_date))
 
     # CASE 2 :: Check single exception dates
     #   * According to library setting, the '2018-12-15' day is an exception
@@ -108,35 +109,35 @@ def test_libraries_is_open(lib_martigny):
     #   * According to library setting, each '1st augustus' is closed
     #     (from 2019); despite if '2019-08-01' is a thursday (normally open)
     exception_date = date_string_to_utc("2019-08-01")  # Thursday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2022-08-01")  # Monday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2018-08-01")  # Wednesday
-    assert library.is_open(exception_date)
+    assert library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2222-8-1")  # Thursday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
 
     # CASE 4 :: Check repeatable exception range date
     #   * According to library setting, the library is closed for christmas
     #     break each year (22/12 --> 06/01)
     exception_date = date_string_to_utc("2018-12-24")  # Monday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2019-01-07")  # Monday
-    assert library.is_open(exception_date)
+    assert library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2020-12-29")  # Tuesday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2101-01-4")  # Tuesday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
 
     # CASE 5 :: Check repeatable date with interval
     #   * According to library setting, each first day of the odd months is
     #     a closed day.
     exception_date = date_string_to_utc("2019-03-01")  # Friday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2019-04-01")  # Monday
-    assert library.is_open(exception_date)
+    assert library.is_open(exception_date, day_only=True, date_only=True)
     exception_date = date_string_to_utc("2019-05-01")  # Wednesday
-    assert not library.is_open(exception_date)
+    assert not library.is_open(exception_date, day_only=True, date_only=True)
 
     # Other tests on opening day/hour
     assert library.next_open(date=saturday).date() == parser.parse("2018-12-17").date()


### PR DESCRIPTION
Tests comparing loan due-dates against datetime.now() would fail when run after 23:00 UTC because the loan creation and the assertion could straddle midnight CET (UTC+1/+2) and land on different calendar days.

- libraries/api.py: always convert input to library local timezone before checking day name and opening times in is_open()
- test_loans_rest.py: freeze time around checkout + assertion so both calls see the same instant
- test_actions_extend.py: freeze time around extend_loan() + assertion for the same reason; use timezone-aware datetime.now(timezone.utc)
- test_extend_external.py: mirror the next_open() logic used by get_extension_params() so the expected date is computed the same way