### PR TITLE
fix(broker): harden RabbitMQ and Redis connections

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -67,11 +67,17 @@ services:
     ports:
       - "5432:5432"
   mq:
-    image: rabbitmq:3-management
+    image: rabbitmq:4.2-management
     restart: "unless-stopped"
     ports:
       - "15672:15672"
       - "5672:5672"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
   es:
     build: ./docker/elasticsearch/
     image: elasticsearch-icu-7.10.2

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -309,6 +309,17 @@ SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE = _("Your RERO ID password has been reset
 SECURITY_LOGIN_FORM = LoginForm
 #: Redis session storage URL.
 ACCOUNTS_SESSION_REDIS_URL = "redis://localhost:6379/1"
+#: Redis instances to expose via the monitoring API, keyed by display name.
+#: Values are config keys; instances whose URL is absent or non-Redis are skipped.
+RERO_ILS_MONITORING_REDIS_INSTANCES = {
+    "cache": "CACHE_REDIS_URL",
+    "sessions": "ACCOUNTS_SESSION_REDIS_URL",
+    "celery_results": "CELERY_RESULT_BACKEND",
+    "ratelimit": "RATELIMIT_STORAGE_URI",
+    "celery_scheduler": "CELERY_REDIS_SCHEDULER_URL",
+    "import_cache": "RERO_ILS_IMPORT_CACHE",
+    "sip2": "SIP2_DATASTORE_REDIS_URL",
+}
 #: Enable session/user id request tracing. This feature will add X-Session-ID
 #: and X-User-ID headers to HTTP response. You MUST ensure that NGINX (or other
 #: proxies) removes these headers again before sending the response to the
@@ -549,7 +560,9 @@ DB_VERSIONING = False
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # Celery
-CELERY_BROKER_HEARTBEAT = 0
+CELERY_BROKER_HEARTBEAT = 60
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_BROKER_CONNECTION_MAX_RETRIES = 10
 CELERY_BEAT_SCHEDULER = "rero_ils.schedulers.DatabaseScheduler"
 
 # Flask configuration

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -578,6 +578,7 @@ class IlsRecordsIndexer(RecordIndexer):
             successful and a list of error responses
         """
         with current_celery_app.pool.acquire(block=True) as conn:
+            conn.ensure_connection(max_retries=current_app.config.get("CELERY_BROKER_CONNECTION_MAX_RETRIES", 10))
             consumer = Consumer(
                 connection=conn,
                 queue=self.mq_queue.name,

--- a/rero_ils/modules/cli/index.py
+++ b/rero_ils/modules/cli/index.py
@@ -39,19 +39,21 @@ from ..tasks import process_bulk_queue
 from .utils import abort_if_false, get_record_class_from_schema_or_pid_type
 
 
-def connect_queue(connection, name):
+def connect_queue(connection=None, name=None):
     """Queue establish connection or create queue.
 
+    :param connection: Kombu connection to bind to. When None, returns an unbound queue.
     :param name: Name for queue, if None the INDEXER_MQ_QUEUE is used.
     :returns: connected queue.
     """
     if name:
         exchange = current_app.config.get("INDEXER_MQ_EXCHANGE")
-        exchange = exchange(connection)
+        if connection:
+            exchange = exchange(connection)
         queue = Queue(name, exchange=exchange, routing_key=name)
     else:
         queue = current_app.config["INDEXER_MQ_QUEUE"]
-    return queue(connection)
+    return queue(connection) if connection else queue
 
 
 @index.command()
@@ -107,10 +109,7 @@ def run(delayed, concurrency, with_stats, version_type=None, queue=None, raise_o
             click.secho(f"Indexing records ({queue})...", fg="green")
         else:
             click.secho("Indexing records ...", fg="green")
-        connected_queue = None
-        if queue:
-            connection = current_app.extensions["invenio-celery"].celery.connection()
-            connected_queue = connect_queue(connection, queue)
+        connected_queue = connect_queue(name=queue) if queue else None
         indexer = IlsRecordsIndexer(
             version_type=version_type,
             queue=connected_queue,

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -39,6 +39,7 @@ from invenio_records.signals import (
 from invenio_records_rest.errors import JSONSchemaValidationError
 from invenio_search import current_search_client
 from jsonschema.exceptions import ValidationError
+from redis import Redis
 
 from rero_ils.filter import (
     address_block,
@@ -213,6 +214,18 @@ class REROILSAPP:
         NormalizerStopWords(app)
         self.init_config(app)
         app.extensions["rero-ils"] = self
+        instances = {}
+        for name, config_key in app.config.get("RERO_ILS_MONITORING_REDIS_INSTANCES", {}).items():
+            url = app.config.get(config_key)
+            if url and url.startswith(("redis://", "rediss://", "unix://")):
+                instances[name] = Redis.from_url(url)
+        app.extensions["rero_ils_redis_instances"] = instances
+        if "import_cache" in instances:
+            app.extensions["rero_ils_import_cache"] = instances["import_cache"]
+        else:
+            app.extensions["rero_ils_import_cache"] = Redis.from_url(
+                app.config.get("RERO_ILS_IMPORT_CACHE", "redis://localhost:6379/5")
+            )
         REROILSAPP.register_import_api_blueprint(app)
         REROILSAPP.register_users_api_blueprint(app)
         REROILSAPP.register_sru_api_blueprint(app)

--- a/rero_ils/modules/imports/api.py
+++ b/rero_ils/modules/imports/api.py
@@ -28,7 +28,6 @@ from dojson.contrib.marc21.utils import create_record
 from dojson.utils import GroupableOrderedDict
 from flask import current_app, jsonify, url_for
 from lxml import etree
-from redis import Redis
 
 from rero_ils.modules.documents.dojson.contrib.marc21tojson import (
     marc21_dnb,
@@ -63,7 +62,7 @@ class Import:
         assert self.search.get("anywhere")
         assert self.to_json_processor
         self.init_results()
-        self.cache = Redis.from_url(current_app.config.get("RERO_ILS_IMPORT_CACHE"))
+        self.cache = current_app.extensions["rero_ils_import_cache"]
         self.cache_expire = current_app.config.get("RERO_ILS_IMPORT_CACHE_EXPIRE")
 
     def init_results(self):

--- a/rero_ils/modules/messages.py
+++ b/rero_ils/modules/messages.py
@@ -17,11 +17,9 @@
 
 """Message interface."""
 
-from flask import current_app
 from flask_caching.backends import RedisCache
 from invenio_cache.proxies import current_cache
 from markupsafe import Markup
-from redis import Redis
 
 
 class Message:
@@ -64,15 +62,12 @@ class Message:
         """Get All Messages."""
         messages = {}
         if isinstance(current_cache.cache, RedisCache):
-            # current_cache for REDIS has no function to get all values. Get them directly from REDIS.
-            if url := current_app.config.get("CACHE_REDIS_URL"):
-                redis = Redis.from_url(url)
-                redis_keys = [
-                    redis_key.decode("utf-8").replace(f"cache::{cls.prefix}", "")
-                    for redis_key in redis.scan_iter(f"cache::{cls.prefix}*")
-                ]
-                for key in redis_keys:
-                    messages[key] = cls.get(key)
+            # current_cache has no API to scan keys; use the underlying client directly.
+            full_prefix = f"{current_cache.cache._get_prefix()}{cls.prefix}"
+            for redis_key in current_cache.cache._write_client.scan_iter(f"{full_prefix}*"):
+                key_str = redis_key.decode("utf-8") if isinstance(redis_key, bytes) else redis_key
+                msg_key = key_str.removeprefix(full_prefix)
+                messages[msg_key] = cls.get(msg_key)
         else:
             # needed for tests
             messages = {key.replace(f"{cls.prefix}", ""): current_cache.get(key) for key in current_cache.cache._cache}

--- a/rero_ils/modules/monitoring/cli.py
+++ b/rero_ils/modules/monitoring/cli.py
@@ -23,7 +23,6 @@ from flask.cli import with_appcontext
 from invenio_cache import current_cache
 from invenio_db import db
 from invenio_search import current_search_client
-from redis import Redis
 
 from .api import DB_CONNECTION_COUNTS_QUERY, DB_CONNECTIONS_QUERY, Monitoring
 
@@ -128,11 +127,14 @@ def es_indices():
 @monitoring.command()
 @with_appcontext
 def redis():
-    """Displays redis info."""
-    url = current_app.config.get("ACCOUNTS_SESSION_REDIS_URL", "redis://localhost:6379")
-    redis = Redis.from_url(url)
-    for key, value in redis.info().items():
-        click.echo(f"{key:<33}: {value}")
+    """Displays redis info for all configured instances."""
+    for name, client in current_app.extensions.get("rero_ils_redis_instances", {}).items():
+        click.secho(f"\n[{name}]", fg="green")
+        try:
+            for key, value in client.info().items():
+                click.echo(f"  {key:<33}: {value}")
+        except Exception as err:
+            click.secho(f"  ERROR: {err}", fg="red")
 
 
 @monitoring.command("db_connection_counts")

--- a/rero_ils/modules/monitoring/views.py
+++ b/rero_ils/modules/monitoring/views.py
@@ -25,7 +25,7 @@ from flask_login import current_user
 from invenio_cache import current_cache
 from invenio_db import db
 from invenio_search import current_search_client
-from redis import Redis
+from redis.exceptions import RedisError
 
 from ...permissions import monitoring_permission
 from .api import DB_CONNECTION_COUNTS_QUERY, DB_CONNECTIONS_QUERY, Monitoring
@@ -230,14 +230,17 @@ def missing_pids(doc_type):
 @api_blueprint.route("/redis")
 @check_authentication
 def redis():
-    """Displays redis info.
+    """Displays redis info for all configured instances.
 
-    :return: jsonified redis info.
+    :return: jsonified redis info keyed by instance name.
     """
-    url = current_app.config.get("ACCOUNTS_SESSION_REDIS_URL", "redis://localhost:6379")
-    redis = Redis.from_url(url)
-    info = redis.info()
-    return jsonify({"data": info})
+    data = {}
+    for name, client in current_app.extensions.get("rero_ils_redis_instances", {}).items():
+        try:
+            data[name] = {"name": name, **client.info()}
+        except RedisError:
+            data[name] = {"name": name, "status": "error"}
+    return jsonify({"data": data})
 
 
 @api_blueprint.route("/es")

--- a/rero_ils/modules/tasks.py
+++ b/rero_ils/modules/tasks.py
@@ -19,7 +19,6 @@
 """Celery tasks to index records."""
 
 from celery import shared_task
-from flask import current_app
 
 from .api import IlsRecordsIndexer
 from .utils import set_timestamp
@@ -30,8 +29,7 @@ def process_bulk_queue(version_type=None, queue=None, search_bulk_kwargs=None, s
     """Process bulk indexing queue.
 
     :param str version_type: Elasticsearch version type.
-    :param Queue queue: Queue to use.
-    :param str routing_key: Routing key to use.
+    :param str queue: Queue name to use (also used as routing key).
     :param dict search_bulk_kwargs: Passed to
         :func:`elasticsearch:elasticsearch.helpers.bulk`.
     :param boolean stats_only: if `True` only report number of
@@ -41,10 +39,7 @@ def process_bulk_queue(version_type=None, queue=None, search_bulk_kwargs=None, s
     """
     from .cli.index import connect_queue
 
-    connected_queue = None
-    if queue:
-        connection = current_app.extensions["invenio-celery"].celery.connection()
-        connected_queue = connect_queue(connection, queue)
+    connected_queue = connect_queue(name=queue) if queue else None
     indexer = IlsRecordsIndexer(version_type=version_type, queue=connected_queue, routing_key=queue)
     return indexer.process_bulk_queue(search_bulk_kwargs=search_bulk_kwargs, stats_only=stats_only)
 

--- a/tests/api/test_monitoring_rest.py
+++ b/tests/api/test_monitoring_rest.py
@@ -20,7 +20,9 @@
 
 import time
 
-from flask import url_for
+import pytest
+from flask import current_app, url_for
+from flask_security.utils import hash_password
 from invenio_access.models import ActionUsers
 from invenio_access.permissions import superuser_access
 from invenio_accounts.testutils import login_user_via_session
@@ -32,6 +34,21 @@ from rero_ils.modules.entities.remote_entities.api import (
 )
 from rero_ils.modules.utils import get_timestamp, set_timestamp
 from tests.utils import get_json
+
+
+@pytest.fixture()
+def monitoring_user(app, db, default_user_password):
+    """Create a user with the monitoring role."""
+    ds = app.extensions["invenio-accounts"].datastore
+    user = ds.create_user(
+        email="monitoring@rero.ch",
+        password=hash_password(default_user_password),
+        active=True,
+    )
+    role = ds.create_role(name="monitoring", description="Monitoring Group")
+    ds.add_role_to_user(user, role)
+    ds.commit()
+    return ds.get_user("monitoring@rero.ch")
 
 
 def test_monitoring_es_db_counts(client):
@@ -128,20 +145,30 @@ def test_monitoring_check_es_db_counts(app, client, entity_person_data, system_l
     }
 
 
-def test_timestamps(app, client):
+def test_monitoring_redis(client, monitoring_user):
+    """Test monitoring redis."""
+    res = client.get(url_for("api_monitoring.redis"))
+    assert res.status_code == 401
+
+    login_user_via_session(client, monitoring_user)
+
+    res = client.get(url_for("api_monitoring.redis"))
+    assert res.status_code == 200
+    data = get_json(res)["data"]
+    expected = set(current_app.extensions.get("rero_ils_redis_instances", {}).keys())
+    assert set(data.keys()) == expected
+    assert all("redis_version" in info for info in data.values())
+    assert all(info["name"] == name for name, info in data.items())
+
+
+def test_timestamps(client, monitoring_user):
     """Test timestamps."""
     time_stamp = set_timestamp("test", msg="test msg")
     assert get_timestamp("test") == {"time": time_stamp, "msg": "test msg"}
     res = client.get(url_for("api_monitoring.timestamps"))
     assert res.status_code == 401
 
-    ds = app.extensions["invenio-accounts"].datastore
-    user = ds.create_user(email="monitoring@rero.ch", password="1234", active=True)
-    role = ds.create_role(name="monitoring", description="Monitoring Group")
-    ds.add_role_to_user(user, role)
-    ds.commit()
-    user = ds.get_user("monitoring@rero.ch")
-    login_user_via_session(client, user)
+    login_user_via_session(client, monitoring_user)
     res = client.get(url_for("api_monitoring.timestamps"))
     assert res.status_code == 200
     assert get_json(res) == {


### PR DESCRIPTION
* upgrade RabbitMQ from 3.x to 4.2-management in docker-services.yml
* add healthcheck for mq service
* add CELERY_BROKER_HEARTBEAT=60 and CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP to detect stale connections
* add conn.ensure_connection() in process_bulk_queue to recover from dead pool connections after worker restarts
* remove unnecessary celery.connection() calls in tasks and cli/index; use unbound Queue instead to avoid connection leaks
* initialize all Redis clients once at app startup in ext.py via RERO_ILS_MONITORING_REDIS_INSTANCES config
* replace per-call Redis.from_url() in messages, imports and monitoring with app-level shared clients
* expose all configured Redis instances in monitoring API
* add test for /monitoring/redis endpoint