### PR TITLE
tests(documents): add dojson source model unit tests

### DIFF
--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -1116,7 +1116,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
                     error_print("ERROR SERIAL TYPE:", self.bib_id, self.rero_id, err)
                 self.date1_from_008 = self.field_008_data[7:11]
                 self.date2_from_008 = self.field_008_data[11:15]
-                self.date_type_from_008 = self.field_008_data[6]
+                self.date_type_from_008 = self.field_008_data[6] if len(self.field_008_data) > 6 else ""
                 if self.date_type_from_008 == "r":
                     self.original_date_from_008 = self.date2_from_008
             self.admin_meta_data = {}

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/kul/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/kul/model.py
@@ -82,9 +82,10 @@ def marc21_to_language(self, key, value):
     language = do_language(self, marc21)
     # is fiction
     self["fiction_statement"] = DocumentFictionType.Unspecified.value
-    if value[33] in ["1", "d", "f", "j", "p"]:
+    char_33 = value[33] if len(value) > 33 else ""
+    if char_33 in ["1", "d", "f", "j", "p"]:
         self["fiction_statement"] = DocumentFictionType.Fiction.value
-    elif value[33] in ["0", "e", "h", "i", "s"]:
+    elif char_33 in ["0", "e", "h", "i", "s"]:
         self["fiction_statement"] = DocumentFictionType.NonFiction.value
     return language or None
 

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/sources.mmd
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/sources.mmd
@@ -1,0 +1,89 @@
+%%mermaid
+%% Maintenance: update annotations in the UTILS subgraph whenever a source
+%% adds, removes, or overrides a utils.py function (e.g. "→ DNB · UGent").
+%%{init: {"theme": "base", "themeVariables": {"fontSize": "13px"}}}%%
+flowchart TB
+
+    classDef source  fill:#4A90D9,color:#fff,stroke:#2E6BA8
+    classDef custom  fill:#F57C00,color:#fff,stroke:#E65100
+    classDef handler fill:#AB47BC,color:#fff,stroke:#7B1FA2
+    classDef helper  fill:#7CB342,color:#fff,stroke:#558B2F
+    classDef ref     fill:#ECEFF1,color:#333,stroke:#90A4AE
+
+    %% ── Sources ──────────────────────────────────────────────────
+
+    subgraph STANDARD["Standard sources<br/>(share LOC subject handler)"]
+        direction TB
+        DNB["DNB<br/>no 010  ·  no do_credits<br/>fiction from 008[33]"]:::source
+        UGent["UGent<br/>custom credits: 511 → FR prefix<br/>fiction from 008[33]"]:::source
+        KUL["KUL<br/>490 series handler disabled<br/>fiction from 008[33]"]:::source
+    end
+
+    subgraph CUSTOM["Custom sources<br/>(own subject handlers)"]
+        direction TB
+        LOC["LOC<br/>custom work_access_point 130/240/730<br/>custom 440 series handler"]:::custom
+        SLSP["SLSP<br/>custom pid from 001<br/>len(008)>33 guard"]:::custom
+        RERO["RERO<br/>custom type · language · contribution<br/>custom part_of · classification"]:::custom
+    end
+
+    %% ── Subject handlers ─────────────────────────────────────────
+
+    subgraph SUBJECTS["Subject handlers  (inline per model)"]
+        direction TB
+        sLOC["LOC handler<br/>───<br/>$2 gnd → subjects<br/>$2 rero/idref → subjects_imported<br/>ind2=0 → LCSH  ·  ind2=2 → MeSH<br/>GND $0 → MEF \$ref"]:::handler
+        sSLSP["SLSP handler<br/>───<br/>gnd / rero / idref / rerovoc<br/>$0 → identifiedBy<br/>648 Temporal  ·  655 genreForm"]:::handler
+        sRERO["RERO handler<br/>───<br/>full subdivision support<br/>creator-embedded work subjects"]:::handler
+    end
+
+    uSubdiv(["perform_subdivisions"]):::helper
+
+    %% ── Connections ──────────────────────────────────────────────
+
+    DNB   -.->|delegates| sLOC
+    UGent -.->|delegates| sLOC
+    KUL   -.->|delegates| sLOC
+    LOC   -->             sLOC
+    SLSP  -->             sSLSP
+    RERO  -->             sRERO
+
+    sLOC  --> uSubdiv
+    sSLSP --> uSubdiv
+    sRERO --> uSubdiv
+
+    uSubdiv ~~~ UTILS
+
+    %% ── Utils reference ──────────────────────────────────────────
+
+    subgraph UTILS["utils.py — function reference  (annotations show which sources use each)"]
+        direction TB
+
+        subgraph U_SOME["Used by subset of sources"]
+            direction LR
+            r14(["do_identified_by_010  LCCN<br/>→ UGent · KUL · LOC · SLSP"]):::ref
+            r15(["do_work_access_point<br/>→ DNB · UGent · KUL · SLSP · RERO"]):::ref
+            r16(["do_work_access_point_240<br/>→ DNB · UGent · KUL · SLSP"]):::ref
+            r17(["do_credits<br/>→ all except UGent  ·  UGent overrides with 511 FR prefix"]):::ref
+        end
+
+        subgraph U_MOST["Used by all except RERO"]
+            direction LR
+            r11(["do_type  ·  do_language"]):::ref
+            r12(["do_contribution"]):::ref
+            r13(["do_part_of  ·  do_classification"]):::ref
+        end
+
+        subgraph U_ALL["Used by all 6 sources"]
+            direction LR
+            r1(["do_issuance"]):::ref
+            r2(["do_title  ·  do_abbreviated_title"]):::ref
+            r3(["do_provision_activity  ·  do_edition_statement  ·  do_copyright_date"]):::ref
+            r4(["do_summary  ·  do_dissertation  ·  do_notes_and_original_title"]):::ref
+            r5(["do_table_of_contents  ·  do_intended_audience"]):::ref
+            r6(["do_electronic_locator_856  ·  do_specific_document_relation"]):::ref
+            r7(["do_scale_and_cartographic  ·  do_temporal_coverage"]):::ref
+            r8(["do_sequence_numbering  ·  do_frequency"]):::ref
+            r9(["do_usage_and_access_policy  ·  do_acquisition_terms"]):::ref
+            r10(["do_identified_by_020 / 022 / 024 / 028 / 035"]):::ref
+        end
+
+    end

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
@@ -379,10 +379,9 @@ def do_type(data, marc21):
         if marc21.bib_level == "m":
             doc_type = [{"main_type": "docmaintype_book", "subtype": "docsubtype_other_book"}]
 
-            field_008 = None
-            field_008 = marc21.get_fields("008")
+            field_008 = marc21.get_fields("008") or None
             # if it's an electronic book
-            if field_008[0]["data"][23] in ("o", "s"):
+            if field_008 and len(field_008[0]["data"]) > 23 and field_008[0]["data"][23] in ("o", "s"):
                 doc_type = [{"main_type": "docmaintype_book", "subtype": "docsubtype_e-book"}]
         elif marc21.bib_level == "s":
             doc_type = [{"main_type": "docmaintype_serial"}]

--- a/tests/unit/documents/test_documents_dojson_dnb.py
+++ b/tests/unit/documents/test_documents_dojson_dnb.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2026 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""DOJSON DNB model tests."""
+
+import pytest
+from dojson.contrib.marc21.utils import create_record
+
+from rero_ils.modules.documents.dojson.contrib.marc21tojson.dnb import marc21
+from rero_ils.modules.documents.models import DocumentFictionType
+
+
+@pytest.mark.parametrize(
+    "char,expected",
+    [
+        ("1", DocumentFictionType.Fiction.value),
+        ("d", DocumentFictionType.Fiction.value),
+        ("f", DocumentFictionType.Fiction.value),
+        ("j", DocumentFictionType.Fiction.value),
+        ("p", DocumentFictionType.Fiction.value),
+        ("0", DocumentFictionType.NonFiction.value),
+        ("e", DocumentFictionType.NonFiction.value),
+        ("h", DocumentFictionType.NonFiction.value),
+        ("i", DocumentFictionType.NonFiction.value),
+        ("s", DocumentFictionType.NonFiction.value),
+        (" ", DocumentFictionType.Unspecified.value),
+    ],
+)
+def test_marc21_to_fiction_statement(char, expected):
+    """Test fiction_statement extraction from 008 position 33."""
+    marc21xml = f"""
+    <record>
+      <controlfield tag="008">160315s2015    cc ||| |  ||||00| {char}|chi d</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == expected

--- a/tests/unit/documents/test_documents_dojson_kul.py
+++ b/tests/unit/documents/test_documents_dojson_kul.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2026 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""DOJSON KUL model tests."""
+
+import pytest
+from dojson.contrib.marc21.utils import create_record
+
+from rero_ils.modules.documents.dojson.contrib.marc21tojson.kul import marc21
+from rero_ils.modules.documents.models import DocumentFictionType
+
+
+@pytest.mark.parametrize(
+    "char,expected",
+    [
+        ("1", DocumentFictionType.Fiction.value),
+        ("d", DocumentFictionType.Fiction.value),
+        ("f", DocumentFictionType.Fiction.value),
+        ("j", DocumentFictionType.Fiction.value),
+        ("p", DocumentFictionType.Fiction.value),
+        ("0", DocumentFictionType.NonFiction.value),
+        ("e", DocumentFictionType.NonFiction.value),
+        ("h", DocumentFictionType.NonFiction.value),
+        ("i", DocumentFictionType.NonFiction.value),
+        ("s", DocumentFictionType.NonFiction.value),
+        (" ", DocumentFictionType.Unspecified.value),
+    ],
+)
+def test_marc21_to_fiction_statement(char, expected):
+    """Test fiction_statement extraction from 008 position 33."""
+    marc21xml = f"""
+    <record>
+      <controlfield tag="008">160315s2015    cc ||| |  ||||00| {char}|chi d</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == expected
+
+
+def test_marc21_to_fiction_statement_short_008():
+    """Test fiction_statement defaults to Unspecified for a short 008 field."""
+    marc21xml = """
+    <record>
+      <controlfield tag="008">160315</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == DocumentFictionType.Unspecified.value
+
+
+def test_marc21_series_statement_ignored():
+    """Test that 490 series statement fields are ignored by KUL."""
+    marc21xml = """
+    <record>
+      <datafield tag="490" ind1="0" ind2=" ">
+        <subfield code="a">Some series title</subfield>
+        <subfield code="v">vol. 3</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("seriesStatement") is None
+
+
+def test_marc21_to_identified_by_from_field_010():
+    """Test LCCN identifier extraction from field 010."""
+    marc21xml = """
+    <record>
+      <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">  2021001234  </subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("identifiedBy") == [{"type": "bf:Lccn", "value": "2021001234"}]

--- a/tests/unit/documents/test_documents_dojson_loc.py
+++ b/tests/unit/documents/test_documents_dojson_loc.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019 RERO
+# Copyright (C) 2019-2026 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -329,3 +329,88 @@ def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
         }
     ]
     assert data.get("subjects") is None
+
+
+def test_marc21_to_work_access_point_130():
+    """Test work access point from field 130 with title, language, and parts."""
+    marc21xml = """
+    <record>
+      <datafield tag="130" ind1="0" ind2=" ">
+        <subfield code="a">Bible.</subfield>
+        <subfield code="l">English</subfield>
+        <subfield code="n">N.T.</subfield>
+        <subfield code="p">Gospels.</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("work_access_point") == [
+        {
+            "title": "Bible.",
+            "language": "English",
+            "part": [{"partNumber": "N.T.", "partName": "Gospels"}],
+        }
+    ]
+
+
+def test_marc21_to_work_access_point_130_miscellaneous():
+    """Test that 130 $g and $s subfields are joined into miscellaneous_information."""
+    marc21xml = """
+    <record>
+      <datafield tag="130" ind1="0" ind2=" ">
+        <subfield code="a">Some work</subfield>
+        <subfield code="g">Selections</subfield>
+        <subfield code="s">Variant title</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("work_access_point") == [
+        {
+            "title": "Some work",
+            "miscellaneous_information": "Selections. Variant title",
+        }
+    ]
+
+
+def test_marc21_to_series_440_with_enumeration():
+    """Test LOC 440 series statement: trailing punctuation removed from title."""
+    marc21xml = """
+    <record>
+      <datafield tag="440" ind1=" " ind2="0">
+        <subfield code="a">Lecture notes in mathematics,</subfield>
+        <subfield code="v">vol. 42</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("seriesStatement") == [
+        {
+            "seriesTitle": [{"value": "Lecture notes in mathematics"}],
+            "seriesEnumeration": [{"value": "vol. 42"}],
+        }
+    ]
+
+
+def test_marc21_to_series_440_with_subseries():
+    """Test LOC 440 series statement with subseries built from $n and $p."""
+    marc21xml = """
+    <record>
+      <datafield tag="440" ind1=" " ind2="0">
+        <subfield code="a">Main series.</subfield>
+        <subfield code="n">Part 1.</subfield>
+        <subfield code="p">Subseries title</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("seriesStatement") == [
+        {
+            "seriesTitle": [{"value": "Main series"}],
+            "subseriesStatement": [{"subseriesTitle": [{"value": "Part 1. Subseries title"}]}],
+        }
+    ]

--- a/tests/unit/documents/test_documents_dojson_rero.py
+++ b/tests/unit/documents/test_documents_dojson_rero.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2026 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""DOJSON RERO model tests."""
+
+from unittest import mock
+
+import pytest
+from dojson.contrib.marc21.utils import create_record
+
+from rero_ils.modules.documents.dojson.contrib.marc21tojson.rero import marc21
+from rero_ils.modules.documents.models import DocumentFictionType
+
+
+@pytest.mark.parametrize(
+    "char,expected",
+    [
+        ("1", DocumentFictionType.Fiction.value),
+        ("d", DocumentFictionType.Fiction.value),
+        ("f", DocumentFictionType.Fiction.value),
+        ("j", DocumentFictionType.Fiction.value),
+        ("p", DocumentFictionType.Fiction.value),
+        ("0", DocumentFictionType.NonFiction.value),
+        ("e", DocumentFictionType.NonFiction.value),
+        ("h", DocumentFictionType.NonFiction.value),
+        ("i", DocumentFictionType.NonFiction.value),
+        ("s", DocumentFictionType.NonFiction.value),
+        (" ", DocumentFictionType.Unspecified.value),
+    ],
+)
+def test_marc21_to_fiction_statement(char, expected):
+    """Test fiction_statement extraction from 008 position 33."""
+    marc21xml = f"""
+    <record>
+      <controlfield tag="008">160315s2015    cc ||| |  ||||00| {char}|chi d</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == expected
+
+
+@pytest.mark.parametrize("genre_form_value", ["Fictions", "Films de fiction"])
+@mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.rero.model.get_mef_link")
+def test_marc21_to_fiction_statement_from_genreform(mock_get_mef_link, genre_form_value):
+    """Test that fiction genreForm terms set fiction_statement to Fiction."""
+    marc21xml = f"""
+    <record>
+      <datafield tag="655" ind1="0" ind2="7">
+        <subfield code="a">{genre_form_value}</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == DocumentFictionType.Fiction.value
+
+
+@mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.rero.model.get_mef_link")
+def test_marc21_to_fiction_statement_genreform_overrides_008(mock_get_mef_link):
+    """Test that 'Fictions' genreForm overrides NonFiction value derived from 008."""
+    marc21xml = """
+    <record>
+      <controlfield tag="008">160315s2015    cc ||| |  ||||00| 0|chi d</controlfield>
+      <datafield tag="655" ind1="0" ind2="7">
+        <subfield code="a">Fictions</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == DocumentFictionType.Fiction.value
+
+
+@mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.rero.model.get_mef_link")
+def test_marc21_to_subjects_rero_vocabulary(mock_get_mef_link):
+    """Test that 650 $2 rero subjects go to subjects, not subjects_imported."""
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Informatique</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = None
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [
+        {
+            "entity": {
+                "type": "bf:Topic",
+                "source": "rero",
+                "authorized_access_point": "Informatique",
+            }
+        }
+    ]
+    assert data.get("subjects_imported") is None
+
+
+@mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.rero.model.get_mef_link")
+def test_marc21_to_subjects_rero_vocabulary_with_mef_link(mock_get_mef_link):
+    """Test that 650 $2 rero with a MEF link resolves to a $ref in subjects."""
+    marc21xml = """
+    <record>
+      <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Informatique</subfield>
+        <subfield code="0">(RERO)A001234567</subfield>
+        <subfield code="2">rero</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    mock_get_mef_link.return_value = "https://mef.rero.ch/api/concepts/rero/A001234567"
+    data = marc21.do(marc21json)
+    assert data.get("subjects") == [{"entity": {"$ref": "https://mef.rero.ch/api/concepts/rero/A001234567"}}]
+    assert data.get("subjects_imported") is None

--- a/tests/unit/documents/test_documents_dojson_slsp.py
+++ b/tests/unit/documents/test_documents_dojson_slsp.py
@@ -19,9 +19,11 @@
 
 from unittest import mock
 
+import pytest
 from dojson.contrib.marc21.utils import create_record
 
 from rero_ils.modules.documents.dojson.contrib.marc21tojson.slsp import marc21
+from rero_ils.modules.documents.models import DocumentFictionType
 
 
 def test_marc21_to_contribution():
@@ -662,3 +664,67 @@ def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
         }
     ]
     assert data.get("subjects") is None
+
+
+def test_marc21_to_pid():
+    """Test PID extraction from field 001 with REROILS prefix."""
+    marc21xml = """
+    <record>
+      <controlfield tag="001">REROILS:12345</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("pid") == "12345"
+
+
+def test_marc21_to_pid_non_rero_prefix_ignored():
+    """Test that 001 values without REROILS prefix produce no pid."""
+    marc21xml = """
+    <record>
+      <controlfield tag="001">ALMA:99999</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("pid") is None
+
+
+@pytest.mark.parametrize(
+    "char,expected",
+    [
+        ("1", DocumentFictionType.Fiction.value),
+        ("d", DocumentFictionType.Fiction.value),
+        ("f", DocumentFictionType.Fiction.value),
+        ("j", DocumentFictionType.Fiction.value),
+        ("p", DocumentFictionType.Fiction.value),
+        ("0", DocumentFictionType.NonFiction.value),
+        ("e", DocumentFictionType.NonFiction.value),
+        ("h", DocumentFictionType.NonFiction.value),
+        ("i", DocumentFictionType.NonFiction.value),
+        ("s", DocumentFictionType.NonFiction.value),
+        (" ", DocumentFictionType.Unspecified.value),
+    ],
+)
+def test_marc21_to_fiction_statement(char, expected):
+    """Test fiction_statement extraction from 008 position 33."""
+    marc21xml = f"""
+    <record>
+      <controlfield tag="008">160315s2015    cc ||| |  ||||00| {char}|chi d</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == expected
+
+
+def test_marc21_to_fiction_statement_short_008():
+    """Test that a short 008 field (no position 33) defaults to Unspecified."""
+    marc21xml = """
+    <record>
+      <controlfield tag="008">160315</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == DocumentFictionType.Unspecified.value

--- a/tests/unit/documents/test_documents_dojson_ugent.py
+++ b/tests/unit/documents/test_documents_dojson_ugent.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2026 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""DOJSON UGent model tests."""
+
+import pytest
+from dojson.contrib.marc21.utils import create_record
+
+from rero_ils.modules.documents.dojson.contrib.marc21tojson.ugent import marc21
+from rero_ils.modules.documents.models import DocumentFictionType
+
+
+@pytest.mark.parametrize(
+    "char,expected",
+    [
+        ("1", DocumentFictionType.Fiction.value),
+        ("d", DocumentFictionType.Fiction.value),
+        ("f", DocumentFictionType.Fiction.value),
+        ("j", DocumentFictionType.Fiction.value),
+        ("p", DocumentFictionType.Fiction.value),
+        ("0", DocumentFictionType.NonFiction.value),
+        ("e", DocumentFictionType.NonFiction.value),
+        ("h", DocumentFictionType.NonFiction.value),
+        ("i", DocumentFictionType.NonFiction.value),
+        ("s", DocumentFictionType.NonFiction.value),
+        (" ", DocumentFictionType.Unspecified.value),
+    ],
+)
+def test_marc21_to_fiction_statement(char, expected):
+    """Test fiction_statement extraction from 008 position 33."""
+    marc21xml = f"""
+    <record>
+      <controlfield tag="008">160315s2015    cc ||| |  ||||00| {char}|chi d</controlfield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data["fiction_statement"] == expected
+
+
+def test_marc21_to_credits_511_prefix():
+    """Test that field 511 gets a French-language prefix in credits."""
+    marc21xml = """
+    <record>
+      <datafield tag="511" ind1="0" ind2=" ">
+        <subfield code="a">John Doe, Jane Smith</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("credits") == ["Participants ou interprètes: John Doe, Jane Smith"]
+
+
+def test_marc21_to_credits_508_no_prefix():
+    """Test that field 508 (creation/production credits) gets no prefix."""
+    marc21xml = """
+    <record>
+      <datafield tag="508" ind1=" " ind2=" ">
+        <subfield code="a">Photography by John Doe</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21.do(marc21json)
+    assert data.get("credits") == ["Photography by John Doe"]


### PR DESCRIPTION
* Add unit tests for all six marc21tojson import sources (DNB, UGent, KUL, LOC, SLSP, RERO) covering source-specific inline logic: fiction statement extraction from 008[33], SLSP pid from 001 and short-008 guard, UGent 511 FR credit prefix, KUL 490 series suppression, LOC work_access_point (130/240) and 440 series handler, and LOC subject routing (gnd→subjects, rero/idref→subjects_imported, LCSH/MeSH).
* Also add a Mermaid architecture diagram (sources.mmd) documenting the relationships between the six sources, their subject handlers, and the shared utils.py functions.
* Closes rero/rero-ils#3952