### PR TITLE
feat(sru): add result sets, record schema negotiation and CQL 1.2

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -4021,6 +4021,8 @@ RERO_INVENIO_BASE_EXPORT_REST_ENDPOINTS = dict(
 RERO_ILS_SRU_NUMBER_OF_RECORDS = 100
 # Maximum number of records which can be harvested with an request.
 RERO_ILS_SRU_MAXIMUM_RECORDS = 1000
+# Result set cache lifetime in seconds (0 disables result sets).
+RERO_ILS_SRU_RESULT_SET_TTL = 300
 
 # SIP2
 # ====

--- a/rero_ils/modules/documents/dojson/contrib/jsontodc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontodc/model.py
@@ -484,7 +484,7 @@ def json_to_identifiers(self, key, value):
 
     Output format:
 
-    - With source: "Type|Value(Source)" (e.g., "bf:Doi|10.1000/xyz(CrossRef)")
+    - With source: "Type|(Source)Value" (e.g., "bf:Doi|(CrossRef)10.1000/xyz")
     - Without source: "Type|Value" (e.g., "bf:Isbn|9781234567890")
 
     :param self: The Dublin Core record being built.
@@ -516,14 +516,14 @@ def json_to_identifiers(self, key, value):
             'source': 'CrossRef'
         }
         json_to_identifiers(dc, 'identifiedBy', value)
-        # Returns: 'bf:Doi|10.1000/xyz(CrossRef)'
+        # Returns: 'bf:Doi|(CrossRef)10.1000/xyz'
     """
     itype = value.get("type")
     identifier_value = value.get("value")
     if not itype or not identifier_value:
         return None
     if source := value.get("source"):
-        return f"{itype}|{identifier_value}({source})"
+        return f"{itype}|({source}){identifier_value}"
     return f"{itype}|{identifier_value}"
 
 

--- a/rero_ils/modules/documents/serializers/dc.py
+++ b/rero_ils/modules/documents/serializers/dc.py
@@ -29,6 +29,7 @@ from werkzeug.local import LocalProxy
 
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.dojson.contrib.jsontodc import dublincore
+from rero_ils.modules.sru.cql_parser import SRU_DC_SCHEMA_URI
 
 from ..dumpers import document_replace_refs_dumper
 from ..utils import process_i18n_literal_fields
@@ -166,17 +167,25 @@ class DublinCoreSerializer(_DublinCoreSerializer):
         """
         total = search_result["hits"]["total"]["value"]
         sru = search_result["hits"].get("sru", {})
+        operation = sru.get("operation")
         start_record = sru.get("start_record", 0)
         maximum_records = sru.get("maximum_records", 0)
         cql_query = sru.get("cql_query")
         search_query = sru.get("search_query")
-        next_record = start_record + maximum_records + 1
+        record_schema = sru.get("record_schema", SRU_DC_SCHEMA_URI)
+        result_set_id = sru.get("result_set_id")
+        result_set_ttl = sru.get("result_set_ttl", 0)
+        next_record = start_record + maximum_records
 
-        element = ElementMaker()
+        srw_ns = "http://www.loc.gov/zing/srw/"
+        element = ElementMaker(namespace=srw_ns, nsmap={"zs": srw_ns})
         xml_root = element.searchRetrieveResponse()
         if sru:
             xml_root.append(element.version("1.1"))
         xml_root.append(element.numberOfRecords(str(total)))
+        if result_set_id:
+            xml_root.append(element.resultSetId(result_set_id))
+            xml_root.append(element.resultSetIdleTime(str(result_set_ttl)))
         xml_records = element.records()
 
         language = request.args.get("ln", DEFAULT_LANGUAGE)
@@ -197,20 +206,24 @@ class DublinCoreSerializer(_DublinCoreSerializer):
                 attribs=self.container_attribs,
             )
             xml_records.append(element_record)
-        xml_root.append(xml_records)
+        if len(xml_records):
+            xml_root.append(xml_records)
 
         if sru:
+            if maximum_records > 0 and next_record <= total:
+                xml_root.append(element.nextRecordPosition(str(next_record)))
             echoed_search_rr = element.echoedSearchRetrieveRequest()
+            echoed_search_rr.append(element.version("1.1"))
+            if operation:
+                echoed_search_rr.append(element.operation(operation))
             if cql_query:
                 echoed_search_rr.append(element.query(cql_query))
             if search_query:
                 echoed_search_rr.append(element.search_query(search_query))
-            if start_record:
-                echoed_search_rr.append(element.startRecord(str(start_record)))
-            if next_record > 1 and next_record < total:
-                echoed_search_rr.append(element.nextRecordPosition(str(next_record)))
-            if maximum_records:
-                echoed_search_rr.append(element.maximumRecords(str(maximum_records)))
+            echoed_search_rr.append(element.startRecord(str(start_record)))
+            echoed_search_rr.append(element.maximumRecords(str(maximum_records)))
             echoed_search_rr.append(element.recordPacking("XML"))
+            echoed_search_rr.append(element.recordSchema(record_schema))
+            echoed_search_rr.append(element.resultSetTTL(str(result_set_ttl)))
             xml_root.append(echoed_search_rr)
         return etree.tostring(xml_root, encoding="utf-8", method="xml", pretty_print=True)

--- a/rero_ils/modules/documents/serializers/marc.py
+++ b/rero_ils/modules/documents/serializers/marc.py
@@ -34,6 +34,7 @@ from rero_ils.modules.documents.dojson.contrib.jsontomarc21.model import (
 )
 from rero_ils.modules.entities.remote_entities.api import RemoteEntitiesSearch
 from rero_ils.modules.serializers import JSONSerializer
+from rero_ils.modules.sru.cql_parser import SRU_MARCXML_SCHEMA_URI
 from rero_ils.modules.utils import strip_chars
 
 DEFAULT_LANGUAGE = LocalProxy(lambda: current_app.config.get("BABEL_DEFAULT_LANGUAGE"))
@@ -363,7 +364,7 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
         _ = xslt_filename  # intentionally unused; kept for API compatibility
         element = ElementMaker(namespace=self.MARC21_ZS, nsmap={"zs": self.MARC21_ZS})
 
-        def dump_record(record, idx):
+        def dump_record(record, idx, schema=SRU_MARCXML_SCHEMA_URI):
             """Serialize a single MARC record to SRU XML format.
 
             Converts a MARC record dictionary into an XML structure with:
@@ -374,6 +375,7 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             Args:
                 record (GroupableOrderedDict): MARC record with fields as keys.
                 idx (int): Record position in the result set (1-based).
+                schema (str): Canonical schema URI to embed in the record element.
 
             Returns:
                 lxml.etree.Element: SRU record element containing the MARC data.
@@ -381,8 +383,8 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             rec_element = ElementMaker(namespace=self.MARC21_REC, nsmap={prefix: self.MARC21_REC})
             data_element = ElementMaker(namespace=self.MARC21_REC, nsmap={prefix: self.MARC21_REC})
             rec = element.record()
+            rec.append(element.recordSchema(schema))
             rec.append(element.recordPacking("xml"))
-            rec.append(element.recordSchema("marcxml"))
 
             rec_record_data = element.recordData()
             rec_data = rec_element.record()
@@ -455,33 +457,41 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             root = dump_record(records, 1)
         else:
             number_of_records = total["value"]
+            operation = sru.get("operation")
             start_record = sru.get("start_record", 1)
             maximum_records = sru.get("maximum_records", 0)
             cql_query = sru.get("cql_query")
             search_query = sru.get("search_query")
+            record_schema = sru.get("record_schema", SRU_MARCXML_SCHEMA_URI)
+            result_set_id = sru.get("result_set_id")
+            result_set_ttl = sru.get("result_set_ttl", 0)
             next_record = start_record + maximum_records
             root = element.searchRetrieveResponse()
             root.append(element.version("1.1"))
             root.append(element.numberOfRecords(str(number_of_records)))
-            if next_record > 1 and next_record <= number_of_records:
-                root.append(element.nextRecordPosition(str(next_record)))
+            if result_set_id:
+                root.append(element.resultSetId(result_set_id))
+                root.append(element.resultSetIdleTime(str(result_set_ttl)))
             data = element.records()
             for idx, record in enumerate(records, start_record):
-                data.append(dump_record(record, idx))
-            root.append(data)
+                data.append(dump_record(record, idx, record_schema))
+            if len(data):
+                root.append(data)
+            if maximum_records > 0 and next_record <= number_of_records:
+                root.append(element.nextRecordPosition(str(next_record)))
             echoed_search_rr = element.echoedSearchRetrieveRequest()
             echoed_search_rr.append(element.version("1.1"))
+            if operation:
+                echoed_search_rr.append(element.operation(operation))
             if cql_query:
                 echoed_search_rr.append(element.query(cql_query))
             if search_query:
                 echoed_search_rr.append(element.search_query(search_query))
-            if start_record:
-                echoed_search_rr.append(element.startRecord(str(start_record)))
-            if maximum_records:
-                echoed_search_rr.append(element.maximumRecords(str(maximum_records)))
+            echoed_search_rr.append(element.startRecord(str(start_record)))
+            echoed_search_rr.append(element.maximumRecords(str(maximum_records)))
             echoed_search_rr.append(element.recordPacking("XML"))
-            echoed_search_rr.append(element.recordSchema("info:sru/schema/1/marcxml-v1.1-light"))
-            echoed_search_rr.append(element.resultSetTTL("0"))
+            echoed_search_rr.append(element.recordSchema(record_schema))
+            echoed_search_rr.append(element.resultSetTTL(str(result_set_ttl)))
             root.append(echoed_search_rr)
 
         # Needed if we use display with XSLT file.

--- a/rero_ils/modules/sru/cql_parser.py
+++ b/rero_ils/modules/sru/cql_parser.py
@@ -50,7 +50,6 @@ See Also:
     - SRU Standard: http://www.loc.gov/standards/sru/
 """
 
-from copy import deepcopy
 from io import StringIO
 from shlex import shlex
 
@@ -62,15 +61,29 @@ from ..utils import strip_chars
 SERVER_CHOICE_RELATION = "="
 SERVER_CHOICE_INDEX = "cql.serverchoice"
 
+#: Canonical SRU schema URI for MARC XML records.
+SRU_MARCXML_SCHEMA_URI = "info:srw/schema/1/marcxml-v1.1-light"
+
+#: Canonical SRU schema URI for Dublin Core records.
+SRU_DC_SCHEMA_URI = "info:srw/schema/1/dc-v1.1"
+
 ORDER = ["=", ">", ">=", "<", "<=", "<>"]
-MODIFIER_SEPERATOR = "/"
+MODIFIER_SEPARATOR = "/"
 BOOLEANS = ["and", "or", "not", "prox"]
 SORT_WORD = "sortby"
 
 RESERVED_PREFIXES = {
     "srw": "http://www.loc.gov/zing/cql/srw-indexes/v1.0/",
-    "cql": "info:srw/cql-context-set/1/cql-v1.1",
+    "cql": "info:srw/cql-context-set/1/cql-v1.2",
     "dc": "http://purl.org/dc/elements/1.1/",
+}
+
+#: Both CQL context set URIs that map to the built-in ``cql`` prefix.
+#: v1.1 is kept for backward compatibility with clients that declare
+#: ``>cql=info:srw/cql-context-set/1/cql-v1.1`` explicitly.
+CQL_CONTEXT_SET_URIS = {
+    "info:srw/cql-context-set/1/cql-v1.1",
+    "info:srw/cql-context-set/1/cql-v1.2",
 }
 
 XCQL_NAMESPACE = "http://www.loc.gov/zing/cql/xcql/"
@@ -97,8 +110,17 @@ SEARCH_SORT_MODIFIERS = {
     "sort.missingomit": "missingomit",
 }
 
-#: CQL sort index to search index sortable field mapping.
-#: Maps Dublin Core and custom indexes to search fields suitable for sorting.
+#: Maps missing-value CQL sort modifiers to ES ``missing`` values per sort order.
+#: Tuple layout: (asc_value, desc_value).
+#: "missingomit" is unsupported by ES and falls back to "_last" for both orders.
+_SORT_MISSING_MAP = {
+    "missinglow": ("_first", "_last"),
+    "missinghigh": ("_last", "_first"),
+    "missingomit": ("_last", "_last"),
+}
+
+#: CQL sort index to Elasticsearch sortable field mapping.
+#: Maps Dublin Core and custom indexes to ES fields suitable for sorting.
 #: These fields should be keyword type or have doc_values enabled for
 #: efficient sorting. Use '_relevance' to sort by search score.
 SEARCH_SORT_INDEX_MAPPINGS = {
@@ -106,9 +128,8 @@ SEARCH_SORT_INDEX_MAPPINGS = {
     "dc.date": "provisionActivity.startDate",
     "dc.creator": "facet_contribution_en",
     "dc.contributor": "facet_contribution_en",
-    "dc.publisher": "provisionActivity.statement.label.value.raw",
-    "dc.identifier": "identified_by.value.raw",
-    "dc.subject": "subject.entity.authorized_access_point.raw",
+    "dc.identifier": "identifiedBy.value.raw",
+    "dc.subject": "facet_subject_en",
     "dc.type": "type.main_type",
     "dc.language": "language.value",
     "_relevance": "_score",
@@ -178,27 +199,25 @@ SEARCH_INDEX_MAPPINGS = {
     "authorized_access_point",
     "dc.date": 'provisionActivity.type:"bf:Publication" AND provisionActivity.startDate',
     "dc.title": "title.\\*",
-    # TODO: description search also in: note.label, dissertation.label and
-    # supplementaryContent.description
-    "dc.description": "summary.label",
+    "dc.description": "(summary.label OR note.label OR dissertation.label OR supplementaryContent)",
     "dc.language": "language.value",
     "dc.publisher": 'provisionActivity.type:"bf:Publication" AND '
     'provisionActivity.statement.type:"bf:Agent" AND '
     "provisionActivity.statement.label.value",
     "dc.type": "type.main_type",
     "dc.subtype": "type.subtype",
-    "dc.identifier": "identified_by.value",
+    "dc.identifier": "identifiedBy.value",
     "dc.relation": "(issuedWith.label OR otherEdition.label OR "
     "otherPhysicalFormat.label OR precededBy.label OR relatedTo.label OR "
     "succeededBy.label OR supplement.label OR supplementTo.label)",
     "dc.coverage": "(temporalCoverage.date OR temporalCoverage.start_date OR "
-    "temporalCoverage.end_date OR subjects.entity.authorized_access_point)",
+    "temporalCoverage.end_date OR subjects.entity.authorized_access_point_\\*)",
     "dc.format": "(extent OR dimensions OR bookFormat OR duration OR "
     "contentMediaCarrier.contentType OR contentMediaCarrier.mediaType OR "
     "contentMediaCarrier.carrierType)",
     "dc.rights": "(usageAndAccessPolicy.label OR copyrightDate)",
     "dc.source": "adminMetadata.source",
-    "dc.subject": "subject.entity.authorized_access_point",
+    "dc.subject": "subjects.entity.authorized_access_point_\\*",
     "dc.organisation": "organisation_pid",
     "dc.library": "library_pid",
     "dc.location": "holdings.location.pid",
@@ -245,14 +264,12 @@ def _convert_sort_keys_to_search(sort_keys, query=""):
         # Get the index name
         index_name = str(sort_key).lower()
 
-        # Map to search sortable field
-        search_field = SEARCH_SORT_INDEX_MAPPINGS.get(index_name)
-        if not search_field:
-            # Try without prefix
-            search_field = SEARCH_SORT_INDEX_MAPPINGS.get(f"dc.{sort_key.value}")
-        if not search_field:
-            # Use the field as-is (might be a direct search field name)
-            search_field = index_name
+        # Map to ES sortable field; fall back to prefixed dc. form, then the raw index name
+        search_field = (
+            SEARCH_SORT_INDEX_MAPPINGS.get(index_name)
+            or SEARCH_SORT_INDEX_MAPPINGS.get(f"dc.{sort_key.value}")
+            or index_name
+        )
 
         # Default sort order is ascending
         order = "asc"
@@ -267,12 +284,7 @@ def _convert_sort_keys_to_search(sort_keys, query=""):
                 if "." in mod_type:
                     mod_type = mod_type.split(".")[-1]
                 if mod_type not in valid_sort_modifiers:
-                    diag = Diagnostic()
-                    diag.code = 21
-                    diag.message = "Unsupported sort modifier"
-                    diag.details = mod_type
-                    diag.query = query
-                    raise diag
+                    raise Diagnostic(code=21, message="Unsupported sort modifier", details=mod_type, query=query)
                 if mod_type == "descending":
                     order = "desc"
                 elif mod_type == "ascending":
@@ -280,14 +292,9 @@ def _convert_sort_keys_to_search(sort_keys, query=""):
                 elif mod_type in ("missinglow", "missinghigh", "missingomit"):
                     missing_pref = mod_type
 
-        if missing_pref == "missinglow":
-            missing = "_first" if order == "asc" else "_last"
-        elif missing_pref == "missinghigh":
-            missing = "_last" if order == "asc" else "_first"
-        elif missing_pref == "missingomit":
-            # NOTE: search doesn't support omitting docs with missing values in sort.
-            # Documents with missing values will be placed last instead.
-            missing = "_last"
+        if missing_pref in _SORT_MISSING_MAP:
+            asc_val, desc_val = _SORT_MISSING_MAP[missing_pref]
+            missing = asc_val if order == "asc" else desc_val
 
         # Build the sort specification
         if search_field == "_score":
@@ -380,15 +387,21 @@ class Diagnostic(Exception):
         echoed_search_rr.append(element_srw.query(self.query))
         echoed_search_rr.append(element_srw.recordPacking("xml"))
         self.xml_root.append(echoed_search_rr)
-        diagnostics = element_srw_diag.diagnostics()
-        diagnostics.append(element_srw_diag.uri(f"{self.uri}{self.code}"))
-        diagnostics.append(element_srw_diag.details(self.details))
-        diagnostics.append(element_srw_diag.message(f"{self.message}"))
+        diagnostics = element_srw.diagnostics()
+        diagnostic = element_srw_diag.diagnostic()
+        diagnostic.append(element_srw_diag.uri(f"{self.uri}{self.code}"))
+        diagnostic.append(element_srw_diag.details(self.details))
+        diagnostic.append(element_srw_diag.message(f"{self.message}"))
+        diagnostics.append(diagnostic)
         self.xml_root.append(diagnostics)
 
 
 class PrefixableObject:
-    """Root object for triple and searchClause."""
+    """Base class for CQL objects that carry prefix declarations.
+
+    Provides prefix registration and resolution, climbing the parent tree
+    until a match is found or the config is consulted.
+    """
 
     prefixes = {}
     parent = None
@@ -396,25 +409,36 @@ class PrefixableObject:
     error_on_duplicate_prefix = ERROR_ON_DUPLICATE_PREFIX
 
     def __init__(self, query):
-        """Constructor."""
+        """Initialise with the raw CQL query string for use in diagnostics.
+
+        :param query: The original CQL query string.
+        """
         self.prefixes = {}
         self.parent = None
         self.config = None
         self.query = query
 
     def add_prefix(self, name, identifier):
-        """Add prefix."""
+        """Register a CQL prefix-to-URI mapping on this object.
+
+        :param name: The prefix name (e.g. ``'dc'``).
+        :param identifier: The URI the prefix maps to.
+        :raises Diagnostic: code 45 if duplicate prefix detection is enabled
+            and the prefix is already declared.
+        """
         if self.error_on_duplicate_prefix and (name in self.prefixes or name in RESERVED_PREFIXES):
-            # Maybe error
-            diag = Diagnostic()
-            diag.code = 45
-            diag.details = name
-            diag.query = self.query
-            raise diag
+            raise Diagnostic(code=45, details=name, query=self.query)
         self.prefixes[name] = identifier
 
     def resolve_prefix(self, name):
-        """Resolve prefix."""
+        """Resolve a prefix name to its URI by climbing the parent tree.
+
+        Checks reserved prefixes first, then this object's local declarations,
+        then delegates upward to the parent, and finally to the config.
+
+        :param name: The prefix name to look up.
+        :returns: The URI string for the prefix, or ``None`` if not found.
+        """
         # Climb tree
         if name in RESERVED_PREFIXES:
             return RESERVED_PREFIXES[name]
@@ -426,7 +450,11 @@ class PrefixableObject:
 
 
 class PrefixedObject:
-    """Root object for index, relation, relationModifier."""
+    """Base class for CQL objects with an optional namespace prefix.
+
+    Handles the ``prefix.value`` dotted syntax, quoted identifier stripping,
+    and validation of multiple dots or a null indexset.
+    """
 
     prefix = ""
     prefix_uri = ""
@@ -434,7 +462,13 @@ class PrefixedObject:
     parent = None
 
     def __init__(self, val, query, error_on_quoted_identifier=ERROR_ON_QUOTED_IDENTIFIER):
-        """Constructor."""
+        """Parse ``val`` into a prefix and local name.
+
+        :param val: Raw token string (e.g. ``'dc.title'`` or ``'title'``).
+        :param query: Original CQL query string, used in diagnostics.
+        :param error_on_quoted_identifier: Raise diagnostic 14 when ``val`` is
+            a quoted string. Defaults to ``ERROR_ON_QUOTED_IDENTIFIER``.
+        """
         # All prefixed things are case insensitive
         self.error_on_quoted_identifier = error_on_quoted_identifier
         self.orig_value = val
@@ -442,11 +476,7 @@ class PrefixedObject:
         val = val.lower()
         if val and val[0] == '"' and val[-1] == '"':
             if self.error_on_quoted_identifier:
-                diag = Diagnostic()
-                diag.code = 14
-                diag.details = val
-                diag.query = self.query
-                raise diag
+                raise Diagnostic(code=14, details=val, query=self.query)
             val = val[1:-1]
         self.value = val
         self.split_value()
@@ -456,26 +486,27 @@ class PrefixedObject:
         return f"{self.prefix}.{self.value}" if self.prefix else f"{self.value}"
 
     def split_value(self):
-        """Split value."""
+        """Split a dotted value into prefix and local-name components.
+
+        :raises Diagnostic: code 15 on multiple dots or a leading dot (null indexset).
+        """
         find_point = self.value.find(".")
         if self.value.count(".") > 1:
-            diag = Diagnostic()
-            diag.code = 15
-            diag.details = f'Multiple "." characters: {self.value}'
-            diag.query = self.query
-            raise diag
+            raise Diagnostic(code=15, details=f'Multiple "." characters: {self.value}', query=self.query)
         if find_point == 0:
-            diag = Diagnostic()
-            diag.code = 15
-            diag.details = "Null indexset"
-            diag.query = self.query
-            raise diag
+            raise Diagnostic(code=15, details="Null indexset", query=self.query)
         if find_point >= 0:
             self.prefix = self.value[:find_point].lower()
             self.value = self.value[find_point + 1 :].lower()
 
     def resolve_prefix(self):
-        """Resolve prefix."""
+        """Resolve this object's prefix to its full URI.
+
+        Delegates to the parent's ``resolve_prefix`` and caches the result
+        in ``prefix_uri``.
+
+        :returns: The URI string for this object's prefix.
+        """
         if not self.prefix_uri:
             if isinstance(self.parent, PrefixedObject):
                 self.prefix_uri = self.parent.resolve_prefix()
@@ -485,18 +516,26 @@ class PrefixedObject:
 
 
 class ModifiableObject:
-    """Mofifiable object."""
+    """Mixin for CQL objects that accept modifier clauses (e.g. ``/relevant``)."""
 
-    def __init__(self):
-        """Constructor."""
-        self.modifiers = []
+    def __init__(self, modifiers=None):
+        """Initialise the modifiers list.
+
+        :param modifiers: Pre-parsed list of :class:`ModifierClause` objects,
+            or ``None`` to start with an empty list.
+        """
+        self.modifiers = modifiers or []
 
     def __getitem__(self, key):
-        """Get item."""
+        """Return a modifier by index or by type name.
+
+        :param key: Integer index, or a type-name string to match against.
+        :returns: The matching :class:`ModifierClause`, or ``None`` if not found.
+        """
         if isinstance(key, int):
             try:
                 return self.modifiers[key]
-            except Exception:
+            except IndexError:
                 return None
         return next(
             (modifier for modifier in self.modifiers if str(modifier.type) == key or modifier.type.value == key),
@@ -505,7 +544,7 @@ class ModifiableObject:
 
 
 class Triple(PrefixableObject):
-    """Object to represent a CQL triple."""
+    """CQL boolean combination of two operands (left op boolean right)."""
 
     left_operand = None
     right_operand = None
@@ -516,21 +555,13 @@ class Triple(PrefixableObject):
         """Create the search representation of the object."""
         boolean = self.boolean.to_search()
         if boolean == "prox":
-            diag = Diagnostic()
-            diag.code = 37
-            diag.message = "Unsupported boolean operator"
-            diag.details = "prox"
-            diag.query = self.query
-            raise diag
-        txt = [self.left_operand.to_search()]
-        if boolean == "not":
-            txt.append("AND")
-        else:
-            txt.append(boolean.upper())
-        txt.append(self.right_operand.to_search())
+            raise Diagnostic(code=37, message="Unsupported boolean operator", details="prox", query=self.query)
+        left = self.left_operand.to_search()
+        right = self.right_operand.to_search()
         # Sort keys are handled separately via get_search_sort()
-        pre = "NOT" if boolean == "not" else ""
-        return f"{pre}({' '.join(txt)})"
+        if boolean == "not":
+            return f"({left} AND NOT {right})"
+        return f"({left} {boolean.upper()} {right})"
 
     def get_search_sort(self):
         """Extract sort keys in search index format.
@@ -543,15 +574,21 @@ class Triple(PrefixableObject):
         return _convert_sort_keys_to_search(self.sort_keys, query=self.query)
 
     def get_result_set_id(self, top=None):
-        """Get result set id."""
-        if FULL_RESULT_SET_NAME_CHECK == 0 or self.boolean.value in ["not", "prox"]:
+        """Return the result set ID referenced by this query, or an empty string.
+
+        Recursively checks both operands. Returns the ID only when every leaf in
+        the tree references the same result set (the CQL 1.2 ``FULL_RESULT_SET_NAME_CHECK``
+        rule). Returns ``''`` for NOT/PROX booleans or when no result set is found.
+
+        :param top: Internal recursion sentinel; callers should omit this.
+        :returns: The result set ID string, or ``''`` if none is referenced.
+        """
+        if FULL_RESULT_SET_NAME_CHECK == 0 or self.boolean.value in ("not", "prox"):
             return ""
 
-        if top is None:
-            top_level = 1
+        is_top_level = top is None
+        if is_top_level:
             top = self
-        else:
-            top_level = 0
 
         # Iterate over operands and build a list
         rs_list = []
@@ -564,13 +601,13 @@ class Triple(PrefixableObject):
         else:
             rs_list.append(self.right_operand.get_result_set_id(top))
 
-        if top_level == 1:
+        if is_top_level:
             return rs_list[0] if len(rs_list) == rs_list.count(rs_list[0]) else ""
         return rs_list
 
 
 class SearchClause(PrefixableObject):
-    """Object to represent a CQL search clause."""
+    """CQL search clause: a single index/relation/term triplet."""
 
     index = None
     relation = None
@@ -578,7 +615,13 @@ class SearchClause(PrefixableObject):
     sort_keys = []
 
     def __init__(self, ind, rel, term, query):
-        """Constructor."""
+        """Construct a search clause from its parsed components.
+
+        :param ind: The :class:`Index` object.
+        :param rel: The :class:`Relation` object.
+        :param term: The :class:`Term` object.
+        :param query: Original CQL query string, used in diagnostics.
+        """
         PrefixableObject.__init__(self, query)
         self.index = ind
         self.relation = rel
@@ -592,7 +635,7 @@ class SearchClause(PrefixableObject):
 
         def index_term(index, relation, term):
             """Clean term."""
-            from .explaine import Explain
+            from .explain import Explain
 
             # try to map dc mappings
             index = SEARCH_INDEX_MAPPINGS.get(index.lower(), index)
@@ -630,12 +673,7 @@ class SearchClause(PrefixableObject):
             elif relation == "all":
                 text = f"({' AND '.join(texts)})"
             else:
-                diag = Diagnostic()
-                diag.code = 19
-                diag.message = "Unsupported relation"
-                diag.details = relation
-                diag.query = self.query
-                raise diag
+                raise Diagnostic(code=19, message="Unsupported relation", details=relation, query=self.query)
         # Sort keys are handled separately via get_search_sort()
         return text
 
@@ -650,143 +688,146 @@ class SearchClause(PrefixableObject):
         return _convert_sort_keys_to_search(self.sort_keys, query=self.query)
 
     def get_result_set_id(self, top=None):
-        """Get result set id."""
+        """Return the result set ID if this clause is ``cql.resultSetId = <id>``.
+
+        :param top: Internal recursion sentinel (matches :class:`Triple` interface).
+        :returns: The result set ID string, or ``''`` if this clause is not a
+            result set reference.
+        """
+        if self.relation.value not in ("=", "=="):
+            return ""
         idx = self.index
         idx.resolve_prefix()
-        if idx.prefix_uri == RESERVED_PREFIXES["cql"] and idx.value.lower() == "resultsetid":
-            return self.term.value
+        if idx.prefix_uri in CQL_CONTEXT_SET_URIS and idx.value.lower() == "resultsetid":
+            val = self.term.value
+            if len(val) >= 2 and val[0] == '"' and val[-1] == '"':
+                val = val[1:-1]
+            return val
         return ""
 
 
+def _collect_unsupported_modifiers(modifiers, supported_set):
+    """Return a list of unsupported modifier type strings from ``modifiers``.
+
+    Strips any ``prefix.`` component before checking membership. Modifiers in
+    ``UNSUPPORTED_RELATION_MODIFIERS`` include an explanatory note in parentheses.
+
+    :param modifiers: Iterable of :class:`ModifierClause` objects to check.
+    :param supported_set: Set of lower-case modifier type names that are allowed.
+    :returns: List of unsupported modifier description strings (empty if all valid).
+    """
+    unsupported = []
+    for modifier in modifiers:
+        mod_type = str(modifier.type).lower()
+        if "." in mod_type:
+            mod_type = mod_type.rsplit(".", 1)[-1]
+        if mod_type not in supported_set:
+            if mod_type in UNSUPPORTED_RELATION_MODIFIERS:
+                unsupported.append(f"{mod_type} ({UNSUPPORTED_RELATION_MODIFIERS[mod_type]})")
+            else:
+                unsupported.append(mod_type)
+    return unsupported
+
+
 class Index(PrefixedObject, ModifiableObject):
-    """Object to represent a CQL index."""
+    """CQL index name, optionally prefixed (e.g. ``dc.title``)."""
 
     def __init__(self, val, query):
-        """Constructor."""
+        """Construct an Index, rejecting reserved operator characters.
+
+        :param val: Raw index token string.
+        :param query: Original CQL query string, used in diagnostics.
+        :raises Diagnostic: code 10 when ``val`` is a parenthesis or relation operator.
+        """
         ModifiableObject.__init__(self)
         PrefixedObject.__init__(self, val, query)
-        if self.value in ["(", ")", *ORDER]:
-            diag = Diagnostic()
-            diag.message = "Invalid characters in index name"
-            diag.details = self.value
-            diag.query = self.query
-            raise diag
+        if self.value in ("(", ")", *ORDER):
+            raise Diagnostic(message="Invalid characters in index name", details=self.value, query=self.query)
 
     def to_search(self):
         """Create the search representation of the object."""
         if self.modifiers:
-            # Index modifiers are typically used for sorting (handled separately)
-            # Check for any unsupported modifiers
-            unsupported = []
-            for modifier in self.modifiers:
-                mod_type = str(modifier.type).lower()
-                if "." in mod_type:
-                    mod_type = mod_type.split(".")[-1]
-                # Sort modifiers are handled by get_search_sort()
-                if mod_type not in SEARCH_SORT_MODIFIERS and mod_type not in SUPPORTED_RELATION_MODIFIERS:
-                    if mod_type in UNSUPPORTED_RELATION_MODIFIERS:
-                        unsupported.append(f"{mod_type} ({UNSUPPORTED_RELATION_MODIFIERS[mod_type]})")
-                    else:
-                        unsupported.append(mod_type)
-            if unsupported:
-                diag = Diagnostic()
-                diag.code = 21
-                diag.message = "Unsupported index modifier(s)"
-                diag.details = ", ".join(unsupported)
-                diag.query = self.query
-                raise diag
+            # Sort modifiers are handled by get_search_sort(); check remaining ones.
+            supported = SEARCH_SORT_MODIFIERS.keys() | SUPPORTED_RELATION_MODIFIERS.keys()
+            if unsupported := _collect_unsupported_modifiers(self.modifiers, supported):
+                raise Diagnostic(
+                    code=21, message="Unsupported index modifier(s)", details=", ".join(unsupported), query=self.query
+                )
         return str(self)
 
 
 class Relation(PrefixedObject, ModifiableObject):
-    """Object to represent a CQL relation."""
+    """CQL relation operator (``=``, ``any``, ``all``, ``<``, etc.) with optional modifiers."""
 
-    def __init__(self, rel, query, mods=[]):
-        """Constructor."""
+    def __init__(self, rel, query, mods=None):
+        """Construct a Relation with optional modifiers.
+
+        :param rel: Raw relation token (e.g. ``'='``, ``'any'``).
+        :param query: Original CQL query string, used in diagnostics.
+        :param mods: Pre-parsed list of :class:`ModifierClause` objects.
+        """
         self.prefix = "cql"
+        ModifiableObject.__init__(self, mods)
         PrefixedObject.__init__(self, rel, query)
-        self.modifiers = mods
-        for mod in mods:
+        for mod in self.modifiers:
             mod.parent = self
 
     def to_search(self):
         """Create the search representation of the object."""
         if self.modifiers:
-            # Check if all modifiers are supported
-            unsupported = []
-            for modifier in self.modifiers:
-                mod_type = str(modifier.type).lower()
-                # Remove prefix if present (e.g., cql.relevant -> relevant)
-                if "." in mod_type:
-                    mod_type = mod_type.split(".")[-1]
-                if mod_type not in SUPPORTED_RELATION_MODIFIERS:
-                    if mod_type in UNSUPPORTED_RELATION_MODIFIERS:
-                        unsupported.append(f"{mod_type} ({UNSUPPORTED_RELATION_MODIFIERS[mod_type]})")
-                    else:
-                        unsupported.append(mod_type)
-            if unsupported:
-                diag = Diagnostic()
-                diag.code = 21
-                diag.message = "Unsupported relation modifier(s)"
-                diag.details = ", ".join(unsupported)
-                diag.query = self.query
-                raise diag
-            # Supported modifiers are acknowledged but don't change search query
-            # (search handles relevance, word matching, case insensitivity by default)
+            if unsupported := _collect_unsupported_modifiers(self.modifiers, SUPPORTED_RELATION_MODIFIERS):
+                raise Diagnostic(
+                    code=21,
+                    message="Unsupported relation modifier(s)",
+                    details=", ".join(unsupported),
+                    query=self.query,
+                )
+            # Supported modifiers are acknowledged but don't change the ES query
+            # (ES handles relevance, word matching, and case insensitivity by default)
         return self.value
 
 
 class Term:
-    """Term."""
+    """CQL search term, validated at construction time."""
 
     value = ""
 
     def __init__(self, value, query, error_on_empty_term=ERROR_ON_EMPTY_TERM):
-        """Constructor."""
+        """Construct and validate a CQL search term.
+
+        Raises diagnostics for reserved operator tokens, anchoring-only terms,
+        badly placed backslashes, and (optionally) empty terms.
+
+        :param value: Raw term string from the lexer.
+        :param query: Original CQL query string, used in diagnostics.
+        :param error_on_empty_term: Raise diagnostic 27 for empty terms.
+            Defaults to ``ERROR_ON_EMPTY_TERM``.
+        :raises Diagnostic: codes 25, 26, 27, or 32 for invalid term content.
+        """
         if value != "":
             # Unquoted literal
-            if value in [">=", "<=", ">", "<", "<>", "/", "="]:
-                diag = Diagnostic()
-                diag.code = 25
-                diag.details = value
-                diag.query = query
-                raise diag
+            if value in (">=", "<=", ">", "<", "<>", "/", "="):
+                raise Diagnostic(code=25, details=value, query=query)
 
-            nonanchar = next((1 for char in value if char != "^"), 0)
-            if not nonanchar:
-                diag = Diagnostic()
-                diag.code = 32
-                diag.details = f"Only anchoring charater(s) in term: {value}"
-                diag.query = query
-                raise diag
+            if not any(char != "^" for char in value):
+                raise Diagnostic(code=32, details=f"Only anchoring character(s) in term: {value}", query=query)
 
             # Unescape quotes
             # if (value[0] == '"' and value[-1] == '"'):
             #     value = value[1:-1]
             # value = value.replace('\\"', '"')
 
-            # Check for badly placed \s
-            startidx = 0
-            idx = value.find("\\", startidx)
-            while idx > -1:
-                if len(value) < idx + 2 or value[idx + 1] not in [
-                    "?",
-                    "\\",
-                    "*",
-                    "^",
-                ]:
-                    diag = Diagnostic()
-                    diag.code = 26
-                    diag.details = value
-                    diag.query = query
-                    raise diag
-                startidx = idx + 2 if value[idx + 1] == "\\" else idx + 1
-                idx = value.find("\\", startidx)
+            # Check for badly placed backslashes
+            idx = 0
+            while True:
+                idx = value.find("\\", idx)
+                if idx == -1:
+                    break
+                if idx + 1 >= len(value) or value[idx + 1] not in ("?", "\\", "*", "^"):
+                    raise Diagnostic(code=26, details=value, query=query)
+                idx += 2 if value[idx + 1] == "\\" else 1
         elif error_on_empty_term:
-            diag = Diagnostic()
-            diag.code = 27
-            diag.query = query
-            raise diag
+            raise Diagnostic(code=27, query=query)
         self.value = value
 
     def __str__(self):
@@ -799,36 +840,41 @@ class Term:
 
 
 class Boolean(ModifiableObject):
-    """Object to represent a CQL boolean."""
+    """CQL boolean operator (``and``, ``or``, ``not``, ``prox``) with optional modifiers."""
 
     value = ""
     parent = None
 
-    def __init__(self, bool_value, query, mods=[]):
-        """Constructor."""
+    def __init__(self, bool_value, query, mods=None):
+        """Construct a Boolean operator with optional modifiers.
+
+        :param bool_value: Boolean keyword (``'and'``, ``'or'``, ``'not'``, ``'prox'``).
+        :param query: Original CQL query string, used in diagnostics.
+        :param mods: Pre-parsed list of :class:`ModifierClause` objects.
+        """
+        ModifiableObject.__init__(self, mods)
         self.value = bool_value
-        self.modifiers = mods
         self.parent = None
         self.query = query
 
     def to_search(self):
         """Create the search representation of the object."""
         if self.modifiers:
-            diag = Diagnostic()
-            diag.code = 21
-            diag.message = "Unsupported boolean modifier(s)"
-            diag.details = ", ".join(str(m.type) for m in self.modifiers)
-            diag.query = self.query
-            raise diag
+            raise Diagnostic(
+                code=21,
+                message="Unsupported boolean modifier(s)",
+                details=", ".join(str(m.type) for m in self.modifiers),
+                query=self.query,
+            )
         return f"{self.value}"
 
     def resolve_prefix(self, name):
-        """Resolve prefix."""
+        """Resolve a prefix by delegating to the parent :class:`Triple`."""
         return self.parent.resolve_prefix(name)
 
 
 class ModifierTypeType(PrefixedObject):
-    """Modifier type."""
+    """CQL modifier type name, parsed as a prefixed object."""
 
     # Same as index, but we'll XCQLify in ModifierClause
     parent = None
@@ -836,7 +882,7 @@ class ModifierTypeType(PrefixedObject):
 
 
 class ModifierClause:
-    """Object to represent a relation modifier."""
+    """A single slash-separated CQL modifier (e.g. ``/relevant`` or ``/sort.ascending``)."""
 
     parent = None
     type = None
@@ -844,7 +890,13 @@ class ModifierClause:
     value = ""
 
     def __init__(self, modifier_type, comp="", val="", query=""):
-        """Constructor."""
+        """Construct a modifier clause.
+
+        :param modifier_type: The modifier type string (e.g. ``'relevant'``, ``'descending'``).
+        :param comp: Optional comparison operator (``'='``, ``'<'``, etc.).
+        :param val: Optional modifier value.
+        :param query: Original CQL query string, used in diagnostics.
+        """
         self.type = ModifierType(modifier_type, query)
         self.type.parent = self
         self.comparison = comp
@@ -857,11 +909,11 @@ class ModifierClause:
         return f"{self.type}"
 
     def to_search(self):
-        """Create the search representation of the object."""
+        """Return self; modifier clauses are consumed directly by their parent objects."""
         return self
 
     def resolve_prefix(self, name):
-        """Resolve prefix."""
+        """Resolve a prefix by skipping the immediate parent (boolean/relation) and delegating up."""
         # Need to skip parent, which has its own resolve_prefix
         # eg boolean or relation, neither of which is prefixable
         return self.parent.parent.resolve_prefix(name)
@@ -877,122 +929,154 @@ class CQLshlex(shlex):
     next_token = ""
 
     def __init__(self, thing, query):
-        """Constructor."""
+        """Set up the CQL lexer with extended word characters for CQL syntax.
+
+        :param thing: File-like object to read tokens from.
+        :param query: Original CQL query string, stored for use in diagnostics.
+        """
         shlex.__init__(self, thing)
         self.wordchars += "!@#$%^&*-+{}[];,.?|~`:\\"
         self.query = query
 
     def read_token(self):
         """Read a token from the input stream (no pushback or inclusions)."""
-        while 1:
-            if self.next_token != "":
+        while True:
+            if self.next_token:
                 self.token = self.next_token
                 self.next_token = ""
-                # Bah. SUPER ugly non portable
                 if self.token == "/":
                     self.state = " "
                     break
 
             nextchar = self.instream.read(1)
             if nextchar == "\n":
-                self.lineno = self.lineno + 1
+                self.lineno += 1
 
             if self.state is None:
                 self.token = ""  # past end of file
                 break
             if self.state == " ":
-                if not nextchar:
-                    self.state = None  # end of file
-                    break
-                if nextchar in self.whitespace:
-                    if self.token:
-                        break  # emit current token
-                    continue
-                if nextchar in self.commenters:
-                    self.instream.readline()
-                    self.lineno = self.lineno + 1
-                elif nextchar in self.wordchars:
-                    self.token = nextchar
-                    self.state = "a"
-                elif nextchar in self.quotes:
-                    self.token = nextchar
-                    self.state = nextchar
-                elif nextchar in ["<", ">"]:
-                    self.token = nextchar
-                    self.state = "<"
-                else:
-                    self.token = nextchar
-                    if self.token:
-                        break  # emit current token
-                    continue
+                done = self._read_token_space(nextchar)
             elif self.state == "<":
-                # Only accumulate <=, >= or <>
-                if self.token == ">" and nextchar == "=":
-                    self.token = self.token + nextchar
-                    self.state = " "
-                    break
-                if self.token == "<" and nextchar in [">", "="]:
-                    self.token = self.token + nextchar
-                    self.state = " "
-                    break
-                if not nextchar:
-                    self.state = None
-                    break
-                if nextchar == "/":
-                    self.state = "/"
-                    self.next_token = "/"
-                    break
-                if nextchar in self.wordchars:
-                    self.state = "a"
-                    self.next_token = nextchar
-                    break
-                if nextchar in self.quotes:
-                    self.state = nextchar
-                    self.next_token = nextchar
-                    break
-                self.state = " "
+                done = self._read_token_angle(nextchar)
+            elif self.state in self.quotes:
+                done = self._read_token_quote(nextchar)
+            elif self.state == "a":
+                done = self._read_token_word(nextchar)
+            else:
+                done = False
+            if done:
                 break
 
-            elif self.state in self.quotes:
-                self.token = self.token + nextchar
-                # Allow escaped quotes
-                if nextchar == self.state and self.token[-2] != "\\":
-                    self.state = " "
-                    break
-                if not nextchar:  # end of file
-                    # Override SHLEX's ValueError to throw diagnostic
-                    diag = Diagnostic()
-                    diag.details = self.token[:-1]
-                    diag.query = self.query
-                    raise diag
-            elif self.state == "a":
-                if not nextchar:
-                    self.state = None  # end of file
-                    break
-                if nextchar in self.whitespace:
-                    self.state = " "
-                    if self.token:
-                        break  # emit current token
-                    continue
-                if nextchar in self.commenters:
-                    self.instream.readline()
-                    self.lineno = self.lineno + 1
-                elif ord(nextchar) > 126 or nextchar in self.wordchars or nextchar in self.quotes:
-                    self.token = self.token + nextchar
-                elif nextchar in [">", "<"]:
-                    self.next_token = nextchar
-                    self.state = "<"
-                    break
-                else:
-                    self.push_token(nextchar)
-                    # self.pushback = [nextchar] + self.pushback
-                    self.state = " "
-                    if self.token:
-                        break  # emit current token
-                    continue
         result = self.token
         self.token = ""
         return result
+
+    def _read_token_space(self, nextchar):
+        """Handle space state: scanning between tokens.
+
+        :param nextchar: The next character read from the input stream.
+        :returns: True if a token boundary was reached, False otherwise.
+        :rtype: bool
+        """
+        if not nextchar:
+            self.state = None
+            return True
+        if nextchar in self.whitespace:
+            return bool(self.token)
+        if nextchar in self.commenters:
+            self.instream.readline()
+            self.lineno += 1
+        elif nextchar in self.wordchars:
+            self.token = nextchar
+            self.state = "a"
+        elif nextchar in self.quotes:
+            self.token = nextchar
+            self.state = nextchar
+        elif nextchar in ["<", ">"]:
+            self.token = nextchar
+            self.state = "<"
+        else:
+            self.token = nextchar
+            return bool(self.token)
+        return False
+
+    def _read_token_angle(self, nextchar):
+        """Handle angle-bracket state: accumulating <=, >= or <>.
+
+        :param nextchar: The next character read from the input stream.
+        :returns: Always True — any character ends this state.
+        :rtype: bool
+        """
+        if self.token == ">" and nextchar == "=":
+            self.token += nextchar
+            self.state = " "
+            return True
+        if self.token == "<" and nextchar in [">", "="]:
+            self.token += nextchar
+            self.state = " "
+            return True
+        if not nextchar:
+            self.state = None
+            return True
+        if nextchar == "/":
+            self.state = "/"
+            self.next_token = "/"
+            return True
+        if nextchar in self.wordchars:
+            self.state = "a"
+            self.next_token = nextchar
+            return True
+        if nextchar in self.quotes:
+            self.state = nextchar
+            self.next_token = nextchar
+            return True
+        self.state = " "
+        return True
+
+    def _read_token_quote(self, nextchar):
+        """Handle quoted-string state: accumulating until the closing quote.
+
+        :param nextchar: The next character read from the input stream.
+        :returns: True if the closing quote was found, False otherwise.
+        :rtype: bool
+        :raises Diagnostic: If end of file is reached inside a quoted string.
+        """
+        self.token += nextchar
+        if nextchar == self.state and self.token[-2] != "\\":
+            self.state = " "
+            return True
+        if not nextchar:
+            raise Diagnostic(details=self.token[:-1], query=self.query)
+        return False
+
+    def _read_token_word(self, nextchar):
+        """Handle word state: accumulating an unquoted token.
+
+        :param nextchar: The next character read from the input stream.
+        :returns: True if a token boundary was reached, False otherwise.
+        :rtype: bool
+        """
+        if not nextchar:
+            self.state = None
+            return True
+        if nextchar in self.whitespace:
+            self.state = " "
+            return bool(self.token)
+        if nextchar in self.commenters:
+            self.instream.readline()
+            self.lineno += 1
+        elif ord(nextchar) > 126 or nextchar in self.wordchars or nextchar in self.quotes:
+            self.token += nextchar
+        elif nextchar in [">", "<"]:
+            self.next_token = nextchar
+            self.state = "<"
+            return True
+        else:
+            self.push_token(nextchar)
+            self.state = " "
+            return bool(self.token)
+        return False
 
 
 class CQLParser:
@@ -1010,12 +1094,12 @@ class CQLParser:
 
     @staticmethod
     def is_sort(token):
-        """Is sort."""
+        """Return ``True`` if ``token`` is the ``sortBy`` keyword."""
         return token.lower() == SORT_WORD
 
     @staticmethod
     def is_boolean(token):
-        """Is the token a boolean."""
+        """Return ``True`` if ``token`` is a CQL boolean keyword."""
         token = token.lower()
         return token in BOOLEANS
 
@@ -1025,7 +1109,10 @@ class CQLParser:
         self.next_token = self.parser.get_token()
 
     def prefixes(self):
-        """Create prefixes dictionary."""
+        """Parse all ``>prefix=uri`` declarations at the current position.
+
+        :returns: Dict mapping prefix names to URI strings.
+        """
         prefs = {}
         while self.current_token == ">":
             # Strip off maps
@@ -1050,10 +1137,15 @@ class CQLParser:
         return prefs
 
     def query(self):
-        """Parse query."""
+        """Parse a complete CQL query and return a :class:`Triple` or :class:`SearchClause`.
+
+        Handles prefix declarations, boolean combinations, and ``sortBy`` clauses.
+
+        :returns: The parsed query root object.
+        """
         prefs = self.prefixes()
         left = self.sub_query()
-        while 1 and self.current_token:
+        while self.current_token:
             if self.is_boolean(self.current_token):
                 boolobject = self.boolean()
                 right = self.sub_query()
@@ -1076,16 +1168,16 @@ class CQLParser:
         return left
 
     def sort_query(self):
-        """Sort query."""
+        """Parse sort key specifications following the ``sortBy`` keyword.
+
+        :returns: List of :class:`Index` objects representing the sort keys.
+        :raises Diagnostic: code 10 when no sort keys follow ``sortBy``.
+        """
         # current is 'sort' reserved word
         self.fetch_token()
         keys = []
         if not self.current_token:
-            # trailing sort with no keys
-            diag = Diagnostic()
-            diag.message = "No sort keys supplied"
-            diag.query = self.parser.query
-            raise diag
+            raise Diagnostic(message="No sort keys supplied", query=self.parser.query)
         while self.current_token and self.current_token != ")":
             index = IndexerType(self.current_token, self.parser.query)
             self.fetch_token()
@@ -1094,17 +1186,17 @@ class CQLParser:
         return keys
 
     def sub_query(self):
-        """Find either query or clause."""
+        """Parse a parenthesised sub-query, a prefix block, or a plain search clause.
+
+        :returns: Parsed :class:`Triple` or :class:`SearchClause`.
+        """
         if self.current_token == "(":
             self.fetch_token()  # Skip (
             query = self.query()
             if self.current_token == ")":
                 self.fetch_token()  # Skip )
             else:
-                diag = Diagnostic()
-                diag.details = self.current_token
-                diag.query = self.parser.query
-                raise diag
+                raise Diagnostic(details=self.current_token, query=self.parser.query)
         elif prefs := self.prefixes():
             query = self.query()
             for key, value in prefs.items():
@@ -1114,13 +1206,16 @@ class CQLParser:
         return query
 
     def clause(self):
-        """Find searchClause."""
+        """Parse a search clause (index, relation, and term) or a server-choice clause.
+
+        :returns: A :class:`SearchClause` object.
+        """
         is_boolean = self.is_boolean(self.next_token)
         sort = self.is_sort(self.next_token)
         if not sort and not is_boolean and self.next_token not in [")", "(", ""]:
             irt = self._parse_index_clause()
         elif self.current_token and (is_boolean or sort or self.next_token in [")", ""]):
-            irt = RelatioSearchClauseType(
+            irt = SearchClauseType(
                 IndexerType(SERVER_CHOICE_INDEX, self.parser.query),
                 RelationType(SERVER_CHOICE_RELATION, self.parser.query),
                 TermType(self.current_token, self.parser.query),
@@ -1136,11 +1231,10 @@ class CQLParser:
             return clause
 
         else:
-            diag = Diagnostic()
-            token = self.current_token
-            diag.details = f"Expected Boolean or Relation but got: {token}"
-            diag.query = self.parser.query
-            raise diag
+            raise Diagnostic(
+                details=f"Expected Boolean or Relation but got: {self.current_token}",
+                query=self.parser.query,
+            )
         return irt
 
     def _parse_index_clause(self):
@@ -1148,26 +1242,23 @@ class CQLParser:
         self.fetch_token()  # Skip Index
         relation = self.relation()
         if self.current_token == "":
-            diag = Diagnostic()
-            diag.details = "Expected Term, got end of query."
-            diag.query = self.parser.query
-            raise diag
+            raise Diagnostic(details="Expected Term, got end of query.", query=self.parser.query)
         term = TermType(self.current_token, self.parser.query)
         self.fetch_token()  # Skip Term
-        return RelatioSearchClauseType(index, relation, term, self.parser.query)
+        return SearchClauseType(index, relation, term, self.parser.query)
 
     def modifiers(self):
-        """Modifiers."""
+        """Parse zero or more slash-separated modifier clauses at the current position.
+
+        :returns: List of :class:`ModifierClause` objects.
+        """
         mods = []
-        while self.current_token == MODIFIER_SEPERATOR:
+        while self.current_token == MODIFIER_SEPARATOR:
             self.fetch_token()
             mod = self.current_token
             mod = mod.lower()
-            if mod == MODIFIER_SEPERATOR:
-                diag = Diagnostic()
-                diag.details = "Null modifier"
-                diag.query = self.parser.query
-                raise diag
+            if mod == MODIFIER_SEPARATOR:
+                raise Diagnostic(details="Null modifier", query=self.parser.query)
             self.fetch_token()
             comp = self.current_token
             if comp in ORDER:
@@ -1181,23 +1272,26 @@ class CQLParser:
         return mods
 
     def boolean(self):
-        """Find boolean."""
+        """Parse a boolean operator and any attached modifiers.
+
+        :returns: A :class:`Boolean` object.
+        :raises Diagnostic: code 10 if the current token is not a valid boolean.
+        """
         self.current_token = self.current_token.lower()
-        if self.current_token in BOOLEANS:
-            bool_type = BooleanType(self.current_token, self.parser.query)
-            self.fetch_token()
-            bool_type.modifiers = self.modifiers()
-            for modifier in bool_type.modifiers:
-                modifier.parent = bool_type
-        else:
-            diag = Diagnostic()
-            diag.details = self.current_token
-            diag.query = self.parser.query
-            raise diag
+        if self.current_token not in BOOLEANS:
+            raise Diagnostic(details=self.current_token, query=self.parser.query)
+        bool_type = BooleanType(self.current_token, self.parser.query)
+        self.fetch_token()
+        bool_type.modifiers = self.modifiers()
+        for modifier in bool_type.modifiers:
+            modifier.parent = bool_type
         return bool_type
 
     def relation(self):
-        """Find relation."""
+        """Parse a relation operator and any attached modifiers.
+
+        :returns: A :class:`Relation` object.
+        """
         self.current_token = self.current_token.lower()
         relation = RelationType(self.current_token, self.parser.query)
         self.fetch_token()
@@ -1208,31 +1302,26 @@ class CQLParser:
 
 
 def parse(query):
-    """Return a searchClause/triple object from CQL string."""
+    """Parse a CQL query string and return a :class:`Triple` or :class:`SearchClause`.
+
+    :param query: CQL query string to parse.
+    :returns: Parsed :class:`Triple` or :class:`SearchClause` object.
+    :raises Diagnostic: on any parse error.
+    """
     query = strip_chars(query)
-    query_orig = deepcopy(query)
-    query_io_string = StringIO(query)
-    lexer = CQLshlex(query_io_string, query)
+    lexer = CQLshlex(StringIO(query), query)
     parser = CQLParser(lexer)
-    query = parser.query()
+    result = parser.query()
     if parser.current_token != "":
-        diag = Diagnostic()
-        diag.code = 10
-        current_token = repr(parser.current_token)
-        diag.details = f"Unprocessed tokens remain: {current_token}"
-        diag.query = query_orig
-        raise diag
-    del lexer
-    del parser
-    del query_io_string
-    return query
+        raise Diagnostic(code=10, details=f"Unprocessed tokens remain: {parser.current_token!r}", query=query)
+    return result
 
 
 # Assign our objects to generate
 TripleType = Triple
 BooleanType = Boolean
 RelationType = Relation
-RelatioSearchClauseType = SearchClause
+SearchClauseType = SearchClause
 ModifierClauseType = ModifierClause
 ModifierType = ModifierTypeType
 IndexerType = Index

--- a/rero_ils/modules/sru/explain.py
+++ b/rero_ils/modules/sru/explain.py
@@ -30,7 +30,7 @@ See Also:
     - Z39.50 Explain DTD 2.1: http://explain.z3950.org/dtd/2.1/
 """
 
-from functools import cache
+from weakref import WeakKeyDictionary
 
 import jsonref
 from flask import current_app
@@ -39,44 +39,56 @@ from lxml import etree
 from lxml.builder import ElementMaker
 
 from ..utils import get_schema_for_resource
-from .cql_parser import SEARCH_INDEX_MAPPINGS
+from .cql_parser import SEARCH_INDEX_MAPPINGS, SRU_DC_SCHEMA_URI, SRU_MARCXML_SCHEMA_URI
+
+#: Per-app ES mapping cache. Keyed by Flask app instance so each app gets its
+#: own cache and entries are collected when the app is destroyed.
+_es_mappings_cache: WeakKeyDictionary = WeakKeyDictionary()
 
 
 def _get_properties(data):
     """Recursively extract searchable field paths from search mapping properties."""
     keys = []
     for key, value in data.items():
-        if isinstance(value, dict):
-            if properties := value.get("properties"):
-                sub_keys = _get_properties(properties)
-                for sub_key in sub_keys:
-                    first_segment = sub_key.split(".")[0]
-                    if ("." in sub_key and sub_key[0] != "$") or properties.get(first_segment, {}).get("index", True):
-                        keys.append(".".join([key, sub_key]))
-            elif key[0] != "$" and value.get("index", True):
-                keys.append(key)
+        if not isinstance(value, dict):
+            continue
+        if properties := value.get("properties"):
+            for sub_key in _get_properties(properties):
+                first_segment = sub_key.split(".")[0]
+                is_compound = "." in sub_key and sub_key[0] != "$"
+                first_is_indexed = properties.get(first_segment, {}).get("index", True)
+                if is_compound or first_is_indexed:
+                    keys.append(f"{key}.{sub_key}")
+        elif key[0] != "$" and value.get("index", True):
+            keys.append(key)
     return keys
 
 
-@cache
 def _get_search_mappings(index):
-    """Load and cache field mappings from the search index definition.
+    """Load and cache field mappings from the Elasticsearch index definition.
 
-    :param index: The search index alias name.
-    :type index: str
-    :returns: Mapping of normalized index names to search field paths.
-    :rtype: dict
+    Results are cached per Flask application instance so the cache is isolated
+    between apps (e.g. in tests) and is collected when the app is destroyed.
+
+    :param index: The Elasticsearch index alias name.
+    :returns: Mapping of normalized index names to ES field paths.
     """
+    app = current_app._get_current_object()
+    app_cache = _es_mappings_cache.setdefault(app, {})
+    if index in app_cache:
+        return app_cache[index]
+    result = {}
     try:
         index_alias = current_search.aliases.get(index)
         index_file_name = next(iter(index_alias.values()))
         with open(index_file_name, encoding="utf-8") as f:
             data = jsonref.load(f)
         if properties := data.get("mappings", {}).get("properties", {}):
-            return {field.lower().replace(".", "__"): field for field in _get_properties(properties)}
+            result = {field.lower().replace(".", "__"): field for field in _get_properties(properties)}
     except Exception:
-        current_app.logger.debug("Failed to load search mappings for index: %s", index, exc_info=True)
-    return {}
+        current_app.logger.debug("Failed to load Search mappings for index: %s", index, exc_info=True)
+    app_cache[index] = result
+    return result
 
 
 class Explain:
@@ -104,10 +116,9 @@ class Explain:
     def __init__(self, database, doc_type="doc"):
         """Initialize the Explain response generator.
 
-        Args:
-            database: The SRU database path used in the serverInfo element.
-            doc_type: Document type key for looking up the search index
-                in RECORDS_REST_ENDPOINTS configuration. Defaults to 'doc'.
+        :param database: The SRU database path used in the serverInfo element.
+        :param doc_type: Document type key for looking up the Elasticsearch index
+            in RECORDS_REST_ENDPOINTS configuration. Defaults to ``'doc'``.
         """
         self.database = database
         self.number_of_records = current_app.config.get("RERO_ILS_SRU_NUMBER_OF_RECORDS", 100)
@@ -120,8 +131,7 @@ class Explain:
     def __str__(self):
         """Return the Explain response as a formatted XML string.
 
-        Returns:
-            A pretty-printed XML string representation of the Explain response.
+        :returns: Pretty-printed XML string representation of the Explain response.
         """
         return etree.tostring(self.xml_root, pretty_print=True).decode()
 
@@ -136,9 +146,10 @@ class Explain:
             - recordSchema
             - recordData
               - explain
-                - serverInfo (protocol, host, database)
-                - indexInfo (DC indexes + search field indexes)
-                - schemaInfo (JSON schema reference)
+                - serverInfo (protocol, host, database, authentication)
+                - databaseInfo (title, contact, implementation)
+                - indexInfo (set declarations + DC indexes + search field indexes)
+                - schemaInfo (supported retrieval schemas)
                 - configInfo (default/maximum records settings)
         """
         sru_ns = "http://www.loc.gov/standards/sru/"
@@ -158,16 +169,21 @@ class Explain:
             {
                 "protocol": "SRU",
                 "version": "1.1",
-                "transport": current_app.config.get("RERO_ILS_URL_SCHEME"),
+                "transport": current_app.config.get("RERO_ILS_URL_SCHEME", "https"),
                 "method": "GET",
             }
         )
-        server_info.append(element_zr.host(current_app.config.get("RERO_ILS_HOST")))
-        # server_info.append(element_zr.port('5000'))
+        server_info.append(element_zr.host(current_app.config.get("RERO_ILS_HOST", "localhost")))
         server_info.append(element_zr.database(self.database))
+        server_info.append(element_zr.authentication({"type": "open"}))
         explain.append(server_info)
 
+        explain.append(self.init_database_info(element_zr))
+
+        rero_ils_ns = get_schema_for_resource("doc")
         index_info = element_zr.indexInfo()
+        index_info.append(element_zr.set({"identifier": "info:srw/cql-context-set/1/dc-v1.1", "name": "dc"}))
+        index_info.append(element_zr.set({"identifier": rero_ils_ns, "name": "rero-ils"}))
         index_info.append(self.init_index_info_dc())
         index_info.append(self.init_index_info())
         explain.append(index_info)
@@ -179,14 +195,32 @@ class Explain:
         record.append(record_data)
         self.xml_root.append(record)
 
+    def init_database_info(self, element):
+        """Create the database information element.
+
+        Includes a human-readable title, contact address, and implementation
+        block so SRU clients can identify the server software.
+
+        :param element: The ElementMaker instance for creating XML elements.
+        :returns: A ``databaseInfo`` lxml Element.
+        """
+        db_info = element.databaseInfo()
+        title = current_app.config.get("RERO_ILS_SRU_DATABASE_TITLE", "RERO ILS Document Search")
+        db_info.append(element.title(title, {"lang": "en", "primary": "true"}))
+        if contact := current_app.config.get("RERO_ILS_SRU_CONTACT", ""):
+            db_info.append(element.contact(contact))
+        impl = element.implementation({"version": "1.0", "identifier": "https://github.com/rero/rero-ils"})
+        impl.append(element.title("RERO ILS"))
+        db_info.append(impl)
+        return db_info
+
     def init_index_info_dc(self):
         """Create the Dublin Core index information element.
 
         Generates an XML element listing all supported Dublin Core indexes
         from the SEARCH_INDEX_MAPPINGS configuration.
 
-        Returns:
-            An lxml Element containing the DC index map with all supported
+        :returns: lxml Element containing the DC index map with all supported
             Dublin Core search indexes (title, creator, subject, etc.).
         """
         dc_ns = "info:srw/cql-context-set/1/dc-v1.1"
@@ -204,8 +238,7 @@ class Explain:
         Generates an XML element listing all search index field indexes
         available for searching, using the RERO-ILS namespace.
 
-        Returns:
-            An lxml Element containing the index map with all search field paths
+        :returns: lxml Element containing the index map with all search field paths
             that can be used directly in CQL queries.
         """
         rero_ils_ns = get_schema_for_resource("doc")
@@ -218,18 +251,18 @@ class Explain:
         return index
 
     def init_schema_info(self, element):
-        """Create the schema information element.
+        """Create the schema information element listing supported retrieval schemas.
 
-        Args:
-            element: The ElementMaker instance for creating XML elements.
-
-        Returns:
-            An lxml Element containing schema information with the JSON
-            schema identifier for the document resource.
+        :param element: The ElementMaker instance for creating XML elements.
+        :returns: A ``schemaInfo`` lxml Element with one ``schema`` child per
+            supported retrieval schema.
         """
-        schema = element.schemaInfo()
-        schema.append(element.set({"name": "json", "identifier": get_schema_for_resource("doc")}))
-        return schema
+        schema_info = element.schemaInfo()
+        schema_info.append(
+            element.schema({"identifier": SRU_MARCXML_SCHEMA_URI, "name": "marcxml", "retrieve": "true"})
+        )
+        schema_info.append(element.schema({"identifier": SRU_DC_SCHEMA_URI, "name": "dc", "retrieve": "true"}))
+        return schema_info
 
     def init_config_info(self, element):
         """Create the configuration information element.
@@ -237,13 +270,9 @@ class Explain:
         Includes the default and maximum number of records settings
         that control pagination behavior for search results.
 
-        Args:
-            element: The ElementMaker instance for creating XML elements.
-
-        Returns:
-            An lxml Element containing:
-            - default numberOfRecords setting
-            - maximum numberOfRecords setting
+        :param element: The ElementMaker instance for creating XML elements.
+        :returns: lxml Element containing the default and maximum
+            numberOfRecords settings.
         """
         config = element.configInfo()
         config.append(element.default(str(self.number_of_records), {"type": "numberOfRecords"}))

--- a/rero_ils/modules/sru/views.py
+++ b/rero_ils/modules/sru/views.py
@@ -44,10 +44,12 @@ See Also:
 """
 
 import hashlib
+import uuid
 
 from elasticsearch.exceptions import RequestError as ESRequestError
 from flask import current_app
 from flask import request as flask_request
+from invenio_cache import current_cache
 from invenio_rest import ContentNegotiatedMethodView
 from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Response
@@ -59,8 +61,8 @@ from ..documents.serializers import (
     xml_marcxmlsru_search,
 )
 from ..utils import strip_chars
-from .cql_parser import Diagnostic, parse
-from .explaine import Explain
+from .cql_parser import SRU_DC_SCHEMA_URI, SRU_MARCXML_SCHEMA_URI, Diagnostic, parse
+from .explain import Explain
 
 #: Cache duration for Explain responses (1 hour in seconds).
 #: Explain data changes rarely, only on deployment/configuration changes.
@@ -74,15 +76,61 @@ SEARCH_CACHE_MAX_AGE = 60
 #: Allows serving stale content while fetching fresh results in background.
 SEARCH_STALE_WHILE_REVALIDATE = 300
 
+#: Mapping from recordSchema parameter values (URIs and short names) to format aliases.
+SUPPORTED_RECORD_SCHEMAS = {
+    SRU_MARCXML_SCHEMA_URI: "marcxmlsru",
+    "marcxml": "marcxmlsru",
+    SRU_DC_SCHEMA_URI: "dc",
+    "dc": "dc",
+}
+
+#: Canonical schema URI for each format alias, used for echoing in responses.
+CANONICAL_RECORD_SCHEMA = {
+    "marcxmlsru": SRU_MARCXML_SCHEMA_URI,
+    "dc": SRU_DC_SCHEMA_URI,
+}
+
+#: Redis key prefix for stored SRU result sets.
+_SRU_RSET_PREFIX = "sru:rset:"
+
+
+def _save_result_set(query_cql, search_query, ttl, sort_keys=None, result_set_id=None):
+    """Store a CQL search as a named result set and return its UUID.
+
+    :param query_cql: Original CQL query string to associate with the result set.
+    :param search_query: Search index query string for the search.
+    :param ttl: Cache lifetime in seconds. 0 disables result set creation.
+    :param sort_keys: Search index sort specifications to preserve across pages.
+    :param result_set_id: Existing result set UUID to reuse; a fresh UUID is generated
+        when ``None``.
+    :returns: Result set UUID string, or ``None`` if TTL is zero.
+    """
+    if not ttl:
+        return None
+    rsid = result_set_id or str(uuid.uuid4())
+    current_cache.set(
+        f"{_SRU_RSET_PREFIX}{rsid}",
+        {"query_cql": query_cql, "search_query": search_query, "sort_keys": sort_keys or []},
+        timeout=ttl,
+    )
+    return rsid
+
+
+def _load_result_set(rsid):
+    """Retrieve a previously saved result set by its UUID.
+
+    :param rsid: Result set UUID returned by :func:`_save_result_set`.
+    :returns: ``{"query_cql": ..., "search_query": ..., "sort_keys": [...]}`` dict,
+        or ``None`` if expired/unknown.
+    """
+    return current_cache.get(f"{_SRU_RSET_PREFIX}{rsid}")
+
 
 def _generate_etag(content):
     """Generate an ETag hash from response content.
 
-    Args:
-        content: The response body as string or bytes.
-
-    Returns:
-        A quoted ETag string suitable for HTTP headers.
+    :param content: The response body as string or bytes.
+    :returns: A quoted ETag string suitable for use in HTTP headers.
     """
     if isinstance(content, str):
         content = content.encode("utf-8")
@@ -92,14 +140,11 @@ def _generate_etag(content):
 def _add_cache_headers(response, max_age, stale_while_revalidate=None, etag=None):
     """Add HTTP caching headers to a response.
 
-    Args:
-        response: The Flask/Werkzeug Response object.
-        max_age: Cache duration in seconds.
-        stale_while_revalidate: Optional duration for stale-while-revalidate.
-        etag: Optional ETag value for conditional requests.
-
-    Returns:
-        The response with caching headers added.
+    :param response: The Flask/Werkzeug Response object to modify.
+    :param max_age: Cache duration in seconds for the ``max-age`` directive.
+    :param stale_while_revalidate: Optional ``stale-while-revalidate`` duration in seconds.
+    :param etag: Optional ETag value to set on the response.
+    :returns: The response with caching headers added.
     """
     cache_control = f"public, max-age={max_age}"
     if stale_while_revalidate:
@@ -107,6 +152,41 @@ def _add_cache_headers(response, max_age, stale_while_revalidate=None, etag=None
     response.headers["Cache-Control"] = cache_control
     if etag:
         response.headers["ETag"] = etag
+    return response
+
+
+def _parse_int_param(name, raw_value, query):
+    """Parse an integer SRU query parameter, raising a diagnostic on failure.
+
+    :param name: parameter name used in the error detail.
+    :param raw_value: raw string value from the request.
+    :param query: original CQL query string for the diagnostic.
+    :returns: parsed integer value.
+    :raises HTTPException: with SRU diagnostic code 6 if not a valid integer.
+    """
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise HTTPException(
+            response=_diagnostic_response(
+                Diagnostic(
+                    code=6,
+                    message="Unsupported parameter value",
+                    details=f"{name}: {raw_value!r} is not a valid integer",
+                    query=query,
+                )
+            )
+        ) from exc
+
+
+def _diagnostic_response(diag):
+    """Build an XML ``Response`` from a ``Diagnostic`` instance.
+
+    :param diag: the Diagnostic exception to serialise.
+    :returns: a Werkzeug Response with content-type application/xml.
+    """
+    response = Response(diag.xml_str())
+    response.headers["content-type"] = "application/xml"
     return response
 
 
@@ -128,8 +208,8 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
     def __init__(self, **kwargs):
         """Initialize the SRU search view with content negotiation settings.
 
-        Args:
-            **kwargs: Additional arguments passed to ContentNegotiatedMethodView.
+        :param kwargs: Additional arguments passed to
+            :class:`~invenio_rest.ContentNegotiatedMethodView`.
         """
         super().__init__(
             method_serializers={
@@ -149,117 +229,245 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
             **kwargs,
         )
 
+    def match_serializers(self, serializers, default_media_type):
+        """Select a serializer, giving precedence to the SRU ``recordSchema`` parameter.
+
+        If the client supplies a recognised ``recordSchema`` value it takes priority
+        over the ``format`` query parameter so that standard SRU clients can select
+        the output schema without knowing RERO-ILS's custom ``format`` extension.
+
+        :param serializers: Dict of mime-type → serializer callable.
+        :param default_media_type: Fallback mime type when no match is found.
+        :returns: The matching serializer callable, or ``None``.
+        """
+        record_schema = flask_request.args.get("recordSchema")
+        if record_schema and record_schema in SUPPORTED_RECORD_SCHEMAS:
+            fmt = SUPPORTED_RECORD_SCHEMAS[record_schema]
+            mime = self.serializers_query_aliases[fmt]
+            return serializers.get(mime)
+        return super().match_serializers(serializers, default_media_type)
+
     def get(self, **kwargs):
         """Handle GET requests to the SRU endpoint.
 
-        Processes SRU searchRetrieve and explain operations. For searchRetrieve,
-        parses the CQL query, executes it against search index, and returns
-        results in the requested format. For explain (or when no operation is
-        specified), returns the server's capabilities.
-
-        Args:
-            **kwargs: Additional arguments from the URL route.
-
-        Returns:
-            A Flask response with search results or explain information.
-            Content-Type depends on format requested (XML or JSON).
+        Dispatches to :meth:`_search_retrieve` or :meth:`_explain` after
+        validating the common query parameters.
 
         Raises:
-            HTTPException: When CQL parsing fails, returns an XML diagnostic
-                response with the error details.
+            HTTPException: On validation failure or when returning any SRU
+                response (both success and error paths use HTTPException so
+                that Flask skips further processing).
         """
         operation = flask_request.args.get("operation", None)
         cql_query = flask_request.args.get("query", None)
-        start_record = max(int(flask_request.args.get("startRecord", 1)), 1)
-        maximum_records = min(
-            int(
-                flask_request.args.get(
-                    "maximumRecords",
-                    current_app.config.get("RERO_ILS_SRU_NUMBER_OF_RECORDS", 100),
+
+        # TODO: implement the SRU 'scan' operation (index term browsing).
+        # See http://www.loc.gov/standards/sru/sru-1-1.html#scan for the spec.
+        # The CQL parser (cheshire3 port) already handles the grammar; the remaining
+        # work is: (1) request validation (scanClause, responsePosition, maximumTerms),
+        # (2) ES terms-aggregation query, (3) scanResponse XML serialization.
+        #
+        # Blocker: most useful scan targets (dc.title, dc.subject, dc.creator,
+        # dc.publisher, dc.description, ...) are plain `text` fields in the document
+        # mapping with no `.raw`/`.keyword` sub-field, so ES cannot aggregate them.
+        # Fields that can be used in a terms aggregation without a mapping change:
+        #   - keyword fields: contribution.role, language.value, type.main_type,
+        #     type.subtype, contentMediaCarrier.*Type, org_pid, library_pid,
+        #     holdings.location.pid
+        #   - has .raw sub-field: identifiedBy.value (use identifiedBy.value.raw)
+        # To support the remaining fields, add `.raw` keyword sub-fields to the
+        # relevant text fields in document-v0.0.1.json and reindex documents.
+        if operation is not None and operation not in ("searchRetrieve", "explain"):
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(code=4, message="Unsupported operation", details=operation, query=cql_query or "")
                 )
-            ),
-            current_app.config.get("RERO_ILS_SRU_MAXIMUM_RECORDS", 1000),
+            )
+
+        # Validate version (code 5: unsupported version)
+        version = flask_request.args.get("version", None)
+        if version is not None and version != "1.1":
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(code=5, message="Unsupported version", details=version, query=cql_query or "")
+                )
+            )
+
+        # Validate recordPacking (code 6: unsupported parameter value) — only xml supported
+        record_packing = flask_request.args.get("recordPacking", None)
+        if record_packing is not None and record_packing.lower() != "xml":
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(
+                        code=6,
+                        message="Unsupported parameter value",
+                        details=f"recordPacking: {record_packing!r} is not supported (only 'xml')",
+                        query=cql_query or "",
+                    )
+                )
+            )
+
+        # Validate recordSchema (code 66: unknown schema for retrieval)
+        record_schema_param = flask_request.args.get("recordSchema", None)
+        if record_schema_param is not None and record_schema_param not in SUPPORTED_RECORD_SCHEMAS:
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(
+                        code=66,
+                        message="Unknown schema for retrieval",
+                        details=record_schema_param,
+                        query=cql_query or "",
+                    )
+                )
+            )
+        # Resolve canonical schema URI for echoing in responses.
+        # recordSchema takes precedence; fall back to the format param.
+        if record_schema_param:
+            canonical_schema = CANONICAL_RECORD_SCHEMA[SUPPORTED_RECORD_SCHEMAS[record_schema_param]]
+        else:
+            fmt = flask_request.args.get("format", "marcxmlsru")
+            canonical_schema = CANONICAL_RECORD_SCHEMA.get(fmt, SRU_MARCXML_SCHEMA_URI)
+
+        # Validate startRecord (code 6: must be a positive integer)
+        start_record = _parse_int_param("startRecord", flask_request.args.get("startRecord", "1"), cql_query or "")
+        if start_record < 1:
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(
+                        code=6,
+                        message="Unsupported parameter value",
+                        details=f"startRecord: {start_record} must be 1 or greater",
+                        query=cql_query or "",
+                    )
+                )
+            )
+
+        # Validate maximumRecords (code 6: must be a non-negative integer); 0 is valid (returns count only)
+        default_max = current_app.config.get("RERO_ILS_SRU_NUMBER_OF_RECORDS", 100)
+        maximum_records = _parse_int_param(
+            "maximumRecords", flask_request.args.get("maximumRecords", str(default_max)), cql_query or ""
         )
-        if operation == "searchRetrieve" and cql_query:
-            try:
-                parsed_query = parse(cql_query)
-                search_query = parsed_query.to_search()
-                # Extract sort keys if present
+        if maximum_records < 0:
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(
+                        code=6,
+                        message="Unsupported parameter value",
+                        details=f"maximumRecords: {maximum_records} must be 0 or greater",
+                        query=cql_query or "",
+                    )
+                )
+            )
+        maximum_records = min(maximum_records, current_app.config.get("RERO_ILS_SRU_MAXIMUM_RECORDS", 1000))
+
+        if operation == "searchRetrieve":
+            return self._search_retrieve(cql_query, start_record, maximum_records, canonical_schema)
+        raise HTTPException(response=self._explain())
+
+    def _search_retrieve(self, query, start_record, maximum_records, record_schema):
+        """Execute a CQL searchRetrieve operation and return a response.
+
+        :param query: raw CQL query string from the request.
+        :param start_record: 1-based first record index (already validated).
+        :param maximum_records: maximum number of records to return (already validated).
+        :param record_schema: canonical schema URI to echo in the response.
+        :raises HTTPException: on missing query, CQL parse error, or ES error.
+        """
+        if not query:
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(code=7, message="Mandatory parameter not supplied", details="query", query="")
+                )
+            )
+        try:
+            parsed_query = parse(query)
+            if rsid_ref := parsed_query.get_result_set_id():
+                stored = _load_result_set(rsid_ref)
+                if stored is None:
+                    raise Diagnostic(code=33, message="Result set does not exist", details=rsid_ref, query=query)
+                query_string = stored["search_query"]
+                save_cql = stored["query_cql"]
+                sort_keys = stored.get("sort_keys", [])
+            else:
+                query_string = parsed_query.to_search()
+                save_cql = strip_chars(query)
                 sort_keys = parsed_query.get_search_sort()
-            except Diagnostic as err:
-                response = Response(err.xml_str())
-                response.headers["content-type"] = "application/xml"
-                raise HTTPException(response=response) from err
+        except Diagnostic as err:
+            raise HTTPException(response=_diagnostic_response(err)) from err
 
-            search = (
-                DocumentsSearch()
-                .query("query_string", query=search_query)
-                .exclude("term", _masked=True)
-                .exclude("term", _draft=True)
-            )
-            # Apply sort if specified in CQL query
-            if sort_keys:
-                search = search.sort(*sort_keys)
-            records = []
-            total = 0
-            search = search[(start_record - 1) : maximum_records + (start_record - 1)]
-            try:
-                response = search.execute()
-                for hit in response:
-                    records.append(
-                        {
-                            "_id": hit.meta.id,
-                            "_index": hit.meta.index,
-                            "_source": hit.to_dict(),
-                            "_version": 0,
-                        }
-                    )
-                total = response.hits.total.value if hasattr(response.hits.total, "value") else response.hits.total
-            except ESRequestError as e:
-                _err_text = str(getattr(e, "info", e))
-                if "Result window" in _err_text or "result_window" in _err_text:
-                    # startRecord window exceeds search max_result_window; return 0 records.
-                    current_app.logger.warning(f"search window overflow during SRU search: {e}")
-                else:
-                    current_app.logger.error(f"search backend error during SRU search: {e}")
-                    diag = Diagnostic(
-                        code=2,
-                        message="System temporarily unavailable",
-                        details=str(e),
-                        query=cql_query,
-                    )
-                    diag_response = Response(diag.xml_str())
-                    diag_response.headers["content-type"] = "application/xml"
-                    raise HTTPException(response=diag_response) from e
+        search = (
+            DocumentsSearch()
+            .query("query_string", query=query_string)
+            .exclude("term", _masked=True)
+            .exclude("term", _draft=True)
+        )
+        if sort_keys:
+            search = search.sort(*sort_keys)
+        search = search[(start_record - 1) : maximum_records + (start_record - 1)]
 
-            result = {
-                "hits": {
-                    "hits": records,
-                    "total": {"value": total, "relation": "eq"},
-                    "sru": {
-                        "cql_query": strip_chars(cql_query),
-                        "search_query": search_query,
-                        "start_record": start_record,
-                        "maximum_records": maximum_records,
-                    },
-                }
+        records, total = self._execute_search(search, query)
+
+        result_set_ttl = current_app.config.get("RERO_ILS_SRU_RESULT_SET_TTL", 0)
+        result_set_id = _save_result_set(save_cql, query_string, result_set_ttl, sort_keys, rsid_ref or None)
+
+        result = {
+            "hits": {
+                "hits": records,
+                "total": {"value": total, "relation": "eq"},
+                "sru": {
+                    "operation": "searchRetrieve",
+                    "cql_query": strip_chars(query),
+                    "search_query": query_string,
+                    "start_record": start_record,
+                    "maximum_records": maximum_records,
+                    "record_schema": record_schema,
+                    "result_set_id": result_set_id,
+                    "result_set_ttl": result_set_ttl,
+                },
             }
-            response = self.make_response(pid_fetcher=document_id_fetcher, search_result=result)
-            # Add caching headers for search results (short cache with stale-while-revalidate)
-            response.headers["Vary"] = "Accept"
-            _add_cache_headers(
-                response,
-                max_age=SEARCH_CACHE_MAX_AGE,
-                stale_while_revalidate=SEARCH_STALE_WHILE_REVALIDATE,
-            )
-            return response
+        }
+        response = self.make_response(pid_fetcher=document_id_fetcher, search_result=result)
+        response.headers["Vary"] = "Accept"
+        _add_cache_headers(response, max_age=SEARCH_CACHE_MAX_AGE, stale_while_revalidate=SEARCH_STALE_WHILE_REVALIDATE)
+        return response
 
-        # Explain operation (default) - cacheable for longer duration
-        explain = Explain("api/sru/documents")
-        content = str(explain)
+    def _execute_search(self, search, query):
+        """Run the ES search and return ``(records, total)``.
+
+        :param search: prepared :class:`DocumentsSearch` instance.
+        :param query: original CQL string, used in diagnostic messages.
+        :raises HTTPException: on fatal ES errors.
+        """
+        try:
+            response = search.execute()
+            records = [
+                {"_id": hit.meta.id, "_index": hit.meta.index, "_source": hit.to_dict(), "_version": 0}
+                for hit in response
+            ]
+            total = getattr(response.hits.total, "value", response.hits.total)
+            return records, total
+        except ESRequestError as e:
+            err_text = str(getattr(e, "info", e))
+            if "Result window" in err_text or "result_window" in err_text:
+                current_app.logger.warning(f"ES window overflow during SRU search: {e}")
+                return [], 0
+            current_app.logger.error(f"ES backend error during SRU search: {e}")
+            raise HTTPException(
+                response=_diagnostic_response(
+                    Diagnostic(code=2, message="System temporarily unavailable", details=str(e), query=query)
+                )
+            ) from e
+
+    def _explain(self):
+        """Build and return the SRU Explain XML response.
+
+        Handles conditional GET (``If-None-Match``) and attaches cache headers.
+
+        :returns: a Werkzeug :class:`Response` ready to be raised as an
+            :class:`HTTPException`.
+        """
+        content = str(Explain("api/sru/documents"))
         etag = _generate_etag(content)
-        # Conditional GET: return 304 if client already has the current version
-        # Check If-None-Match header (may contain multiple ETags or wildcard)
         if_none_match = flask_request.headers.get("If-None-Match", "")
         client_etags = [e.strip() for e in if_none_match.split(",")]
         if etag in client_etags or "*" in client_etags:
@@ -267,10 +475,9 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
             not_modified.headers["ETag"] = etag
             not_modified.headers["Cache-Control"] = f"public, max-age={EXPLAIN_CACHE_MAX_AGE}"
             not_modified.headers["Vary"] = "Accept"
-            raise HTTPException(response=not_modified)
+            return not_modified
         response = Response(content)
         response.headers["Content-Type"] = "application/xml"
         response.headers["Vary"] = "Accept"
-        # Add caching headers for explain (long cache with ETag)
         _add_cache_headers(response, max_age=EXPLAIN_CACHE_MAX_AGE, etag=etag)
-        raise HTTPException(response=response)
+        return response

--- a/tests/api/sru/conftest.py
+++ b/tests/api/sru/conftest.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # RERO ILS
-# Copyright (C) 2019-2022 RERO
-# Copyright (C) 2019-2022 UCLouvain
+# Copyright (C) 2019 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -16,12 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""SRU (Search/Retrieve via URL) and CQL (Contextual Query Language) support.
+"""SRU test fixtures."""
 
-Implements the SRU 1.1 protocol for searching documents via standard CQL queries,
-including query parsing, Elasticsearch translation, and result set management.
+import pytest
 
-See Also:
-    - SRU Standard: http://www.loc.gov/standards/sru/
-    - CQL Specification: http://www.loc.gov/standards/sru/cql/
-"""
+
+@pytest.fixture()
+def sru_result_set_client(client):
+    """Yield a client with RERO_ILS_SRU_RESULT_SET_TTL set to 60 seconds."""
+    client.application.config["RERO_ILS_SRU_RESULT_SET_TTL"] = 60
+    yield client
+    client.application.config.pop("RERO_ILS_SRU_RESULT_SET_TTL", None)

--- a/tests/api/sru/test_sru_rest.py
+++ b/tests/api/sru/test_sru_rest.py
@@ -19,6 +19,7 @@
 
 from flask import url_for
 
+from rero_ils.modules.sru.cql_parser import SRU_MARCXML_SCHEMA_URI
 from tests.utils import get_xml_dict
 
 
@@ -41,12 +42,13 @@ def test_sru_documents(client, document_ref, entity_person_data):
     search_rr = xml_dict["zs:searchRetrieveResponse"]
     assert search_rr.get("zs:echoedSearchRetrieveRequest") == {
         "zs:version": "1.1",
+        "zs:operation": "searchRetrieve",
         "zs:maximumRecords": "100",
         "zs:query": "al-Wajīz",
         "zs:search_query": "al-Wajīz",
         "zs:recordPacking": "XML",
-        "zs:recordSchema": "info:sru/schema/1/marcxml-v1.1-light",
-        "zs:resultSetTTL": "0",
+        "zs:recordSchema": SRU_MARCXML_SCHEMA_URI,
+        "zs:resultSetTTL": "300",
         "zs:startRecord": "1",
     }
     # Search should return only documents matching the query, not all documents
@@ -74,7 +76,7 @@ def test_sru_documents_items(client, document_sion_items):
         version="1.1",
         operation="searchRetrieve",
         query='"La reine Berthe et son fils"',
-        format="marcxml",
+        format="marcxmlsru",
     )
     res = client.get(api_url)
     assert res.status_code == 200
@@ -94,10 +96,10 @@ def test_sru_documents_items(client, document_sion_items):
     res = client.get(api_url)
     assert res.status_code == 200
     xml_dict = get_xml_dict(res)
-    assert "searchRetrieveResponse" in xml_dict
-    ech_srr = xml_dict["searchRetrieveResponse"]["echoedSearchRetrieveRequest"]
-    assert ech_srr["query"] == 'dc.title="La reine Berthe et son fils"'
-    assert ech_srr["search_query"] == 'title.\\*:"La reine Berthe et son fils"'
+    assert "zs:searchRetrieveResponse" in xml_dict
+    ech_srr = xml_dict["zs:searchRetrieveResponse"]["zs:echoedSearchRetrieveRequest"]
+    assert ech_srr["zs:query"] == 'dc.title="La reine Berthe et son fils"'
+    assert ech_srr["zs:search_query"] == 'title.\\*:"La reine Berthe et son fils"'
 
 
 def test_sru_excludes_masked_and_draft(client, document_ref):
@@ -144,7 +146,8 @@ def test_sru_documents_diagnostics(client):
     assert res.status_code == 200
     xml_dict = get_xml_dict(res)
     assert "srw:searchRetrieveResponse" in xml_dict
-    assert xml_dict["srw:searchRetrieveResponse"]["diag:diagnostics"]["diag:message"] == "Malformed Query"
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:message"] == "Malformed Query"
 
 
 def test_sru_explain_conditional_get(client):
@@ -175,7 +178,7 @@ def test_sru_search_backend_error(client):
     assert res.status_code == 200
     xml_dict = get_xml_dict(res)
     assert "srw:searchRetrieveResponse" in xml_dict
-    diag = xml_dict["srw:searchRetrieveResponse"]["diag:diagnostics"]
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
     assert diag["diag:message"] == "System temporarily unavailable"
 
 
@@ -203,6 +206,60 @@ def test_sru_search_window_overflow(client):
     assert xml_dict["zs:searchRetrieveResponse"]["zs:numberOfRecords"] == "0"
 
 
+def test_sru_unsupported_operation(client):
+    """Test SRU returns diagnostic code 4 for an unknown operation."""
+    api_url = url_for("api_sru.documents", operation="unknownOp")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/4"
+    assert diag["diag:message"] == "Unsupported operation"
+    assert diag["diag:details"] == "unknownOp"
+
+
+def test_sru_invalid_start_record(client):
+    """Test SRU returns diagnostic code 6 when startRecord is not an integer."""
+    api_url = url_for("api_sru.documents", version="1.1", operation="searchRetrieve", query="test", startRecord="abc")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/6"
+    assert diag["diag:message"] == "Unsupported parameter value"
+    assert "startRecord" in diag["diag:details"]
+
+
+def test_sru_invalid_maximum_records(client):
+    """Test SRU returns diagnostic code 6 when maximumRecords is not an integer."""
+    api_url = url_for(
+        "api_sru.documents", version="1.1", operation="searchRetrieve", query="test", maximumRecords="xyz"
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/6"
+    assert diag["diag:message"] == "Unsupported parameter value"
+    assert "maximumRecords" in diag["diag:details"]
+
+
+def test_sru_missing_query(client):
+    """Test SRU returns diagnostic code 7 when searchRetrieve is called without a query."""
+    api_url = url_for("api_sru.documents", version="1.1", operation="searchRetrieve")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/7"
+    assert diag["diag:message"] == "Mandatory parameter not supplied"
+    assert diag["diag:details"] == "query"
+
+
 def test_sru_sort(client, document_sion_items):
     """Test SRU search with sortBy CQL clause."""
     api_url = url_for(
@@ -215,3 +272,284 @@ def test_sru_sort(client, document_sion_items):
     assert res.status_code == 200
     xml_dict = get_xml_dict(res)
     assert "zs:searchRetrieveResponse" in xml_dict
+
+
+def test_sru_unsupported_version(client):
+    """Test SRU returns diagnostic code 5 for an unsupported version."""
+    api_url = url_for("api_sru.documents", version="2.0", operation="searchRetrieve", query="test")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/5"
+    assert diag["diag:message"] == "Unsupported version"
+    assert diag["diag:details"] == "2.0"
+
+
+def test_sru_unsupported_record_packing(client):
+    """Test SRU returns diagnostic code 6 for an unsupported recordPacking value."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query="test",
+        recordPacking="json",
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/6"
+    assert diag["diag:message"] == "Unsupported parameter value"
+    assert "recordPacking" in diag["diag:details"]
+
+
+def test_sru_start_record_zero(client):
+    """Test SRU returns diagnostic code 6 when startRecord is 0 (must be >= 1)."""
+    api_url = url_for("api_sru.documents", version="1.1", operation="searchRetrieve", query="test", startRecord="0")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/6"
+    assert diag["diag:message"] == "Unsupported parameter value"
+    assert "startRecord" in diag["diag:details"]
+
+
+def test_sru_start_record_negative(client):
+    """Test SRU returns diagnostic code 6 when startRecord is negative."""
+    api_url = url_for("api_sru.documents", version="1.1", operation="searchRetrieve", query="test", startRecord="-1")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/6"
+    assert diag["diag:message"] == "Unsupported parameter value"
+    assert "startRecord" in diag["diag:details"]
+
+
+def test_sru_maximum_records_negative(client):
+    """Test SRU returns diagnostic code 6 when maximumRecords is negative."""
+    api_url = url_for("api_sru.documents", version="1.1", operation="searchRetrieve", query="test", maximumRecords="-1")
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/6"
+    assert diag["diag:message"] == "Unsupported parameter value"
+    assert "maximumRecords" in diag["diag:details"]
+
+
+def test_sru_maximum_records_zero(client, document_sion_items):
+    """Test SRU returns total count but no records when maximumRecords=0."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils"',
+        maximumRecords="0",
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "zs:searchRetrieveResponse" in xml_dict
+    search_rr = xml_dict["zs:searchRetrieveResponse"]
+    assert int(search_rr["zs:numberOfRecords"]) >= 1
+    assert "zs:records" not in search_rr or search_rr["zs:records"] == {}
+    assert "zs:nextRecordPosition" not in search_rr
+    echoed = search_rr["zs:echoedSearchRetrieveRequest"]
+    assert echoed["zs:maximumRecords"] == "0"
+    assert echoed["zs:operation"] == "searchRetrieve"
+
+
+def test_sru_maximum_records_zero_dc(client, document_sion_items):
+    """Test DC format returns total count but no records element when maximumRecords=0."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils"',
+        maximumRecords="0",
+        format="dc",
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "zs:searchRetrieveResponse" in xml_dict
+    search_rr = xml_dict["zs:searchRetrieveResponse"]
+    assert int(search_rr["zs:numberOfRecords"]) >= 1
+    assert "zs:records" not in search_rr or search_rr["zs:records"] == {}
+    echoed = search_rr["zs:echoedSearchRetrieveRequest"]
+    assert echoed["zs:maximumRecords"] == "0"
+    assert echoed["zs:resultSetTTL"] == "300"
+    assert "zs:nextRecordPosition" not in search_rr
+
+
+def test_sru_unknown_schema(client):
+    """Test SRU returns diagnostic code 66 for an unrecognised recordSchema."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query="test",
+        recordSchema="info:srw/schema/1/unknown",
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/66"
+    assert diag["diag:message"] == "Unknown schema for retrieval"
+    assert "info:srw/schema/1/unknown" in diag["diag:details"]
+
+
+def test_sru_record_schema_echoed(client, document_sion_items):
+    """Test SRU echoes back the canonical recordSchema URI in the response."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils"',
+        recordSchema="marcxml",
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "zs:searchRetrieveResponse" in xml_dict
+    echoed = xml_dict["zs:searchRetrieveResponse"]["zs:echoedSearchRetrieveRequest"]
+    assert echoed["zs:recordSchema"] == SRU_MARCXML_SCHEMA_URI
+
+
+def test_sru_next_record_position(client):
+    """Test SRU emits nextRecordPosition at the response top level when more records exist."""
+    from unittest.mock import patch
+
+    from rero_ils.modules.sru.views import SRUDocumentsSearch
+
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query="books",
+        startRecord="1",
+        maximumRecords="5",
+        format="dc",
+    )
+    with patch.object(SRUDocumentsSearch, "_execute_search", return_value=([], 20)):
+        res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "zs:searchRetrieveResponse" in xml_dict
+    search_rr = xml_dict["zs:searchRetrieveResponse"]
+    assert search_rr["zs:numberOfRecords"] == "20"
+    # nextRecordPosition must be a top-level sibling of records, not inside echoedSearchRetrieveRequest
+    assert search_rr["zs:nextRecordPosition"] == "6"
+    assert "zs:nextRecordPosition" not in search_rr.get("zs:echoedSearchRetrieveRequest", {})
+
+
+def test_sru_result_set_created(sru_result_set_client, document_sion_items):
+    """Test SRU includes resultSetId when RERO_ILS_SRU_RESULT_SET_TTL > 0."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils"',
+    )
+    res = sru_result_set_client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    search_rr = xml_dict["zs:searchRetrieveResponse"]
+    assert "zs:resultSetId" in search_rr
+    assert search_rr["zs:resultSetIdleTime"] == "60"
+
+
+def test_sru_result_set_lookup(sru_result_set_client, document_sion_items):
+    """Test SRU result set lookup returns the same record count as the original search."""
+    # First request: save the result set and capture its ID
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils"',
+    )
+    res1 = sru_result_set_client.get(api_url)
+    assert res1.status_code == 200
+    search_rr1 = get_xml_dict(res1)["zs:searchRetrieveResponse"]
+    rsid = search_rr1["zs:resultSetId"]
+    total1 = search_rr1["zs:numberOfRecords"]
+
+    # Second request: reference the saved result set
+    api_url2 = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query=f'cql.resultSetId = "{rsid}"',
+    )
+    res2 = sru_result_set_client.get(api_url2)
+    assert res2.status_code == 200
+    search_rr2 = get_xml_dict(res2)["zs:searchRetrieveResponse"]
+    assert search_rr2["zs:numberOfRecords"] == total1
+
+
+def test_sru_result_set_preserves_sort(sru_result_set_client, document_sion_items):
+    """Test that a result set lookup re-applies the sort order from the original query."""
+    from unittest.mock import patch
+
+    from rero_ils.modules.sru.views import SRUDocumentsSearch
+
+    # First request with an explicit sort clause
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='"La reine Berthe et son fils" sortBy dc.date/descending',
+    )
+    res1 = sru_result_set_client.get(api_url)
+    assert res1.status_code == 200
+    search_rr1 = get_xml_dict(res1)["zs:searchRetrieveResponse"]
+    rsid = search_rr1["zs:resultSetId"]
+
+    # Second request via resultSetId — capture the ES search dict
+    captured = {}
+
+    def capture_and_return(search, query):
+        captured["search_dict"] = search.to_dict()
+        return [], 0
+
+    api_url2 = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query=f'cql.resultSetId = "{rsid}"',
+    )
+    with patch.object(SRUDocumentsSearch, "_execute_search", side_effect=capture_and_return):
+        res2 = sru_result_set_client.get(api_url2)
+
+    assert res2.status_code == 200
+    # The dc.date/descending sort must be preserved (maps to provisionActivity.startDate desc)
+    assert "sort" in captured["search_dict"], "Sort must be present in result set lookup"
+    assert any("provisionActivity.startDate" in str(s) for s in captured["search_dict"]["sort"])
+
+
+def test_sru_result_set_not_found(client):
+    """Test SRU returns diagnostic code 33 for an unknown or expired result set ID."""
+    api_url = url_for(
+        "api_sru.documents",
+        version="1.1",
+        operation="searchRetrieve",
+        query='cql.resultSetId = "no-such-id"',
+    )
+    res = client.get(api_url)
+    assert res.status_code == 200
+    xml_dict = get_xml_dict(res)
+    assert "srw:searchRetrieveResponse" in xml_dict
+    diag = xml_dict["srw:searchRetrieveResponse"]["srw:diagnostics"]["diag:diagnostic"]
+    assert diag["diag:uri"] == "info:srw/diagnostic/1/33"
+    assert diag["diag:message"] == "Result set does not exist"
+    assert "no-such-id" in diag["diag:details"]

--- a/tests/unit/documents/test_documents_dojson_dc.py
+++ b/tests/unit/documents/test_documents_dojson_dc.py
@@ -167,7 +167,7 @@ def test_identified_by_to_dc():
     """Test identifiedBy transformation to Dublin Core."""
     record = {"identifiedBy": [{"value": "R003461120", "type": "bf:Local", "source": "RERO"}]}
     result = dublincore.do(record)
-    assert result == {"identifiers": ["bf:Local|R003461120(RERO)"]}
+    assert result == {"identifiers": ["bf:Local|(RERO)R003461120"]}
     record = {
         "identifiedBy": [
             {"qualifier": "vol. 5", "value": "604907014223", "type": "bf:Upc"},
@@ -180,7 +180,7 @@ def test_identified_by_to_dc():
         "identifiers": [
             "bf:Upc|604907014223",
             "bf:AudioIssueNumber|Arbiter 142",
-            "bf:Local|R005918723(RERO)",
+            "bf:Local|(RERO)R005918723",
         ]
     }
 

--- a/tests/unit/test_cql_parser.py
+++ b/tests/unit/test_cql_parser.py
@@ -377,7 +377,7 @@ def test_term():
     assert str(err.value) == ("info:srw/diagnostic/1/25 [Malformed Query]: >=")
     with pytest.raises(Diagnostic) as err:
         Term("^", query="query")
-    assert str(err.value) == ("info:srw/diagnostic/1/32 [Malformed Query]: Only anchoring charater(s) in term: ^")
+    assert str(err.value) == ("info:srw/diagnostic/1/32 [Malformed Query]: Only anchoring character(s) in term: ^")
     with pytest.raises(Diagnostic) as err:
         Term("\\\\x\\yz\\", query="query")
     assert str(err.value) == ("info:srw/diagnostic/1/26 [Malformed Query]: \\\\x\\yz\\")

--- a/tests/unit/test_sru_explain.py
+++ b/tests/unit/test_sru_explain.py
@@ -17,7 +17,7 @@
 
 """Test explain."""
 
-from rero_ils.modules.sru.explaine import Explain
+from rero_ils.modules.sru.explain import Explain
 
 
 def test_explain(app):


### PR DESCRIPTION
* Add result set support: _save_result_set/_load_result_set using invenio_cache with UUID keys and configurable TTL (RERO_ILS_SRU_RESULT_SET_TTL); resultSetId/resultSetIdleTime included in responses
* Add SUPPORTED_RECORD_SCHEMAS and CANONICAL_RECORD_SCHEMA mappings; honour recordSchema parameter for marcxmlsru and dc formats
* Refactor SRUDocumentsSearch.get() into _search_retrieve, _execute_search and _explain private methods
* Add _parse_int_param and _diagnostic_response helpers to reduce duplication in views.py
* Fix nextRecordPosition calculation and always emit startRecord and maximumRecords in echoed request (both serializers)
* Add operation and version fields to echoedSearchRetrieveRequest in DC and MARCXML serializers
* Fix MARCXML recordSchema URI from "marcxml" to canonical info:srw/schema/1/marcxml-v1.1-light
* Add proper SRW XML namespace to DC serializer response envelope
* Fix CQL context set URI from cql-v1.1 to cql-v1.2
* Add CQL_CONTEXT_SET_URIS so get_result_set_id accepts v1.1 and v1.2
* Extract CQLshlex.read_token into four focused helper methods to reduce cognitive complexity