### PR TITLE
refactor(loans): simplify anonymisation to a single 12-month delay

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -3619,10 +3619,10 @@ RERO_ILS_DEFAULT_PICKUP_HOLD_DURATION = 10
 # =============================================================================
 # ANONYMIZATION PROCESS CONFIGURATION
 # =============================================================================
-# Specify the delay (in days) under which no loan can"t be anonymized anyway (for circulation management process).
-RERO_ILS_ANONYMISATION_MIN_TIME_LIMIT = 3 * 365 / 12
-# Specify the delay (in days) when a loan should be anonymized anyway after it concluded.
-RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT = 6 * 365 / 12
+# Specify the delay (in days) after which a concluded loan is anonymized.
+# All concluded loans are anonymized after this delay regardless of the patron
+# keep_history preference (default: 12 months).
+RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT = 365
 
 #: Invenio circulation configuration.
 CIRCULATION_ITEM_EXISTS = Item.item_exists

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -23,8 +23,7 @@ from bisect import bisect_right
 from datetime import datetime, timedelta, timezone
 
 import ciso8601
-from dateutil.relativedelta import relativedelta
-from elasticsearch_dsl import A, Q
+from elasticsearch_dsl import A
 from flask import current_app
 from flask_babel import gettext as _
 from invenio_circulation.errors import MissingRequiredParameterError
@@ -888,38 +887,20 @@ class Loan(IlsRecord):
     def get_anonymized_candidates(cls):
         """Search for loans to anonymize.
 
-        Depending on the related patron `keep_history` setting, there is two
-        ways for searching loan candidates to:
-        1) If the patron specifies to keep transaction history : we keep
-           history for the 6 last months. After this delay, all loans will be
-           anonymized anyway.
-        2) If the patron doesn't specify to keep history : we can anonymize
-           related loans except if they are not concluded than 3 months ago
-           (we need to keep transactions for the last 3 months for circulation
-           management).
+        Returns all concluded loans older than the configured time limit
+        (default: 12 months) that have not yet been anonymized, regardless of
+        patron history preferences.
 
-        :return: a generator of `Loan` candidate to anonymize.
+        :return: a generator of `Loan` candidates to anonymize.
         """
-        three_month_ago = datetime.now() - relativedelta(months=3)
-        six_month_ago = datetime.now() - relativedelta(months=6)
-
-        patron_query = PatronsSearch().filter(
-            "bool",
-            must_not=[Q("exists", field="keep_history"), Q("term", keep_history=True)],
-        )
-        anonym_patron_pids = [h.pid for h in patron_query.source("pid").scan()]
+        limit = current_app.config.get("RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT", math.inf)
+        time_limit = datetime.now() - timedelta(days=limit)
 
         query = (
             LoansSearch()
             .filter("terms", state=LoanState.CONCLUDED)
             .filter("term", to_anonymize=False)
-            .filter(
-                "bool",
-                should=[
-                    Q("range", transaction_date={"lt": six_month_ago}),
-                    (Q("terms", patron_pid=anonym_patron_pids) & Q("range", transaction_date={"lt": three_month_ago})),
-                ],
-            )
+            .filter("range", transaction_date={"lt": time_limit})
             .source(False)
         )
         for hit in list(query.scan()):
@@ -944,57 +925,22 @@ class Loan(IlsRecord):
         return 0
 
     @classmethod
-    def can_anonymize(cls, loan_data=None, patron=None):
-        """Check if a loan can be anonymized and excluded from loan searches.
+    def can_anonymize(cls, loan_data=None):
+        """Check if a loan can be anonymized.
 
-        Loan can be anonymized if:
-        1. it is concluded and 6 months old
-        2. patron has the keep_history set to False and the loan is concluded.
-
-        This method is class method because it needs to check the loan record
-        during the loan.update process. this way, you can have access to the
-        old and new version of the loan.
+        A loan can be anonymized when it is concluded and older than the
+        configured time limit (default: 12 months). The patron's keep_history
+        preference does not affect when a loan gets anonymized; it only
+        controls visibility in the patron profile.
 
         :param loan_data: the loan data to check (could be a `Loan` or a dict).
-        :param patron: the patron to check.
         :return: True if the loan can be anonymized, False otherwise.
         """
-        # force `loan_data` as a `Loan` object instance if it's not yet.
         loan = loan_data if isinstance(loan_data, cls) else cls(loan_data)
-
-        # CHECK #1 : Is the loan is concluded ?
-        #   If the loan is still alive (item in loan, item requested), we can't
-        #   anonymize it
         if not loan.is_concluded():
             return False
-
-        # CHECK #2 : is the loan is an old loan ?
-        #   A concluded loan, older than a limit, could always be anonymized.
-        #   Limit could be configured by 'RERO_ILS_ANONYMISATION_TIME_LIMIT'
-        #   key into `config.py`.
-        max_limit = current_app.config.get("RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT", math.inf)
-        loan_age = loan.age()
-        if loan_age > max_limit:
-            return True
-
-        # CHECK #3 : is the loan is just concluded ?
-        #   Circulation management and/or library manager needs to keep loan
-        #   information for a delay (in days) after the concluded date anyway.
-        min_limit = current_app.config.get("RERO_ILS_ANONYMISATION_MIN_TIME_LIMIT", -math.inf)
-        if loan_age < (min_limit + 1):
-            return False
-
-        # CHECK #5 : Check about patron preferences
-        #   Patron could specify if it wants to keep transaction history or not
-        patron_pid = loan_data.get("patron_pid")
-        patron = patron or Patron.get_record_by_pid(patron_pid)
-        keep_history = True
-        if patron:
-            keep_history = patron.user.user_profile.get("keep_history", True)
-        else:
-            msg = f"Cannot anonymize loan: {loan_data.get('pid')} no patron: {loan_data.get('patron_pid')}"
-            current_app.logger.warning(msg)
-        return not keep_history
+        limit = current_app.config.get("RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT", math.inf)
+        return loan.age() >= limit
 
 
 def action_required_params(action=None):
@@ -1243,7 +1189,7 @@ def anonymize_loans(patron=None, org_pid=None, dbcommit=False, reindex=False):
     """
     counter = 0
     for loan in get_non_anonymized_loans(patron=patron, org_pid=org_pid):
-        if Loan.can_anonymize(loan_data=loan, patron=patron):
+        if Loan.can_anonymize(loan_data=loan):
             loan.anonymize(loan, dbcommit=dbcommit, reindex=reindex)
             counter += 1
     return counter

--- a/rero_ils/modules/loans/tasks.py
+++ b/rero_ils/modules/loans/tasks.py
@@ -42,7 +42,7 @@ def loan_anonymizer(dbcommit=True, reindex=True):
     """
     counter = 0
     for loan in Loan.get_anonymized_candidates():
-        if Loan.can_anonymize(loan_data=loan, patron=None):
+        if Loan.can_anonymize(loan_data=loan):
             loan.anonymize(dbcommit=dbcommit, reindex=reindex)
             counter += 1
 

--- a/rero_ils/modules/patrons/listener.py
+++ b/rero_ils/modules/patrons/listener.py
@@ -79,8 +79,3 @@ def update_from_profile(sender, user, **kwargs):
     """
     for patron in Patron.get_patrons_by_user(user):
         patron.reindex()
-        if patron.is_patron:
-            from ..loans.api import anonymize_loans
-
-            if not user.user_profile.get("keep_history", True):
-                anonymize_loans(patron=patron, dbcommit=True, reindex=True)

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -30,6 +30,7 @@ from invenio_records_rest.errors import InvalidQueryRESTError
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 
 from rero_ils.modules.ill_requests.models import ILLRequestStatus
+from rero_ils.modules.loans.models import LoanState
 
 from .facets import default_facets_factory
 from .modules.items.models import TypeOfItem
@@ -320,6 +321,7 @@ def circulation_search_factory(self, search, query_parser=None):
     Restricts results to organisation level for librarian and sys_lib.
     Restricts results to its loans for users with role patron.
     Exclude to_anonymize loans from results.
+    For patrons with keep_history=False, only non-concluded loans are shown.
     """
     search, urlkwargs = search_factory(self, search)
     # a user can be patron and librarian, it should search in his own loan and
@@ -330,7 +332,13 @@ def circulation_search_factory(self, search, query_parser=None):
     if current_librarian:
         filters |= Q("term", organisation__pid=current_librarian.organisation_pid)
     if current_patrons:
-        filters |= Q("terms", patron_pid=[ptrn.pid for ptrn in current_patrons])
+        for ptrn in current_patrons:
+            if ptrn.user.user_profile.get("keep_history", True):
+                # patron wants to keep history: show all their loans
+                filters |= Q("term", patron_pid=ptrn.pid)
+            else:
+                # patron opted out of history: only show active (non-concluded) loans
+                filters |= Q("term", patron_pid=ptrn.pid) & ~Q("terms", state=LoanState.CONCLUDED)
     if filters is not Q("match_none"):
         search = search.filter("bool", must=[filters])
 

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -658,3 +658,96 @@ def test_librarian_request_on_blocked_user(
     assert res.status_code == 403
     data = get_json(res)
     assert "blocked" in data.get("message")
+
+
+def test_keep_history_loan_visibility(
+    client,
+    librarian_martigny,
+    loc_public_martigny,
+    item_on_loan_martigny_patron_and_loan_on_loan,
+):
+    """Test that keep_history controls patron visibility of concluded loans.
+
+    A patron with keep_history=False must not see their concluded loans in the
+    search API, but must still see their active loans. A librarian must see all
+    loans regardless of the patron's keep_history preference.
+    """
+    item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    active_loan_pid = loan.pid
+    loan_search_url = url_for("invenio_records_rest.loanid_list")
+
+    # -------------------------------------------------------------------------
+    # CHECK #1: patron with keep_history=False DOES see their active loan
+    # -------------------------------------------------------------------------
+    patron.set_keep_history(False)
+    login_user_via_session(client, patron.user)
+    res = client.get(loan_search_url)
+    assert res.status_code == 200
+    pids = [h["id"] for h in get_json(res)["hits"]["hits"]]
+    assert active_loan_pid in pids
+
+    # -------------------------------------------------------------------------
+    # SETUP: checkin to produce a concluded loan
+    # -------------------------------------------------------------------------
+    login_user_via_session(client, librarian_martigny.user)
+    res, _ = postdata(
+        client,
+        "api_item.checkin",
+        {
+            "item_pid": item.pid,
+            "pid": active_loan_pid,
+            "transaction_location_pid": loc_public_martigny.pid,
+            "transaction_user_pid": librarian_martigny.pid,
+        },
+    )
+    assert res.status_code == 200
+    LoansSearch.flush_and_refresh()
+
+    concluded_loan = Loan.get_record_by_pid(active_loan_pid)
+    assert concluded_loan["state"] in LoanState.CONCLUDED
+
+    # -------------------------------------------------------------------------
+    # CHECK #2: patron with keep_history=False does NOT see concluded loans
+    # -------------------------------------------------------------------------
+    login_user_via_session(client, patron.user)
+    res = client.get(loan_search_url)
+    assert res.status_code == 200
+    pids = [h["id"] for h in get_json(res)["hits"]["hits"]]
+    assert active_loan_pid not in pids
+
+    # -------------------------------------------------------------------------
+    # CHECK #3: patron with keep_history=True DOES see their concluded loan
+    # -------------------------------------------------------------------------
+    patron.set_keep_history(True)
+    res = client.get(loan_search_url)
+    assert res.status_code == 200
+    pids = [h["id"] for h in get_json(res)["hits"]["hits"]]
+    assert active_loan_pid in pids
+
+    # -------------------------------------------------------------------------
+    # CHECK #4: librarian sees all loans regardless of patron's keep_history
+    # -------------------------------------------------------------------------
+    patron.set_keep_history(False)
+    login_user_via_session(client, librarian_martigny.user)
+    res = client.get(loan_search_url)
+    assert res.status_code == 200
+    pids = [h["id"] for h in get_json(res)["hits"]["hits"]]
+    assert active_loan_pid in pids
+
+    # -------------------------------------------------------------------------
+    # CHECK #5: once anonymized, nobody sees the loan — not even the librarian
+    # -------------------------------------------------------------------------
+    concluded_loan.anonymize(dbcommit=True, reindex=True)
+    LoansSearch.flush_and_refresh()
+
+    res = client.get(loan_search_url)
+    assert res.status_code == 200
+    pids = [h["id"] for h in get_json(res)["hits"]["hits"]]
+    assert active_loan_pid not in pids
+
+    patron.set_keep_history(True)
+    login_user_via_session(client, patron.user)
+    res = client.get(loan_search_url)
+    assert res.status_code == 200
+    pids = [h["id"] for h in get_json(res)["hits"]["hits"]]
+    assert active_loan_pid not in pids

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -25,6 +25,7 @@ import ciso8601
 from freezegun import freeze_time
 from invenio_circulation.proxies import current_circulation
 
+from rero_ils.config import RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT
 from rero_ils.modules.circ_policies.api import DUE_SOON_REMINDER_TYPE
 from rero_ils.modules.items.models import ItemStatus
 from rero_ils.modules.libraries.api import Library
@@ -225,31 +226,13 @@ def test_loan_keep_and_to_anonymize(
     }
     item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)
-    # CHECK #1 : loan concluded but patron doesn't request to anonymized loans.
-    #  * item checked-in
-    #  * no open events
-    #  * patron doesn't specify any information into `keep_history`
+    # CHECK #1 : loan concluded but not old enough to be anonymized.
     assert loan.is_concluded()
     assert not Loan.can_anonymize(loan_data=loan)
 
-    # CHECK #2 : Update the patron 'keep_history'
-    #   * patron should anonymize loans
-    #   * as loan concluded date > 3 months, system need to keep reference and
-    #     loan cannot be anonymized yet.
-    #   TODO :: Adapt the value depending of the
-    #           RERO_ILS_ANONYMISATION_MIN_TIME_LIMIT parameter
-    patron.set_keep_history(False)
-    loan = Loan.get_record_by_pid(loan.pid)
-    assert loan.is_concluded()
-    assert not Loan.can_anonymize(loan_data=loan)
-
-    # CHECK #3 : Check if loan is concluded between 3 and 6 months.
-    #   Between 3 and 6 months, the loan could be anonymized depending of
-    #   patron setting. After 6 months, all loans are anonymized.
-    #   TODO :: Adapt the value depending of the
-    #           RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT parameter
-    four_months_ago = datetime.utcnow() - timedelta(days=4 * 31)
-    loan["transaction_date"] = four_months_ago.isoformat()
+    # CHECK #2 : Loan older than 12 months is anonymized.
+    thirteen_months_ago = datetime.now(timezone.utc) - timedelta(days=RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT + 1)
+    loan["transaction_date"] = thirteen_months_ago.isoformat()
     assert loan.is_concluded()
     assert loan.can_anonymize(loan_data=loan)
 
@@ -313,9 +296,8 @@ def test_anonymizer_job(
     assert not loan.is_concluded()
     assert not Loan.can_anonymize(loan_data=loan)
 
-    # update the patron `keep_history` setting to ensure the patron want keep
-    # its history --> transaction concluded less than 6 months ago cannot be
-    # anonymized.
+    # The patron's keep_history preference does not affect anonymization timing.
+    # Check-in while there are open fee transactions keeps the loan non-concluded.
     patron.set_keep_history(True)
     params = {
         "transaction_location_pid": loc_public_martigny.pid,
@@ -332,10 +314,9 @@ def test_anonymizer_job(
     count = loan_anonymizer(dbcommit=True, reindex=True)
     assert count == 0
 
-    # We will now update the loan `transaction_date` to 1 year ago and close
-    # all open transactions about it.
-    patron.set_keep_history(False)
-    one_year_ago = datetime.now() - timedelta(days=365)
+    # Update the loan transaction_date to more than 12 months ago and close
+    # all open transactions so the loan is concluded and old enough to anonymize.
+    one_year_ago = datetime.now(timezone.utc) - timedelta(days=RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT + 1)
     loan["transaction_date"] = one_year_ago.isoformat()
     loan = loan.update(loan, dbcommit=True, reindex=True)
     # close open transactions and notifications
@@ -348,7 +329,7 @@ def test_anonymizer_job(
     assert Loan.can_anonymize(loan_data=loan)
 
     # run the `loan_anonymizer` task and check the result. At least our loan
-    # should be anonymize.
+    # should be anonymized.
     count = len(list(Loan.get_anonymized_candidates()))
     msg = loan_anonymizer(dbcommit=True, reindex=True)
     assert msg == count
@@ -377,9 +358,8 @@ def test_anonymize_candidates(
     candidates = [loan.pid for loan in Loan.get_anonymized_candidates()]
     assert loan.pid not in candidates
 
-    # Force the patron to keep history and conclude the loan.
-    # Force the transaction date to 1 year ago. The loan should now be into
-    # the anonymize candidate.
+    # Conclude the loan and force the transaction date to more than 12 months
+    # ago. The loan should now be an anonymize candidate.
     patron.set_keep_history(True)
     params = {
         "transaction_location_pid": loc_public_martigny.pid,
@@ -387,16 +367,17 @@ def test_anonymize_candidates(
     }
     item.checkin(**params)
     loan = Loan.get_record_by_pid(loan.pid)
-    one_year_ago = datetime.now(timezone.utc) - timedelta(days=365)
-    loan["transaction_date"] = one_year_ago.isoformat()
+    over_one_year_ago = datetime.now(timezone.utc) - timedelta(days=RERO_ILS_ANONYMISATION_MAX_TIME_LIMIT + 1)
+    loan["transaction_date"] = over_one_year_ago.isoformat()
     loan = loan.update(loan, dbcommit=True, reindex=True)
     LoansSearch.flush_and_refresh()
 
     candidates = [loan.pid for loan in Loan.get_anonymized_candidates()]
     assert loan.pid in candidates
 
-    # Set the transaction date to 4 months ago. As the patron want to keep
-    # history, the loan isn't yet an anonymize candidate.
+    # Set the transaction date to 4 months ago. The loan is too recent
+    # (< 12 months) so it is not yet an anonymize candidate, regardless of
+    # the patron's keep_history preference.
     four_month_ago = datetime.now(timezone.utc) - timedelta(days=4 * 30)
     loan["transaction_date"] = four_month_ago.isoformat()
     loan = loan.update(loan, dbcommit=True, reindex=True)
@@ -405,12 +386,11 @@ def test_anonymize_candidates(
     candidates = [loan.pid for loan in Loan.get_anonymized_candidates()]
     assert loan.pid not in candidates
 
-    # Now force the patron to not keep history setting. The loan is older than
-    # 3 months, the loan must be an anonymize candidate.
+    # The patron's keep_history=False preference does not affect when loans
+    # are anonymized: a 4-month-old concluded loan is still not a candidate.
     patron.set_keep_history(False)
-
     candidates = [loan.pid for loan in Loan.get_anonymized_candidates()]
-    assert loan.pid in candidates
+    assert loan.pid not in candidates
 
 
 def test_loan_get_overdue_fees(item_on_loan_martigny_patron_and_loan_on_loan):


### PR DESCRIPTION
Replace the 3-month/6-month two-tier mechanism with a single 12-month delay for all patrons:

- remove RERO_ILS_ANONYMISATION_MIN_TIME_LIMIT; update MAX to 12 months
- simplify can_anonymize() and get_anonymized_candidates(): concluded loans older than 12 months are anonymised unconditionally
- remove keep_history=False immediate anonymisation trigger from the patron listener
- move patron history visibility to circulation_search_factory(): patrons who opt out only see non-concluded loans; librarians see all loans up to 12 months regardless of patron preference
- add test_keep_history_loan_visibility covering patron/librarian search visibility and post-anonymisation exclusion for all users
- Closes #4042.