### PR TITLE
feat(patrons): add not_expired facet filter

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -143,7 +143,7 @@ from .modules.patron_types.permissions import PatronTypePermissionPolicy
 from .modules.patrons.api import Patron
 from .modules.patrons.models import CommunicationChannel
 from .modules.patrons.permissions import PatronPermissionPolicy
-from .modules.patrons.query import patron_expired
+from .modules.patrons.query import patron_expiration_filter
 from .modules.selfcheck.permissions import seflcheck_permission_factory
 from .modules.stats.api.api import Stat
 from .modules.stats.permissions import StatisticsPermissionPolicy
@@ -2412,7 +2412,8 @@ RECORDS_REST_FACETS = dict(
             _("city"): and_term_filter("facet_city"),
             _("patron_type"): and_term_filter("patron.type.pid"),
             _("blocked"): and_term_filter("patron.blocked"),
-            _("expired"): patron_expired(),
+            _("expired"): patron_expiration_filter(),
+            _("not_expired"): patron_expiration_filter(expired=False),
         },
     ),
     acq_accounts=dict(

--- a/rero_ils/modules/patrons/query.py
+++ b/rero_ils/modules/patrons/query.py
@@ -22,10 +22,18 @@ from datetime import datetime
 from elasticsearch_dsl import Q
 
 
-def patron_expired():
-    """Create a filter for the patron account is expired."""
+def patron_expiration_filter(expired=True):
+    """Create a filter for the patron account expiration status.
+
+    :param expired: if True, filter expired accounts (expiration_date <= now),
+                    if False, filter active accounts (expiration_date > now OR no expiration_date).
+    """
 
     def inner(values):
-        return Q("range", patron__expiration_date={"lte": datetime.now()}) if values[0] == "true" else Q()
+        if not values or values[0] != "true":
+            return Q()
+        if expired:
+            return Q("range", patron__expiration_date={"lte": datetime.now()})
+        return Q("range", patron__expiration_date={"gt": datetime.now()}) | ~Q("exists", field="patron.expiration_date")
 
     return inner

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -591,8 +591,8 @@ def test_patrons_expired(client, librarian_martigny, patron_martigny):
     login_user_via_session(client, librarian_martigny.user)
     list_url = url_for("invenio_records_rest.ptrn_list", simple="1")
     res = client.get(list_url)
-    hits = get_json(res)["hits"]
-    assert hits["total"]["value"] == 6
+    total_patrons = get_json(res)["hits"]["total"]["value"]
+    assert total_patrons == 6
 
     original_expiration_date = patron_martigny["patron"]["expiration_date"]
     patron_martigny["patron"]["barcode"] = ["4098124352"]
@@ -603,8 +603,14 @@ def test_patrons_expired(client, librarian_martigny, patron_martigny):
 
     list_url = url_for("invenio_records_rest.ptrn_list", expired="true", simple="1")
     res = client.get(list_url)
-    hits = get_json(res)["hits"]
-    assert hits["total"]["value"] == 1
+    expired_patrons = get_json(res)["hits"]["total"]["value"]
+    assert expired_patrons == 1
+
+    expected_not_expired = total_patrons - expired_patrons
+    not_expired_url = url_for("invenio_records_rest.ptrn_list", not_expired="true", simple="1")
+    res = client.get(not_expired_url)
+    not_expired_patrons = get_json(res)["hits"]["total"]["value"]
+    assert not_expired_patrons == expected_not_expired
 
     patron_martigny["patron"]["expiration_date"] = original_expiration_date
     patron_martigny.update(patron_martigny, dbcommit=True, reindex=True)


### PR DESCRIPTION
Rename `patron_expired` to `patron_expiration_filter` with an `expired`
parameter to support both expired and active patron filtering.
Add a `not_expired` facet using `patron_expiration_filter(expired=False)`
to allow filtering patrons that are not expired (either no
expiration_date or expiration_date in the future).