### PR TITLE
refactor(search): rename all ES identifiers to search equivalents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -442,8 +442,8 @@ templates = "rero_ils.modules.templates.mappings"
 vendors = "rero_ils.modules.vendors.mappings"
 
 [project.entry-points."invenio_search.templates"]
-operation_logs = "rero_ils.modules.operation_logs.es_templates:list_es_templates"
-rero_ils = "rero_ils.es_templates:list_es_templates"
+operation_logs = "rero_ils.modules.operation_logs.es_templates:list_search_templates"
+rero_ils = "rero_ils.es_templates:list_search_templates"
 
 # ---------------------------------------------------------------------------
 # Tool configurations

--- a/rero_ils/alembic/a941628259e1_add_keys_into_loan_index.py
+++ b/rero_ils/alembic/a941628259e1_add_keys_into_loan_index.py
@@ -35,7 +35,7 @@ indexing_chunck_size = 1000
 
 
 def upgrade():
-    """Reindex 'opened' loans to add some keys into ES index."""
+    """Reindex 'opened' loans to add some keys into search index."""
     # Keep only loan without `location_pid` field (these loans are already
     # indexed with correct data)
     query = (

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -647,7 +647,7 @@ DEBUG_TB_INTERCEPT_REDIRECTS = False
 # RERO_ILS_DB_LOGGING = 1
 
 #: Enable Indexer logging (level)
-# RERO_ILS_ES_LOGGING = 1
+# RERO_ILS_SEARCH_LOGGING = 1
 
 # REST API Configuration
 # ======================
@@ -674,7 +674,7 @@ REST_MIMETYPE_QUERY_ARG_NAME = "format"
 """Name of the query argument to specify the mimetype wanted for the output."""
 
 MAX_RESULT_WINDOW = 100000
-"""max result window for ES, must be the same in json mapping files."""
+"""max result window for search, must be the same in json mapping files."""
 
 RECORDS_REST_ENDPOINTS = dict(
     coll=dict(
@@ -2778,7 +2778,7 @@ RECORDS_REST_FACETS = dict(
     ),
 )
 
-# Elasticsearch fields boosting by index
+# search index fields boosting by index
 RERO_ILS_QUERY_BOOSTING = {
     "documents": [
         "autocomplete_title^3",

--- a/rero_ils/es_templates/__init__.py
+++ b/rero_ils/es_templates/__init__.py
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Records Templates Elasticsearch."""
+"""Records Templates search index."""
 
 
-def list_es_templates():
-    """Elasticsearch templates path."""
+def list_search_templates():
+    """Search index templates path."""
     return ["rero_ils.es_templates"]

--- a/rero_ils/es_templates/v7/__init__.py
+++ b/rero_ils/es_templates/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""ES Templates module for RERO-ils."""
+"""search Templates module for RERO-ils."""

--- a/rero_ils/filter.py
+++ b/rero_ils/filter.py
@@ -34,7 +34,7 @@ from .modules.messages import Message
 from .modules.utils import extracted_data_from_ref
 
 
-def get_record_by_ref(ref, type="es_record"):
+def get_record_by_ref(ref, type="search_record"):
     """Get record by ref.
 
     :param ref: The json $ref. Ex: {$ref: 'xxxxx'}.

--- a/rero_ils/modules/acquisition/acq_accounts/api.py
+++ b/rero_ils/modules/acquisition/acq_accounts/api.py
@@ -415,7 +415,7 @@ class AcqAccount(AcquisitionIlsRecord):
 
 
 class AcqAccountsIndexer(IlsRecordsIndexer):
-    """Indexing AcqAccount in Elasticsearch."""
+    """Indexing AcqAccount in search index."""
 
     record_cls = AcqAccount
 

--- a/rero_ils/modules/acquisition/acq_accounts/listener.py
+++ b/rero_ils/modules/acquisition/acq_accounts/listener.py
@@ -75,7 +75,7 @@ def enrich_acq_account_data(
     (self_amount, total_amount) = account.remaining_balance
     json["remaining_balance"] = {"self": self_amount, "total": total_amount}
 
-    # additional fields for ES
+    # additional fields for search
     json["is_active"] = account.is_active
     json["depth"] = account.depth
     json["distribution"] = account.distribution

--- a/rero_ils/modules/acquisition/acq_accounts/mappings/__init__.py
+++ b/rero_ils/modules/acquisition/acq_accounts/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_accounts/mappings/v7/__init__.py
+++ b/rero_ils/modules/acquisition/acq_accounts/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_accounts/serializers/csv.py
+++ b/rero_ils/modules/acquisition/acq_accounts/serializers/csv.py
@@ -31,7 +31,7 @@ class AcqAccountCSVSerializer(CSVSerializer):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/acquisition/acq_accounts/serializers/json.py
+++ b/rero_ils/modules/acquisition/acq_accounts/serializers/json.py
@@ -35,7 +35,7 @@ class AcqAccountJSONSerializer(ACQJSONSerializer):
 
     def preprocess_record(self, pid, record, links_factory=None, **kwargs):
         """Prepare a record and persistent identifier for serialization."""
-        # Add some ES stored keys into response
+        # Add some search stored keys into response
         query = AcqAccountsSearch().filter("term", pid=record.pid).source()
         if hit := next(query.scan(), None):
             hit_metadata = hit.to_dict()

--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -238,7 +238,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
     def status(self):
         """Calculate the order line status.
 
-        The status of the order line is saved only in the elasticsearch index
+        The status of the order line is saved only in the search index
         and it is calculated based on the following roles:
         * at the creation, the order line receives the `APPROVED` status
         * if field `is_cancelled` is checked, it receives the `CANCELLED`status
@@ -251,7 +251,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
         status = AcqOrderLineStatus.ORDERED if self.order.get("order_date") else AcqOrderLineStatus.APPROVED
 
         received_quantity = self.received_quantity
-        # not use the property to prevent an extra ES call
+        # not use the property to prevent an extra search call
         unreceived_quantity = self.quantity - received_quantity
         if unreceived_quantity == 0:  # fully received
             status = AcqOrderLineStatus.RECEIVED
@@ -312,7 +312,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
 
 
 class AcqOrderLinesIndexer(IlsRecordsIndexer):
-    """Indexing AcqOrderLine in Elasticsearch."""
+    """Indexing AcqOrderLine in search index."""
 
     record_cls = AcqOrderLine
 

--- a/rero_ils/modules/acquisition/acq_order_lines/mappings/__init__.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_order_lines/mappings/v7/__init__.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_orders/api.py
+++ b/rero_ils/modules/acquisition/acq_orders/api.py
@@ -169,7 +169,7 @@ class AcqOrder(AcquisitionIlsRecord):
         results = search.execute()
         statuses = [hit.key for hit in results.aggregations.status.buckets]
 
-        # If the ES query return multiple values, then we can remove
+        # If the search query return multiple values, then we can remove
         # 'CANCELLED' status to compute the correct order status value.
         if len(statuses) > 1 and AcqOrderLineStatus.CANCELLED in statuses:
             statuses.remove(AcqOrderLineStatus.CANCELLED)
@@ -482,7 +482,7 @@ class AcqOrder(AcquisitionIlsRecord):
 
 
 class AcqOrdersIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = AcqOrder
 
@@ -496,10 +496,10 @@ class AcqOrdersIndexer(IlsRecordsIndexer):
     def delete(self, record):
         """Delete a record from indexer.
 
-        First delete order lines from the ES index, then delete the order.
+        First delete order lines from the search index, then delete the order.
         """
-        es_query = AcqOrderLinesSearch().filter("term", acq_order__pid=record.pid)
-        if es_query.count():
-            es_query.delete()
+        search_query = AcqOrderLinesSearch().filter("term", acq_order__pid=record.pid)
+        if search_query.count():
+            search_query.delete()
             AcqOrderLinesSearch.flush_and_refresh()
         super().delete(record)

--- a/rero_ils/modules/acquisition/acq_orders/listener.py
+++ b/rero_ils/modules/acquisition/acq_orders/listener.py
@@ -43,7 +43,7 @@ def enrich_acq_order_data(
     if index.split("-")[0] != AcqOrdersSearch.Meta.index:
         return
     # NOTES PERFORMING ----------------------------------------------------
-    #   We include notes from multiple sources into the AcqOrder ES index
+    #   We include notes from multiple sources into the AcqOrder search index
     #   to allow search on each terms of any notes related to this parent
     #   resource :
     #     - AcqOrder self notes.

--- a/rero_ils/modules/acquisition/acq_orders/mappings/__init__.py
+++ b/rero_ils/modules/acquisition/acq_orders/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_orders/mappings/v7/__init__.py
+++ b/rero_ils/modules/acquisition/acq_orders/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_orders/serializers/csv.py
+++ b/rero_ils/modules/acquisition/acq_orders/serializers/csv.py
@@ -65,7 +65,7 @@ class AcqOrderCSVSerializer(CSVSerializer):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/acquisition/acq_receipt_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/api.py
@@ -219,7 +219,7 @@ class AcqReceiptLine(AcquisitionIlsRecord):
 
 
 class AcqReceiptLinesIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = AcqReceiptLine
 

--- a/rero_ils/modules/acquisition/acq_receipt_lines/mappings/__init__.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/mappings/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_receipt_lines/mappings/v7/__init__.py
+++ b/rero_ils/modules/acquisition/acq_receipt_lines/mappings/v7/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_receipts/api.py
+++ b/rero_ils/modules/acquisition/acq_receipts/api.py
@@ -323,7 +323,7 @@ class AcqReceipt(AcquisitionIlsRecord):
 
 
 class AcqReceiptsIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = AcqReceipt
 

--- a/rero_ils/modules/acquisition/acq_receipts/mappings/__init__.py
+++ b/rero_ils/modules/acquisition/acq_receipts/mappings/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/acq_receipts/mappings/v7/__init__.py
+++ b/rero_ils/modules/acquisition/acq_receipts/mappings/v7/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/budgets/api.py
+++ b/rero_ils/modules/acquisition/budgets/api.py
@@ -120,7 +120,7 @@ class Budget(AcquisitionIlsRecord):
 
 
 class BudgetsIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = Budget
 
@@ -141,7 +141,7 @@ class BudgetsIndexer(IlsRecordsIndexer):
         """Detect is `is_active` field changed.
 
         In this case, we need to reindex related accounts to set them as
-        inactive into the AcqAccount ES index.
+        inactive into the AcqAccount search index.
 
         :param record: the record to index.
         """

--- a/rero_ils/modules/acquisition/budgets/mappings/__init__.py
+++ b/rero_ils/modules/acquisition/budgets/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/acquisition/budgets/mappings/v7/__init__.py
+++ b/rero_ils/modules/acquisition/budgets/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -121,7 +121,7 @@ class IlsRecordsSearch(RecordsSearch):
         raise NotFoundError(f"Record not found pid: {pid}")
 
     def get_records_by_pids(self, pids, fields=None):
-        """Get ES hits by pids.
+        """Get search hits by pids.
 
         :param pids: the list of record pids to retrieve.
         :param fields: a list of field to return. If ``None`` all fields will
@@ -621,7 +621,7 @@ class IlsRecordsIndexer(RecordIndexer):
         :param op_type: Indexing operation (one of ``index``, ``create``,
             ``delete`` or ``update``).
         :param index: The search engine index. (Default: ``None``)
-        :param doc_type: The Elasticsearch doc_type. (Default: ``None``)
+        :param doc_type: The search index doc_type. (Default: ``None``)
         """
         with self.create_producer() as producer:
             for rec in record_id_iterator:
@@ -661,7 +661,7 @@ class IlsRecordsIndexer(RecordIndexer):
         """Bulk index action.
 
         :param payload: Decoded message body.
-        :return: Dictionary defining an Elasticsearch bulk 'index' action.
+        :return: Dictionary defining a search index bulk 'index' action.
         """
         record = self.record_cls.get_record(payload["id"])
         index = self.record_to_index(record)
@@ -685,8 +685,8 @@ class IlsRecordsIndexer(RecordIndexer):
         """Prepare record data for indexing.
 
         :param record: The record to prepare.
-        :param index: The Elasticsearch index.
-        :param arguments: The arguments to send to Elasticsearch upon indexing.
+        :param index: The search index.
+        :param arguments: The arguments to send to search index upon indexing.
         :param **kwargs: Extra parameters.
         :return: The record metadata.
         """
@@ -708,7 +708,7 @@ class IlsRecordsIndexer(RecordIndexer):
         data["_created"] = pytz.utc.localize(record.created).isoformat() if record.created else None
         data["_updated"] = pytz.utc.localize(record.updated).isoformat() if record.updated else None
 
-        # Allow modification of data prior to sending to Elasticsearch.
+        # Allow modification of data prior to sending to search index.
         before_record_index.send(
             current_app._get_current_object(),
             json=data,

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -462,7 +462,7 @@ class CircPolicy(IlsRecord):
 
 
 class CircPoliciesIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = CircPolicy
 

--- a/rero_ils/modules/circ_policies/mappings/__init__.py
+++ b/rero_ils/modules/circ_policies/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Circulation policies Elasticsearch mappings."""
+"""Circulation policies search index mappings."""

--- a/rero_ils/modules/circ_policies/mappings/v7/__init__.py
+++ b/rero_ils/modules/circ_policies/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Circulation policies elasticsearch mappings."""
+"""Circulation policies search index mappings."""

--- a/rero_ils/modules/cli/index.py
+++ b/rero_ils/modules/cli/index.py
@@ -78,11 +78,11 @@ def connect_queue(connection=None, name=None):
     default=None,
     help="Name of the celery queue used to put the tasks into.",
 )
-@click.option("--version-type", help="Elasticsearch version type to use.")
+@click.option("--version-type", help="search index version type to use.")
 @click.option(
     "--raise-on-error/--skip-errors",
     default=True,
-    help="Controls if ES bulk indexing errors raise an exception.",
+    help="Controls if search bulk indexing errors raise an exception.",
 )
 @with_appcontext
 def run(delayed, concurrency, with_stats, version_type=None, queue=None, raise_on_error=True):
@@ -223,7 +223,7 @@ def reindex_missing(pid_types, verbose):
             )
             continue
         monitoring = Monitoring(time_delta=0)
-        pids_es, pids_db, pids_es_double, index = monitoring.get_es_db_missing_pids(p_type)
+        pids_search, pids_db, pids_search_double, index = monitoring.get_search_db_missing_pids(p_type)
         click.secho(
             f"{len(pids_db)}",
             fg="green",
@@ -268,7 +268,7 @@ def init(force):
 @click.argument("old")
 @click.argument("new")
 def switch_index(old, new):
-    """Switch index using the elasticsearch aliases.
+    """Switch index using the search index aliases.
 
     :param old: full name of the old index
     :param new: full name of the fresh created index

--- a/rero_ils/modules/cli/utils.py
+++ b/rero_ils/modules/cli/utils.py
@@ -726,13 +726,13 @@ def check_pid_dependencies(dependency_file, directory, verbose):
     sys.exit(dependency_tests.missing + dependency_tests.not_found)
 
 
-@utils.command("dump_es_mappings")
+@utils.command("dump_search_mappings")
 @click.option("-v", "--verbose", "verbose", is_flag=True, default=False)
 @click.option("-o", "--outfile", "outfile", type=click.File("w"), default=None)
 @with_appcontext
-def dump_es_mappings(verbose, outfile):
-    """Dumps ES mappings."""
-    click.secho("Dump ES mappings:", fg="green")
+def dump_search_mappings(verbose, outfile):
+    """Dumps search mappings."""
+    click.secho("Dump search mappings:", fg="green")
     aliases = current_search.client.indices.get_alias("*")
     mappings = current_search.client.indices.get_mapping()
     for alias in sorted(aliases):

--- a/rero_ils/modules/collections/api.py
+++ b/rero_ils/modules/collections/api.py
@@ -129,7 +129,7 @@ class Collection(IlsRecord):
 
 
 class CollectionsIndexer(IlsRecordsIndexer):
-    """Indexing collections in Elasticsearch."""
+    """Indexing collections in search index."""
 
     record_cls = Collection
 

--- a/rero_ils/modules/collections/mappings/__init__.py
+++ b/rero_ils/modules/collections/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/collections/mappings/v7/__init__.py
+++ b/rero_ils/modules/collections/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/deduplications/api.py
+++ b/rero_ils/modules/deduplications/api.py
@@ -38,12 +38,14 @@ from rero_ils.modules.documents.views import main_title_text
 class Deduplication:
     """Document deduplication class."""
 
-    def __init__(self, es_hosts=None):
+    def __init__(self, search_hosts=None):
         """Constructor.
 
-        :param es_hosts: Elasticsearch hosts to search duplicates.
+        :param search_hosts: search index hosts to search duplicates.
         """
-        self.search = self.base_query(es_hosts).source(
+        if search_hosts is None:
+            search_hosts = []
+        self.search = self.base_query(search_hosts).source(
             [
                 "pid",
                 "title",
@@ -59,17 +61,17 @@ class Deduplication:
         )
 
     @classmethod
-    def base_query(cls, es_hosts):
-        """Elasticsearch base query.
+    def base_query(cls, search_hosts):
+        """Search index base query.
 
-        :param es_hosts: Elasticsearch hosts to search duplicates.
-        :returns: Elasticsearch search instance.
+        :param search_hosts: search index hosts to search for duplicates.
+        :returns: search instance.
         """
         search = DocumentsSearch()
-        if es_hosts:
+        if search_hosts:
             search = search.using(
                 Elasticsearch(
-                    hosts=es_hosts,
+                    hosts=search_hosts,
                     retry_on_timeout=True,
                     max_retries=5,
                     timeout=20,
@@ -362,7 +364,7 @@ class Deduplication:
         :param candidates: the current candidate list to filter.
         :returns: the score and a dict containing some detailed score information.
         """
-        # get the candidate data from ES format
+        # get the candidate data from search format
         candidate = candidate._source.to_dict()
 
         scores = {

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -349,8 +349,8 @@ class Document(IlsRecord):
             acq_order_lines = sorted_pids(acq_order_lines_query)
             local_fields = sorted_pids(local_fields_query)
             documents = {}
-            for relation, relation_es in relation_types.items():
-                doc_query = DocumentsSearch().filter({"term": {relation_es: self.pid}})
+            for relation, relation_search in relation_types.items():
+                doc_query = DocumentsSearch().filter({"term": {relation_search: self.pid}})
                 if pids := sorted_pids(doc_query):
                     documents[relation] = pids
         else:
@@ -361,8 +361,8 @@ class Document(IlsRecord):
             acq_order_lines = acq_order_lines_query.count()
             local_fields = local_fields_query.count()
             documents = 0
-            for relation_es in relation_types.values():
-                doc_query = DocumentsSearch().filter({"term": {relation_es: self.pid}})
+            for relation_search in relation_types.values():
+                doc_query = DocumentsSearch().filter({"term": {relation_search: self.pid}})
                 documents += doc_query.count()
 
         links = {
@@ -440,9 +440,9 @@ class Document(IlsRecord):
 
         a serial document has mode_of_issuance main_type equal to rdami:1003
         """
-        es_documents = DocumentsSearch().filter("term", issuance__main_type="rdami:1003").source(["pid"]).scan()
-        for es_document in es_documents:
-            yield es_document.pid
+        search_documents = DocumentsSearch().filter("term", issuance__main_type="rdami:1003").source(["pid"]).scan()
+        for search_document in search_documents:
+            yield search_document.pid
 
     @classmethod
     def get_document_pids_by_issn(cls, issn_number):
@@ -454,11 +454,11 @@ class Document(IlsRecord):
         """
         criteria = Q("term", nested_identifiers__type=IdentifierType.ISSN)
         criteria &= Q("term", nested_identifiers__value__raw=issn_number)
-        es_documents = (
+        search_documents = (
             DocumentsSearch().filter("nested", path="nested_identifiers", query=criteria).source("pid").scan()
         )
-        for es_document in es_documents:
-            yield es_document.pid
+        for search_document in search_documents:
+            yield search_document.pid
 
     def get_identifiers(self, filters=None, with_alternatives=False):
         """Get the document identifier object filtered by identifier types.
@@ -530,29 +530,29 @@ class Document(IlsRecord):
 
 
 class DocumentsIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = Document
     # data dumper for indexing
     record_dumper = document_indexer_dumper
 
     @classmethod
-    def _es_document(cls, record):
+    def _search_document(cls, record):
         """Get the document from the corresponding index.
 
         :param record: an item object
-        :returns: the elasticsearch document or {}
+        :returns: the search index document or {}
         """
         try:
-            es_item = current_search_client.get(DocumentsSearch.Meta.index, record.id)
-            return es_item["_source"]
+            search_item = current_search_client.get(DocumentsSearch.Meta.index, record.id)
+            return search_item["_source"]
         except NotFoundError:
             return {}
 
     def index(self, record):
         """Index an document."""
         # get previous indexed version
-        es_document = self._es_document(record)
+        search_document = self._search_document(record)
 
         # call the parent index method
         return_value = super().index(record)
@@ -565,7 +565,7 @@ class DocumentsIndexer(IlsRecordsIndexer):
         # has been changed
         # the comparison should be done on the dumps as _text is
         # added for indexing
-        if not es_document or (record.dumps().get("title") != es_document.get("title")):
+        if not search_document or (record.dumps().get("title") != search_document.get("title")):
             search = DocumentsSearch().filter("term", partOf__document__pid=record.pid)
             if ids := [doc.meta.id for doc in search.source().scan()]:
                 # reindex in background as the list can be huge

--- a/rero_ils/modules/documents/dumpers/indexer.py
+++ b/rero_ils/modules/documents/dumpers/indexer.py
@@ -39,8 +39,8 @@ class IndexerDumper(Dumper):
         from rero_ils.modules.items.models import ItemNoteTypes
 
         holdings = []
-        es_holdings = HoldingsSearch().filter("term", document__pid=record["pid"]).source().scan()
-        for holding in es_holdings:
+        search_holdings = HoldingsSearch().filter("term", document__pid=record["pid"]).source().scan()
+        for holding in search_holdings:
             holding = holding.to_dict()
             hold_data = {
                 "pid": holding["pid"],
@@ -75,8 +75,8 @@ class IndexerDumper(Dumper):
                 hold_data["notes"] = notes
 
             # Index items attached to each holdings record
-            es_items = ItemsSearch().filter("term", holding__pid=holding["pid"]).scan()
-            for item in es_items:
+            search_items = ItemsSearch().filter("term", holding__pid=holding["pid"]).scan()
+            for item in search_items:
                 item = item.to_dict()
                 item_data = {
                     "pid": item["pid"],
@@ -131,17 +131,17 @@ class IndexerDumper(Dumper):
         identifiers = {
             IdentifierFactory.create_identifier(identifier_data) for identifier_data in data.get("identifiedBy", [])
         }
-        # enrich elasticsearch data with encoded identifier alternatives. The
+        # enrich search index data with encoded identifier alternatives. The
         # result identifiers list should contain only distinct identifier !
         for identifier in list(identifiers):
             identifiers.update(identifier.get_alternatives())
         data["identifiedBy"] = [identifier.dump() for identifier in identifiers]
         # DEV NOTES :: Why copy `identifiedBy` into `nested_identifiers`
         # We use an alternative `nested_identifiers` to duplicate identifiers
-        # into a nested structure into ES. Doing this we can continue to search
+        # into a nested structure into search. Doing this we can continue to search
         # about `identifiedBy.*` using query string (nested field could not be
         # use with query string)
-        # DEV NOTES :: Why not use `copy_to` into the ES mapping.
+        # DEV NOTES :: Why not use `copy_to` into the search mapping.
         # It's not possible to copy an "object" field (with properties) into a
         # "nested" field using the `copy_to` directive ; this will cause an
         # exception during index creation.

--- a/rero_ils/modules/documents/extensions/title.py
+++ b/rero_ils/modules/documents/extensions/title.py
@@ -42,7 +42,7 @@ class TitleExtension(RecordExtension):
         parallel_titles = []
         for title in titles:
             if isinstance(title, AttrDict):
-                # force title to dict because ES gives AttrDict
+                # force title to dict because search gives AttrDict
                 title = title.to_dict()
             title = dict(title)
             if title.get("type") == "bf:Title":

--- a/rero_ils/modules/documents/mappings/__init__.py
+++ b/rero_ils/modules/documents/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/documents/mappings/v7/__init__.py
+++ b/rero_ils/modules/documents/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/documents/serializers/base.py
+++ b/rero_ils/modules/documents/serializers/base.py
@@ -117,8 +117,8 @@ class BaseDocumentFormatterMixin(ABC):
         def _extract_part_of_title_callback(part_of):
             """Extract title for the partOf document."""
             pid = part_of.get("document", {}).get("pid")
-            if es_doc := DocumentsSearch().get_record_by_pid(pid):
-                title = es_doc.to_dict().get("title", [])
+            if search_doc := DocumentsSearch().get_record_by_pid(pid):
+                title = search_doc.to_dict().get("title", [])
                 return next(filter(lambda x: x.get("type") == "bf:Title", title), {}).get("_text")
             return None
 

--- a/rero_ils/modules/documents/serializers/dc.py
+++ b/rero_ils/modules/documents/serializers/dc.py
@@ -108,7 +108,7 @@ class DublinCoreSerializer(_DublinCoreSerializer):
 
         Args:
             pid (str): Persistent identifier of the document.
-            record (dict): Elasticsearch hit source (minimal record data).
+            record (dict): search index hit source (minimal record data).
             links_factory (callable, optional): Factory function for generating
                 record links. Defaults to None.
             language (str, optional): Target language for i18n fields.
@@ -128,7 +128,7 @@ class DublinCoreSerializer(_DublinCoreSerializer):
         )
 
     def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None, **kwargs):
-        """Serialize Elasticsearch search results into Dublin Core XML.
+        """Serialize search index search results into Dublin Core XML.
 
         Generates an SRU-compliant searchRetrieveResponse containing Dublin Core
         records for all search hits. The response includes:
@@ -146,7 +146,7 @@ class DublinCoreSerializer(_DublinCoreSerializer):
         Args:
             pid_fetcher (callable): Function to extract persistent identifier from hits.
                 Currently unused; PIDs are extracted directly from record source.
-            search_result (dict): Elasticsearch search response containing:
+            search_result (dict): search index search response containing:
                 - hits.total.value: Total number of matching documents
                 - hits.hits: List of search result hits
                 - hits.sru: SRU-specific metadata (optional)
@@ -168,8 +168,8 @@ class DublinCoreSerializer(_DublinCoreSerializer):
         sru = search_result["hits"].get("sru", {})
         start_record = sru.get("start_record", 0)
         maximum_records = sru.get("maximum_records", 0)
-        query = sru.get("query")
-        query_es = sru.get("query_es")
+        cql_query = sru.get("cql_query")
+        search_query = sru.get("search_query")
         next_record = start_record + maximum_records + 1
 
         element = ElementMaker()
@@ -201,10 +201,10 @@ class DublinCoreSerializer(_DublinCoreSerializer):
 
         if sru:
             echoed_search_rr = element.echoedSearchRetrieveRequest()
-            if query:
-                echoed_search_rr.append(element.query(query))
-            if query_es:
-                echoed_search_rr.append(element.query_es(query_es))
+            if cql_query:
+                echoed_search_rr.append(element.query(cql_query))
+            if search_query:
+                echoed_search_rr.append(element.search_query(search_query))
             if start_record:
                 echoed_search_rr.append(element.startRecord(str(start_record)))
             if next_record > 1 and next_record < total:

--- a/rero_ils/modules/documents/serializers/json.py
+++ b/rero_ils/modules/documents/serializers/json.py
@@ -239,7 +239,7 @@ class DocumentExportJSONSerializer(JSONSerializer):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/documents/serializers/marc.py
+++ b/rero_ils/modules/documents/serializers/marc.py
@@ -110,7 +110,7 @@ class DocumentMARCXMLSerializer(JSONSerializer):
         links_factory=None,
         **kwargs,
     ):
-        """Transform an Elasticsearch search hit into MARC 21 representation.
+        """Transform a search index search hit into MARC 21 representation.
 
         Converts a document record from RERO ILS JSON format to MARC 21 format
         using DoJSON transformation rules. Optionally includes holdings and items
@@ -118,7 +118,7 @@ class DocumentMARCXMLSerializer(JSONSerializer):
 
         Args:
             pid (str): Persistent identifier of the document.
-            record_hit (dict): Elasticsearch hit source containing document data.
+            record_hit (dict): search index hit source containing document data.
             language (str, optional): Target language for language-dependent fields.
                 Affects contribution label selection. Defaults to None.
             with_holdings_items (bool, optional): Whether to include holdings and
@@ -177,11 +177,11 @@ class DocumentMARCXMLSerializer(JSONSerializer):
         location_pids=None,
         item_links_factory=None,
     ):
-        """Transform multiple Elasticsearch hits into MARC 21 records with entity resolution.
+        """Transform multiple search index hits into MARC 21 records with entity resolution.
 
         This method processes multiple search hits efficiently by:
             1. Collecting all contribution entity PIDs from all hits
-            2. Batch-fetching all entities in a single Elasticsearch query
+            2. Batch-fetching all entities in a single search index query
             3. Enriching each contribution with full entity data
             4. Applying language-specific source ordering for agent labels
             5. Transforming each record to MARC 21 format
@@ -190,7 +190,7 @@ class DocumentMARCXMLSerializer(JSONSerializer):
         entities individually for each record.
 
         Args:
-            hits (list): List of Elasticsearch search hits, each containing
+            hits (list): List of search index search hits, each containing
                 a '_source' field with document data.
             pid_fetcher (callable): Function to extract PID from document ID.
             language (str): Target language for entity label selection. Used to
@@ -214,19 +214,19 @@ class DocumentMARCXMLSerializer(JSONSerializer):
             for different languages.
         """
         # Collect all contribution entity PIDs from all hits for batch resolution.
-        # This prevents N+1 query problem by fetching all entities in one ES query.
+        # This prevents N+1 query problem by fetching all entities in one search query.
         contribution_pids = []
         for hit in hits:
             for contribution in hit["_source"].get("contribution", []):
                 if contribution_pid := contribution.get("entity", {}).get("pid"):
                     contribution_pids.append(contribution_pid)
-        # Batch-fetch all unique entities from Elasticsearch and cache them
+        # Batch-fetch all unique entities from search index and cache them
         # in a dictionary for O(1) lookup during record processing.
         search = RemoteEntitiesSearch().filter("terms", pid=list(set(contribution_pids)))
-        es_contributions = {}
+        search_contributions = {}
         for hit in search.scan():
             contribution = hit.to_dict()
-            es_contributions[contribution["pid"]] = contribution
+            search_contributions[contribution["pid"]] = contribution
 
         # Get language-specific source order for agent labels (e.g., prefer idref
         # for French, gnd for German). Falls back to default language if not found.
@@ -242,9 +242,9 @@ class DocumentMARCXMLSerializer(JSONSerializer):
             contributions = document.get("contribution", [])
             for contribution in contributions:
                 contribution_pid = contribution.get("entity", {}).get("pid")
-                if contribution_pid in es_contributions:
+                if contribution_pid in search_contributions:
                     # Deep copy prevents modifying the cached entity data
-                    contribution["entity"] = deepcopy(es_contributions[contribution_pid])
+                    contribution["entity"] = deepcopy(search_contributions[contribution_pid])
                     # Select the best authorized access point based on language preferences
                     replace_contribution_sources(contribution=contribution, source_order=source_order)
 
@@ -268,7 +268,7 @@ class DocumentMARCXMLSerializer(JSONSerializer):
     #     """Serialize a search result.
     #
     #     :param pid_fetcher: Persistent identifier fetcher.
-    #     :param search_result: Elasticsearch search result.
+    #     :param search_result: search index search result.
     #     :param item_links_factory: Factory function for the items in result.
     #         (Default: ``None``)
     #     :returns: The objects serialized.
@@ -336,15 +336,15 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
         MARC 21 records with proper namespace declarations and metadata.
 
         Args:
-            total (dict): Total hits information from Elasticsearch with 'value' key.
+            total (dict): Total hits information from search index with 'value' key.
             records (list or dict): Either a list of MARC records (for search results)
                 or a single MARC record dict. Each record should be a GroupableOrderedDict
                 with MARC fields as keys (e.g., 'leader', '245__', '100__').
             sru (dict): SRU request parameters containing:
                 - start_record (int): Starting position in result set
                 - maximum_records (int): Number of records requested
-                - query (str): Original CQL query string
-                - query_es (str): Elasticsearch query translation
+                - cql_query (str): Original CQL query string
+                - search_query (str): search index query translation
             xslt_filename (str, optional): Path to XSLT stylesheet for transformation.
                 Currently disabled but can be used for output formatting. Defaults to None.
             prefix (str, optional): XML namespace prefix for MARC fields.
@@ -457,8 +457,8 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             number_of_records = total["value"]
             start_record = sru.get("start_record", 1)
             maximum_records = sru.get("maximum_records", 0)
-            query = sru.get("query")
-            query_es = sru.get("query_es")
+            cql_query = sru.get("cql_query")
+            search_query = sru.get("search_query")
             next_record = start_record + maximum_records
             root = element.searchRetrieveResponse()
             root.append(element.version("1.1"))
@@ -471,10 +471,10 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             root.append(data)
             echoed_search_rr = element.echoedSearchRetrieveRequest()
             echoed_search_rr.append(element.version("1.1"))
-            if query:
-                echoed_search_rr.append(element.query(query))
-            if query_es:
-                echoed_search_rr.append(element.query_es(query_es))
+            if cql_query:
+                echoed_search_rr.append(element.query(cql_query))
+            if search_query:
+                echoed_search_rr.append(element.search_query(search_query))
             if start_record:
                 echoed_search_rr.append(element.startRecord(str(start_record)))
             if maximum_records:
@@ -498,7 +498,7 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
         return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8", **kwargs)
 
     def serialize_search(self, pid_fetcher, search_result, item_links_factory=None, **kwargs):
-        """Serialize Elasticsearch search results into SRU MARCXML format.
+        """Serialize search index search results into SRU MARCXML format.
 
         This method orchestrates the complete serialization process:
             1. Extracts language and filtering parameters from request
@@ -511,11 +511,11 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             - without_items: Flag to exclude holdings/items (default: False)
 
         Organisation/library/location filters are automatically extracted from
-        the Elasticsearch query string when present.
+        the search index query string when present.
 
         Args:
             pid_fetcher (callable): Function to extract PID from document ID.
-            search_result (dict): Elasticsearch search response with structure:
+            search_result (dict): search index search response with structure:
                 - hits.total: Total number of matching documents
                 - hits.hits: Array of search result hits
                 - hits.sru: SRU-specific metadata (query, pagination)
@@ -532,7 +532,7 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
             serializer = DocumentMARCXMLSRUSerializer()
             xml = serializer.serialize_search(
                 pid_fetcher=lambda id, doc: doc['pid'],
-                search_result=es_response
+                search_result=search_response
             )
         """
         # Extract request parameters for language and item inclusion
@@ -540,13 +540,13 @@ class DocumentMARCXMLSRUSerializer(DocumentMARCXMLSerializer):
         without_items_param = request.args.get("without_items", "").lower()
         with_holdings_items = without_items_param not in ("true", "1", "yes")
 
-        # Parse organisation/library/location filters from the Elasticsearch query.
+        # Parse organisation/library/location filters from the search index query.
         # These filters control which holdings/items are included in the output.
         sru = search_result["hits"].get("sru", {})
-        query_es = sru.get("query_es", "")
-        organisation_pids = re.findall(r"organisation_pid:([A-Za-z0-9_-]+)", query_es)
-        library_pids = re.findall(r"library_pid:([A-Za-z0-9_-]+)", query_es)
-        location_pids = re.findall(r"holdings\.location\.pid:([A-Za-z0-9_-]+)", query_es)
+        search_query = sru.get("search_query", "")
+        organisation_pids = re.findall(r"organisation_pid:([A-Za-z0-9_-]+)", search_query)
+        library_pids = re.findall(r"library_pid:([A-Za-z0-9_-]+)", search_query)
+        location_pids = re.findall(r"holdings\.location\.pid:([A-Za-z0-9_-]+)", search_query)
         records = self.transform_records(
             hits=search_result["hits"]["hits"],
             pid_fetcher=pid_fetcher,

--- a/rero_ils/modules/documents/serializers/ris.py
+++ b/rero_ils/modules/documents/serializers/ris.py
@@ -59,7 +59,7 @@ class RISSerializer(SerializerMixinInterface):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/documents/tasks.py
+++ b/rero_ils/modules/documents/tasks.py
@@ -45,7 +45,7 @@ def reindex_document(pid):
 def delete_orphan_harvested(delete=False, verbose=False):
     """Delete orphan harvested documents.
 
-    :param delete: if True, delete from DB and ES.
+    :param delete: if True, delete from DB and search.
     :param verbose: if True, print progress output to the terminal.
     :returns: count of deleted documents.
     """
@@ -84,7 +84,7 @@ def delete_drafts(days=1, delete=False, verbose=False):
     """Delete drafts.
 
     :param days: delete drafts older than this number of days.
-    :param delete: if True, delete from DB and ES.
+    :param delete: if True, delete from DB and search.
     :param verbose: if True, print progress output to the terminal.
     :returns: count of deleted drafts.
     """

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -84,7 +84,7 @@ def doc_item_view_method(pid, record, template=None, **kwargs):
         template,
         pid=pid,
         record=record,
-        es_record=record.dumps(document_indexer_dumper),
+        search_record=record.dumps(document_indexer_dumper),
         holdings_count=holdings_count,
         viewcode=viewcode,
         recordType="documents",

--- a/rero_ils/modules/entities/local_entities/mappings/__init__.py
+++ b/rero_ils/modules/entities/local_entities/mappings/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/entities/local_entities/mappings/v7/__init__.py
+++ b/rero_ils/modules/entities/local_entities/mappings/v7/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/entities/local_entities/proxy.py
+++ b/rero_ils/modules/entities/local_entities/proxy.py
@@ -54,7 +54,7 @@ class LocalEntityProxy:
         yield from query.execute()
 
     def _create_base_query(self):
-        """Build the base ES query object to search `LocalEntity`.
+        """Build the base search query object to search `LocalEntity`.
 
         Either the search_category is key for a predefined configuration,
         either the search_category will be used as local entity type search

--- a/rero_ils/modules/entities/remote_entities/api.py
+++ b/rero_ils/modules/entities/remote_entities/api.py
@@ -86,11 +86,14 @@ class RemoteEntity(Entity):
         if ref_type == "mef":
             return cls.get_record_by_pid(ref_pid)
 
-        es_filter = Q("term", **{f"{ref_type}.pid": ref_pid})
+        search_filter = Q("term", **{f"{ref_type}.pid": ref_pid})
         if ref_type == "viaf":
-            es_filter = Q("term", viaf_pid=ref_pid)
+            search_filter = Q("term", viaf_pid=ref_pid)
         query = (
-            RemoteEntitiesSearch().params(preserve_order=True).sort({"_updated": {"order": "desc"}}).filter(es_filter)
+            RemoteEntitiesSearch()
+            .params(preserve_order=True)
+            .sort({"_updated": {"order": "desc"}})
+            .filter(search_filter)
         )
         with contextlib.suppress(StopIteration):
             pid = next(query.source("pid").scan()).pid

--- a/rero_ils/modules/entities/remote_entities/mappings/__init__.py
+++ b/rero_ils/modules/entities/remote_entities/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/entities/remote_entities/mappings/v7/__init__.py
+++ b/rero_ils/modules/entities/remote_entities/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/entities/remote_entities/replace.py
+++ b/rero_ils/modules/entities/remote_entities/replace.py
@@ -113,7 +113,7 @@ class ReplaceIdentifiedBy:
 
     @property
     def query(self):
-        """ES query for documents with identifiedBy and entity types."""
+        """Search query for documents with identifiedBy and entity types."""
         entity_types = list(current_app.config["RERO_ILS_ENTITY_TYPES"].keys())
         return (
             DocumentsSearch()

--- a/rero_ils/modules/entities/remote_entities/sync.py
+++ b/rero_ils/modules/entities/remote_entities/sync.py
@@ -170,17 +170,17 @@ class SyncEntity:
         :returns: the list of the contribution identifiers.
         :rtype: list of strings.
         """
-        es_query = RemoteEntitiesSearch().filter("query_string", query=query)
-        total = es_query.count()
+        search_query = RemoteEntitiesSearch().filter("query_string", query=query)
+        total = search_query.count()
         if not from_date and self.from_date:
             from_date = self.from_date
         if from_date:
             self.logger.info(f"Get records updated after: {from_date}")
 
-        def get_mef_pids(es_query, chunk_size=1000):
-            """Get the identifiers from elasticsearch.
+        def get_mef_pids(search_query, chunk_size=1000):
+            """Get the identifiers from search index.
 
-            :param es_query: (string) the elasticsearch query to limit the
+            :param search_query: (string) the search index query to limit the
                 results
             :param chunk_size: (integer) the maximum number of pid per chunk
             :returns: iterator over all pids
@@ -193,13 +193,15 @@ class SyncEntity:
                 n_part = int(total / chunk_size)
                 for i in range(n_part):
                     # processing the slice should be faster than 30m
-                    for hit in es_query.extra(slice={"id": i, "max": n_part}).params(scroll="30m").source("pid").scan():
+                    for hit in (
+                        search_query.extra(slice={"id": i, "max": n_part}).params(scroll="30m").source("pid").scan()
+                    ):
                         yield hit.pid
             # no need to slice as the part is smaller than the number
             # of results
             # the results can be in memory as it is small
             else:
-                for hit in list(es_query.params(scroll="30m").scan()):
+                for hit in list(search_query.params(scroll="30m").scan()):
                     yield hit.pid
 
         # ask the MEF server to know which MEF pids has been updated
@@ -238,12 +240,12 @@ class SyncEntity:
 
             if total:
                 return (
-                    get_updated_mef(pids=get_mef_pids(es_query), chunk_size=5000),
+                    get_updated_mef(pids=get_mef_pids(search_query), chunk_size=5000),
                     total,
                 )
             return [], 0
         # considers all MEF pids
-        return get_mef_pids(es_query), total
+        return get_mef_pids(search_query), total
 
     def sync_record(self, pid):
         """Sync a MEF record.

--- a/rero_ils/modules/entities/remote_entities/utils.py
+++ b/rero_ils/modules/entities/remote_entities/utils.py
@@ -118,7 +118,7 @@ def get_mef_data_by_type(
         try:
             json_data = request.json()
             if hits := json_data.get("hits", {}):
-                # we got an ES response
+                # we got an search response
                 data = hits.get("hits", [None])[0].get("metadata", {})
             else:
                 # we got an DB response

--- a/rero_ils/modules/entities/serializers/base.py
+++ b/rero_ils/modules/entities/serializers/base.py
@@ -27,7 +27,7 @@ class EntityJSONSerializer(JSONSerializer):
     def _postprocess_search_links(self, search_results, pid_fetcher):
         """Post-process search links.
 
-        :param search_results: Elasticsearch search result.
+        :param search_results: search index search result.
         :param pid_fetcher: Persistent identifier fetcher related to records
                             into the search result.
         """

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -231,11 +231,11 @@ class REROILSAPP:
         REROILSAPP.register_sru_api_blueprint(app)
         if db_log := app.config.get("RERO_ILS_DB_LOGGING"):
             logging.getLogger("sqlalchemy.engine").setLevel(db_log)
-        if es_log := app.config.get("RERO_ILS_ES_LOGGING"):
-            es_trace_logger = logging.getLogger("elasticsearch.trace")
-            es_trace_logger.setLevel(es_log)
+        if search_log := app.config.get("RERO_ILS_SEARCH_LOGGING"):
+            search_trace_logger = logging.getLogger("elasticsearch.trace")
+            search_trace_logger.setLevel(search_log)
             handler = logging.StreamHandler()
-            es_trace_logger.addHandler(handler)
+            search_trace_logger.addHandler(handler)
         app_loaded.connect(set_boosting_query_fields)
         connections.add_connection("default", current_search_client)
 

--- a/rero_ils/modules/extensions.py
+++ b/rero_ils/modules/extensions.py
@@ -41,10 +41,10 @@ class UniqueFieldsExtension(RecordExtension):
         class attribute. This extension require 2 parameters :
           * a list of tuple. Each tuple could provide 2 data :
             - the record attribute to check (required).
-            - the corresponding field into ES index (optional).
-            if no ES field is provided, the same key should be used to search
-            into ES.
-          * the search class allowing to search into the ES index.
+            - the corresponding field into search index (optional).
+            if no search field is provided, the same key should be used to search
+            into search.
+          * the search class allowing to search into the search index.
 
     EXAMPLE:
         _extensions = UniqueFieldsExtension(
@@ -53,10 +53,10 @@ class UniqueFieldsExtension(RecordExtension):
         )
 
     NOTE FOR DEVELOPERS:
-        Avoid to use search on ES `text` analyzed field. It will generate
+        Avoid to use search on search `text` analyzed field. It will generate
         strange result (see https://www.elastic.co/guide/en/elasticsearch/
         reference/current/query-dsl-term-query.html#avoid-term-query-text-
-        fields). Use a ES `keyword` analyzed field.
+        fields). Use a search `keyword` analyzed field.
     """
 
     def __init__(self, fields, record_search_class):
@@ -89,9 +89,9 @@ class UniqueFieldsExtension(RecordExtension):
         # Create an `OR` query with all fields to check and exclude the current
         # record from the result. If one hit matches, raise a ValidationError,
         # otherwise, all should be fine. Enjoy !
-        terms = [Q("term", **{es_field: record[attr]}) for attr, es_field in self.fields if attr in record]
+        terms = [Q("term", **{search_field: record[attr]}) for attr, search_field in self.fields if attr in record]
 
-        es_query = (
+        search_query = (
             self.search_class()
             .query("bool", should=terms, minimum_should_match=1)
             .exclude("term", pid=record.pid)
@@ -100,7 +100,7 @@ class UniqueFieldsExtension(RecordExtension):
         )
 
         _exhausted = object()
-        matching_hit = next(es_query, _exhausted)
+        matching_hit = next(search_query, _exhausted)
         if matching_hit != _exhausted:
             pid = matching_hit.pid
             field_keys = " and/or ".join(attrs_to_check)

--- a/rero_ils/modules/files/api.py
+++ b/rero_ils/modules/files/api.py
@@ -29,7 +29,7 @@ class RecordWithFile(RecordWithFileBase):
     # Jsonschema
     schema = ConstantField("$schema", "local://files/record-v1.0.0.json")
 
-    # Elasticsearch index
+    # search index
     index = IndexField("files-record-v1.0.0", search_alias="files")
 
 

--- a/rero_ils/modules/files/mappings/__init__.py
+++ b/rero_ils/modules/files/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Record File Elasticsearch mappings."""
+"""Record File search index mappings."""

--- a/rero_ils/modules/files/mappings/v7/__init__.py
+++ b/rero_ils/modules/files/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Record File Elasticsearch mappings."""
+"""Record File search index mappings."""

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -89,7 +89,7 @@ class HoldingsSearch(IlsRecordsSearch):
     def available_query(self):
         """Base query for holding availability.
 
-        :returns: a filtered Elasticsearch query.
+        :returns: a filtered search index query.
         """
         # should not masked
         return self.exclude("term", _masked=True)
@@ -378,24 +378,24 @@ class Holding(IlsRecord):
     @classmethod
     def get_holdings_pid_by_document_pid(cls, document_pid, with_masked=True):
         """Returns holding pids attached for a given document pid."""
-        es_query = HoldingsSearch().filter("term", document__pid=document_pid).source(["pid"])
+        search_query = HoldingsSearch().filter("term", document__pid=document_pid).source(["pid"])
         if not with_masked:
-            es_query = es_query.filter("bool", must_not=[Q("term", _masked=True)])
-        for holding in es_query.scan():
+            search_query = search_query.filter("bool", must_not=[Q("term", _masked=True)])
+        for holding in search_query.scan():
             yield holding.pid
 
     @classmethod
     def get_holdings_pid_by_document_pid_by_org(cls, document_pid, org_pid, with_masked=True):
         """Returns holding pids attached for a given document pid."""
-        es_query = (
+        search_query = (
             HoldingsSearch()
             .filter("term", document__pid=document_pid)
             .filter("term", organisation__pid=org_pid)
             .source(["pid"])
         )
         if not with_masked:
-            es_query = es_query.filter("bool", must_not=[Q("term", _masked=True)])
-        for holding in es_query.scan():
+            search_query = search_query.filter("bool", must_not=[Q("term", _masked=True)])
+        for holding in search_query.scan():
             yield holding.pid
 
     def get_items_filter_by_viewcode(self, viewcode):

--- a/rero_ils/modules/holdings/cli.py
+++ b/rero_ils/modules/holdings/cli.py
@@ -38,8 +38,8 @@ from rero_ils.modules.utils import read_json_record
 
 def get_document_pid_by_rero_number(rero_control_number):
     """Get pid of document by rero control number."""
-    es_documents = DocumentsSearch().filter("term", identifiedBy__value__raw=rero_control_number).source("pid")
-    documents = [document.pid for document in es_documents.scan()]
+    search_documents = DocumentsSearch().filter("term", identifiedBy__value__raw=rero_control_number).source("pid")
+    documents = [document.pid for document in search_documents.scan()]
     return documents[0] if documents else None
 
 

--- a/rero_ils/modules/holdings/mappings/__init__.py
+++ b/rero_ils/modules/holdings/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Holdings Elasticsearch mappings."""
+"""Holdings search index mappings."""

--- a/rero_ils/modules/holdings/mappings/v7/__init__.py
+++ b/rero_ils/modules/holdings/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Holdings Elasticsearch mappings."""
+"""Holdings search index mappings."""

--- a/rero_ils/modules/holdings/tasks.py
+++ b/rero_ils/modules/holdings/tasks.py
@@ -27,9 +27,9 @@ from .api import Holding, HoldingsIndexer, HoldingsSearch
 @shared_task(ignore_result=True)
 def delete_standard_holdings_having_no_items():
     """Removes standard holdings records with no attached items."""
-    es_query = HoldingsSearch().filter("term", holdings_type="standard").filter("term", items_count=0).source("pid")
+    search_query = HoldingsSearch().filter("term", holdings_type="standard").filter("term", items_count=0).source("pid")
 
-    search_results = list(es_query.scan())
+    search_results = list(search_query.scan())
     count = len(search_results)
     deleted = 0
     errors = 0

--- a/rero_ils/modules/ill_requests/api.py
+++ b/rero_ils/modules/ill_requests/api.py
@@ -172,7 +172,7 @@ class ILLRequest(IlsRecord):
 
 
 class ILLRequestsIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = ILLRequest
 

--- a/rero_ils/modules/ill_requests/listener.py
+++ b/rero_ils/modules/ill_requests/listener.py
@@ -34,7 +34,7 @@ def enrich_ill_request_data(sender, json=None, record=None, index=None, doc_type
         if not isinstance(record, ILLRequest):
             record = ILLRequest.get_record_by_pid(record.get("pid"))
         json["organisation"] = {"pid": record.organisation_pid}
-        # add patron name to ES index (for faceting)
+        # add patron name to search index (for faceting)
         patron = extracted_data_from_ref(record.get("patron").get("$ref"), "record")
         json["patron"]["name"] = patron.formatted_name
         if loc_pid := json.get("pickup_location", {}).get("pid"):

--- a/rero_ils/modules/ill_requests/mappings/__init__.py
+++ b/rero_ils/modules/ill_requests/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/ill_requests/mappings/v7/__init__.py
+++ b/rero_ils/modules/ill_requests/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/imports/serializers/serializers.py
+++ b/rero_ils/modules/imports/serializers/serializers.py
@@ -50,7 +50,7 @@ class ImportsSearchSerializer(JSONSerializer):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         """
         for hit in search_result["hits"]["hits"]:
@@ -84,7 +84,7 @@ class ImportsSearchSerializer(JSONSerializer):
         """Serialize a single record.
 
         :param pid: Persistent identifier instance.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         """
         return json.dumps(
@@ -171,7 +171,7 @@ class ImportsMarcSearchSerializer(JSONSerializer):
         """Serialize a single record.
 
         :param pid: Persistent identifier instance.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         """
         return json.dumps(self.convert_marc_to_marc_text_dict(record), **self._format_args())

--- a/rero_ils/modules/item_types/api.py
+++ b/rero_ils/modules/item_types/api.py
@@ -101,7 +101,7 @@ class ItemType(IlsRecord):
 
         :param name: the circulation category name to check.
         :param organisation_pid: the organisation pid to check.
-        :return: A ES hit if a circulation category already use thi name in
+        :return: A search hit if a circulation category already use thi name in
                  the organisation; otherwise, return None.
         """
         item_type = (
@@ -187,7 +187,7 @@ class ItemType(IlsRecord):
 
 
 class ItemTypesIndexer(IlsRecordsIndexer):
-    """Indexing documents in Elasticsearch."""
+    """Indexing documents in search index."""
 
     record_cls = ItemType
 

--- a/rero_ils/modules/item_types/mappings/__init__.py
+++ b/rero_ils/modules/item_types/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item type Elasticsearch mapping."""
+"""Item type search index mapping."""

--- a/rero_ils/modules/item_types/mappings/v7/__init__.py
+++ b/rero_ils/modules/item_types/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item type Elasticsearch mapping."""
+"""Item type search index mapping."""

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -62,9 +62,9 @@ class ItemsSearch(IlsRecordsSearch):
         default_filter = None
 
     def available_query(self):
-        """Base elasticsearch query to compute availability.
+        """Base search index query to compute availability.
 
-        :returns: elasticsearch query.
+        :returns: search index query.
         """
         must_not_filters = [
             # should not be masked
@@ -215,40 +215,40 @@ class Item(ItemCirculation, ItemIssue):
         """
         end_date = cls.format_end_date(end_date)
         items_query = ItemsSearch()
-        loc_es_quey = items_query.filter("range", temporary_location__end_date={"lte": end_date})
-        locs = [(hit.meta.id, "loc") for hit in loc_es_quey.source("pid").scan()]
+        loc_search_query = items_query.filter("range", temporary_location__end_date={"lte": end_date})
+        locs = [(hit.meta.id, "loc") for hit in loc_search_query.source("pid").scan()]
 
-        itty_es_query = items_query.filter("range", temporary_item_type__end_date={"lte": end_date})
-        itty = [(hit.meta.id, "itty") for hit in itty_es_query.source("pid").scan()]
+        itty_search_query = items_query.filter("range", temporary_item_type__end_date={"lte": end_date})
+        itty = [(hit.meta.id, "itty") for hit in itty_search_query.source("pid").scan()]
         hits = itty + locs
         for id, field_type in hits:
             yield Item.get_record(id), field_type
 
 
 class ItemsIndexer(IlsRecordsIndexer):
-    """Indexing items in Elasticsearch."""
+    """Indexing items in search index."""
 
     record_cls = Item
 
     @classmethod
-    def _es_item(cls, record):
+    def _search_item(cls, record):
         """Get the item from the corresponding index.
 
         :param record: an item object
-        :returns: the elasticsearch document or {}
+        :returns: the search index document or {}
         """
         try:
-            es_item = current_search_client.get(ItemsSearch.Meta.index, record.id)
-            return es_item["_source"]
+            search_item = current_search_client.get(ItemsSearch.Meta.index, record.id)
+            return search_item["_source"]
         except NotFoundError:
             return {}
 
     @classmethod
-    def _update_status_in_doc(cls, record, es_item):
+    def _update_status_in_doc(cls, record, search_item):
         """Update the status of a given item in the document index.
 
         :param record: an item object
-        :param es_item: a dict of the elasticsearch item
+        :param search_item: a dict of the search index item
         """
         # retrieve the document in the corresponding es index
         document_pid = extracted_data_from_ref(record.get("document"))
@@ -281,14 +281,14 @@ class ItemsIndexer(IlsRecordsIndexer):
         from ...holdings.api import Holding
 
         # get previous indexed version
-        es_item = self._es_item(record)
+        search_item = self._search_item(record)
 
         # call the parent
         return_value = super().index(record)
 
         # fast document reindex for circulation operations
-        if es_item and record.get("status") != es_item.get("status"):
-            self._update_status_in_doc(record, es_item)
+        if search_item and record.get("status") != search_item.get("status"):
+            self._update_status_in_doc(record, search_item)
             return return_value
 
         # reindex the holding / doc for non circulation operations
@@ -297,9 +297,9 @@ class ItemsIndexer(IlsRecordsIndexer):
         holding.reindex()
         # reindex the old holding
         old_holding_pid = None
-        if es_item:
+        if search_item:
             # reindex old holding ot update hte count
-            old_holding_pid = es_item.get("holding", {}).get("pid")
+            old_holding_pid = search_item.get("holding", {}).get("pid")
             if old_holding_pid != holding_pid:
                 old_holding = Holding.get_record_by_pid(old_holding_pid)
                 old_holding.reindex()

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -1184,8 +1184,8 @@ class ItemCirculation(ItemRecord):
             sort_term = sort_by or "_created"
             if sort_term.startswith("-"):
                 (sort_term, order_by) = (sort_term[1:], "desc")
-            es_query = query.params(preserve_order=True).sort({sort_term: {"order": order_by}})
-            for result in es_query.scan():
+            search_query = query.params(preserve_order=True).sort({sort_term: {"order": order_by}})
+            for result in search_query.scan():
                 yield Loan.get_record_by_pid(result.pid)
 
         query = search_by_pid(

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -285,7 +285,7 @@ class ItemRecord(IlsRecord):
         """Returns item pids from holding pid."""
         from . import ItemsSearch
 
-        es_query = (
+        search_query = (
             ItemsSearch()
             .params(preserve_order=True)
             .filter("term", holding__pid=holding_pid)
@@ -293,8 +293,8 @@ class ItemRecord(IlsRecord):
             .source(["pid"])
         )
         if not with_masked:
-            es_query = es_query.filter("bool", must_not=[Q("term", _masked=True)])
-        for item in es_query.scan():
+            search_query = search_query.filter("bool", must_not=[Q("term", _masked=True)])
+        for item in search_query.scan():
             yield item.pid
 
     @property

--- a/rero_ils/modules/items/listener.py
+++ b/rero_ils/modules/items/listener.py
@@ -59,7 +59,7 @@ def enrich_item_data(
         json["local_fields"] = local_fields
 
     if record.is_issue:
-        # `sort_key` used exclusively for ES sorting.
+        # `sort_key` used exclusively for search sorting.
         json["issue"]["sort_key"] = record.sort_date or record.expected_date
         # inherited_first_call_number to issue
         if call_number := record.issue_inherited_first_call_number:

--- a/rero_ils/modules/items/mappings/__init__.py
+++ b/rero_ils/modules/items/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item Elasticsearch mappings."""
+"""Item search index mappings."""

--- a/rero_ils/modules/items/mappings/v7/__init__.py
+++ b/rero_ils/modules/items/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item Elasticsearch mappings."""
+"""Item search index mappings."""

--- a/rero_ils/modules/items/serializers/collector.py
+++ b/rero_ils/modules/items/serializers/collector.py
@@ -180,7 +180,7 @@ class Collector:
     def get_item_data(hit):
         """Collect es items data.
 
-        :param hit: ES item hit.
+        :param hit: search item hit.
         :return csv_data: dictionary of data.
         """
         hit = hit.to_dict()
@@ -373,7 +373,7 @@ class Collector:
     def append_loan_data(hit, csv_data, items_stats):
         """Append item loan.
 
-        :param hit: item ES record.
+        :param hit: item search record.
         :param csv_data: dictionary of data.
         :param loans: loans data.
         """

--- a/rero_ils/modules/items/serializers/csv.py
+++ b/rero_ils/modules/items/serializers/csv.py
@@ -40,7 +40,7 @@ class ItemCSVSerializer(CSVSerializer, CachedDataSerializerMixin):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/items/tasks.py
+++ b/rero_ils/modules/items/tasks.py
@@ -118,7 +118,7 @@ def delete_holding(holding_pid, force=False, dbcommit=True, delindex=True):
     if holding_pid:
         holding_rec = Holding.get_record_by_pid(holding_pid)
         try:
-            # TODO: Need to split DB and elasticsearch deletion.
+            # TODO: Need to split DB and search index deletion.
             holding_rec.delete(force=force, dbcommit=dbcommit, delindex=delindex)
         except IlsRecordError.NotDeleted:
             current_app.logger.warning(f"Holding not deleted: {holding_pid}")

--- a/rero_ils/modules/items/utils.py
+++ b/rero_ils/modules/items/utils.py
@@ -102,7 +102,7 @@ def get_provisional_items_candidate_to_delete():
     """
     from rero_ils.modules.items.api import Item, ItemsSearch
 
-    # query ES index for open fees
+    # query search index for open fees
     query_fees = (
         PatronTransactionsSearch()
         .filter("term", status="open")

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -159,7 +159,7 @@ def do_item_jsonify_action(func):
       * Generic Exception errors (catch-all)
     - The removal info is NOT returned for:
       * NotFound errors (item not found before removal is attempted)
-      * RequestError errors (Elasticsearch errors before removal is attempted)
+      * RequestError errors (search index errors before removal is attempted)
     """
 
     def _add_removed_item_type_info(error_response, removed_temp_item_type_name):

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -153,7 +153,7 @@ class Library(IlsRecord):
         )
 
     def location_pids(self):
-        """Return a generator of ES Hits of all pids of library locations."""
+        """Return a generator of search Hits of all pids of library locations."""
         return LocationsSearch().filter("term", library__pid=self.pid).source(["pid"]).scan()
 
     def get_pickup_locations_pids(self):

--- a/rero_ils/modules/libraries/mappings/__init__.py
+++ b/rero_ils/modules/libraries/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Libraries Elasticsearch mappings."""
+"""Libraries search index mappings."""

--- a/rero_ils/modules/libraries/mappings/v7/__init__.py
+++ b/rero_ils/modules/libraries/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -84,7 +84,7 @@ class LoansSearch(IlsRecordsSearch):
 
         Unavailable if some active loans exists.
 
-        :returns: an elasticsearch query
+        :returns: a search index query
         """
         states = [LoanState.PENDING] + current_app.config["CIRCULATION_STATES_LOAN_ACTIVE"]
         return self.filter("terms", state=states)

--- a/rero_ils/modules/loans/logs/api.py
+++ b/rero_ils/modules/loans/logs/api.py
@@ -32,7 +32,7 @@ class LoanOperationLogsSearch(OperationLogsSearch):
         """Get the operation logs base es search.
 
         :param triggers: list[str] - loan triggers value to filter
-        :return: an elasticsearch dsl search query
+        :return: a search index dsl search query
         """
         query = self.filter("term", record__type="loan").filter("terms", loan__trigger=triggers)
         if date_range:
@@ -45,7 +45,7 @@ class LoanOperationLog(OperationLog, SpecificOperationLog):
 
     @classmethod
     def create(cls, data, id_=None, index_refresh="false", **kwargs):
-        """Create a new record instance and store it in elasticsearch.
+        """Create a new record instance and store it in search index.
 
         :param loan_data: Dict with the loan metadata.
         :param id_: Specify a UUID to use for the new record, instead of
@@ -124,7 +124,7 @@ class NoCirculationOperationLog(OperationLog, SpecificOperationLog):
 
     @classmethod
     def create(cls, scan, id_=None, index_refresh="false", **kwargs):
-        """Create a new record instance and store it in elasticsearch.
+        """Create a new record instance and store it in search index.
         :param item_data: Dict with the item metadata.
         :param loan: Dict with the loan metadata.
         :param message: Message for item category.

--- a/rero_ils/modules/loans/mappings/__init__.py
+++ b/rero_ils/modules/loans/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Loans Elasticsearch Mappings."""
+"""Loans search index Mappings."""

--- a/rero_ils/modules/loans/mappings/v7/__init__.py
+++ b/rero_ils/modules/loans/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Loans Elasticsearch mappings."""
+"""Loans search index mappings."""

--- a/rero_ils/modules/loans/serializers/csv.py
+++ b/rero_ils/modules/loans/serializers/csv.py
@@ -88,7 +88,7 @@ class LoanStreamedCSVSerializer(CSVSerializer, StreamSerializerMixin, CachedData
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/loans/serializers/json.py
+++ b/rero_ils/modules/loans/serializers/json.py
@@ -135,14 +135,14 @@ class LoanJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
             _enrich_buckets(aggr_loc, LocationsSearch, "name")
 
         # Add configuration for `end_date` and `request_expire_date`
-        #   ES `date_histogram` facet need some configuration settings to
+        #   search `date_histogram` facet need some configuration settings to
         #   display the widget.
         for aggr_name in ["end_date", "request_expire_date"]:
             aggr = aggregations.get(aggr_name, {})
             JSONSerializer.add_date_range_configuration(aggr)
 
         # Miscellaneous status
-        #   The `misc_status` aggregation buckets are based on ES filters
+        #   The `misc_status` aggregation buckets are based on search filters
         #   queries. We need to rebuild this aggregation to display each
         #   filter query hit as a 'classic' term facet hit.
         if misc_aggr := aggregations.get("misc_status", {}).get("buckets"):

--- a/rero_ils/modules/local_fields/mappings/__init__.py
+++ b/rero_ils/modules/local_fields/mappings/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/local_fields/mappings/v7/__init__.py
+++ b/rero_ils/modules/local_fields/mappings/v7/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/locations/mappings/__init__.py
+++ b/rero_ils/modules/locations/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/locations/mappings/v7/__init__.py
+++ b/rero_ils/modules/locations/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/migrations/api.py
+++ b/rero_ils/modules/migrations/api.py
@@ -111,7 +111,7 @@ class Migration(Document):
         self.meta["id"] = self.name
 
     def save(self, **kwargs):
-        """Put the data on the elasticsearch index."""
+        """Put the data on the search index."""
         self._set_default_values()
         self.updated_at = datetime.now(timezone.utc)
         to_return = super().save(**kwargs)

--- a/rero_ils/modules/migrations/cli.py
+++ b/rero_ils/modules/migrations/cli.py
@@ -52,9 +52,9 @@ def index():
 @index.command()
 @with_appcontext
 def init():
-    """Initialize the migration elasticsearch index."""
+    """Initialize the migration search index."""
     Migration.init()
-    click.echo("Elasticsearch Index created.")
+    click.echo("search index created.")
 
 
 @index.command()
@@ -67,11 +67,11 @@ def init():
     prompt="Do you really want to remove all migration data?",
 )
 def destroy():
-    """Remove the migration elasticsearch index."""
+    """Remove the migration search index."""
     for migration in Migration.search().source().scan():
         migration.delete()
     Index(Migration.Index.name).delete()
-    click.echo("Migration Elasticsearch Index has been deleted.")
+    click.echo("Migration search index has been deleted.")
 
 
 @migrations.command()

--- a/rero_ils/modules/migrations/data/api.py
+++ b/rero_ils/modules/migrations/data/api.py
@@ -173,7 +173,7 @@ class MigrationData(Document):
             self.created_at = datetime.now(timezone.utc)
 
     def save(self, **kwargs):
-        """Put the data on the elasticsearch index."""
+        """Put the data on the search index."""
         _id = self._set_default_values()
         self.updated_at = datetime.now(timezone.utc)
         return super().save(**kwargs)

--- a/rero_ils/modules/monitoring/api.py
+++ b/rero_ils/modules/monitoring/api.py
@@ -77,30 +77,30 @@ class Monitoring:
     def __init__(self, time_delta=1):
         """Constructor.
 
-        :param time_delta: Minutes to subtract from DB ES creation time.
+        :param time_delta: Minutes to subtract from DB search creation time.
         """
         self.time_delta = int(time_delta)
 
     def __str__(self):
-        """Table representation of database and elasticsearch differences.
+        """Table representation of database and search index differences.
 
-        :return: string representation of database and elasticsearch
+        :return: string representation of database and search index
         differences. Following columns are in the string:
-            1. database count minus elasticsearch count
+            1. database count minus search index count
             2. document type
             3. database count
-            4. elasticsearch index
-            5. elasticsearch count
+            4. search index
+            5. search index count
         """
         result = ""
-        msg_head = f"DB - ES{'type':>8}{'count':>11}{'index':>27}{'count':>11}"
+        msg_head = f"DB - search{'type':>8}{'count':>11}{'index':>27}{'count':>11}"
         msg_head += f"\n{'':-^64s}\n"
         for doc_type, info in sorted(self.info().items()):
-            db_es = info.get("db-es", "")
+            db_search = info.get("db-search", "")
             count_db = info.get("db", "")
-            msg = f"{db_es:>7}  {doc_type:>6} {count_db:>10}"
+            msg = f"{db_search:>7}  {doc_type:>6} {count_db:>10}"
             if index := info.get("index", ""):
-                msg += f"  {index:>25} {info.get('es', ''):>10}"
+                msg += f"  {index:>25} {info.get('search', ''):>10}"
             result += msg + "\n"
         return msg_head + result
 
@@ -124,10 +124,10 @@ class Monitoring:
         return query.count()
 
     @classmethod
-    def get_es_count(cls, index, date=None):
-        """Get elasticsearch count.
+    def get_search_count(cls, index, date=None):
+        """Get search index count.
 
-        Get count of items in elasticsearch for the given index.
+        Get count of items in search index for the given index.
 
         :param index: index.
         :return: items count.
@@ -138,7 +138,7 @@ class Monitoring:
                 query = query.filter("range", _created={"lte": date})
             result = query.count()
         except NotFoundError:
-            result = f"No >>{index}<< in ES"
+            result = f"No >>{index}<< in search"
         return result
 
     @classmethod
@@ -169,37 +169,37 @@ class Monitoring:
             for identifier in query:
                 yield identifier.pid_value
 
-    def get_es_db_missing_pids(self, doc_type, with_deleted=False):
-        """Get ES and DB counts."""
+    def get_search_db_missing_pids(self, doc_type, with_deleted=False):
+        """Get search and DB counts."""
         endpoint = current_app.config.get("RECORDS_REST_ENDPOINTS").get(doc_type, {})
         index = endpoint.get("search_index")
-        pids_es_double = []
-        pids_es = []
+        pids_search_double = []
+        pids_search = []
         pids_db = []
         if index and doc_type not in self.has_no_db:
             date = datetime.utcnow() - timedelta(minutes=self.time_delta)
-            pids_es = {}
-            es_query = RecordsSearch(index=index).filter("range", _created={"lte": date})
-            for hit in es_query.source("pid").scan():
-                if pids_es.get(hit.pid):
-                    pids_es_double.append(hit.pid)
-                pids_es[hit.pid] = 1
+            pids_search = {}
+            search_query = RecordsSearch(index=index).filter("range", _created={"lte": date})
+            for hit in search_query.source("pid").scan():
+                if pids_search.get(hit.pid):
+                    pids_search_double.append(hit.pid)
+                pids_search[hit.pid] = 1
             pids_db = []
             for pid in self.get_all_pids(doc_type, with_deleted=with_deleted, date=date):
-                if pids_es.get(pid):
-                    pids_es.pop(pid)
+                if pids_search.get(pid):
+                    pids_search.pop(pid)
                 else:
                     pids_db.append(pid)
-        return list(pids_es), pids_db, pids_es_double, index
+        return list(pids_search), pids_db, pids_search_double, index
 
-    def info(self, with_deleted=False, difference_db_es=False):
+    def info(self, with_deleted=False, difference_db_search=False):
         """Info.
 
         Get count details for all records rest endpoints in json format.
 
         :param with_deleted: count also deleted items in database.
-        :return: dictionary with database, elasticsearch and database minus
-        elasticsearch count information.
+        :return: dictionary with database, search index and database minus
+        search index count information.
         """
         info = {}
         for doc_type, endpoint in current_app.config.get("RECORDS_REST_ENDPOINTS").items():
@@ -210,65 +210,65 @@ class Monitoring:
                 count_db = count_db if isinstance(count_db, int) else 0
                 info[doc_type]["db"] = count_db
             if index := endpoint.get("search_index", ""):
-                count_es = self.get_es_count(index, date=date)
-                count_es = count_es if isinstance(count_es, int) else 0
-                db_es = count_db - count_es
+                count_search = self.get_search_count(index, date=date)
+                count_search = count_search if isinstance(count_search, int) else 0
+                db_search = count_db - count_search
                 info[doc_type]["index"] = index
-                info[doc_type]["es"] = count_es
+                info[doc_type]["search"] = count_search
                 if doc_type not in self.has_no_db:
-                    info[doc_type]["db-es"] = db_es
-                    if db_es == 0 and difference_db_es:
-                        missing_in_db, missing_in_es, pids_es_double, index = self.get_es_db_missing_pids(
+                    info[doc_type]["db-search"] = db_search
+                    if db_search == 0 and difference_db_search:
+                        missing_in_db, missing_in_search, pids_search_double, index = self.get_search_db_missing_pids(
                             doc_type=doc_type, with_deleted=with_deleted
                         )
                         if index:
                             if missing_in_db:
                                 info[doc_type]["db-"] = list(missing_in_db)
-                            if missing_in_es:
-                                info[doc_type]["es-"] = list(missing_in_es)
+                            if missing_in_search:
+                                info[doc_type]["search-"] = list(missing_in_search)
                 else:
                     info[doc_type]["db"] = 0
-                    info[doc_type]["db-es"] = 0
+                    info[doc_type]["db-search"] = 0
         return info
 
-    def check(self, with_deleted=False, difference_db_es=False):
-        """Compare elasticsearch with database counts.
+    def check(self, with_deleted=False, difference_db_search=False):
+        """Compare search index with database counts.
 
         :param with_deleted: count also deleted items in database.
         :return: dictionary with all document types with a difference in
-        database and elasticsearch counts.
+        database and search index counts.
         """
         checks = {}
-        for info, data in self.info(with_deleted=with_deleted, difference_db_es=difference_db_es).items():
-            db_es = data.get("db-es", "")
-            if db_es and db_es not in [0, ""]:
+        for info, data in self.info(with_deleted=with_deleted, difference_db_search=difference_db_search).items():
+            db_search = data.get("db-search", "")
+            if db_search and db_search not in [0, ""]:
                 checks.setdefault(info, {})
-                checks[info]["db_es"] = db_es
+                checks[info]["db_search"] = db_search
             if data.get("db-"):
                 checks.setdefault(info, {})
                 checks[info]["db-"] = len(data.get("db-"))
-            if data.get("es-"):
+            if data.get("search-"):
                 checks.setdefault(info, {})
-                checks[info]["es-"] = len(data.get("es-"))
+                checks[info]["search-"] = len(data.get("search-"))
         return checks
 
     def missing(self, doc_type, with_deleted=False):
         """Get missing pids.
 
-        Get missing pids in database and elasticsearch and find duplicate
-        pids in elasticsearch.
+        Get missing pids in database and search index and find duplicate
+        pids in search index.
 
         :param doc_type: doc type to get missing pids.
         :return: dictionary with all missing pids.
         """
-        missing_in_db, missing_in_es, pids_es_double, index = self.get_es_db_missing_pids(
+        missing_in_db, missing_in_search, pids_search_double, index = self.get_search_db_missing_pids(
             doc_type=doc_type, with_deleted=with_deleted
         )
         if index:
             return {
                 "DB": list(missing_in_db),
-                "ES": list(missing_in_es),
-                "ES duplicate": pids_es_double,
+                "search": list(missing_in_search),
+                "search duplicate": pids_search_double,
             }
         return {"ERROR": f"Document type not found: {doc_type}"}
 
@@ -281,12 +281,12 @@ class Monitoring:
         if "ERROR" in missing:
             click.secho(f"Error: {missing['ERROR']}", fg="yellow")
         else:
-            if missing.get("ES duplicate"):
+            if missing.get("search duplicate"):
                 click.secho(
-                    f"ES duplicate {doc_type}: {', '.join(missing['ES duplicate'])}",
+                    f"SEARCH duplicate {doc_type}: {', '.join(missing['search duplicate'])}",
                     fg="red",
                 )
-            if missing.get("ES"):
-                click.secho(f"ES missing {doc_type}: {', '.join(missing['ES'])}", fg="red")
+            if missing.get("search"):
+                click.secho(f"SEARCH missing {doc_type}: {', '.join(missing['search'])}", fg="red")
             if missing.get("DB"):
                 click.secho(f"DB missing {doc_type}: {', '.join(missing['DB'])}", fg="red")

--- a/rero_ils/modules/monitoring/cli.py
+++ b/rero_ils/modules/monitoring/cli.py
@@ -32,7 +32,7 @@ def monitoring():
     """Monitoring commands."""
 
 
-@monitoring.command("es_db_counts")
+@monitoring.command("search_db_counts")
 @click.option(
     "-m",
     "--missing",
@@ -46,32 +46,32 @@ def monitoring():
     "--delay",
     "delay",
     default=1,
-    help="Get ES and DB counts from delay min minutes in the past.",
+    help="Get search and DB counts from delay min minutes in the past.",
 )
 @with_appcontext
-def es_db_counts_cli(missing, delay):
-    """Print ES and DB counts.
+def search_db_counts_cli(missing, delay):
+    """Print search and DB counts.
 
-    Prints a table representation of database and elasticsearch counts.
+    Prints a table representation of database and search index counts.
     Columns:
-    1. database count minus elasticsearch count
+    1. database count minus search index count
     2. document type
     3. database count
-    4. elasticsearch index
-    5. elasticsearch count
+    4. search index
+    5. search index count
     """
     missing_doc_types = []
     mon = Monitoring(time_delta=delay)
-    msg_head = f"DB - ES{'type':>8}{'count':>11}{'index':>27}{'count':>11}\n"
+    msg_head = f"DB - search{'type':>8}{'count':>11}{'index':>27}{'count':>11}\n"
     msg_head += f"{'':-^64s}"
     click.echo(msg_head)
-    info = mon.info(with_deleted=False, difference_db_es=False)
+    info = mon.info(with_deleted=False, difference_db_search=False)
     for doc_type in sorted(info):
-        db_es = info[doc_type].get("db-es", "")
+        db_es = info[doc_type].get("db-search", "")
         msg = f"{db_es:>7}{doc_type:>8}{info[doc_type].get('db', ''):>11}"
         index = info[doc_type].get("index", "")
         if index:
-            msg += f"{index:>27}{info[doc_type].get('es', ''):>11}"
+            msg += f"{index:>27}{info[doc_type].get('search', ''):>11}"
         if db_es not in [0, ""]:
             click.secho(msg, fg="red")
         else:
@@ -82,17 +82,17 @@ def es_db_counts_cli(missing, delay):
         mon.print_missing(missing_doc_type)
 
 
-@monitoring.command("es_db_missing")
+@monitoring.command("search_db_missing")
 @click.argument("doc_type")
 @click.option(
     "-d",
     "--delay",
     "delay",
     default=1,
-    help="Get ES and DB counts from delay minutes in the past.",
+    help="Get search and DB counts from delay minutes in the past.",
 )
 @with_appcontext
-def es_db_missing_cli(doc_type, delay):
+def search_db_missing_cli(doc_type, delay):
     """Print missing pids informations."""
     mon = Monitoring(time_delta=delay)
     mon.print_missing(doc_type)
@@ -112,15 +112,15 @@ def time_stamps_cli():
 @monitoring.command("es")
 @with_appcontext
 def es():
-    """Displays Elasticsearch cluster info."""
+    """Displays search index cluster info."""
     for key, value in current_search_client.cluster.health().items():
         click.echo(f"{key:<33}: {value}")
 
 
-@monitoring.command("es_indices")
+@monitoring.command("search_indices")
 @with_appcontext
-def es_indices():
-    """Displays Elasticsearch indices info."""
+def search_indices():
+    """Displays search index indices info."""
     click.echo(current_search_client.cat.indices(s="index"))
 
 

--- a/rero_ils/modules/monitoring/views.py
+++ b/rero_ils/modules/monitoring/views.py
@@ -98,54 +98,54 @@ def db_connections():
     return jsonify({"data": data})
 
 
-@api_blueprint.route("/es_db_counts")
-def es_db_counts():
-    """Display count for elasticsearch and documents.
+@api_blueprint.route("/search_db_counts")
+def search_db_counts():
+    """Display count for search index and documents.
 
     Displays for all document types defined in config.py following information:
     - index name for document type
     - count of records in database
-    - count of records in elasticsearch
-    - difference between the count in elasticsearch and database
-    :return: jsonified count for elasticsearch and documents
+    - count of records in search index
+    - difference between the count in search index and database
+    :return: jsonified count for search index and documents
     """
-    difference_db_es = request.args.get("diff", False)
+    difference_db_search = request.args.get("diff", False)
     with_deleted = request.args.get("deleted", False)
     time_delta = request.args.get("delay", 1)
     mon = Monitoring(time_delta=time_delta)
-    return jsonify({"data": mon.info(with_deleted=with_deleted, difference_db_es=difference_db_es)})
+    return jsonify({"data": mon.info(with_deleted=with_deleted, difference_db_search=difference_db_search)})
 
 
-@api_blueprint.route("/check_es_db_counts")
-def check_es_db_counts():
-    """Displays health status for elasticsearch and database counts.
+@api_blueprint.route("/check_search_db_counts")
+def check_search_db_counts():
+    """Displays health status for search index and database counts.
 
     If there are no problems the status in returned data will be `green`,
     otherwise the status will be `red` and in the returned error
     links will be provided with more detailed information.
-    :return: jsonified health status for elasticsearch and database counts
+    :return: jsonified health status for search index and database counts
     """
     result = {"data": {"status": "green"}}
-    difference_db_es = request.args.get("diff", False)
+    difference_db_search = request.args.get("diff", False)
     with_deleted = request.args.get("deleted", False)
     time_delta = request.args.get("delay", 1)
     mon = Monitoring(time_delta=time_delta)
-    checks = mon.check(with_deleted=with_deleted, difference_db_es=difference_db_es)
+    checks = mon.check(with_deleted=with_deleted, difference_db_search=difference_db_search)
     if checks:
         result = {"data": {"status": "red"}}
         errors = []
         for doc_type, doc_type_data in checks.items():
-            links = {"about": url_for("api_monitoring.check_es_db_counts", _external=True)}
+            links = {"about": url_for("api_monitoring.check_search_db_counts", _external=True)}
             for info, count in doc_type_data.items():
-                if info == "db_es":
-                    msg = f"There are {count} items from {doc_type} missing in ES."
+                if info == "db_search":
+                    msg = f"There are {count} items from {doc_type} missing in search."
                     links[doc_type] = url_for("api_monitoring.missing_pids", doc_type=doc_type, _external=True)
                     errors.append(
                         {
-                            "id": "DB_ES_COUNTER_MISMATCH",
+                            "id": "DB_SEARCH_COUNTER_MISMATCH",
                             "links": links,
-                            "code": "DB_ES_COUNTER_MISMATCH",
-                            "title": "DB items counts don't match ES items count.",
+                            "code": "DB_SEARCH_COUNTER_MISMATCH",
+                            "title": "DB items counts don't match search items count.",
                             "details": msg,
                         }
                     )
@@ -154,22 +154,22 @@ def check_es_db_counts():
                     links[doc_type] = url_for("api_monitoring.missing_pids", doc_type=doc_type, _external=True)
                     errors.append(
                         {
-                            "id": "DB_ES_UNEQUAL",
+                            "id": "DB_SEARCH_UNEQUAL",
                             "links": links,
-                            "code": "DB_ES_UNEQUAL",
-                            "title": "DB items unequal ES items.",
+                            "code": "DB_SEARCH_UNEQUAL",
+                            "title": "DB items unequal search items.",
                             "details": msg,
                         }
                     )
-                elif info == "es-":
-                    msg = f"There are {count} items from {doc_type} missing in ES."
+                elif info == "search-":
+                    msg = f"There are {count} items from {doc_type} missing in search."
                     links[doc_type] = url_for("api_monitoring.missing_pids", doc_type=doc_type, _external=True)
                     errors.append(
                         {
-                            "id": "DB_ES_UNEQUAL",
+                            "id": "DB_SEARCH_UNEQUAL",
                             "links": links,
-                            "code": "DB_ES_UNEQUAL",
-                            "title": "DB items unequal ES items.",
+                            "code": "DB_SEARCH_UNEQUAL",
+                            "title": "DB items unequal search items.",
                             "details": msg,
                         }
                     )
@@ -184,8 +184,8 @@ def missing_pids(doc_type):
 
     Following information will be displayed:
     - missing pids in database
-    - missing pids in elasticsearch
-    - pids indexed multiple times in elasticsearch
+    - missing pids in search index
+    - pids indexed multiple times in search index
     If possible, direct links will be provided to the corresponding records.
     This view needs an logged in system admin.
 
@@ -208,22 +208,22 @@ def missing_pids(doc_type):
                 "details": res.get("ERROR"),
             }
         }
-    data = {"DB": [], "ES": [], "ES duplicate": []}
+    data = {"DB": [], "search": [], "search duplicate": []}
     for pid in res.get("DB"):
         if api_url:
             data["DB"].append(f'{api_url}?q=pid:"{pid}"')
         else:
             data["DB"].append(pid)
-    for pid in res.get("ES"):
+    for pid in res.get("search"):
         if api_url:
-            data["ES"].append(f"{api_url}{pid}")
+            data["search"].append(f"{api_url}{pid}")
         else:
-            data["ES"].append(pid)
-    for pid in res.get("ES duplicate"):
+            data["search"].append(pid)
+    for pid in res.get("search duplicate"):
         if api_url:
-            data["ES duplicate"].append(f'{api_url}?q=pid:"{pid}"')
+            data["search duplicate"].append(f'{api_url}?q=pid:"{pid}"')
         else:
-            data["ES duplicate"].append(pid)
+            data["search duplicate"].append(pid)
     return jsonify({"data": data})
 
 
@@ -246,20 +246,20 @@ def redis():
 @api_blueprint.route("/es")
 @check_authentication
 def elastic_search():
-    """Displays Elasticsearch cluster info.
+    """Displays search index cluster info.
 
-    :return: jsonified Elasticsearch cluster info.
+    :return: jsonified search index cluster info.
     """
     info = current_search_client.cluster.health()
     return jsonify({"data": info})
 
 
-@api_blueprint.route("/es_indices")
+@api_blueprint.route("/search_indices")
 @check_authentication
-def elastic_search_indices():
-    """Displays Elasticsearch indices info.
+def search_indices():
+    """Displays search index indices info.
 
-    :return: jsonified Elasticsearch indices info.
+    :return: jsonified search index indices info.
     """
     info = current_search_client.cat.indices(bytes="b", format="json", s="index")
     info = {data["index"]: data for data in info}

--- a/rero_ils/modules/notifications/logs/api.py
+++ b/rero_ils/modules/notifications/logs/api.py
@@ -29,7 +29,7 @@ class NotificationOperationLog(OperationLog, SpecificOperationLog):
 
     @classmethod
     def create(cls, data, id_=None, index_refresh="false", **kwargs):
-        """Create a new record instance and store it in elasticsearch.
+        """Create a new record instance and store it in search index.
 
         :param data: Dict with the notification metadata.
         :param id_: Specify a UUID to use for the new record, instead of

--- a/rero_ils/modules/notifications/mappings/__init__.py
+++ b/rero_ils/modules/notifications/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Notifications Elasticsearch mappings."""
+"""Notifications search index mappings."""

--- a/rero_ils/modules/notifications/mappings/v7/__init__.py
+++ b/rero_ils/modules/notifications/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Notifications elasticsearch mappings."""
+"""Notifications search index mappings."""

--- a/rero_ils/modules/operation_logs/api.py
+++ b/rero_ils/modules/operation_logs/api.py
@@ -84,7 +84,7 @@ class OperationLog(RecordBase):
 
     @classmethod
     def create(cls, data, id_=None, index_refresh="false", **kwargs):
-        """Create a new record instance and store it in elasticsearch.
+        """Create a new record instance and store it in search index.
 
         :param data: Dict with the record metadata.
         :param id_: Specify a UUID to use for the new record, instead of
@@ -163,7 +163,7 @@ class OperationLog(RecordBase):
             actions.append(action)
         n_succeed, errors = bulk(current_search_client, actions)
         if n_succeed != len(data):
-            raise Exception(f"Elasticsearch Indexing Errors: {errors}")
+            raise Exception(f"search indexing Errors: {errors}")
 
     @classmethod
     def get_record(cls, _id):
@@ -173,17 +173,17 @@ class OperationLog(RecordBase):
         :param id_: record ID.
         :returns: The :class:`Record` instance.
         """
-        # here the elasticsearch get API cannot be used with an index alias
+        # here the search index get API cannot be used with an index alias
         return cls(next(RecordsSearch(index=cls.index_name).filter("term", _id=_id).scan()).to_dict())
 
     @classmethod
     def get_indices(cls):
-        """Get all index names present in the elasticsearch server."""
+        """Get all index names present in the search index server."""
         return {v["index"] for v in current_search_client.cat.indices(index=f"{cls.index_name}*", format="json")}
 
     @classmethod
     def delete_indices(cls):
-        """Remove all index names present in the elasticsearch server."""
+        """Remove all index names present in the search index server."""
         current_search_client.indices.delete(f"{cls.index_name}*")
         return True
 
@@ -191,7 +191,7 @@ class OperationLog(RecordBase):
     def update(cls, _id, date, data):
         """Update all data for a record.
 
-        :param str _id: Elasticsearch document ID.
+        :param str _id: search index document ID.
         :param str date: Log date, useful for getting the right index.
         :param dict data: New record data.
         """

--- a/rero_ils/modules/operation_logs/es_templates/__init__.py
+++ b/rero_ils/modules/operation_logs/es_templates/__init__.py
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch templates for Operation log records."""
+"""search index templates for Operation log records."""
 
 
-def list_es_templates():
-    """Elasticsearch templates path."""
+def list_search_templates():
+    """Search index templates path."""
     return ["rero_ils.modules.operation_logs.es_templates"]

--- a/rero_ils/modules/operation_logs/es_templates/v7/__init__.py
+++ b/rero_ils/modules/operation_logs/es_templates/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""ES Templates module for the operation logs."""
+"""search Templates module for the operation logs."""

--- a/rero_ils/modules/organisations/mappings/__init__.py
+++ b/rero_ils/modules/organisations/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Organisation Elasticsearch mappings."""
+"""Organisation search index mappings."""

--- a/rero_ils/modules/organisations/mappings/v7/__init__.py
+++ b/rero_ils/modules/organisations/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/patron_transaction_events/mappings/__init__.py
+++ b/rero_ils/modules/patron_transaction_events/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/patron_transaction_events/mappings/v7/__init__.py
+++ b/rero_ils/modules/patron_transaction_events/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/patron_transaction_events/serializers/csv.py
+++ b/rero_ils/modules/patron_transaction_events/serializers/csv.py
@@ -45,7 +45,7 @@ class PatronTransactionEventCSVSerializer(CSVSerializer, CachedDataSerializerMix
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """
@@ -175,7 +175,7 @@ def _extract_operator_data(record):
 def _extract_patron_type_data(record):
     """Extract data from patron type to include into the csv export file.
 
-    :param record: a dictionary with indexed ES data about the patron type.
+    :param record: a dictionary with indexed search data about the patron type.
     :returns a dictionary containing desired patron type data.
     """
     return {"patron_type": record.get("name")}

--- a/rero_ils/modules/patron_transactions/mappings/__init__.py
+++ b/rero_ils/modules/patron_transactions/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/patron_transactions/mappings/v7/__init__.py
+++ b/rero_ils/modules/patron_transactions/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/patron_types/mappings/__init__.py
+++ b/rero_ils/modules/patron_types/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Patron type elasticsearch mappings."""
+"""Patron type search index mappings."""

--- a/rero_ils/modules/patron_types/mappings/v7/__init__.py
+++ b/rero_ils/modules/patron_types/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Patron type elasticsearch mappings."""
+"""Patron type search index mappings."""

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -640,7 +640,7 @@ class Patron(IlsRecord):
         """
 
         def basic_query(channel):
-            """Return basic ES query."""
+            """Return basic search query."""
             return (
                 PatronsSearch()
                 .filter("term", user_id=user.id)

--- a/rero_ils/modules/patrons/mappings/__init__.py
+++ b/rero_ils/modules/patrons/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings for patrons."""
+"""search index mappings for patrons."""

--- a/rero_ils/modules/patrons/mappings/v7/__init__.py
+++ b/rero_ils/modules/patrons/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings for patrons."""
+"""search index mappings for patrons."""

--- a/rero_ils/modules/record_extensions.py
+++ b/rero_ils/modules/record_extensions.py
@@ -30,11 +30,11 @@ def _add_org_and_lib(record):
     :param record: the record metadata.
     """
     location_pid = extracted_data_from_ref(record.get("location"))
-    # try on the elasticsearch location index
+    # try on the search index location index
     try:
-        es_loc = next(LocationsSearch().filter("term", pid=location_pid).source(["organisation", "library"]).scan())
-        organisation_pid = es_loc.organisation.pid
-        library_pid = es_loc.library.pid
+        search_loc = next(LocationsSearch().filter("term", pid=location_pid).source(["organisation", "library"]).scan())
+        organisation_pid = search_loc.organisation.pid
+        library_pid = search_loc.library.pid
     except StopIteration:
         # ok go to the db
         library = Location.get_record_by_pid(location_pid).get_library()

--- a/rero_ils/modules/serializers/base.py
+++ b/rero_ils/modules/serializers/base.py
@@ -60,7 +60,7 @@ class JSONSerializer(_JSONSerializer, PostprocessorMixin):
 
     @staticmethod
     def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
-        """Prepare a record hit from Elasticsearch for serialization."""
+        """Prepare a record hit from search index for serialization."""
         record = _JSONSerializer.preprocess_search_hit(
             pid=pid, record_hit=record_hit, links_factory=links_factory, kwargs=kwargs
         )
@@ -73,7 +73,7 @@ class JSONSerializer(_JSONSerializer, PostprocessorMixin):
         """Serialize a search result.
 
         :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
+        :param search_result: search index search result.
         :param links: Dictionary of links to add to response.
         :param item_links_factory: Factory function for record links.
         """

--- a/rero_ils/modules/serializers/mixins.py
+++ b/rero_ils/modules/serializers/mixins.py
@@ -71,7 +71,7 @@ class PostprocessorMixin(PostprocessorMixinInterface):
     def _postprocess_search_links(self, search_results, pid_fetcher):
         """Post-process search links.
 
-        :param search_results: Elasticsearch search result.
+        :param search_results: search index search result.
         :param pid_fetcher: Persistent identifier fetcher related to records
                             into the search result.
         """
@@ -192,7 +192,7 @@ class CachedDataSerializerMixin:
 
 
 class StreamSerializerMixin:
-    """Utility class to deal with streamed result response (ES.scan())."""
+    """Utility class to deal with streamed result response (search.scan())."""
 
     """ The default chunk size to use. This attribute can be override."""
     chunk_size = 1000
@@ -206,7 +206,7 @@ class StreamSerializerMixin:
           hits with outside data. For example: reading a list 2400 loans with
           a chunk_size=1000, you will get 3 chunks (1000, 1000, 400). For each
           chunk, you could extract the list of related document pids and call
-          once ES document index to get document data ==> 3 calls to document
+          once search document index to get document data ==> 3 calls to document
           index instead of potentially 2400 (much better).
 
         :param results: the result iterator to process.

--- a/rero_ils/modules/sru/cql_parser.py
+++ b/rero_ils/modules/sru/cql_parser.py
@@ -20,7 +20,7 @@
 """CQL (Contextual Query Language) Parser for SRU.
 
 This module provides a CQL 1.2 parser that translates CQL queries into
-Elasticsearch query strings. It supports the standard CQL features including
+search index query strings. It supports the standard CQL features including
 boolean operators, relation modifiers, sort specifications, and prefix
 declarations.
 
@@ -35,15 +35,15 @@ Features:
     - Relations: =, <, >, <=, >=, <>, all, any
     - Sort specifications with ascending/descending modifiers
     - Relation modifiers: /relevant, /exact, /word, /ignoreCase
-    - Dublin Core index mappings to Elasticsearch fields
+    - Dublin Core index mappings to search index fields
     - Prefix declarations for custom context sets
 
 Example::
 
     from rero_ils.modules.sru.cql_parser import parse
     query = parse('dc.title all "python programming" sortBy dc.date/descending')
-    es_query = query.to_es()
-    sort_keys = query.get_es_sort()
+    search_query = query.to_search()
+    sort_keys = query.get_search_sort()
 
 See Also:
     - CQL Specification: http://www.loc.gov/standards/sru/cql/
@@ -81,10 +81,10 @@ ERROR_ON_DUPLICATE_PREFIX = False  # >a=b >a=c ''
 FULL_RESULT_SET_NAME_CHECK = True  # cql.rsn=a and cql.rsn=a    (mutant!)
 
 
-#: CQL sort modifier to Elasticsearch sort order mapping.
-#: Maps CQL sort modifiers (e.g., /ascending, /descending) to ES sort orders.
+#: CQL sort modifier to search index sort order mapping.
+#: Maps CQL sort modifiers (e.g., /ascending, /descending) to search sort orders.
 #: Supports both short form (/ascending) and prefixed form (/sort.ascending).
-ES_SORT_MODIFIERS = {
+SEARCH_SORT_MODIFIERS = {
     "ascending": "asc",
     "descending": "desc",
     "sort.ascending": "asc",
@@ -97,11 +97,11 @@ ES_SORT_MODIFIERS = {
     "sort.missingomit": "missingomit",
 }
 
-#: CQL sort index to Elasticsearch sortable field mapping.
-#: Maps Dublin Core and custom indexes to ES fields suitable for sorting.
+#: CQL sort index to search index sortable field mapping.
+#: Maps Dublin Core and custom indexes to search fields suitable for sorting.
 #: These fields should be keyword type or have doc_values enabled for
 #: efficient sorting. Use '_relevance' to sort by search score.
-ES_SORT_INDEX_MAPPINGS = {
+SEARCH_SORT_INDEX_MAPPINGS = {
     "dc.title": "sort_title",
     "dc.date": "provisionActivity.startDate",
     "dc.creator": "facet_contribution_en",
@@ -116,12 +116,12 @@ ES_SORT_INDEX_MAPPINGS = {
 
 #: Supported CQL relation modifiers that are processed without error.
 #: These modifiers are acknowledged by the parser. Most map to default
-#: Elasticsearch behavior (relevance scoring, word matching, case insensitivity).
+#: search index behavior (relevance scoring, word matching, case insensitivity).
 #:
-#: - ``relevant``: Use relevance scoring (default ES behavior)
+#: - ``relevant``: Use relevance scoring (default search behavior)
 #: - ``exact``: Exact match semantics
-#: - ``word``: Word-based matching (default ES behavior)
-#: - ``ignorecase``: Case-insensitive matching (default ES behavior)
+#: - ``word``: Word-based matching (default search behavior)
+#: - ``ignorecase``: Case-insensitive matching (default search behavior)
 #: - ``string``: Treat search term as a string literal
 SUPPORTED_RELATION_MODIFIERS = {
     "relevant": "relevant",
@@ -143,8 +143,8 @@ UNSUPPORTED_RELATION_MODIFIERS = {
     "isodate": "ISO date parsing not supported",
 }
 
-#: Dublin Core index to Elasticsearch query mapping.
-#: Maps standard Dublin Core elements and CQL indexes to Elasticsearch
+#: Dublin Core index to search index query mapping.
+#: Maps standard Dublin Core elements and CQL indexes to search index
 #: query expressions. Complex mappings may include boolean operators
 #: and field constraints (e.g., filtering by contribution role).
 #:
@@ -153,7 +153,7 @@ UNSUPPORTED_RELATION_MODIFIERS = {
 #: rights, source, subject.
 #:
 #: Custom extensions: organisation, library, location, subtype.
-ES_INDEX_MAPPINGS = {
+SEARCH_INDEX_MAPPINGS = {
     "cql.anywhere": SERVER_CHOICE_INDEX,
     "dc.anywhere": SERVER_CHOICE_INDEX,
     "dc.contributor": "contribution.role:("
@@ -211,10 +211,10 @@ ES_INDEX_MAPPINGS = {
 # End of 'configurable' stuff
 
 
-def _convert_sort_keys_to_es(sort_keys, query=""):
-    """Convert CQL sort keys to Elasticsearch sort format.
+def _convert_sort_keys_to_search(sort_keys, query=""):
+    """Convert CQL sort keys to search index sort format.
 
-    Transforms a list of CQL sort key Index objects into Elasticsearch
+    Transforms a list of CQL sort key Index objects into search index
     sort specifications. Handles sort direction modifiers (/ascending,
     /descending) and missing value handling (/missingLow, /missingHigh).
 
@@ -225,7 +225,7 @@ def _convert_sort_keys_to_es(sort_keys, query=""):
             raised for unsupported modifiers.
 
     Returns:
-        list: Elasticsearch sort specifications. Each item is a dict like::
+        list: search index sort specifications. Each item is a dict like::
 
             {"field_name": {"order": "asc", "missing": "_last"}}
 
@@ -236,23 +236,23 @@ def _convert_sort_keys_to_es(sort_keys, query=""):
     Example::
 
         # For query: sortBy dc.title/descending dc.date/ascending
-        sort_specs = _convert_sort_keys_to_es(query.sort_keys)
+        sort_specs = _convert_sort_keys_to_search(query.sort_keys)
         # Returns: [{"title._text.raw": {"order": "desc", ...}}, ...]
     """
     valid_sort_modifiers = {"ascending", "descending", "missinglow", "missinghigh", "missingomit"}
-    es_sort = []
+    search_sort = []
     for sort_key in sort_keys:
         # Get the index name
         index_name = str(sort_key).lower()
 
-        # Map to ES sortable field
-        es_field = ES_SORT_INDEX_MAPPINGS.get(index_name)
-        if not es_field:
+        # Map to search sortable field
+        search_field = SEARCH_SORT_INDEX_MAPPINGS.get(index_name)
+        if not search_field:
             # Try without prefix
-            es_field = ES_SORT_INDEX_MAPPINGS.get(f"dc.{sort_key.value}")
-        if not es_field:
-            # Use the field as-is (might be a direct ES field name)
-            es_field = index_name
+            search_field = SEARCH_SORT_INDEX_MAPPINGS.get(f"dc.{sort_key.value}")
+        if not search_field:
+            # Use the field as-is (might be a direct search field name)
+            search_field = index_name
 
         # Default sort order is ascending
         order = "asc"
@@ -285,18 +285,18 @@ def _convert_sort_keys_to_es(sort_keys, query=""):
         elif missing_pref == "missinghigh":
             missing = "_last" if order == "asc" else "_first"
         elif missing_pref == "missingomit":
-            # NOTE: ES doesn't support omitting docs with missing values in sort.
+            # NOTE: search doesn't support omitting docs with missing values in sort.
             # Documents with missing values will be placed last instead.
             missing = "_last"
 
         # Build the sort specification
-        if es_field == "_score":
+        if search_field == "_score":
             # Relevance sorting
-            es_sort.append({"_score": {"order": order}})
+            search_sort.append({"_score": {"order": order}})
         else:
-            es_sort.append({es_field: {"order": order, "missing": missing}})
+            search_sort.append({search_field: {"order": order, "missing": missing}})
 
-    return es_sort
+    return search_sort
 
 
 class Diagnostic(Exception):
@@ -512,9 +512,9 @@ class Triple(PrefixableObject):
     boolean = None
     sort_keys = []
 
-    def to_es(self):
-        """Create the ES representation of the object."""
-        boolean = self.boolean.to_es()
+    def to_search(self):
+        """Create the search representation of the object."""
+        boolean = self.boolean.to_search()
         if boolean == "prox":
             diag = Diagnostic()
             diag.code = 37
@@ -522,25 +522,25 @@ class Triple(PrefixableObject):
             diag.details = "prox"
             diag.query = self.query
             raise diag
-        txt = [self.left_operand.to_es()]
+        txt = [self.left_operand.to_search()]
         if boolean == "not":
             txt.append("AND")
         else:
             txt.append(boolean.upper())
-        txt.append(self.right_operand.to_es())
-        # Sort keys are handled separately via get_es_sort()
+        txt.append(self.right_operand.to_search())
+        # Sort keys are handled separately via get_search_sort()
         pre = "NOT" if boolean == "not" else ""
         return f"{pre}({' '.join(txt)})"
 
-    def get_es_sort(self):
-        """Extract sort keys in Elasticsearch format.
+    def get_search_sort(self):
+        """Extract sort keys in search index format.
 
-        Returns a list of sort specifications for Elasticsearch.
+        Returns a list of sort specifications for search index.
         Each item is either a string (field name) or a dict with options.
         """
         if not self.sort_keys:
             return []
-        return _convert_sort_keys_to_es(self.sort_keys, query=self.query)
+        return _convert_sort_keys_to_search(self.sort_keys, query=self.query)
 
     def get_result_set_id(self, top=None):
         """Get result set id."""
@@ -587,40 +587,40 @@ class SearchClause(PrefixableObject):
         rel.parent = self
         term.parent = self
 
-    def to_es(self):
-        """Create the ES representation of the object."""
+    def to_search(self):
+        """Create the search representation of the object."""
 
         def index_term(index, relation, term):
             """Clean term."""
             from .explaine import Explain
 
             # try to map dc mappings
-            index = ES_INDEX_MAPPINGS.get(index.lower(), index)
-            # try to map es mappings
-            index = Explain("tmp").es_mappings.get(index, index)
+            index = SEARCH_INDEX_MAPPINGS.get(index.lower(), index)
+            # try to map search mappings
+            index = Explain("tmp").search_mappings.get(index, index)
             if relation in ["=", "all", "any"]:
                 relation = ""
             if str(index) == SERVER_CHOICE_INDEX:
                 return f"{relation}{term}"
             # Handle multi-field OR expression: "(field1 OR field2)" + term
-            # ES query string does not support "(f1 OR f2):value"; expand each field.
+            # search query string does not support "(f1 OR f2):value"; expand each field.
             if index.startswith("(") and index.endswith(")"):
                 fields = [f.strip() for f in index[1:-1].split(" OR ")]
                 return f"({' OR '.join(f'{f}:{relation}{term}' for f in fields)})"
             return f"{index}:{relation}{term}"
 
-        index = self.index.to_es()
-        relation = self.relation.to_es()
+        index = self.index.to_search()
+        relation = self.relation.to_search()
         if relation == "<>":
-            es_term = self.term.to_es()
-            if not (es_term.startswith('"') and es_term.endswith('"')):
-                es_term = f'"{es_term}"'
-            text = index_term(index, "-", es_term)
+            search_term = self.term.to_search()
+            if not (search_term.startswith('"') and search_term.endswith('"')):
+                search_term = f'"{search_term}"'
+            text = index_term(index, "-", search_term)
         elif relation in ORDER:
-            text = index_term(index, relation, self.term.to_es())
+            text = index_term(index, relation, self.term.to_search())
         else:
             texts = []
-            for term in self.term.to_es().split(" "):
+            for term in self.term.to_search().split(" "):
                 texts.append(index_term(index, relation, term))
             if texts:
                 texts[0] = texts[0].replace('"', "")
@@ -636,18 +636,18 @@ class SearchClause(PrefixableObject):
                 diag.details = relation
                 diag.query = self.query
                 raise diag
-        # Sort keys are handled separately via get_es_sort()
+        # Sort keys are handled separately via get_search_sort()
         return text
 
-    def get_es_sort(self):
-        """Extract sort keys in Elasticsearch format.
+    def get_search_sort(self):
+        """Extract sort keys in search index format.
 
-        Returns a list of sort specifications for Elasticsearch.
+        Returns a list of sort specifications for search index.
         Each item is either a string (field name) or a dict with options.
         """
         if not self.sort_keys:
             return []
-        return _convert_sort_keys_to_es(self.sort_keys, query=self.query)
+        return _convert_sort_keys_to_search(self.sort_keys, query=self.query)
 
     def get_result_set_id(self, top=None):
         """Get result set id."""
@@ -672,8 +672,8 @@ class Index(PrefixedObject, ModifiableObject):
             diag.query = self.query
             raise diag
 
-    def to_es(self):
-        """Create the ES representation of the object."""
+    def to_search(self):
+        """Create the search representation of the object."""
         if self.modifiers:
             # Index modifiers are typically used for sorting (handled separately)
             # Check for any unsupported modifiers
@@ -682,8 +682,8 @@ class Index(PrefixedObject, ModifiableObject):
                 mod_type = str(modifier.type).lower()
                 if "." in mod_type:
                     mod_type = mod_type.split(".")[-1]
-                # Sort modifiers are handled by get_es_sort()
-                if mod_type not in ES_SORT_MODIFIERS and mod_type not in SUPPORTED_RELATION_MODIFIERS:
+                # Sort modifiers are handled by get_search_sort()
+                if mod_type not in SEARCH_SORT_MODIFIERS and mod_type not in SUPPORTED_RELATION_MODIFIERS:
                     if mod_type in UNSUPPORTED_RELATION_MODIFIERS:
                         unsupported.append(f"{mod_type} ({UNSUPPORTED_RELATION_MODIFIERS[mod_type]})")
                     else:
@@ -709,8 +709,8 @@ class Relation(PrefixedObject, ModifiableObject):
         for mod in mods:
             mod.parent = self
 
-    def to_es(self):
-        """Create the ES representation of the object."""
+    def to_search(self):
+        """Create the search representation of the object."""
         if self.modifiers:
             # Check if all modifiers are supported
             unsupported = []
@@ -731,8 +731,8 @@ class Relation(PrefixedObject, ModifiableObject):
                 diag.details = ", ".join(unsupported)
                 diag.query = self.query
                 raise diag
-            # Supported modifiers are acknowledged but don't change ES query
-            # (ES handles relevance, word matching, case insensitivity by default)
+            # Supported modifiers are acknowledged but don't change search query
+            # (search handles relevance, word matching, case insensitivity by default)
         return self.value
 
 
@@ -793,8 +793,8 @@ class Term:
         """String representation of the object."""
         return f"{self.value}"
 
-    def to_es(self):
-        """Create the ES representation of the object."""
+    def to_search(self):
+        """Create the search representation of the object."""
         return self.value
 
 
@@ -811,8 +811,8 @@ class Boolean(ModifiableObject):
         self.parent = None
         self.query = query
 
-    def to_es(self):
-        """Create the ES representation of the object."""
+    def to_search(self):
+        """Create the search representation of the object."""
         if self.modifiers:
             diag = Diagnostic()
             diag.code = 21
@@ -856,8 +856,8 @@ class ModifierClause:
             return f"{self.type}{self.comparison}{self.value}"
         return f"{self.type}"
 
-    def to_es(self):
-        """Create the ES representation of the object."""
+    def to_search(self):
+        """Create the search representation of the object."""
         return self
 
     def resolve_prefix(self, name):

--- a/rero_ils/modules/sru/explaine.py
+++ b/rero_ils/modules/sru/explaine.py
@@ -39,11 +39,11 @@ from lxml import etree
 from lxml.builder import ElementMaker
 
 from ..utils import get_schema_for_resource
-from .cql_parser import ES_INDEX_MAPPINGS
+from .cql_parser import SEARCH_INDEX_MAPPINGS
 
 
 def _get_properties(data):
-    """Recursively extract searchable field paths from ES mapping properties."""
+    """Recursively extract searchable field paths from search mapping properties."""
     keys = []
     for key, value in data.items():
         if isinstance(value, dict):
@@ -59,12 +59,12 @@ def _get_properties(data):
 
 
 @cache
-def _get_es_mappings(index):
-    """Load and cache field mappings from the Elasticsearch index definition.
+def _get_search_mappings(index):
+    """Load and cache field mappings from the search index definition.
 
-    :param index: The Elasticsearch index alias name.
+    :param index: The search index alias name.
     :type index: str
-    :returns: Mapping of normalized index names to ES field paths.
+    :returns: Mapping of normalized index names to search field paths.
     :rtype: dict
     """
     try:
@@ -75,7 +75,7 @@ def _get_es_mappings(index):
         if properties := data.get("mappings", {}).get("properties", {}):
             return {field.lower().replace(".", "__"): field for field in _get_properties(properties)}
     except Exception:
-        current_app.logger.debug("Failed to load ES mappings for index: %s", index, exc_info=True)
+        current_app.logger.debug("Failed to load search mappings for index: %s", index, exc_info=True)
     return {}
 
 
@@ -90,9 +90,9 @@ class Explain:
         database: The SRU database path (e.g., 'api/sru/documents').
         number_of_records: Default number of records returned per request.
         maximum_records: Maximum allowed records per request.
-        doc_type: The document type for Elasticsearch index lookup.
-        index: The Elasticsearch index name.
-        es_mappings: Dictionary mapping normalized index names to ES field paths.
+        doc_type: The document type for search index lookup.
+        index: The search index name.
+        search_mappings: Dictionary mapping normalized index names to search field paths.
         xml_root: The root XML element of the Explain response.
 
     Example::
@@ -106,7 +106,7 @@ class Explain:
 
         Args:
             database: The SRU database path used in the serverInfo element.
-            doc_type: Document type key for looking up the Elasticsearch index
+            doc_type: Document type key for looking up the search index
                 in RECORDS_REST_ENDPOINTS configuration. Defaults to 'doc'.
         """
         self.database = database
@@ -114,7 +114,7 @@ class Explain:
         self.maximum_records = current_app.config.get("RERO_ILS_SRU_MAXIMUM_RECORDS", 1000)
         self.doc_type = doc_type
         self.index = current_app.config.get("RECORDS_REST_ENDPOINTS", {}).get(doc_type, {}).get("search_index")
-        self.es_mappings = _get_es_mappings(self.index) if self.index else {}
+        self.search_mappings = _get_search_mappings(self.index) if self.index else {}
         self.init_xml()
 
     def __str__(self):
@@ -137,7 +137,7 @@ class Explain:
             - recordData
               - explain
                 - serverInfo (protocol, host, database)
-                - indexInfo (DC indexes + ES field indexes)
+                - indexInfo (DC indexes + search field indexes)
                 - schemaInfo (JSON schema reference)
                 - configInfo (default/maximum records settings)
         """
@@ -183,7 +183,7 @@ class Explain:
         """Create the Dublin Core index information element.
 
         Generates an XML element listing all supported Dublin Core indexes
-        from the ES_INDEX_MAPPINGS configuration.
+        from the SEARCH_INDEX_MAPPINGS configuration.
 
         Returns:
             An lxml Element containing the DC index map with all supported
@@ -193,7 +193,7 @@ class Explain:
         element_dc = ElementMaker(namespace=dc_ns, nsmap={"dc": dc_ns})
         index = element_dc.index()
         dc_map = element_dc.map()
-        for dc_index in ES_INDEX_MAPPINGS:
+        for dc_index in SEARCH_INDEX_MAPPINGS:
             dc_map.append(element_dc.name(dc_index.replace("dc.", "")))
         index.append(dc_map)
         return index
@@ -201,20 +201,20 @@ class Explain:
     def init_index_info(self):
         """Create the RERO-ILS specific index information element.
 
-        Generates an XML element listing all Elasticsearch field indexes
+        Generates an XML element listing all search index field indexes
         available for searching, using the RERO-ILS namespace.
 
         Returns:
-            An lxml Element containing the index map with all ES field paths
+            An lxml Element containing the index map with all search field paths
             that can be used directly in CQL queries.
         """
         rero_ils_ns = get_schema_for_resource("doc")
         element_rero_ils = ElementMaker(namespace=rero_ils_ns, nsmap={"rero-ils": rero_ils_ns})
         index = element_rero_ils.index()
-        es_map = element_rero_ils.map()
-        for rero_ils_index in self.es_mappings:
-            es_map.append(element_rero_ils.name(rero_ils_index))
-        index.append(es_map)
+        search_map = element_rero_ils.map()
+        for rero_ils_index in self.search_mappings:
+            search_map.append(element_rero_ils.name(rero_ils_index))
+        index.append(search_map)
         return index
 
     def init_schema_info(self, element):

--- a/rero_ils/modules/sru/views.py
+++ b/rero_ils/modules/sru/views.py
@@ -153,7 +153,7 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
         """Handle GET requests to the SRU endpoint.
 
         Processes SRU searchRetrieve and explain operations. For searchRetrieve,
-        parses the CQL query, executes it against Elasticsearch, and returns
+        parses the CQL query, executes it against search index, and returns
         results in the requested format. For explain (or when no operation is
         specified), returns the server's capabilities.
 
@@ -169,7 +169,7 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
                 response with the error details.
         """
         operation = flask_request.args.get("operation", None)
-        query = flask_request.args.get("query", None)
+        cql_query = flask_request.args.get("query", None)
         start_record = max(int(flask_request.args.get("startRecord", 1)), 1)
         maximum_records = min(
             int(
@@ -180,12 +180,12 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
             ),
             current_app.config.get("RERO_ILS_SRU_MAXIMUM_RECORDS", 1000),
         )
-        if operation == "searchRetrieve" and query:
+        if operation == "searchRetrieve" and cql_query:
             try:
-                parsed_query = parse(query)
-                query_string = parsed_query.to_es()
+                parsed_query = parse(cql_query)
+                search_query = parsed_query.to_search()
                 # Extract sort keys if present
-                sort_keys = parsed_query.get_es_sort()
+                sort_keys = parsed_query.get_search_sort()
             except Diagnostic as err:
                 response = Response(err.xml_str())
                 response.headers["content-type"] = "application/xml"
@@ -193,7 +193,7 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
 
             search = (
                 DocumentsSearch()
-                .query("query_string", query=query_string)
+                .query("query_string", query=search_query)
                 .exclude("term", _masked=True)
                 .exclude("term", _draft=True)
             )
@@ -218,15 +218,15 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
             except ESRequestError as e:
                 _err_text = str(getattr(e, "info", e))
                 if "Result window" in _err_text or "result_window" in _err_text:
-                    # startRecord window exceeds ES max_result_window; return 0 records.
-                    current_app.logger.warning(f"ES window overflow during SRU search: {e}")
+                    # startRecord window exceeds search max_result_window; return 0 records.
+                    current_app.logger.warning(f"search window overflow during SRU search: {e}")
                 else:
-                    current_app.logger.error(f"ES backend error during SRU search: {e}")
+                    current_app.logger.error(f"search backend error during SRU search: {e}")
                     diag = Diagnostic(
                         code=2,
                         message="System temporarily unavailable",
                         details=str(e),
-                        query=query,
+                        query=cql_query,
                     )
                     diag_response = Response(diag.xml_str())
                     diag_response.headers["content-type"] = "application/xml"
@@ -237,8 +237,8 @@ class SRUDocumentsSearch(ContentNegotiatedMethodView):
                     "hits": records,
                     "total": {"value": total, "relation": "eq"},
                     "sru": {
-                        "query": strip_chars(query),
-                        "query_es": query_string,
+                        "cql_query": strip_chars(cql_query),
+                        "search_query": search_query,
                         "start_record": start_record,
                         "maximum_records": maximum_records,
                     },

--- a/rero_ils/modules/stats/api/api.py
+++ b/rero_ils/modules/stats/api/api.py
@@ -75,7 +75,7 @@ class Stat(IlsRecord):
 
 
 class StatsIndexer(IlsRecordsIndexer):
-    """Indexing stats in Elasticsearch."""
+    """Indexing stats in search index."""
 
     record_cls = Stat
 

--- a/rero_ils/modules/stats/api/indicators/base.py
+++ b/rero_ils/modules/stats/api/indicators/base.py
@@ -35,19 +35,19 @@ class IndicatorCfg:
     @property
     @abstractmethod
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
         raise NotImplementedError()
 
     @property
     @abstractmethod
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         raise NotImplementedError()
 
@@ -56,7 +56,7 @@ class IndicatorCfg:
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """

--- a/rero_ils/modules/stats/api/indicators/circulation.py
+++ b/rero_ils/modules/stats/api/indicators/circulation.py
@@ -40,30 +40,30 @@ class NumberOfCirculationCfg(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = (
+        search_query = (
             LoanOperationLogsSearch()[:0]
             .filter("terms", loan__item__library_pid=self.cfg.lib_pids)
             .filter("term", record__type="loan")
             .filter("term", loan__trigger=self.trigger)
         )
         if period := self.cfg.period:
-            es_query = es_query.filter("range", date=self.cfg.get_range_period(period))
+            search_query = search_query.filter("range", date=self.cfg.get_range_period(period))
         if lib_pids := self.cfg.filter_by_libraries:
             loc_pids = [
                 hit.pid for hit in LocationsSearch().filter("terms", library__pid=lib_pids).source("pid").scan()
             ]
-            es_query = es_query.filter("terms", loan__transaction_location__pid=loc_pids)
-        return es_query
+            search_query = search_query.filter("terms", loan__transaction_location__pid=loc_pids)
+        return search_query
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "transaction_location": A("terms", field="loan.transaction_location.pid", size=self.cfg.aggs_size),
@@ -93,7 +93,7 @@ class NumberOfCirculationCfg(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """

--- a/rero_ils/modules/stats/api/indicators/others.py
+++ b/rero_ils/modules/stats/api/indicators/others.py
@@ -35,20 +35,20 @@ class NumberOfDocumentsCfg(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = DocumentsSearch()[:0].filter("term", organisation_pid=self.cfg.org_pid)
+        search_query = DocumentsSearch()[:0].filter("term", organisation_pid=self.cfg.org_pid)
         if pids := self.cfg.filter_by_libraries:
-            es_query = es_query.filter("terms", library_pid=pids)
-        return es_query
+            search_query = search_query.filter("terms", library_pid=pids)
+        return search_query
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distribution name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "owning_library": A(
@@ -81,7 +81,7 @@ class NumberOfDocumentsCfg(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """
@@ -99,24 +99,24 @@ class NumberOfSerialHoldingsCfg(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = (
+        search_query = (
             HoldingsSearch()[:0]
             .filter("term", holdings_type="serial")
             .filter("term", organisation__pid=self.cfg.org_pid)
         )
         if pids := self.cfg.filter_by_libraries:
-            es_query = es_query.filter("terms", library__pid=pids)
-        return es_query
+            search_query = search_query.filter("terms", library__pid=pids)
+        return search_query
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "owning_library": A(
@@ -144,7 +144,7 @@ class NumberOfSerialHoldingsCfg(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """
@@ -161,20 +161,20 @@ class NumberOfItemsCfg(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = ItemsSearch()[:0].filter("term", organisation__pid=self.cfg.org_pid)
+        search_query = ItemsSearch()[:0].filter("term", organisation__pid=self.cfg.org_pid)
         if pids := self.cfg.filter_by_libraries:
-            es_query = es_query.filter("terms", library__pid=pids)
-        return es_query
+            search_query = search_query.filter("terms", library__pid=pids)
+        return search_query
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "owning_library": A(
@@ -215,7 +215,7 @@ class NumberOfItemsCfg(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """
@@ -236,11 +236,11 @@ class NumberOfDeletedItemsCfg(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = (
+        search_query = (
             LoanOperationLogsSearch()[:0]
             .filter(
                 Q("term", record__organisation_pid=self.cfg.org_pid) | Q("term", organisation__value=self.cfg.org_pid)
@@ -249,16 +249,16 @@ class NumberOfDeletedItemsCfg(IndicatorCfg):
             .filter("term", operation="delete")
         )
         if period := self.cfg.period:
-            es_query = es_query.filter("range", date=self.cfg.get_range_period(period))
+            search_query = search_query.filter("range", date=self.cfg.get_range_period(period))
         if pids := self.cfg.filter_by_libraries:
-            es_query = es_query.filter(Q("terms", record__library_pid=pids) | Q("terms", library__value=pids))
-        return es_query
+            search_query = search_query.filter(Q("terms", record__library_pid=pids) | Q("terms", library__value=pids))
+        return search_query
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "owning_library": A("terms", field="record.library_pid", size=self.cfg.aggs_size),
@@ -277,7 +277,7 @@ class NumberOfDeletedItemsCfg(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """
@@ -295,22 +295,22 @@ class NumberOfILLRequests(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = ILLRequestsSearch()[:0].filter("term", organisation__pid=self.cfg.org_pid)
+        search_query = ILLRequestsSearch()[:0].filter("term", organisation__pid=self.cfg.org_pid)
         if period := self.cfg.period:
-            es_query = es_query.filter("range", _created=self.cfg.get_range_period(period))
+            search_query = search_query.filter("range", _created=self.cfg.get_range_period(period))
         if pids := self.cfg.filter_by_libraries:
-            es_query = es_query.filter("terms", library__pid=pids)
-        return es_query
+            search_query = search_query.filter("terms", library__pid=pids)
+        return search_query
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "pickup_location": A("terms", field="pickup_location.pid", size=self.cfg.aggs_size),
@@ -334,7 +334,7 @@ class NumberOfILLRequests(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """

--- a/rero_ils/modules/stats/api/indicators/patron.py
+++ b/rero_ils/modules/stats/api/indicators/patron.py
@@ -36,17 +36,17 @@ class NumberOfPatronsCfg(IndicatorCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
         return PatronsSearch()[:0].filter("term", organisation__pid=self.cfg.org_pid)
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {
             "created_month": A(
@@ -79,7 +79,7 @@ class NumberOfPatronsCfg(IndicatorCfg):
         """Column/Raw label transformations.
 
         :param distrubtion: str - the report distrubtion name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """
@@ -101,11 +101,11 @@ class NumberOfActivePatronsCfg(NumberOfPatronsCfg):
 
     @property
     def query(self):
-        """Base Elasticsearch Query.
+        """Base search index Query.
 
-        :returns: an elasticsearch query object
+        :returns: a search index query object
         """
-        es_query = super().query
+        search_query = super().query
         range_period = self.cfg.get_range_period(self.cfg.period)
         op_query = (
             LoanOperationLogsSearch()[:0]
@@ -130,4 +130,4 @@ class NumberOfActivePatronsCfg(NumberOfPatronsCfg):
         results = op_query.execute()
         convert = {hashlib.md5(f"{i}".encode()).hexdigest(): i for i in range(1, PatronIdentifier.max() + 1)}
         active_patron_pids = [convert[v.key] for v in results.aggregations.hashed_pid.buckets]
-        return es_query.filter("terms", pid=active_patron_pids)
+        return search_query.filter("terms", pid=active_patron_pids)

--- a/rero_ils/modules/stats/api/indicators/requests.py
+++ b/rero_ils/modules/stats/api/indicators/requests.py
@@ -27,10 +27,10 @@ class NumberOfRequestsCfg(NumberOfCirculationCfg):
     """Number of circulation action based on trigger."""
 
     def aggregation(self, distribution):
-        """Elasticsearch Aggregation configuration to compute distributions.
+        """Search index Aggregation configuration to compute distributions.
 
         :param distrubtion: str - report distrubtion name
-        :returns: an elasticsearch aggregation object
+        :returns: a search index aggregation object
         """
         cfg = {"pickup_location": A("terms", field="loan.pickup_location.pid", size=self.cfg.aggs_size)}
         if agg := cfg.get(distribution):
@@ -41,7 +41,7 @@ class NumberOfRequestsCfg(NumberOfCirculationCfg):
         """Column/Raw label transformations.
 
         :param distribution: str - the report distribution name
-        :param bucket: the elasticsearch aggregation bucket
+        :param bucket: the search index aggregation bucket
         :returns: the label
         :rtype: str
         """

--- a/rero_ils/modules/stats/api/librarian.py
+++ b/rero_ils/modules/stats/api/librarian.py
@@ -69,7 +69,7 @@ class StatsForLibrarian(StatsForPricing):
     def process(self, library):
         """Process statistics for a give library.
 
-        :param library: library from the elasticsearch index
+        :param library: library from the search index
         :return: a dict containing all the processed values.
         """
         return {

--- a/rero_ils/modules/stats/api/pricing.py
+++ b/rero_ils/modules/stats/api/pricing.py
@@ -92,7 +92,7 @@ class StatsForPricing:
     def process(self, library):
         """Process statistics for a given library.
 
-        :param library: library from the elasticsearch index
+        :param library: library from the search index
         :return: a dict containing all the processed values.
         """
         return {
@@ -310,10 +310,10 @@ class StatsForPricing:
         :return: the number of matched files
         :rtype: integer
         """
-        es_query = self._get_record_file_query()
-        es_query = es_query.filter("term", metadata__library__pid=library_pid)
-        es_query.aggs.metric("number_of_files", "sum", field="metadata.n_files")
-        return int(es_query.execute().aggs.number_of_files.value)
+        search_query = self._get_record_file_query()
+        search_query = search_query.filter("term", metadata__library__pid=library_pid)
+        search_query.aggs.metric("number_of_files", "sum", field="metadata.n_files")
+        return int(search_query.execute().aggs.number_of_files.value)
 
     def files_volume(self, library_pid):
         """Size in Mb of the files linked to a given library.
@@ -323,7 +323,7 @@ class StatsForPricing:
         :return: the volume taken by the files in Mb
         :rtype: str
         """
-        es_query = self._get_record_file_query()
-        es_query = es_query.filter("term", metadata__library__pid=library_pid)
-        es_query.aggs.metric("files_size", "sum", field="metadata.file_size")
-        return "%.3f" % (es_query.execute().aggs.files_size.value / (1024 * 1024))
+        search_query = self._get_record_file_query()
+        search_query = search_query.filter("term", metadata__library__pid=library_pid)
+        search_query.aggs.metric("files_size", "sum", field="metadata.file_size")
+        return "%.3f" % (search_query.execute().aggs.files_size.value / (1024 * 1024))

--- a/rero_ils/modules/stats/api/report.py
+++ b/rero_ils/modules/stats/api/report.py
@@ -68,8 +68,8 @@ class StatsReport:
             for hit in LibrariesSearch().by_organisation_pid(self.org_pid).source(["pid", "name"]).scan()
         }
         self.lib_pids = list(self.libraries.keys())
-        es_locations = LocationsSearch().by_organisation_pid(self.org_pid).source(["pid", "name", "library"]).scan()
-        self.locations = {hit.pid: f"{self.libraries[hit.library.pid]} / {hit.name}" for hit in es_locations}
+        search_locations = LocationsSearch().by_organisation_pid(self.org_pid).source(["pid", "name", "library"]).scan()
+        self.locations = {hit.pid: f"{self.libraries[hit.library.pid]} / {hit.name}" for hit in search_locations}
         self.patron_types = {
             hit.pid: hit.name
             for hit in PatronTypesSearch().by_organisation_pid(self.org_pid).source(["pid", "name"]).scan()
@@ -101,18 +101,18 @@ class StatsReport:
         }
         return cfg[self.indicator]
 
-    def _process_aggregations(self, es_results):
+    def _process_aggregations(self, search_results):
         """Process the es aggregations structures."""
         results = {}
         y_keys = set()
         iter_distrib = iter(self.distributions)
         if distrib1 := next(iter_distrib, None):
             distrib2 = next(iter_distrib, None)
-            for dist1 in es_results.aggs[distrib1].buckets:
+            for dist1 in search_results.aggs[distrib1].buckets:
                 if isinstance(dist1, str):
                     key1 = dist1
-                    parent_dist = es_results.aggs[distrib1].buckets[key1]
-                    doc_count = es_results.aggs[distrib1].buckets[key1].doc_count
+                    parent_dist = search_results.aggs[distrib1].buckets[key1]
+                    doc_count = search_results.aggs[distrib1].buckets[key1].doc_count
                 else:
                     parent_dist = dist1
                     key1 = self.indicator_cfg.label(distrib1, dist1)
@@ -138,7 +138,7 @@ class StatsReport:
         return self._process_distributions(x_keys, y_keys, results)
 
     def _process_distributions(self, x_keys, y_keys, results):
-        """Process the elasticsearch aggregations results."""
+        """Process the search index aggregations results."""
         data = []
         if y_keys:
             data.append(["", *y_keys])
@@ -179,7 +179,7 @@ class StatsReport:
         return self._process_aggregations(results)
 
     def get_range_period(self, period):
-        """Get the range period for elasticsearch date range aggs."""
+        """Get the range period for search index date range aggs."""
         if period == "month":
             # now - 1 month
             previous_month = datetime.now() - relativedelta(months=1)

--- a/rero_ils/modules/stats/mappings/__init__.py
+++ b/rero_ils/modules/stats/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Stat Elasticsearch mapping."""
+"""Stat search index mapping."""

--- a/rero_ils/modules/stats/mappings/v7/__init__.py
+++ b/rero_ils/modules/stats/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Stat Elasticsearch mapping."""
+"""Stat search index mapping."""

--- a/rero_ils/modules/stats_cfg/api.py
+++ b/rero_ils/modules/stats_cfg/api.py
@@ -110,7 +110,7 @@ class StatConfiguration(IlsRecord):
 
 
 class StatsConfigurationIndexer(IlsRecordsIndexer):
-    """Indexing stats configuration in Elasticsearch."""
+    """Indexing stats configuration in search index."""
 
     record_cls = StatConfiguration
     record_dumper = indexer_dumper

--- a/rero_ils/modules/stats_cfg/mappings/__init__.py
+++ b/rero_ils/modules/stats_cfg/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Stats configuration Elasticsearch mapping."""
+"""Stats configuration search index mapping."""

--- a/rero_ils/modules/stats_cfg/mappings/v7/__init__.py
+++ b/rero_ils/modules/stats_cfg/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Stats configuration Elasticsearch mapping."""
+"""Stats configuration search index mapping."""

--- a/rero_ils/modules/tasks.py
+++ b/rero_ils/modules/tasks.py
@@ -28,7 +28,7 @@ from .utils import set_timestamp
 def process_bulk_queue(version_type=None, queue=None, search_bulk_kwargs=None, stats_only=True):
     """Process bulk indexing queue.
 
-    :param str version_type: Elasticsearch version type.
+    :param str version_type: search index version type.
     :param str queue: Queue name to use (also used as routing key).
     :param dict search_bulk_kwargs: Passed to
         :func:`elasticsearch:elasticsearch.helpers.bulk`.

--- a/rero_ils/modules/templates/api.py
+++ b/rero_ils/modules/templates/api.py
@@ -96,7 +96,7 @@ class Template(IlsRecord):
 
 
 class TemplatesIndexer(IlsRecordsIndexer):
-    """Indexing templates in Elasticsearch."""
+    """Indexing templates in search index."""
 
     record_cls = Template
 

--- a/rero_ils/modules/templates/listener.py
+++ b/rero_ils/modules/templates/listener.py
@@ -38,7 +38,7 @@ def prepare_template_data(
     :param doc_type: The document type of the record.
     """
     if index.split("-")[0] == TemplatesSearch.Meta.index:
-        # remove `data` fields from ES.
+        # remove `data` fields from search.
         #   This metadata isn't required for indexing process and cause some
         #   troubles with $ref resolution
         json.pop("data", None)

--- a/rero_ils/modules/templates/mappings/__init__.py
+++ b/rero_ils/modules/templates/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Templates Elasticsearch mappings."""
+"""Templates search index mappings."""

--- a/rero_ils/modules/templates/mappings/v7/__init__.py
+++ b/rero_ils/modules/templates/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Templates elasticsearch mappings."""
+"""Templates search index mappings."""

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -314,8 +314,8 @@ def extracted_data_from_ref(input, data="pid"):
             return record_class.get_record_by_pid(pid)
         return None
 
-    def get_data_from_es():
-        """Try to load a resource from elasticsearch."""
+    def get_data_from_search():
+        """Try to load a resource from search index."""
         pid = extracted_data_from_ref(input, data="pid")
         resource_list = extracted_data_from_ref(input, data="resource")
         if resource_list is None:
@@ -331,7 +331,7 @@ def extracted_data_from_ref(input, data="pid"):
     if isinstance(input, str):
         input = {"$ref": input}
     switcher = {
-        "es_record": get_data_from_es,
+        "search_record": get_data_from_search,
         "pid": lambda: extract_part(input.get("$ref"), -1),
         "resource": lambda: extract_part(input.get("$ref"), -2),
         "acronym": get_acronym,
@@ -1046,7 +1046,7 @@ def remove_user_name(sender, user):
 
 
 def sorted_pids(query):
-    """Get sorted pids from a ES query."""
+    """Get sorted pids from a search query."""
     pids = [hit.pid for hit in query.source("pid").scan()]
     try:
         return sorted(pids, key=int)

--- a/rero_ils/modules/vendors/mappings/__init__.py
+++ b/rero_ils/modules/vendors/mappings/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/modules/vendors/mappings/v7/__init__.py
+++ b/rero_ils/modules/vendors/mappings/v7/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Elasticsearch mappings."""
+"""search index mappings."""

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -417,7 +417,7 @@ def operation_logs_search_factory(self, search, query_parser=None):
 
 
 def search_factory(self, search, query_parser=None):
-    """Parse query using elasticsearch DSL query.
+    """Parse query using search index DSL query.
 
     Terms defined by: RERO_ILS_QUERY_BOOSTING will be boosted
     at the query level.
@@ -431,7 +431,7 @@ def search_factory(self, search, query_parser=None):
     def _default_parser(qstr=None, query_boosting=None):
         """Default parser that uses the Q() from elasticsearch_dsl."""
         query_type = "query_string"
-        # avoid elasticsearch errors when it can't convert a boolean or
+        # avoid search index errors when it can't convert a boolean or
         # numerical values during the query
         lenient = True
         default_operator = "OR"

--- a/tests/api/acquisition/test_acquisition_reception_workflow.py
+++ b/tests/api/acquisition/test_acquisition_reception_workflow.py
@@ -632,7 +632,7 @@ def test_acquisition_reception_workflow(
     #       - AcqOrderLine.replace_refs(): must not raise JsonRefError when
     #         the order line is re-indexed after document deletion.
     #       - AcqOrderLineESDumper: must fall back to {"pid": ...} only.
-    #       - AcqReceiptLineESDumper: same fallback for receipt-line ES dumps.
+    #       - AcqReceiptLineESDumper: same fallback for receipt-line search dumps.
     doc_pid = document.pid
     url = url_for("invenio_records_rest.doc_item", pid_value=doc_pid)
     res = client.delete(url)
@@ -687,7 +687,7 @@ def test_acquisition_reception_workflow(
         line = AcqReceiptLine.get_record_by_pid(pid)
         assert line is None
     assert AcqReceipt.get_record_by_pid(receipt_2.pid) is None
-    # Check ES is up-to-date
+    # Check search is up-to-date
     response = AcqReceiptLinesSearch().filter("terms", pid=receipt_line_pids).execute()
     assert response.hits.total.value == 0
     response = AcqReceiptsSearch().filter("term", pid=receipt_2.pid).execute()
@@ -705,7 +705,7 @@ def test_acquisition_reception_workflow(
         line = AcqReceiptLine.get_record_by_pid(pid)
         assert line is None
     assert AcqReceipt.get_record_by_pid(receipt_1.pid) is None
-    # Check ES is up-to-date
+    # Check search is up-to-date
     response = AcqReceiptLinesSearch().filter("terms", pid=receipt_line_pids).execute()
     assert response.hits.total.value == 0
     response = AcqReceiptsSearch().filter("term", pid=receipt_1.pid).execute()

--- a/tests/api/acquisition/test_acquisition_scenarios.py
+++ b/tests/api/acquisition/test_acquisition_scenarios.py
@@ -591,7 +591,7 @@ def test_acquisition_order_line_account_changes(
     # We will create an order line related to a first account (acc#A) ; then
     # we updated the related account (acc#B). We need to check if :
     #  - the destination account has enough balance to accept this order_line
-    #  - both account ES hits are correct (encumbrance, balance, ...) after
+    #  - both account search hits are correct (encumbrance, balance, ...) after
     #    this change.
 
     login_user_via_session(client, librarian_martigny.user)
@@ -600,7 +600,7 @@ def test_acquisition_order_line_account_changes(
     #   1) create two independent accounts
     #   2) create an order
     #   3) add an order line related to the acc#A
-    #   4) check if balance/encumbrance are correct into ES indexes.
+    #   4) check if balance/encumbrance are correct into search indexes.
     basic_data = {
         "allocated_amount": 0,
         "budget": {"$ref": get_ref_for_pid("budg", budget_2020_martigny.pid)},

--- a/tests/api/collections/test_collections_rest.py
+++ b/tests/api/collections/test_collections_rest.py
@@ -81,8 +81,8 @@ def test_collection_enrich_data(
     coll_martigny_1.reindex()
     CollectionsSearch.flush_and_refresh()
     query = CollectionsSearch().filter("term", pid=coll_martigny_1.pid).source().scan()
-    coll_martigny_1_es_data = next(query)
-    assert coll_martigny_1_es_data.organisation.pid == "org1"
+    coll_martigny_1_search_data = next(query)
+    assert coll_martigny_1_search_data.organisation.pid == "org1"
 
 
 def test_collection_search(client, coll_sion_1, coll_martigny_1, librarian_martigny, librarian_sion, rero_json_header):

--- a/tests/api/documents/test_documents_add_cover_urls_task.py
+++ b/tests/api/documents/test_documents_add_cover_urls_task.py
@@ -55,7 +55,7 @@ def mock_redis():
 
 @pytest.fixture
 def mock_search():
-    """Patch DocumentsSearch to avoid hitting Elasticsearch."""
+    """Patch DocumentsSearch to avoid hitting search index."""
     with mock.patch("rero_ils.modules.documents.api.DocumentsSearch") as m:
         yield m
 

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -47,7 +47,7 @@ def test_documents_get(client, document_with_files):
     """Test record retrieval."""
     document = document_with_files
 
-    def clean_es_metadata(metadata):
+    def clean_search_metadata(metadata):
         """Clean contribution from authorized_access_point_"""
         # Contributions, subject and genreForm are i18n indexed field, so it's
         # too complicated to compare it from original record. Just take the
@@ -59,7 +59,7 @@ def test_documents_get(client, document_with_files):
         if genreForms := document.get("genreForm"):
             metadata["genreForm"] = genreForms
 
-        # REMOVE DYNAMICALLY ADDED ES KEYS (see indexer.py:IndexerDumper)
+        # REMOVE DYNAMICALLY ADDED search KEYS (see indexer.py:IndexerDumper)
         metadata.pop("sort_date_new", None)
         metadata.pop("sort_date_old", None)
         metadata.pop("sort_title", None)
@@ -76,12 +76,12 @@ def test_documents_get(client, document_with_files):
     assert res.headers["ETag"] == f'"{document.revision_id}"'
     data = get_json(res)
     # DEV NOTES : Why removing `identifiedBy` key
-    #   During the ES enrichment process, we complete the original identifiers
-    #   with alternate identifiers. So comparing ES data identifiers, to
+    #   During the search enrichment process, we complete the original identifiers
+    #   with alternate identifiers. So comparing search data identifiers, to
     #   original data identifiers doesn't make sense.
     document_data = document.dumps()
     document_data.pop("identifiedBy", None)
-    assert document_data == clean_es_metadata(data["metadata"])
+    assert document_data == clean_search_metadata(data["metadata"])
 
     # Check self links
     res = client.get(to_relative_url(data["links"]["self"]))
@@ -91,7 +91,7 @@ def test_documents_get(client, document_with_files):
     assert data == res_content
     document_data = document.dumps()
     document_data.pop("identifiedBy", None)
-    assert document_data == clean_es_metadata(data["metadata"])
+    assert document_data == clean_search_metadata(data["metadata"])
 
     list_url = url_for("invenio_records_rest.doc_list", q=f"pid:{document.pid}")
     res = client.get(list_url)
@@ -107,7 +107,7 @@ def test_documents_get(client, document_with_files):
         "organisation_pid",
         "library_pid",
     }
-    data_clean = clean_es_metadata(metadata)
+    data_clean = clean_search_metadata(metadata)
     document = document.replace_refs().dumps()
     document.pop("identifiedBy", None)
     assert document == data_clean
@@ -756,8 +756,8 @@ def test_document_identifiers_search(client, document):
     res = client.get(url)
     assert success(get_json(res))
 
-    # STEP#6 :: SEARCH USING SHORTCUT ES KEYS
-    #   'isbn' and 'issn' keys are added to the ES stored document. These key
+    # STEP#6 :: SEARCH USING SHORTCUT search KEYS
+    #   'isbn' and 'issn' keys are added to the search stored document. These key
     #   only contains the corresponding identifiers value ; but analyzer
     #   allows search using hyphens or not.
     url = url_for("invenio_records_rest.doc_list", q="isbn:2-84426-778-5")

--- a/tests/api/entities/local_entities/test_local_entities_rest.py
+++ b/tests/api/entities/local_entities/test_local_entities_rest.py
@@ -125,7 +125,7 @@ def test_local_entities_post_put_delete(client, local_entity_person_data, json_h
     data = get_json(res)
     assert data["metadata"]["name"] == "Test Name"
 
-    # Check value from Elasticsearch
+    # Check value from search index
     res = client.get(list_url)
     assert res.status_code == 200
     data = get_json(res)["hits"]["hits"][0]

--- a/tests/api/entities/remote_entities/test_remote_entities_rest.py
+++ b/tests/api/entities/remote_entities/test_remote_entities_rest.py
@@ -80,18 +80,18 @@ def test_remote_entities_get(client, entity_person):
 @mock.patch("rero_ils.modules.decorators.login_and_librarian", mock.MagicMock())
 @mock.patch("requests.request")
 def test_remote_search_proxy(
-    mock_es_concept_get,
+    mock_search_concept_get,
     app,
     client,
-    mef_concept2_es_response,
-    mef_agents1_es_response,
-    mef_places1_es_response,
+    mef_concept2_search_response,
+    mef_agents1_search_response,
+    mef_places1_search_response,
 ):
     """Test entities search on remote servers."""
     # TEST#1 :: Concepts
     #    All results must include a `type` key if a root `metadata` field
     #    exists.
-    mock_es_concept_get.return_value = mock_response(json_data=mef_concept2_es_response)
+    mock_search_concept_get.return_value = mock_response(json_data=mef_concept2_search_response)
 
     response = client.get(
         url_for(
@@ -110,7 +110,7 @@ def test_remote_search_proxy(
 
     # TEST#2 :: Agents
     #   All result must include a `identifiedBy` object if a root
-    mock_es_concept_get.return_value = mock_response(json_data=mef_agents1_es_response)
+    mock_search_concept_get.return_value = mock_response(json_data=mef_agents1_search_response)
     response = client.get(
         url_for(
             "api_remote_entities.remote_search_proxy",
@@ -118,12 +118,12 @@ def test_remote_search_proxy(
             term="UCLouvain",
         )
     )
-    identifier = mef_agents1_es_response["hits"]["hits"][0]["metadata"]["idref"]["identifier"]
+    identifier = mef_agents1_search_response["hits"]["hits"][0]["metadata"]["idref"]["identifier"]
     assert identifier == response.json["hits"]["hits"][0]["metadata"]["idref"]["identifiedBy"][0]["value"]
 
     # TEST#3 :: Places
     #   All result must include a `identifiedBy` object if a root
-    mock_es_concept_get.return_value = mock_response(json_data=mef_places1_es_response)
+    mock_search_concept_get.return_value = mock_response(json_data=mef_places1_search_response)
     response = client.get(
         url_for(
             "api_remote_entities.remote_search_proxy",
@@ -131,7 +131,9 @@ def test_remote_search_proxy(
             term="Rouen",
         )
     )
-    authorized_access_point = mef_places1_es_response["hits"]["hits"][0]["metadata"]["idref"]["authorized_access_point"]
+    authorized_access_point = mef_places1_search_response["hits"]["hits"][0]["metadata"]["idref"][
+        "authorized_access_point"
+    ]
     assert authorized_access_point == response.json["hits"]["hits"][0]["metadata"]["idref"]["authorized_access_point"]
 
     # TEST#4 :: Unknown MEF search type
@@ -150,7 +152,7 @@ def test_remote_search_proxy(
 
     # TEST#4 :: Simulate MEF errors
     #   Simulate than MEF call return an HTTP error and check the response.
-    mock_es_concept_get.return_value = mock_response(status=404)
+    mock_search_concept_get.return_value = mock_response(status=404)
     response = client.get(
         url_for(
             "api_remote_entities.remote_search_proxy",

--- a/tests/api/items/test_items_issue.py
+++ b/tests/api/items/test_items_issue.py
@@ -207,7 +207,7 @@ def test_issues_claim_notifications(
     NotificationsSearch.flush_and_refresh()
     assert issue_item.claims_count == 2
 
-    # Check that all is correctly indexed into ES
+    # Check that all is correctly indexed into search
     url = url_for("invenio_records_rest.item_list", q=f"pid:{issue_pid}", facets="claims_date")
     response = client.get(url)
     data = response.json["hits"]["hits"][0]["metadata"]
@@ -250,7 +250,7 @@ def test_issue_claims_counter_indexed_without_claims(
         # Flush and refresh the index to ensure data is searchable
         ItemsSearch.flush_and_refresh()
 
-        # Query ES to verify the indexed data includes claims.counter = 0
+        # Query search to verify the indexed data includes claims.counter = 0
         url = url_for("invenio_records_rest.item_list", q=f"pid:{issue_item.pid}")
         response = client.get(url)
         assert response.status_code == 200
@@ -279,7 +279,7 @@ def test_issue_sort_key_indexed(
     holding_lib_martigny_w_patterns,
     librarian_martigny,
 ):
-    """Test that ES sort_key reflects expected_date or sort_date correctly.
+    """Test that search sort_key reflects expected_date or sort_date correctly.
 
     The listener computes `sort_key` as `sort_date or expected_date`:
     - when the record has no sort_date, sort_key must equal expected_date
@@ -293,21 +293,21 @@ def test_issue_sort_key_indexed(
 
     try:
         ItemsSearch.flush_and_refresh()
-        es_issue = ItemsSearch().get_record_by_pid(issue_item.pid)
+        search_issue = ItemsSearch().get_record_by_pid(issue_item.pid)
 
         # no sort_date on the record → sort_key falls back to expected_date
         assert not issue_item.sort_date
-        assert es_issue["issue"]["sort_key"] == issue_item.expected_date
+        assert search_issue["issue"]["sort_key"] == issue_item.expected_date
 
         # set sort_date explicitly and reindex
         issue_item.sort_date = issue_item.expected_date
         issue_item = issue_item.update(issue_item, dbcommit=True, reindex=True)
         ItemsSearch.flush_and_refresh()
-        es_issue = ItemsSearch().get_record_by_pid(issue_item.pid)
+        search_issue = ItemsSearch().get_record_by_pid(issue_item.pid)
 
         # sort_date is now set → sort_key must use sort_date
-        assert es_issue["issue"]["sort_key"] == issue_item.sort_date
-        assert es_issue["issue"]["sort_date"] == issue_item.sort_date
+        assert search_issue["issue"]["sort_key"] == issue_item.sort_date
+        assert search_issue["issue"]["sort_date"] == issue_item.sort_date
     finally:
         issue_item.delete(dbcommit=True, delindex=True)
         ItemsSearch.flush_and_refresh()

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -1104,7 +1104,7 @@ def test_items_rest_api_sort(client, item_lib_martigny, item_lib_fully, rero_jso
 
     # STEP 1 :: Sort on 'call_number'
     #   * Ensure sort on `call_number` is possible
-    #   * Ensure `call_number.raw` ES field contains correct value
+    #   * Ensure `call_number.raw` search field contains correct value
     url = url_for("invenio_records_rest.item_list", sort="call_number")
     response = client.get(url, headers=rero_json_header)
     assert response.status_code == 200
@@ -1122,7 +1122,7 @@ def test_items_rest_api_sort(client, item_lib_martigny, item_lib_fully, rero_jso
 
     # STEP 2 :: Sort on 'second_call_number'
     #   * Ensure sort `second_call_number` is possible
-    #   * Ensure `second_call_number.raw` ES field contains correct value
+    #   * Ensure `second_call_number.raw` search field contains correct value
     url = url_for("invenio_records_rest.item_list", sort="second_call_number")
     response = client.get(url, headers=rero_json_header)
     assert response.status_code == 200

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -47,7 +47,7 @@ def test_item_stats_endpoint(item_at_desk_martigny_patron_and_loan_at_desk, clie
 
 
 def test_item_dumps(client, item_lib_martigny, org_martigny, librarian_martigny):
-    """Test item dumps and Elasticsearch version."""
+    """Test item dumps and search index version."""
     item_dumps = Item(item_lib_martigny.dumps()).replace_refs()
 
     assert item_dumps.get("organisation").get("pid") == org_martigny.pid
@@ -130,8 +130,8 @@ def test_item_stats(app, client, librarian_martigny, item_lib_martigny):
     # A mock on the answer has been created, because it is not possible
     # to freeze on the date, because the string "now-1y" passed to
     # the configuration of the "year" facet is calculated
-    # on the Elasticsearch instance.
-    es_response = Response(
+    # on the search index instance.
+    search_response = Response(
         OperationLogsSearch(),
         {
             "aggregations": {
@@ -158,7 +158,7 @@ def test_item_stats(app, client, librarian_martigny, item_lib_martigny):
         },
     )
 
-    es_response_checkin = Response(
+    search_response_checkin = Response(
         OperationLogsSearch(),
         {
             "aggregations": {
@@ -176,7 +176,7 @@ def test_item_stats(app, client, librarian_martigny, item_lib_martigny):
     )
 
     login_user_via_session(client, librarian_martigny.user)
-    with mock.patch.object(OperationLogsSearch, "execute", mock.MagicMock(return_value=es_response)):
+    with mock.patch.object(OperationLogsSearch, "execute", mock.MagicMock(return_value=search_response)):
         # We sum the Legacy_count field in the checkout field
         StatsSearch.flush_and_refresh()
         res = client.get(url_for("api_item.stats", item_pid="item1"))
@@ -185,7 +185,7 @@ def test_item_stats(app, client, librarian_martigny, item_lib_martigny):
             "total_year": {"checkout": 1, "extend": 1, "checkin": 1},
         }
 
-    with mock.patch.object(OperationLogsSearch, "execute", mock.MagicMock(return_value=es_response_checkin)):
+    with mock.patch.object(OperationLogsSearch, "execute", mock.MagicMock(return_value=search_response_checkin)):
         # item found
         # We add the legacy_checkout_count field to the checkout field
         StatsSearch.flush_and_refresh()

--- a/tests/api/operation_logs/test_operation_logs_rest.py
+++ b/tests/api/operation_logs/test_operation_logs_rest.py
@@ -127,9 +127,9 @@ def test_operation_log_on_item(
     OperationLogsSearch.flush_and_refresh()
 
     q = f"record.type:item AND record.value:{item.pid}"
-    es_url = url_for("invenio_records_rest.oplg_list", q=q, sort="mostrecent")
+    search_url = url_for("invenio_records_rest.oplg_list", q=q, sort="mostrecent")
     login_user_via_session(client, librarian_martigny.user)
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
     metadata = data["hits"]["hits"][0]["metadata"]
@@ -142,7 +142,7 @@ def test_operation_log_on_item(
     item = item.update(item, dbcommit=True, reindex=True)
     OperationLogsSearch.flush_and_refresh()
 
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 2
     metadata = data["hits"]["hits"][0]["metadata"]
@@ -155,7 +155,7 @@ def test_operation_log_on_item(
     item = item.update(item, dbcommit=True, reindex=True)
     OperationLogsSearch.flush_and_refresh()
 
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 2
 
@@ -167,7 +167,7 @@ def test_operation_log_on_item(
     item = item.update(item, dbcommit=True, reindex=True)
     OperationLogsSearch.flush_and_refresh()
 
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 3
     metadata = data["hits"]["hits"][0]["metadata"]
@@ -178,7 +178,7 @@ def test_operation_log_on_item(
     item.delete(dbcommit=True, delindex=True)
     OperationLogsSearch.flush_and_refresh()
 
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 4
     metadata = data["hits"]["hits"][0]["metadata"]
@@ -197,8 +197,8 @@ def test_operation_log_on_ill_request(client, ill_request_martigny, librarian_ma
     OperationLogsSearch.flush_and_refresh()
 
     q = f"record.type:illr AND record.value:{ill_request_martigny.pid}"
-    es_url = url_for("invenio_records_rest.oplg_list", q=q, sort="mostrecent")
-    res = client.get(es_url)
+    search_url = url_for("invenio_records_rest.oplg_list", q=q, sort="mostrecent")
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
     metadata = data["hits"]["hits"][0]["metadata"]
@@ -235,8 +235,8 @@ def test_operation_log_on_file(client, librarian_martigny, document, lib_martign
     login_user_via_session(client, librarian_martigny.user)
 
     # record file creation is in the op
-    es_url = url_for("invenio_records_rest.oplg_list", q="record.type:recid AND operation:create")
-    res = client.get(es_url)
+    search_url = url_for("invenio_records_rest.oplg_list", q="record.type:recid AND operation:create")
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
     metadata = data["hits"]["hits"][0]["metadata"]
@@ -246,18 +246,18 @@ def test_operation_log_on_file(client, librarian_martigny, document, lib_martign
     # record file update is in the op
     record_service.update(system_identity, recid, {"metadata": record["metadata"]})
     OperationLogsSearch.flush_and_refresh()
-    es_url = url_for("invenio_records_rest.oplg_list", q="record.type:recid AND operation:update")
-    res = client.get(es_url)
+    search_url = url_for("invenio_records_rest.oplg_list", q="record.type:recid AND operation:update")
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
 
     # file creation is in the op
     pdf_file_name = "doc_doc1_1.pdf"
-    es_url = url_for(
+    search_url = url_for(
         "invenio_records_rest.oplg_list",
         q=f"record.type:file AND operation:create AND record.value:{pdf_file_name}",
     )
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     metadata = data["hits"]["hits"][0]["metadata"]
     assert data["hits"]["total"]["value"] == 1
@@ -274,18 +274,18 @@ def test_operation_log_on_file(client, librarian_martigny, document, lib_martign
     file_service.delete_file(identity=system_identity, id_=recid, file_key=pdf_file_name)
     OperationLogsSearch.flush_and_refresh()
 
-    es_url = url_for(
+    search_url = url_for(
         "invenio_records_rest.oplg_list",
         q=f"record.type:file AND operation:delete AND record.value:{pdf_file_name}",
     )
-    res = client.get(es_url)
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
 
     # record file deletion is in the op
     record_service.delete(identity=system_identity, id_=recid)
     OperationLogsSearch.flush_and_refresh()
-    es_url = url_for("invenio_records_rest.oplg_list", q="record.type:recid AND operation:delete")
-    res = client.get(es_url)
+    search_url = url_for("invenio_records_rest.oplg_list", q="record.type:recid AND operation:delete")
+    res = client.get(search_url)
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -143,7 +143,7 @@ def test_patron_has_valid_subscriptions(
     patron_sion.add_subscription(patron_type_youngsters_sion, start, end)
     assert patron_sion.has_valid_subscription
 
-    # Create a old subscription for `patron_sion`. Call ES to know patrons with
+    # Create a old subscription for `patron_sion`. Call search to know patrons with
     # an obsolete subscription. This query should return the recently updated
     # patron.
     start = datetime.now() - timedelta(days=20)

--- a/tests/api/sru/test_sru_live.py
+++ b/tests/api/sru/test_sru_live.py
@@ -145,60 +145,60 @@ def _check_server():
 @pytest.mark.external
 @pytest.mark.usefixtures("_check_server")
 class TestCQLIndexMappings:
-    """Verify that each DC index is translated to the correct ES field."""
+    """Verify that each DC index is translated to the correct search field."""
 
     def test_serverchoice(self):
-        """Bare term uses server-choice (no field prefix in ES query)."""
+        """Bare term uses server-choice (no field prefix in search query)."""
         xml = sru("swift")
-        assert echoed(xml)["zs:query_es"] == "swift"
+        assert echoed(xml)["zs:search_query"] == "swift"
 
     def test_quoted_term(self):
         """Quoted phrase is passed through as-is."""
         xml = sru('"Les voyages de Gulliver"')
-        assert echoed(xml)["zs:query_es"] == '"Les voyages de Gulliver"'
+        assert echoed(xml)["zs:search_query"] == '"Les voyages de Gulliver"'
         assert n_records(xml) >= 1
 
     def test_dc_title(self):
         """dc.title maps to title.* wildcard field."""
         xml = sru("dc.title=Gulliver")
-        assert echoed(xml)["zs:query_es"] == r"title.\*:Gulliver"
+        assert echoed(xml)["zs:search_query"] == r"title.\*:Gulliver"
         assert n_records(xml) >= 1
 
     def test_dc_title_quoted(self):
-        """Quoted dc.title phrase is preserved in the ES query."""
+        """Quoted dc.title phrase is preserved in the search query."""
         xml = sru('dc.title="Les voyages de Gulliver"')
-        assert echoed(xml)["zs:query_es"] == r'title.\*:"Les voyages de Gulliver"'
+        assert echoed(xml)["zs:search_query"] == r'title.\*:"Les voyages de Gulliver"'
         assert n_records(xml) >= 1
 
     def test_dc_creator(self):
         """dc.creator maps to contribution role + authorized_access_point."""
         xml = sru("dc.creator=Swift")
-        es = echoed(xml)["zs:query_es"]
+        es = echoed(xml)["zs:search_query"]
         assert "authorized_access_point:Swift" in es
         assert "cre" in es  # creator role must be in the role list
 
     def test_dc_language(self):
         """dc.language maps to language.value."""
         xml = sru("dc.language=fre", maximum_records=1)
-        assert echoed(xml)["zs:query_es"] == "language.value:fre"
+        assert echoed(xml)["zs:search_query"] == "language.value:fre"
         assert n_records(xml) >= 1
 
     def test_dc_publisher(self):
         """dc.publisher maps to provisionActivity publication statement."""
         xml = sru("dc.publisher=Edito", maximum_records=1)
-        es = echoed(xml)["zs:query_es"]
+        es = echoed(xml)["zs:search_query"]
         assert "provisionActivity" in es
         assert "Edito" in es
 
     def test_dc_type(self):
         """dc.type maps to type.main_type."""
         xml = sru("dc.type=docmaintype_book", maximum_records=1)
-        assert echoed(xml)["zs:query_es"] == "type.main_type:docmaintype_book"
+        assert echoed(xml)["zs:search_query"] == "type.main_type:docmaintype_book"
 
     def test_dc_organisation(self):
         """dc.organisation maps to organisation_pid."""
         xml = sru("dc.organisation=3", maximum_records=1)
-        assert echoed(xml)["zs:query_es"] == "organisation_pid:3"
+        assert echoed(xml)["zs:search_query"] == "organisation_pid:3"
 
 
 # ---------------------------------------------------------------------------
@@ -212,16 +212,16 @@ class TestCQLBooleans:
     """Verify AND / OR boolean combinations."""
 
     def test_and_title_organisation(self):
-        """AND combines two clauses with parentheses in ES."""
+        """AND combines two clauses with parentheses in search."""
         xml = sru('dc.title="Les voyages de Gulliver" AND dc.organisation=3')
-        es = echoed(xml)["zs:query_es"]
+        es = echoed(xml)["zs:search_query"]
         assert es == r'(title.\*:"Les voyages de Gulliver" AND organisation_pid:3)'
         assert n_records(xml) == 1
 
     def test_and_title_type(self):
         """AND with type filter narrows results correctly."""
         xml = sru("dc.title=Gulliver AND dc.type=docmaintype_book")
-        es = echoed(xml)["zs:query_es"]
+        es = echoed(xml)["zs:search_query"]
         assert r"title.\*:Gulliver" in es
         assert "type.main_type:docmaintype_book" in es
 
@@ -236,7 +236,7 @@ class TestCQLBooleans:
     def test_triple_and(self):
         """Three-clause AND wraps correctly."""
         xml = sru('dc.title="Les voyages de Gulliver" AND dc.organisation=3 AND dc.language=fre')
-        es = echoed(xml)["zs:query_es"]
+        es = echoed(xml)["zs:search_query"]
         assert r'title.\*:"Les voyages de Gulliver"' in es
         assert "organisation_pid:3" in es
         assert "language.value:fre" in es
@@ -257,7 +257,7 @@ class TestCQLSort:
         xml = sru("dc.language=fre sortBy dc.title/ascending", maximum_records=3)
         ech = echoed(xml)
         # Query part strips the sort clause
-        assert "sortBy" not in ech["zs:query_es"]
+        assert "sortBy" not in ech["zs:search_query"]
         # Results are returned
         assert n_records(xml) >= 1
 
@@ -265,13 +265,13 @@ class TestCQLSort:
         """SortBy dc.title/descending is valid."""
         xml = sru("dc.language=fre sortBy dc.title/descending", maximum_records=3)
         assert n_records(xml) >= 1
-        assert "sortBy" not in echoed(xml)["zs:query_es"]
+        assert "sortBy" not in echoed(xml)["zs:search_query"]
 
     def test_sort_by_date_descending(self):
         """SortBy dc.date/descending maps provisionActivity.startDate desc."""
         xml = sru("dc.title=Gulliver sortBy dc.date/descending")
         assert n_records(xml) >= 1
-        assert "sortBy" not in echoed(xml)["zs:query_es"]
+        assert "sortBy" not in echoed(xml)["zs:search_query"]
 
     def test_sort_by_date_ascending(self):
         """SortBy dc.date/ascending is valid."""
@@ -282,18 +282,18 @@ class TestCQLSort:
         """SortBy _relevance maps to _score."""
         xml = sru("dc.title=Gulliver sortBy _relevance")
         assert n_records(xml) >= 1
-        assert "sortBy" not in echoed(xml)["zs:query_es"]
+        assert "sortBy" not in echoed(xml)["zs:search_query"]
 
     def test_sort_multi_key(self):
         """Multiple sort keys (dc.title then dc.date) are accepted."""
         xml = sru("swift sortBy dc.title/ascending dc.date/descending", maximum_records=3)
         assert n_records(xml) >= 1
-        assert "sortBy" not in echoed(xml)["zs:query_es"]
+        assert "sortBy" not in echoed(xml)["zs:search_query"]
 
     def test_sort_with_boolean(self):
         """Sort clause works together with a boolean AND query."""
         xml = sru("dc.title=Gulliver AND dc.language=fre sortBy dc.title", maximum_records=3)
-        es = echoed(xml)["zs:query_es"]
+        es = echoed(xml)["zs:search_query"]
         assert r"title.\*:Gulliver" in es
         assert "sortBy" not in es
 

--- a/tests/api/sru/test_sru_rest.py
+++ b/tests/api/sru/test_sru_rest.py
@@ -43,7 +43,7 @@ def test_sru_documents(client, document_ref, entity_person_data):
         "zs:version": "1.1",
         "zs:maximumRecords": "100",
         "zs:query": "al-Wajīz",
-        "zs:query_es": "al-Wajīz",
+        "zs:search_query": "al-Wajīz",
         "zs:recordPacking": "XML",
         "zs:recordSchema": "info:sru/schema/1/marcxml-v1.1-light",
         "zs:resultSetTTL": "0",
@@ -67,7 +67,7 @@ def test_sru_documents_items(client, document_sion_items):
     assert "zs:searchRetrieveResponse" in xml_dict
     ech_srr = xml_dict["zs:searchRetrieveResponse"]["zs:echoedSearchRetrieveRequest"]
     assert ech_srr["zs:query"] == '"La reine Berthe et son fils"'
-    assert ech_srr["zs:query_es"] == '"La reine Berthe et son fils"'
+    assert ech_srr["zs:search_query"] == '"La reine Berthe et son fils"'
 
     api_url = url_for(
         "api_sru.documents",
@@ -82,7 +82,7 @@ def test_sru_documents_items(client, document_sion_items):
     assert "zs:searchRetrieveResponse" in xml_dict
     ech_srr = xml_dict["zs:searchRetrieveResponse"]["zs:echoedSearchRetrieveRequest"]
     assert ech_srr["zs:query"] == '"La reine Berthe et son fils"'
-    assert ech_srr["zs:query_es"] == '"La reine Berthe et son fils"'
+    assert ech_srr["zs:search_query"] == '"La reine Berthe et son fils"'
 
     api_url = url_for(
         "api_sru.documents",
@@ -97,7 +97,7 @@ def test_sru_documents_items(client, document_sion_items):
     assert "searchRetrieveResponse" in xml_dict
     ech_srr = xml_dict["searchRetrieveResponse"]["echoedSearchRetrieveRequest"]
     assert ech_srr["query"] == 'dc.title="La reine Berthe et son fils"'
-    assert ech_srr["query_es"] == 'title.\\*:"La reine Berthe et son fils"'
+    assert ech_srr["search_query"] == 'title.\\*:"La reine Berthe et son fils"'
 
 
 def test_sru_excludes_masked_and_draft(client, document_ref):
@@ -160,8 +160,8 @@ def test_sru_explain_conditional_get(client):
     assert res.headers.get("ETag") == etag
 
 
-def test_sru_es_backend_error(client):
-    """Test SRU returns a diagnostic on non-recoverable ES backend error."""
+def test_sru_search_backend_error(client):
+    """Test SRU returns a diagnostic on non-recoverable search backend error."""
     from unittest.mock import patch
 
     from elasticsearch.exceptions import RequestError as ESRequestError
@@ -179,8 +179,8 @@ def test_sru_es_backend_error(client):
     assert diag["diag:message"] == "System temporarily unavailable"
 
 
-def test_sru_es_window_overflow(client):
-    """Test SRU returns zero results when ES result window is exceeded."""
+def test_sru_search_window_overflow(client):
+    """Test SRU returns zero results when search result window is exceeded."""
     from unittest.mock import patch
 
     from elasticsearch.exceptions import RequestError as ESRequestError

--- a/tests/api/test_monitoring_rest.py
+++ b/tests/api/test_monitoring_rest.py
@@ -51,74 +51,74 @@ def monitoring_user(app, db, default_user_password):
     return ds.get_user("monitoring@rero.ch")
 
 
-def test_monitoring_es_db_counts(client):
-    """Test monitoring es_db_counts."""
-    res = client.get(url_for("api_monitoring.es_db_counts"))
+def test_monitoring_search_db_counts(client):
+    """Test monitoring search_db_counts."""
+    res = client.get(url_for("api_monitoring.search_db_counts"))
     assert res.status_code == 200
     assert get_json(res) == {
         "data": {
-            "acac": {"db": 0, "db-es": 0, "es": 0, "index": "acq_accounts"},
-            "acol": {"db": 0, "db-es": 0, "es": 0, "index": "acq_order_lines"},
-            "acor": {"db": 0, "db-es": 0, "es": 0, "index": "acq_orders"},
-            "acre": {"db": 0, "db-es": 0, "es": 0, "index": "acq_receipts"},
-            "acrl": {"db": 0, "db-es": 0, "es": 0, "index": "acq_receipt_lines"},
-            "budg": {"db": 0, "db-es": 0, "es": 0, "index": "budgets"},
-            "cipo": {"db": 0, "db-es": 0, "es": 0, "index": "circ_policies"},
-            "coll": {"db": 0, "db-es": 0, "es": 0, "index": "collections"},
-            "rement": {"db": 0, "db-es": 0, "es": 0, "index": "remote_entities"},
-            "doc": {"db": 0, "db-es": 0, "es": 0, "index": "documents"},
-            "hold": {"db": 0, "db-es": 0, "es": 0, "index": "holdings"},
-            "illr": {"db": 0, "db-es": 0, "es": 0, "index": "ill_requests"},
-            "item": {"db": 0, "db-es": 0, "es": 0, "index": "items"},
-            "itty": {"db": 0, "db-es": 0, "es": 0, "index": "item_types"},
-            "lib": {"db": 0, "db-es": 0, "es": 0, "index": "libraries"},
-            "loanid": {"db": 0, "db-es": 0, "es": 0, "index": "loans"},
-            "loc": {"db": 0, "db-es": 0, "es": 0, "index": "locations"},
-            "locent": {"db": 0, "db-es": 0, "es": 0, "index": "local_entities"},
-            "lofi": {"db": 0, "db-es": 0, "es": 0, "index": "local_fields"},
-            "notif": {"db": 0, "db-es": 0, "es": 0, "index": "notifications"},
-            "oplg": {"db": 0, "db-es": 0, "es": 0, "index": "operation_logs"},
-            "org": {"db": 0, "db-es": 0, "es": 0, "index": "organisations"},
+            "acac": {"db": 0, "db-search": 0, "search": 0, "index": "acq_accounts"},
+            "acol": {"db": 0, "db-search": 0, "search": 0, "index": "acq_order_lines"},
+            "acor": {"db": 0, "db-search": 0, "search": 0, "index": "acq_orders"},
+            "acre": {"db": 0, "db-search": 0, "search": 0, "index": "acq_receipts"},
+            "acrl": {"db": 0, "db-search": 0, "search": 0, "index": "acq_receipt_lines"},
+            "budg": {"db": 0, "db-search": 0, "search": 0, "index": "budgets"},
+            "cipo": {"db": 0, "db-search": 0, "search": 0, "index": "circ_policies"},
+            "coll": {"db": 0, "db-search": 0, "search": 0, "index": "collections"},
+            "rement": {"db": 0, "db-search": 0, "search": 0, "index": "remote_entities"},
+            "doc": {"db": 0, "db-search": 0, "search": 0, "index": "documents"},
+            "hold": {"db": 0, "db-search": 0, "search": 0, "index": "holdings"},
+            "illr": {"db": 0, "db-search": 0, "search": 0, "index": "ill_requests"},
+            "item": {"db": 0, "db-search": 0, "search": 0, "index": "items"},
+            "itty": {"db": 0, "db-search": 0, "search": 0, "index": "item_types"},
+            "lib": {"db": 0, "db-search": 0, "search": 0, "index": "libraries"},
+            "loanid": {"db": 0, "db-search": 0, "search": 0, "index": "loans"},
+            "loc": {"db": 0, "db-search": 0, "search": 0, "index": "locations"},
+            "locent": {"db": 0, "db-search": 0, "search": 0, "index": "local_entities"},
+            "lofi": {"db": 0, "db-search": 0, "search": 0, "index": "local_fields"},
+            "notif": {"db": 0, "db-search": 0, "search": 0, "index": "notifications"},
+            "oplg": {"db": 0, "db-search": 0, "search": 0, "index": "operation_logs"},
+            "org": {"db": 0, "db-search": 0, "search": 0, "index": "organisations"},
             "ptre": {
                 "db": 0,
-                "db-es": 0,
-                "es": 0,
+                "db-search": 0,
+                "search": 0,
                 "index": "patron_transaction_events",
             },
-            "ptrn": {"db": 0, "db-es": 0, "es": 0, "index": "patrons"},
-            "pttr": {"db": 0, "db-es": 0, "es": 0, "index": "patron_transactions"},
-            "ptty": {"db": 0, "db-es": 0, "es": 0, "index": "patron_types"},
-            "stacfg": {"db": 0, "db-es": 0, "es": 0, "index": "stats_cfg"},
-            "stat": {"db": 0, "db-es": 0, "es": 0, "index": "stats"},
-            "tmpl": {"db": 0, "db-es": 0, "es": 0, "index": "templates"},
-            "ent": {"db": 0, "db-es": 0, "es": 0, "index": "entities"},
-            "vndr": {"db": 0, "db-es": 0, "es": 0, "index": "vendors"},
+            "ptrn": {"db": 0, "db-search": 0, "search": 0, "index": "patrons"},
+            "pttr": {"db": 0, "db-search": 0, "search": 0, "index": "patron_transactions"},
+            "ptty": {"db": 0, "db-search": 0, "search": 0, "index": "patron_types"},
+            "stacfg": {"db": 0, "db-search": 0, "search": 0, "index": "stats_cfg"},
+            "stat": {"db": 0, "db-search": 0, "search": 0, "index": "stats"},
+            "tmpl": {"db": 0, "db-search": 0, "search": 0, "index": "templates"},
+            "ent": {"db": 0, "db-search": 0, "search": 0, "index": "entities"},
+            "vndr": {"db": 0, "db-search": 0, "search": 0, "index": "vendors"},
         }
     }
 
 
-def test_monitoring_check_es_db_counts(app, client, entity_person_data, system_librarian_martigny):
-    """Test monitoring check_es_db_counts."""
-    res = client.get(url_for("api_monitoring.check_es_db_counts", delay=0))
+def test_monitoring_check_search_db_counts(app, client, entity_person_data, system_librarian_martigny):
+    """Test monitoring check_search_db_counts."""
+    res = client.get(url_for("api_monitoring.check_search_db_counts", delay=0))
     assert res.status_code == 200
     assert get_json(res) == {"data": {"status": "green"}}
 
     pers = RemoteEntity.create(data=entity_person_data, delete_pid=False, dbcommit=True, reindex=False)
     RemoteEntitiesSearch.flush_and_refresh()
-    res = client.get(url_for("api_monitoring.check_es_db_counts", delay=0))
+    res = client.get(url_for("api_monitoring.check_search_db_counts", delay=0))
     assert res.status_code == 200
     assert get_json(res) == {
         "data": {"status": "red"},
         "errors": [
             {
-                "code": "DB_ES_COUNTER_MISMATCH",
-                "details": "There are 1 items from rement missing in ES.",
-                "id": "DB_ES_COUNTER_MISMATCH",
+                "code": "DB_SEARCH_COUNTER_MISMATCH",
+                "details": "There are 1 items from rement missing in search.",
+                "id": "DB_SEARCH_COUNTER_MISMATCH",
                 "links": {
-                    "about": "http://localhost/monitoring/check_es_db_counts",
+                    "about": "http://localhost/monitoring/check_search_db_counts",
                     "rement": "http://localhost/monitoring/missing_pids/rement",
                 },
-                "title": "DB items counts don't match ES items count.",
+                "title": "DB items counts don't match search items count.",
             }
         ],
     }
@@ -139,8 +139,8 @@ def test_monitoring_check_es_db_counts(app, client, entity_person_data, system_l
     assert get_json(res) == {
         "data": {
             "DB": [],
-            "ES": ["http://localhost/remote_entities/ent_pers"],
-            "ES duplicate": [],
+            "search": ["http://localhost/remote_entities/ent_pers"],
+            "search duplicate": [],
         }
     }
 

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -220,7 +220,7 @@ def test_documents_search(client, doc_title_travailleurs, doc_title_travailleuse
     assert hits["total"]["value"] == 1
 
     # test wildcard query with boolean sub property
-    # See: elasticsearch query_string lenient property
+    # See: search index query_string lenient property
     #      for more details
     list_url = url_for("invenio_records_rest.doc_list", q=r"subjects.\*:test")
     res = client.get(list_url)
@@ -228,7 +228,7 @@ def test_documents_search(client, doc_title_travailleurs, doc_title_travailleuse
     assert hits
 
     # test wildcard query with boolean sub property
-    # See: elasticsearch query_string lenient property
+    # See: search index query_string lenient property
     #      for more details
     list_url = url_for("invenio_records_rest.doc_list", q=r"autocomplete_title:travailleu")
     res = client.get(list_url)

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -55,7 +55,7 @@ def test_operation_logs_serializers(
         params=params,
         copy_item=True,
     )
-    # Force update ES index
+    # Force update search index
     OperationLogsSearch.flush_and_refresh()
     list_url = url_for("invenio_records_rest.oplg_list")
     login_user(client, patron_martigny)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,10 +66,10 @@ def thumbnail_covers():
 
 @pytest.fixture(scope="module")
 def search(appctx):
-    """Setup and teardown all registered Elasticsearch indices.
+    """Setup and teardown all registered search index indices.
 
     Scope: module
-    This fixture will create all registered indexes in Elasticsearch and remove
+    This fixture will create all registered indexes in search index and remove
     once done. Fixtures that perform changes (e.g. index or remove documents),
     should used the function-scoped :py:data:`search_clear` fixture to leave the
     indexes clean for the following tests.

--- a/tests/data/mef.json
+++ b/tests/data/mef.json
@@ -172,7 +172,7 @@
       "idref"
     ]
   },
-  "es_concepts_1": {
+  "search_concepts_1": {
     "hits": {
       "hits": [
         {
@@ -249,7 +249,7 @@
       "total": 2
     }
   },
-  "es_agents_1": {
+  "search_agents_1": {
     "hits": {
       "hits": [
         {
@@ -295,7 +295,7 @@
       "total": 1
     }
   },
-  "es_places_1": {
+  "search_places_1": {
     "hits": {
       "hits": [
         {

--- a/tests/fixtures/mef.py
+++ b/tests/fixtures/mef.py
@@ -49,9 +49,9 @@ def mef_concept1_data_tmp(mef_entities):
 
 
 @pytest.fixture(scope="module")
-def mef_concept1_es_response(mef_concept1_data_tmp):
-    """Get MEF ES response for `concept_1` entities."""
-    # transform data to a valid MEF ES hit response
+def mef_concept1_search_response(mef_concept1_data_tmp):
+    """Get MEF search response for `concept_1` entities."""
+    # transform data to a valid MEF search hit response
     data = deepcopy(mef_concept1_data_tmp)
     data["$schema"] = "https://mef.rero.ch/schemas/concepts_mef/mef-concept-v0.0.1.json"
     data.pop("type", None)
@@ -60,18 +60,18 @@ def mef_concept1_es_response(mef_concept1_data_tmp):
 
 
 @pytest.fixture(scope="module")
-def mef_concept2_es_response(mef_entities):
-    """Load MEF es_concept_1 data."""
-    return deepcopy(mef_entities.get("es_concepts_1"))
+def mef_concept2_search_response(mef_entities):
+    """Load MEF search_concept_1 data."""
+    return deepcopy(mef_entities.get("search_concepts_1"))
 
 
 @pytest.fixture(scope="module")
-def mef_agents1_es_response(mef_entities):
-    """Load MEF es_agents_1 data."""
-    return deepcopy(mef_entities.get("es_agents_1"))
+def mef_agents1_search_response(mef_entities):
+    """Load MEF search_agents_1 data."""
+    return deepcopy(mef_entities.get("search_agents_1"))
 
 
 @pytest.fixture(scope="module")
-def mef_places1_es_response(mef_entities):
-    """Load MEF es_places_1 data."""
-    return deepcopy(mef_entities.get("es_places_1"))
+def mef_places1_search_response(mef_entities):
+    """Load MEF search_places_1 data."""
+    return deepcopy(mef_entities.get("search_places_1"))

--- a/tests/migrations/conftest.py
+++ b/tests/migrations/conftest.py
@@ -25,7 +25,7 @@ from rero_ils.modules.migrations.data.api import Deduplication
 
 
 @pytest.fixture(scope="module")
-def migration(es_indices, lib_martigny):
+def migration(search_indices, lib_martigny):
     """Migration fixture."""
     data = {
         "name": "name",
@@ -121,7 +121,7 @@ def migration_data(migration_xml_data, migration):
 
 
 @pytest.fixture(scope="module")
-def es_indices(app):
+def search_indices(app):
     """Create test app."""
     Migration.init()
     yield

--- a/tests/migrations/ui/test_migrations_api.py
+++ b/tests/migrations/ui/test_migrations_api.py
@@ -25,7 +25,7 @@ from elasticsearch_dsl.exceptions import ValidationException
 from rero_ils.modules.migrations.api import Migration
 
 
-def test_migrations_create(es_indices, lib_martigny):
+def test_migrations_create(search_indices, lib_martigny):
     """Test the migration creation."""
     with pytest.raises(ValidationException):
         Migration().save()

--- a/tests/mock_modules/__init__.py
+++ b/tests/mock_modules/__init__.py
@@ -95,7 +95,9 @@ class Converter:
         status = "no match"
         if data.deduplication.status == "pending" or force:
             try:
-                candidates = Deduplication(es_hosts=["10.247.6.4:9200"]).get_candidates(data.conversion.json.to_dict())
+                candidates = Deduplication(search_hosts=["10.247.6.4:9200"]).get_candidates(
+                    data.conversion.json.to_dict()
+                )
             except Exception as err:
                 logs["error"] = [f"{err}"]
                 status = "error"

--- a/tests/ui/acq_accounts/test_acq_accounts_mapping.py
+++ b/tests/ui/acq_accounts/test_acq_accounts_mapping.py
@@ -21,8 +21,8 @@ from rero_ils.modules.acquisition.acq_accounts.api import AcqAccount, AcqAccount
 from tests.utils import get_mapping
 
 
-def test_acq_accounts_es_mapping(search, db, acq_account_fiction_martigny_data, budget_2020_martigny, lib_martigny):
-    """Test acquisition account elasticsearch mapping."""
+def test_acq_accounts_search_mapping(search, db, acq_account_fiction_martigny_data, budget_2020_martigny, lib_martigny):
+    """Test acquisition account search index mapping."""
     search = AcqAccountsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/acq_order_lines/test_acq_order_lines_mapping.py
+++ b/tests/ui/acq_order_lines/test_acq_order_lines_mapping.py
@@ -24,7 +24,7 @@ from rero_ils.modules.acquisition.acq_order_lines.api import (
 from tests.utils import get_mapping
 
 
-def test_acq_order_lines_es_mapping(
+def test_acq_order_lines_search_mapping(
     es,
     db,
     document,
@@ -32,7 +32,7 @@ def test_acq_order_lines_es_mapping(
     acq_order_fiction_martigny,
     acq_order_line_fiction_martigny_data,
 ):
-    """Test aquisition order line elasticsearch mapping."""
+    """Test aquisition order line search index mapping."""
     search = AcqOrderLinesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/acq_orders/test_acq_orders_mapping.py
+++ b/tests/ui/acq_orders/test_acq_orders_mapping.py
@@ -21,8 +21,8 @@ from rero_ils.modules.acquisition.acq_orders.api import AcqOrder, AcqOrdersSearc
 from tests.utils import get_mapping
 
 
-def test_acq_orders_es_mapping(search, db, lib_martigny, vendor_martigny, acq_order_fiction_martigny_data):
-    """Test acquisition orders elasticsearch mapping."""
+def test_acq_orders_search_mapping(search, db, lib_martigny, vendor_martigny, acq_order_fiction_martigny_data):
+    """Test acquisition orders search index mapping."""
     search = AcqOrdersSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/acq_receipt_lines/test_acq_receipt_lines_mapping.py
+++ b/tests/ui/acq_receipt_lines/test_acq_receipt_lines_mapping.py
@@ -25,7 +25,7 @@ from rero_ils.modules.acquisition.acq_receipt_lines.api import (
 from tests.utils import get_mapping
 
 
-def test_acq_receipt_lines_es_mapping(
+def test_acq_receipt_lines_search_mapping(
     search,
     db,
     lib_martigny,
@@ -33,7 +33,7 @@ def test_acq_receipt_lines_es_mapping(
     acq_receipt_line_1_fiction_martigny,
     acq_receipt_line_1_fiction_martigny_data,
 ):
-    """Test acquisition receipt lines elasticsearch mapping."""
+    """Test acquisition receipt lines search index mapping."""
     search = AcqReceiptLinesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/acq_receipts/test_acq_receipts_mapping.py
+++ b/tests/ui/acq_receipts/test_acq_receipts_mapping.py
@@ -24,7 +24,7 @@ from rero_ils.modules.acquisition.acq_receipts.api import AcqReceipt, AcqReceipt
 from tests.utils import get_mapping
 
 
-def test_acq_receipts_es_mapping(
+def test_acq_receipts_search_mapping(
     search,
     db,
     lib_martigny,
@@ -34,7 +34,7 @@ def test_acq_receipts_es_mapping(
     acq_account_fiction_martigny,
     acq_receipt_fiction_martigny_data,
 ):
-    """Test acquisition receipts elasticsearch mapping."""
+    """Test acquisition receipts search index mapping."""
     search = AcqReceiptsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/budgets/test_budgets_api.py
+++ b/tests/ui/budgets/test_budgets_api.py
@@ -35,15 +35,15 @@ def test_budget_cascade_reindex(acq_account_fiction_martigny, budget_2020_martig
 
     # when the `is_active` budget field change, the related account must be
     # reindex too.
-    es_budg = BudgetsSearch().get_record_by_pid(budg.pid)
-    es_acac = AcqAccountsSearch().get_record_by_pid(acac.pid)
-    assert es_budg["is_active"] and es_acac["is_active"]
+    search_budg = BudgetsSearch().get_record_by_pid(budg.pid)
+    search_acac = AcqAccountsSearch().get_record_by_pid(acac.pid)
+    assert search_budg["is_active"] and search_acac["is_active"]
 
     budg["is_active"] = False
     budg.update(budg, dbcommit=True, reindex=True)
     BudgetsSearch.flush_and_refresh()
     AcqAccountsSearch.flush_and_refresh()
 
-    es_budg = BudgetsSearch().get_record_by_pid(budg.pid)
-    es_acac = AcqAccountsSearch().get_record_by_pid(acac.pid)
-    assert not es_budg["is_active"] and not es_acac["is_active"]
+    search_budg = BudgetsSearch().get_record_by_pid(budg.pid)
+    search_acac = AcqAccountsSearch().get_record_by_pid(acac.pid)
+    assert not search_budg["is_active"] and not search_acac["is_active"]

--- a/tests/ui/budgets/test_budgets_mapping.py
+++ b/tests/ui/budgets/test_budgets_mapping.py
@@ -21,8 +21,8 @@ from rero_ils.modules.acquisition.budgets.api import Budget, BudgetsSearch
 from tests.utils import get_mapping
 
 
-def test_budgets_es_mapping(search, db, org_martigny, budget_2017_martigny_data):
-    """Test acquisition budget elasticsearch mapping."""
+def test_budgets_search_mapping(search, db, org_martigny, budget_2017_martigny_data):
+    """Test acquisition budget search index mapping."""
     search = BudgetsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/circ_policies/test_circ_policies_mapping.py
+++ b/tests/ui/circ_policies/test_circ_policies_mapping.py
@@ -21,8 +21,8 @@ from rero_ils.modules.circ_policies.api import CircPoliciesSearch, CircPolicy
 from tests.utils import get_mapping
 
 
-def test_circ_policy_es_mapping(search_clear, db, org_martigny, circ_policy_martigny_data_tmp):
-    """Test circulation policy elasticsearch mapping."""
+def test_circ_policy_search_mapping(search_clear, db, org_martigny, circ_policy_martigny_data_tmp):
+    """Test circulation policy search index mapping."""
     search = CircPoliciesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping
@@ -38,7 +38,7 @@ def test_circ_policies_search_mapping(app, circulation_policies):
     assert c == 4
     c = search.query("match", name="default").count()
     assert c == 2
-    es_query = search.query("match", name="temporary").source(["pid"]).scan()
-    pids = [hit.pid for hit in es_query]
+    search_query = search.query("match", name="temporary").source(["pid"]).scan()
+    pids = [hit.pid for hit in search_query]
     assert len(pids) == 1
     assert "cipo3" in pids

--- a/tests/ui/circulation/test_actions_auto_extend.py
+++ b/tests/ui/circulation/test_actions_auto_extend.py
@@ -113,20 +113,20 @@ def test_auto_extend_task(
 
     # Check that the operation_logs were created
     OperationLogsSearch.flush_and_refresh()
-    es_query = (
+    search_query = (
         OperationLogsSearch()
         .filter("term", loan__pid=loan.pid)
         .filter("term", record__type="loan")
         .filter("term", loan__trigger=ItemCirculationAction.EXTEND)
         .filter("term", loan__auto_extend=True)
     )
-    assert es_query.count() == 1
+    assert search_query.count() == 1
 
-    es_query = (
+    search_query = (
         OperationLogsSearch()
         .filter("term", loan__pid=loan.pid)
         .filter("term", record__type="notif")
         .filter("term", loan__trigger=ItemCirculationAction.EXTEND)
         .filter("term", notification__type="auto_extend")
     )
-    assert es_query.count() == 1
+    assert search_query.count() == 1

--- a/tests/ui/collections/test_collections_mapping.py
+++ b/tests/ui/collections/test_collections_mapping.py
@@ -21,7 +21,7 @@ from rero_ils.modules.collections.api import Collection, CollectionsSearch
 from tests.utils import get_mapping
 
 
-def test_collections_es_mapping(
+def test_collections_search_mapping(
     search,
     db,
     org_martigny,
@@ -29,7 +29,7 @@ def test_collections_es_mapping(
     item_lib_martigny,
     item2_lib_martigny,
 ):
-    """Test collections elasticsearch mapping."""
+    """Test collections search index mapping."""
     search = CollectionsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -108,8 +108,8 @@ def ils_record_2():
 
 
 @pytest.fixture(scope="module")
-def es_default_index(search):
-    """ES default index."""
+def search_default_index(search):
+    """Search default index."""
     index_name = list(current_search_client.indices.get_alias("records-record-v1.0.0").keys()).pop()
     current_search_client.indices.delete(index=index_name)
     current_search_client.indices.create(

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -136,10 +136,10 @@ def test_document_linked_subject(
     app,
     document_data_tmp,
     mef_concept1_data,
-    mef_concept1_es_response,
+    mef_concept1_search_response,
 ):
     """Load document with MEF reference as a subject."""
-    mock_subjects_mef_get.return_value = mock_response(json_data=mef_concept1_es_response)
+    mock_subjects_mef_get.return_value = mock_response(json_data=mef_concept1_search_response)
 
     concept_pid = mef_concept1_data["idref"]["pid"]
     entity_uri = f"https://mef.rero.ch/api/concepts/idref/{concept_pid}"
@@ -151,19 +151,19 @@ def test_document_linked_subject(
 
     # a "bf:Concepts" entity should be created.
     #    - Check if the entity has been created
-    #    - Check if ES mapping is correct for this entity
+    #    - Check if search mapping is correct for this entity
     _, _type, _id = extract_data_from_mef_uri(entity_uri)
     entity = RemoteEntity.get_entity(_type, _id)
     assert _type in entity.get("sources")
 
-    es_record = RemoteEntitiesSearch().get_record_by_pid(entity.pid)
-    assert es_record["type"] == EntityType.TOPIC
-    assert es_record[_type]["pid"] == _id
+    search_record = RemoteEntitiesSearch().get_record_by_pid(entity.pid)
+    assert search_record["type"] == EntityType.TOPIC
+    assert search_record[_type]["pid"] == _id
 
-    # Check the document ES record
+    # Check the document search record
     #    - check if $ref linked subject is correctly dumped
-    es_record = DocumentsSearch().get_record_by_pid(doc.pid)
-    subject = es_record["subjects"][0]
+    search_record = DocumentsSearch().get_record_by_pid(doc.pid)
+    subject = search_record["subjects"][0]
     assert subject["entity"]["primary_source"] == _type
     assert _id in subject["entity"]["pids"][_type]
     assert subject["entity"]["authorized_access_point_fr"] == "Antienzymes"
@@ -314,8 +314,8 @@ def test_document_replace_refs(document, mef_agents_url):
 
     document.update(document, dbcommit=True, reindex=True)
     DocumentsSearch.flush_and_refresh()
-    es_doc = DocumentsSearch().get_record_by_pid(document.pid).to_dict()
-    assert es_doc["contribution"][1]["entity"]["type"] == EntityType.PERSON
+    search_doc = DocumentsSearch().get_record_by_pid(document.pid).to_dict()
+    assert search_doc["contribution"][1]["entity"]["type"] == EntityType.PERSON
 
     data = document.replace_refs()
     assert len(data.get("contribution")) == 2
@@ -354,9 +354,9 @@ def test_document_type_change(app, document, item_lib_martigny):
     item_lib_martigny.update(data=item_lib_martigny, dbcommit=True, reindex=True)
     ItemsSearch.flush_and_refresh()
 
-    es_item = next(ItemsSearch().filter("term", document__pid=document.pid).source("document").scan()).to_dict()
+    search_item = next(ItemsSearch().filter("term", document__pid=document.pid).source("document").scan()).to_dict()
     # Test document.type and es.item.document.document_type are the same.
-    assert document["type"] == es_item["document"]["document_type"]
+    assert document["type"] == search_item["document"]["document_type"]
 
     # Change document type.
     document["type"] = [
@@ -366,6 +366,6 @@ def test_document_type_change(app, document, item_lib_martigny):
     document.update(data=document, dbcommit=True, reindex=True)
     ItemsSearch.flush_and_refresh()
     for hit in ItemsSearch().filter("term", document__pid=document.pid).source("document").scan():
-        es_item = hit.to_dict()
+        search_item = hit.to_dict()
         # Test document.type and es.item.document.document_type are the same.
-        assert document["type"] == es_item["document"]["document_type"]
+        assert document["type"] == search_item["document"]["document_type"]

--- a/tests/ui/documents/test_documents_mapping.py
+++ b/tests/ui/documents/test_documents_mapping.py
@@ -27,7 +27,7 @@ from tests.utils import get_mapping, mock_response
 
 
 @mock.patch("requests.Session.get")
-def test_document_es_mapping(
+def test_document_mapping(
     mock_contributions_mef_get,
     search,
     db,
@@ -36,7 +36,7 @@ def test_document_es_mapping(
     item_lib_martigny,
     entity_person_response_data,
 ):
-    """Test document elasticsearch mapping."""
+    """Test document search index mapping."""
     search = DocumentsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/entities/local_entities/test_local_entities_mapping.py
+++ b/tests/ui/entities/local_entities/test_local_entities_mapping.py
@@ -24,8 +24,8 @@ from rero_ils.modules.entities.local_entities.api import (
 from tests.utils import get_mapping
 
 
-def test_local_entities_es_mapping(app, local_entity_person2_data):
-    """Test local entity elasticsearch mapping."""
+def test_local_entities_search_mapping(app, local_entity_person2_data):
+    """Test local entity search index mapping."""
     search = LocalEntitiesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/entities/remote_entities/test_remote_entities_api.py
+++ b/tests/ui/entities/remote_entities/test_remote_entities_api.py
@@ -425,7 +425,7 @@ def test_entity_get_record_by_ref(mef_agents_url, entity_person, entity_person_d
     dummy_ref = f"{mef_agents_url}/idref/dummy_idref_pid"
     assert RemoteEntity.get_record_by_ref(dummy_ref) == (None, False)
 
-    # Remote entity from ES index
+    # Remote entity from search index
     RemoteEntitiesSearch().filter("term", pid=entity_person.pid).delete()
     RemoteEntitiesSearch.flush_and_refresh()
     ent_ref = f"{mef_agents_url}/idref/{entity_person['idref']['pid']}"

--- a/tests/ui/entities/remote_entities/test_remote_entities_mapping.py
+++ b/tests/ui/entities/remote_entities/test_remote_entities_mapping.py
@@ -25,8 +25,8 @@ from rero_ils.modules.entities.remote_entities.api import (
 from tests.utils import get_mapping
 
 
-def test_remote_entity_es_mapping(search_clear, db, entity_person_data_tmp):
-    """Test contribution entity elasticsearch mapping."""
+def test_remote_entity_search_mapping(search_clear, db, entity_person_data_tmp):
+    """Test contribution entity search index mapping."""
     search = RemoteEntitiesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping
@@ -34,8 +34,8 @@ def test_remote_entity_es_mapping(search_clear, db, entity_person_data_tmp):
     assert mapping == get_mapping(search.Meta.index)
 
 
-def test_concept_entity_es_mapping(search_clear, db, mef_concept1_data_tmp):
-    """Test concept entity elasticsearch mapping."""
+def test_concept_entity_search_mapping(search_clear, db, mef_concept1_data_tmp):
+    """Test concept entity search index mapping."""
     search = RemoteEntitiesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -54,8 +54,8 @@ def test_holding_create(
     assert fetched_pid.pid_type == "hold"
 
     search = HoldingsSearch()
-    es_hit = next(search.filter("term", pid=holding.pid).source("pid").scan())
-    holding_record = Holding.get_record_by_pid(es_hit.pid)
+    search_hit = next(search.filter("term", pid=holding.pid).source("pid").scan())
+    holding_record = Holding.get_record_by_pid(search_hit.pid)
     assert holding_record.organisation_pid == org_martigny.get("pid")
     # holdings does not exist
     assert not Holding.get_holdings_type_by_holding_pid("toto")

--- a/tests/ui/holdings/test_holdings_mapping.py
+++ b/tests/ui/holdings/test_holdings_mapping.py
@@ -21,7 +21,7 @@ from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from tests.utils import get_mapping
 
 
-def test_holding_es_mapping(
+def test_holding_search_mapping(
     search,
     db,
     loc_public_martigny,
@@ -29,7 +29,7 @@ def test_holding_es_mapping(
     document,
     holding_lib_martigny_data,
 ):
-    """Test holding elasticsearch mapping."""
+    """Test holding search index mapping."""
     search = HoldingsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -573,7 +573,7 @@ def test_regular_issue_creation_update_delete_api(
     issue_display, expected_date = holding._get_next_issue_display_text(holding.get("patterns"))
     issue = holding.create_regular_issue(status=ItemIssueStatus.RECEIVED, dbcommit=True, reindex=True)
     issue_pid = issue.pid
-    # flush index to prevent ES conflicts on delete
+    # flush index to prevent search conflicts on delete
     ItemsSearch.flush_and_refresh()
     assert holding.delete(dbcommit=True, delindex=True)
     assert not Item.get_record_by_pid(issue_pid)

--- a/tests/ui/holdings/test_serial_claims.py
+++ b/tests/ui/holdings/test_serial_claims.py
@@ -75,9 +75,9 @@ def test_late_expected(holding_lib_martigny_w_patterns, holding_lib_sion_w_patte
     issue = late_issues[0]
     assert issue.issue_status == ItemIssueStatus.LATE
     original_expected_date = issue.expected_date
-    es_issue = ItemsSearch().get_record_by_pid(issue.pid)
+    search_issue = ItemsSearch().get_record_by_pid(issue.pid)
     assert not issue.sort_date
-    assert es_issue["issue"]["sort_key"] == original_expected_date
+    assert search_issue["issue"]["sort_key"] == original_expected_date
 
     issue.expected_date = tomorrow.strftime("%Y-%m-%d")
     issue = issue.update(issue, dbcommit=True, reindex=True)

--- a/tests/ui/ill_requests/test_ill_requests_mapping.py
+++ b/tests/ui/ill_requests/test_ill_requests_mapping.py
@@ -21,8 +21,8 @@ from rero_ils.modules.ill_requests.api import ILLRequest, ILLRequestsSearch
 from tests.utils import get_mapping
 
 
-def test_ill_request_es_mapping(es, db, loc_public_martigny, patron_martigny, ill_request_martigny_data):
-    """Test ill request elasticsearch mapping."""
+def test_ill_request_search_mapping(es, db, loc_public_martigny, patron_martigny, ill_request_martigny_data):
+    """Test ill request search index mapping."""
     search = ILLRequestsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/item_types/test_item_types_mapping.py
+++ b/tests/ui/item_types/test_item_types_mapping.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Item type elasticsearch mapping tests."""
+"""Item type search index mapping tests."""
 
 from rero_ils.modules.item_types.api import ItemType, ItemTypesSearch
 from tests.utils import get_mapping
 
 
-def test_item_type_es_mapping(search, db, org_martigny, item_type_data_tmp):
-    """Test item type elasticsearch mapping."""
+def test_item_type_search_mapping(search, db, org_martigny, item_type_data_tmp):
+    """Test item type search index mapping."""
     search = ItemTypesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/items/test_items_mapping.py
+++ b/tests/ui/items/test_items_mapping.py
@@ -21,13 +21,13 @@ from rero_ils.modules.items.api import Item, ItemsSearch
 from tests.utils import get_mapping
 
 
-def test_item_es_mapping(
+def test_item_search_mapping(
     document,
     loc_public_martigny,
     item_type_standard_martigny,
     item_lib_martigny_data_tmp,
 ):
-    """Test item elasticsearch mapping."""
+    """Test item search index mapping."""
     search = ItemsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping
@@ -41,7 +41,7 @@ def test_item_sort_call_number(
     item_type_standard_martigny,
     item_lib_martigny_data_tmp,
 ):
-    """Test sort_call_number is correctly populated in the ES index.
+    """Test sort_call_number is correctly populated in the search index.
 
     For a regular item, sort_call_number must equal the item's own call_number.
     For a regular item with no call_number, sort_call_number must be absent/None.

--- a/tests/ui/libraries/test_libraries_mapping.py
+++ b/tests/ui/libraries/test_libraries_mapping.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Libraries elasticsearch mapping tests."""
+"""Libraries search index mapping tests."""
 
 from rero_ils.modules.libraries.api import LibrariesSearch, Library
 from tests.utils import get_mapping
 
 
-def test_library_es_mapping(search, db, lib_martigny_data, org_martigny):
-    """Test library elasticsearch mapping."""
+def test_library_search_mapping(search, db, lib_martigny_data, org_martigny):
+    """Test library search index mapping."""
     search = LibrariesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping
@@ -40,7 +40,7 @@ def test_libraries_search_mapping(app, libraries_records):
     assert search.query("query_string", query="library AND Martigny").count() == 1
     assert search.query("match", name="Aproz").count() == 1
 
-    es_query = search.query("match", name="Sion").source(["pid"]).scan()
-    pids = [hit.pid for hit in es_query]
+    search_query = search.query("match", name="Sion").source(["pid"]).scan()
+    pids = [hit.pid for hit in search_query]
     assert len(pids) == 1
     assert "lib4" in pids

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -50,7 +50,7 @@ from tests.utils import get_mapping
 
 
 def test_loan_es_mapping(search_clear, db):
-    """Test loans elasticsearch mapping."""
+    """Test loans search index mapping."""
     search = current_circulation.loan_search_cls
     mapping = get_mapping(search.Meta.index)
     assert mapping == get_mapping(search.Meta.index)

--- a/tests/ui/local_fields/test_local_fields_api.py
+++ b/tests/ui/local_fields/test_local_fields_api.py
@@ -59,8 +59,8 @@ def test_local_fields(
     LocalFieldsSearch.flush_and_refresh()
     DocumentsSearch.flush_and_refresh()
 
-    es_doc = DocumentsSearch().get_record_by_pid(document.pid).to_dict()
-    assert "local_fields" not in es_doc
+    search_doc = DocumentsSearch().get_record_by_pid(document.pid).to_dict()
+    assert "local_fields" not in search_doc
 
     # TEST#3 :: Delete the document
     #   - Add new LocalFields on the document

--- a/tests/ui/local_fields/test_local_fields_mapping.py
+++ b/tests/ui/local_fields/test_local_fields_mapping.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Libraries elasticsearch mapping tests."""
+"""Libraries search index mapping tests."""
 
 from rero_ils.modules.local_fields.api import LocalField, LocalFieldsSearch
 from tests.utils import get_mapping
 
 
-def test_local_field_es_mapping(es, db, org_martigny, document, local_field_martigny_data):
-    """Test local field elasticsearch mapping."""
+def test_local_field_search_mapping(es, db, org_martigny, document, local_field_martigny_data):
+    """Test local field search index mapping."""
     search = LocalFieldsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/locations/test_locations_api.py
+++ b/tests/ui/locations/test_locations_api.py
@@ -70,20 +70,20 @@ def test_location_restrict_pickup(
 
     # STEP 2 :: Define that loc_m2 isn't yet a pickup location
     #   The `loc_m1` must now only contain `loc_sax` as restriction for
-    #   pickup location. ES index should also reflect this change.
+    #   pickup location. search index should also reflect this change.
     del loc_m2["is_pickup"]
     loc_m2 = loc_m2.update(loc_m2, dbcommit=True, reindex=True)
     loc_m1 = Location.get_record(loc_m1.id)
     assert loc_m1.restrict_pickup_to == [loc_sax.pid]
     LocationsSearch.flush_and_refresh()
-    es_restrictions = [
+    search_restrictions = [
         restriction_loc.pid for restriction_loc in LocationsSearch().get_record_by_pid(loc_m1.pid).restrict_pickup_to
     ]
-    assert es_restrictions == [loc_sax.pid]
+    assert search_restrictions == [loc_sax.pid]
 
     # STEP 3 :: Define that loc_sax isn't yet a pickup location
     #   The `loc_m1` must not contain any restriction for pickup location.
-    #   ES index should reflect this change`
+    #   search index should reflect this change`
     del loc_sax["is_pickup"]
     loc_sax = loc_sax.update(loc_sax, dbcommit=True, reindex=True)
     assert "pickup_name" not in loc_sax

--- a/tests/ui/locations/test_locations_mapping.py
+++ b/tests/ui/locations/test_locations_mapping.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Libraries elasticsearch mapping tests."""
+"""Libraries search index mapping tests."""
 
 from rero_ils.modules.locations.api import Location, LocationsSearch
 from tests.utils import get_mapping
 
 
-def test_location_es_mapping(search, db, loc_public_martigny_data, lib_martigny, org_martigny):
-    """Test library elasticsearch mapping."""
+def test_location_mapping(search, db, loc_public_martigny_data, lib_martigny, org_martigny):
+    """Test library search index mapping."""
     search = LocationsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/notifications/test_notifications_mapping.py
+++ b/tests/ui/notifications/test_notifications_mapping.py
@@ -23,8 +23,8 @@ from rero_ils.modules.notifications.api import Notification, NotificationsSearch
 from tests.utils import get_mapping
 
 
-def test_notification_es_mapping(dummy_notification, loan_validated_martigny):
-    """Test notification elasticsearch mapping."""
+def test_notification_search_mapping(dummy_notification, loan_validated_martigny):
+    """Test notification search index mapping."""
 
     search = NotificationsSearch()
     mapping = get_mapping(search.Meta.index)

--- a/tests/ui/operation_logs/test_operation_logs_mapping.py
+++ b/tests/ui/operation_logs/test_operation_logs_mapping.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Operation logs elasticsearch mapping tests."""
+"""Operation logs search index mapping tests."""
 
 from rero_ils.modules.operation_logs.api import OperationLog
 from tests.utils import get_mapping
 
 
-def test_operation_log_es_mapping(item_lib_sion, operation_log_data):
-    """Test operation log elasticsearch mapping."""
+def test_operation_log_search_mapping(item_lib_sion, operation_log_data):
+    """Test operation log search index mapping."""
     mapping = get_mapping(OperationLog.index_name)
     assert mapping
     OperationLog.create(operation_log_data)

--- a/tests/ui/patron_transaction_events/test_patron_transaction_events_mapping.py
+++ b/tests/ui/patron_transaction_events/test_patron_transaction_events_mapping.py
@@ -24,8 +24,8 @@ from rero_ils.modules.patron_transaction_events.api import (
 from tests.utils import get_mapping
 
 
-def test_patron_transaction_event_es_mapping(es, db, patron_transaction_overdue_event_martigny):
-    """Test patron_transaction event elasticsearch mapping."""
+def test_patron_transaction_event_search_mapping(es, db, patron_transaction_overdue_event_martigny):
+    """Test patron_transaction event search index mapping."""
     search = PatronTransactionEventsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/patron_transactions/test_patron_transactions_mapping.py
+++ b/tests/ui/patron_transactions/test_patron_transactions_mapping.py
@@ -24,8 +24,8 @@ from rero_ils.modules.patron_transactions.api import (
 from tests.utils import get_mapping
 
 
-def test_patron_transaction_es_mapping(search, db, patron_transaction_overdue_martigny):
-    """Test patron_transaction elasticsearch mapping."""
+def test_patron_transaction_search_mapping(search, db, patron_transaction_overdue_martigny):
+    """Test patron_transaction search index mapping."""
     search = PatronTransactionsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/patron_types/test_patron_types_mapping.py
+++ b/tests/ui/patron_types/test_patron_types_mapping.py
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Patron type elasticsearch mapping tests."""
+"""Patron type search index mapping tests."""
 
 from rero_ils.modules.patron_types.api import PatronType, PatronTypesSearch
 from tests.utils import get_mapping
 
 
-def test_patron_type_es_mapping(org_martigny, patron_type_children_martigny_data):
+def test_patron_type_search_mapping(org_martigny, patron_type_children_martigny_data):
     """Test patron types es mapping."""
     search = PatronTypesSearch()
     mapping = get_mapping(search.Meta.index)
@@ -40,14 +40,14 @@ def test_patron_types_search_mapping(app, patron_types_records):
     search = PatronTypesSearch()
 
     c = search.query("query_string", query="patrons").count()
-    # there is one more result from test_patron_type_es_mapping function
+    # there is one more result from test_patron_type_search_mapping function
     assert c == 4
 
     c = search.query("match", name="patrons").count()
     assert c == 0
 
     c = search.query("match", name="children").count()
-    # there is one more result from test_patron_type_es_mapping function
+    # there is one more result from test_patron_type_search_mapping function
     assert c == 1
 
     pids = [r.pid for r in search.query("match", name="children").source(["pid"]).scan()]

--- a/tests/ui/patrons/test_patrons_mapping.py
+++ b/tests/ui/patrons/test_patrons_mapping.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Patron elasticsearch mapping tests."""
+"""Patron search index mapping tests."""
 
 from rero_ils.modules.patrons.api import PatronsSearch
 from tests.utils import get_mapping
 
 
-def test_patron_es_mapping(roles, search, lib_martigny, librarian_martigny_data_tmp):
-    """Test patron elasticsearch mapping."""
+def test_patron_mapping(roles, search, lib_martigny, librarian_martigny_data_tmp):
+    """Test patron search index mapping."""
     search = PatronsSearch()
     mapping = get_mapping(search.Meta.index)
     # TODO: create of an patron

--- a/tests/ui/stats_cfg/test_stats_cfg_mapping.py
+++ b/tests/ui/stats_cfg/test_stats_cfg_mapping.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Statistics Configuration elasticsearch mapping tests."""
+"""Statistics Configuration search index mapping tests."""
 
 from invenio_accounts.testutils import login_user_via_session
 
@@ -23,8 +23,8 @@ from rero_ils.modules.stats_cfg.api import StatConfiguration, StatsConfiguration
 from tests.utils import get_mapping
 
 
-def test_stats_cfg_es_mapping(client, stats_cfg_martigny_data, system_librarian_martigny):
-    """Test statistics configuration elasticsearch mapping."""
+def test_stats_cfg_mapping(client, stats_cfg_martigny_data, system_librarian_martigny):
+    """Test statistics configuration search index mapping."""
     search = StatsConfigurationSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping
@@ -39,7 +39,7 @@ def test_stats_cfg_search_mapping(app, stats_cfg_martigny, stats_cfg_sion):
     """Test statistics configuration search mapping."""
     search = StatsConfigurationSearch()
 
-    es_query = search.source(["pid"]).scan()
-    pids = [hit.pid for hit in es_query]
+    search_query = search.source(["pid"]).scan()
+    pids = [hit.pid for hit in search_query]
     assert len(pids) == 2
     assert "stats_cfg2" in pids

--- a/tests/ui/templates/test_templates_mapping.py
+++ b/tests/ui/templates/test_templates_mapping.py
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Libraries elasticsearch mapping tests."""
+"""Libraries search index mapping tests."""
 
 from rero_ils.modules.templates.api import Template, TemplatesSearch
 from tests.utils import get_mapping
 
 
-def test_template_es_mapping(
+def test_template_mapping(
     search,
     db,
     templ_doc_public_martigny_data,
@@ -29,7 +29,7 @@ def test_template_es_mapping(
     system_librarian_martigny,
     librarian_martigny,
 ):
-    """Test template elasticsearch mapping."""
+    """Test template search index mapping."""
     search = TemplatesSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/test_api.py
+++ b/tests/ui/test_api.py
@@ -114,7 +114,7 @@ class RecordTest(IlsRecord):
     model_cls = TestRecordMetadata
 
 
-def test_ilsrecord(app, es_default_index, ils_record, ils_record_2):
+def test_ilsrecord(app, search_default_index, ils_record, ils_record_2):
     """Test IlsRecord update."""
 
     # the created records will be accessible in all function of this test file
@@ -243,7 +243,7 @@ class FailedIlsRecord(IlsRecord):
     provider = FailedPidProvider
 
 
-def test_ilsrecord_failed_pid(app, es_default_index, ils_record, ils_record_2):
+def test_ilsrecord_failed_pid(app, search_default_index, ils_record, ils_record_2):
     """Test IlsRecord PID after validation failed"""
     schema = {
         "type": "object",

--- a/tests/ui/vendors/test_vendors_mapping.py
+++ b/tests/ui/vendors/test_vendors_mapping.py
@@ -21,8 +21,8 @@ from rero_ils.modules.vendors.api import Vendor, VendorsSearch
 from tests.utils import get_mapping
 
 
-def test_budgets_es_mapping(search, db, org_martigny, vendor_martigny_data):
-    """Test vendors elasticsearch mapping."""
+def test_vendors_search_mapping(search, db, org_martigny, vendor_martigny_data):
+    """Test vendors search index mapping."""
     search = VendorsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/unit/test_cql_parser.py
+++ b/tests/unit/test_cql_parser.py
@@ -20,8 +20,8 @@
 import pytest
 
 from rero_ils.modules.sru.cql_parser import (
-    ES_SORT_INDEX_MAPPINGS,
     RESERVED_PREFIXES,
+    SEARCH_SORT_INDEX_MAPPINGS,
     Boolean,
     Diagnostic,
     Index,
@@ -60,12 +60,12 @@ def test_get_query_clause(app):
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"spam hamm"'
-    es_string = query.to_es()
-    assert es_string == "(spam AND hamm)"
+    search_string = query.to_search()
+    assert search_string == "(spam AND hamm)"
 
     query = parse("((title=spam) or (subtitle=hamm)) or eggs")
-    es_string = query.to_es()
-    assert es_string == "((title:spam OR subtitle:hamm) OR eggs)"
+    search_string = query.to_search()
+    assert search_string == "((title:spam OR subtitle:hamm) OR eggs)"
     assert query.get_result_set_id() == ""
 
 
@@ -79,8 +79,8 @@ def test_get_query_clause_no_xml_character(app):
     # Check query instance
     assert isinstance(query, SearchClause)
     assert query.term.value == '">><<"'
-    es_string = query.to_es()
-    assert es_string == "(>><<)"
+    search_string = query.to_search()
+    assert search_string == "(>><<)"
 
 
 def test_get_query_clause_utf8(app):
@@ -98,8 +98,8 @@ def test_get_query_clause_utf8(app):
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"späm hämm"'
-    es_string = query.to_es()
-    assert es_string == "(späm OR hämm)"
+    search_string = query.to_search()
+    assert search_string == "(späm OR hämm)"
 
 
 def test_get_query_clause_modifiers():
@@ -113,7 +113,7 @@ def test_get_query_clause_modifiers():
     assert str(query.relation.modifiers[1].comparison) == "="
     assert str(query.relation.modifiers[1].value) == "okapi"
     with pytest.raises(Diagnostic):
-        query.to_es()
+        query.to_search()
 
 
 def test_get_query_clause_with_prefix(app):
@@ -131,8 +131,8 @@ def test_get_query_clause_with_prefix(app):
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"spam"'
-    es_string = query.to_es()
-    assert es_string == "(spam)"
+    search_string = query.to_search()
+    assert search_string == "(spam)"
 
 
 def test_get_query_clause_with_relation_modifier():
@@ -149,14 +149,14 @@ def test_get_query_clause_with_relation_modifier():
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"spam"'
-    # /relevant is now a supported modifier (default ES relevance scoring)
-    es_string = query.to_es()
-    assert es_string == "(anywhere:spam)"
+    # /relevant is now a supported modifier (default search relevance scoring)
+    search_string = query.to_search()
+    assert search_string == "(anywhere:spam)"
 
     # Unsupported modifiers should still raise Diagnostic
     query = parse('anywhere all/stem "spam"')
     with pytest.raises(Diagnostic) as err:
-        query.to_es()
+        query.to_search()
     assert "Unsupported relation modifier" in str(err.value)
 
 
@@ -174,20 +174,20 @@ def test_get_query_clause_with_sorting(app):
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == '"cat"'
-    # Sort is now supported - to_es() should work
-    es_string = query.to_es()
-    assert es_string == '"cat"'
+    # Sort is now supported - to_search() should work
+    search_string = query.to_search()
+    assert search_string == '"cat"'
     # Check sort keys are extracted correctly
-    sort_keys = query.get_es_sort()
+    sort_keys = query.get_search_sort()
     assert len(sort_keys) == 1
-    # "title" resolves via dc.title prefix fallback to ES_SORT_INDEX_MAPPINGS["dc.title"]
-    assert ES_SORT_INDEX_MAPPINGS["dc.title"] in sort_keys[0]
+    # "title" resolves via dc.title prefix fallback to SEARCH_SORT_INDEX_MAPPINGS["dc.title"]
+    assert SEARCH_SORT_INDEX_MAPPINGS["dc.title"] in sort_keys[0]
 
     # Test with sort modifiers
     query = parse('"dog" sortBy dc.date/descending')
-    es_string = query.to_es()
-    assert es_string == '"dog"'
-    sort_keys = query.get_es_sort()
+    search_string = query.to_search()
+    assert search_string == '"dog"'
+    sort_keys = query.get_search_sort()
     assert len(sort_keys) == 1
     # dc.date should be mapped to provisionActivity.startDate
     assert sort_keys[0].get("provisionActivity.startDate", {}).get("order") == "desc"
@@ -204,11 +204,11 @@ def test_get_query_clause_with_relation(app):
     # Check Value
     assert isinstance(query.term, Term)
     assert query.term.value == "1999"
-    es_string = query.to_es()
-    assert es_string == "year:>1999"
+    search_string = query.to_search()
+    assert search_string == "year:>1999"
     query = parse("ind1 = 1 AND ind2 > 2 AND ind3 >= 3 AND " + "ind4 < 4 AND ind5 <= 5 AND ind6 <> 6")
-    es_string = query.to_es()
-    assert es_string == ('(((((ind1:1 AND ind2:>2) AND ind3:>=3) AND ind4:<4) AND ind5:<=5) AND ind6:-"6")')
+    search_string = query.to_search()
+    assert search_string == ('(((((ind1:1 AND ind2:>2) AND ind3:>=3) AND ind4:<4) AND ind5:<=5) AND ind6:-"6")')
 
 
 def test_get_query_triple(app):
@@ -219,19 +219,19 @@ def test_get_query_triple(app):
     # Check left clause
     assert isinstance(query.left_operand, SearchClause)
     # remember terms get quoted during parsing
-    assert query.left_operand.to_es() == "(spam)"
+    assert query.left_operand.to_search() == "(spam)"
     # Check boolean
     assert isinstance(query.boolean, Boolean)
     assert query.boolean.value == "and"
     # Check right clause
     assert isinstance(query.right_operand, SearchClause)
     # Remember terms get quoted during parsing
-    assert query.right_operand.to_es() == "(eggs)"
-    es_string = query.to_es()
-    assert es_string == "((spam) AND (eggs))"
+    assert query.right_operand.to_search() == "(eggs)"
+    search_string = query.to_search()
+    assert search_string == "((spam) AND (eggs))"
     query = parse("dc.anywhere prox spam")
     with pytest.raises(Diagnostic) as err:
-        query.to_es()
+        query.to_search()
     assert str(err.value) == ("info:srw/diagnostic/1/37 [Unsupported boolean operator]: prox")
     assert query.get_result_set_id() == ""
 
@@ -242,17 +242,17 @@ def test_get_query_triple_with_sort(app):
     # Check query instance
     assert isinstance(query, Triple)
     # Sort is now supported
-    es_string = query.to_es()
-    assert es_string == "((spam) AND (eggs))"
+    search_string = query.to_search()
+    assert search_string == "((spam) AND (eggs))"
     # Check sort keys are extracted correctly
-    sort_keys = query.get_es_sort()
+    sort_keys = query.get_search_sort()
     assert len(sort_keys) == 1
     assert "subtitle" in sort_keys[0]
 
     # Test with multiple sort keys
     query = parse("title = book sortBy dc.title/ascending dc.date/descending")
-    es_string = query.to_es()
-    sort_keys = query.get_es_sort()
+    search_string = query.to_search()
+    sort_keys = query.get_search_sort()
     assert len(sort_keys) == 2
 
 
@@ -268,14 +268,14 @@ def test_get_query_with_modifiers():
     assert not str(query.relation.modifiers[0].comparison)
     assert not str(query.relation.modifiers[0].value)
     # /relevant is now supported - should not raise
-    es_string = query.to_es()
-    assert es_string == "(spam)"
+    search_string = query.to_search()
+    assert search_string == "(spam)"
 
     # Unsupported relation modifiers should still raise
     q_string = "dc.anywhere any/phonetic spam"
     query = parse(q_string)
     with pytest.raises(Diagnostic) as err:
-        query.to_es()
+        query.to_search()
     assert "Unsupported relation modifier" in str(err.value)
 
     # Boolean modifiers - unsupported ones should raise
@@ -288,7 +288,7 @@ def test_get_query_with_modifiers():
     assert str(query.boolean.modifiers[0].comparison) == "="
     assert str(query.boolean.modifiers[0].value) == "sum"
     with pytest.raises(Diagnostic) as err:
-        query.to_es()
+        query.to_search()
     assert "Unsupported boolean modifier" in str(err.value)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -96,7 +96,7 @@ def test_extract_data_from_ref(app, patron_sion_data, patron_type_grown_sion):
     assert extracted_data_from_ref(ptty, data="record_class") == PatronType
     ptty_record = extracted_data_from_ref(ptty, data="record")
     assert ptty_record.pid == patron_type_grown_sion.pid
-    assert extracted_data_from_ref(ptty, data="es_record")["pid"] == "ptty4"
+    assert extracted_data_from_ref(ptty, data="search_record")["pid"] == "ptty4"
 
     # check dummy data
     assert extracted_data_from_ref("dummy_data", data="pid") is None
@@ -104,7 +104,7 @@ def test_extract_data_from_ref(app, patron_sion_data, patron_type_grown_sion):
     assert extracted_data_from_ref("dummy_data", data="record_class") is None
     assert extracted_data_from_ref("dummy_data", data="record") is None
     assert extracted_data_from_ref(ptty, data="dummy") is None
-    assert extracted_data_from_ref("dummy_data", data="es_record") is None
+    assert extracted_data_from_ref("dummy_data", data="search_record") is None
 
 
 def test_current_language(app):


### PR DESCRIPTION
Prepare the codebase for a future OpenSearch migration by replacing all Elasticsearch-specific identifiers with search-neutral names.

* rename ES_ constants to SEARCH_: ES_SORT_MODIFIERS, ES_INDEX_MAPPINGS, RERO_ILS_ES_LOGGING
* rename es_* variables, parameters and private attributes to search_* across all modules (es_query, es_item, es_document, es_hosts, es_holdings, es_items, es_filter, es_results, ...)
* rename get_es_* and _es_* methods to get_search_* and _search_*
* rename to_es() and _convert_sort_keys_to_es() in CQL parser to to_search() and _convert_sort_keys_to_search()
* rename monitoring REST routes /es_db_counts, /check_es_db_counts and /es_indices to /search_db_counts, /check_search_db_counts and /search_indices
* rename monitoring CLI commands es_db_counts, es_db_missing and es_indices to search_db_counts, search_db_missing and search_indices
* rename monitoring API response keys "db-es", "es", "es-", "ES" and "ES duplicate" to search equivalents (breaking API change)
* rename error codes DB_ES_COUNTER_MISMATCH and DB_ES_UNEQUAL to DB_SEARCH_COUNTER_MISMATCH and DB_SEARCH_UNEQUAL (breaking)
* rename list_es_templates entry point to list_search_templates
* rename dump_es_mappings CLI command to dump_search_mappings
* replace "Elasticsearch"/"ES" product name in all docstrings and comments with "search index"
* update test fixtures, fixture function names and test data keys
* keep Elasticsearch() constructor and elasticsearch library imports unchanged (still required until OpenSearch migration)