### PR TITLE
feat(locations): add a public note field

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -16,6 +16,12 @@
     "pid": "2",
     "code": "AOSTE-CANT1-BIBLIOGR",
     "name": "Bibliographie vald\u00f4taine",
+    "public_note": [
+      {
+        "language": "fr",
+        "label": "Accessible seulement les jours de semaine"
+      }
+    ],
     "library": {
       "$ref": "https://bib.rero.ch/api/libraries/1"
     },
@@ -25,6 +31,12 @@
     "pid": "3",
     "code": "AOSTE-CANT1-MAGA",
     "name": "Magasin A",
+    "public_note": [
+      {
+        "language": "fr",
+        "label": "D\u00e9lai de traitement 24h"
+      }
+    ],
     "library": {
       "$ref": "https://bib.rero.ch/api/libraries/1"
     },
@@ -76,6 +88,12 @@
     "pid": "9",
     "code": "AOSTE-AVISE-ENF",
     "name": "Section enfants",
+    "public_note": [
+      {
+        "language": "fr",
+        "label": "Accessible seulement le mercredi."
+      }
+    ],
     "library": {
       "$ref": "https://bib.rero.ch/api/libraries/3"
     },
@@ -140,6 +158,12 @@
     "pid": "16",
     "code": "HOG-RESTR",
     "name": "Restricted Section",
+    "public_note": [
+      {
+        "language": "en",
+        "label": "Only open to professors or with an authorization"
+      }
+    ],
     "library": {
       "$ref": "https://bib.rero.ch/api/libraries/5"
     },

--- a/rero_ils/modules/holdings/serializers.py
+++ b/rero_ils/modules/holdings/serializers.py
@@ -50,8 +50,10 @@ class HoldingsJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
         metadata["circulation_category"] = circ_category.dumps()
         # Library & location
         if pid := metadata.get("location", {}).get("pid"):
-            loc_name = self.get_resource(LocationsSearch(), pid)["name"]
-            metadata["location"]["name"] = loc_name
+            if loc := self.get_resource(LocationsSearch(), pid):
+                metadata["location"]["name"] = loc["name"]
+                if public_note := loc.get("public_note"):
+                    metadata["location"]["public_note"] = public_note
         if pid := metadata.get("library", {}).get("pid"):
             lib_name = self.get_resource(LibrariesSearch(), pid)["name"]
             metadata["library"]["name"] = lib_name

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -15,6 +15,7 @@
   "propertiesOrder": [
     "name",
     "code",
+    "public_note",
     "is_online",
     "is_pickup",
     "pickup_name",
@@ -63,6 +64,69 @@
       "widget": {
         "formlyConfig": {
           "focus": true
+        }
+      }
+    },
+    "public_note": {
+      "title": "Public note",
+      "description": "A short note displayed to the public about this location.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Note",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "language",
+          "label"
+        ],
+        "propertiesOrder": [
+          "language",
+          "label"
+        ],
+        "properties": {
+          "language": {
+            "$ref": "https://bib.rero.ch/schemas/common/ui-languages-v0.0.1.json#/language"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string",
+            "maxLength": 140,
+            "minLength": 3,
+            "widget": {
+              "formlyConfig": {
+                "props": {
+                  "placeholder": "Example: Request delay 24h",
+                  "itemCssClass": "ui:col-span-12 ui:md:col-span-9"
+                }
+              }
+            }
+          }
+        },
+        "widget": {
+          "formlyConfig": {
+            "props": {
+              "containerCssClass": "ui:grid ui:grid-cols-12 ui:gap-2"
+            }
+          }
+        }
+      },
+      "widget": {
+        "formlyConfig": {
+          "props": {
+            "validation": {
+              "validators": {
+                "uniqueValueKeysInObject": {
+                  "keys": [
+                    "language"
+                  ]
+                }
+              },
+              "messages": {
+                "uniqueValueKeysInObjectMessage": "Only one note per language is allowed."
+              }
+            }
+          }
         }
       }
     },

--- a/rero_ils/modules/locations/mappings/v7/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/mappings/v7/locations/location-v0.0.1.json
@@ -70,6 +70,16 @@
       "allow_request": {
         "type": "boolean"
       },
+      "public_note": {
+        "properties": {
+          "language": {
+            "type": "keyword"
+          },
+          "label": {
+            "type": "text"
+          }
+        }
+      },
       "restrict_pickup_to": {
         "properties": {
           "type": {

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -114,9 +114,10 @@ def test_document_and_holdings_serializers(
     assert response.status_code == 200
     data = get_json(response)
     record = data["hits"]["hits"][0]["metadata"]
-    assert record.get("location", {}).get("name")
-    assert record.get("library", {}).get("name")
-    assert record.get("circulation_category", {}).get("name")
+    assert "name" in record.get("location", {})
+    assert "public_note" in record.get("location", {})
+    assert "name" in record.get("library", {})
+    assert "name" in record.get("circulation_category", {})
 
 
 def test_loans_serializers(

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1020,7 +1020,13 @@
     "pickup_name": "MARTIGNY-PUBLIC: Public Space",
     "is_ill_pickup": true,
     "ill_pickup_name": "MARTIGNY-PUBLIC: ILL Public Space",
-    "allow_request": true
+    "allow_request": true,
+    "public_note": [
+      {
+        "language": "en",
+        "label": "Consultation by appointment only"
+      }
+    ]
   },
   "loc2": {
     "$schema": "https://bib.rero.ch/schemas/locations/location-v0.0.1.json",


### PR DESCRIPTION
Some locations require specific access conditions (e.g. "consultation by appointment", "24-hour notice") that patrons need to be aware of before visiting. A new optional `public_note` field on the location resource makes this possible. The field is exposed through the holdings serializer so it reaches the public and professional interfaces.

Addresses https://tree.taiga.io/project/rero21-reroils/us/2983