### PR TITLE
refactor(theme): replace node_assets with angular_assets for Angular 21

### DIFF
--- a/rero_ils/filter.py
+++ b/rero_ils/filter.py
@@ -17,7 +17,6 @@
 
 """Jinja filters."""
 
-import glob
 import json
 import os
 import re
@@ -44,39 +43,56 @@ def get_record_by_ref(ref, type="search_record"):
     return extracted_data_from_ref(ref, data=type)
 
 
-def node_assets(
-    package,
-    patterns=["runtime*.js", "polyfills*.js", "main*.js"],
-    _type="js",
-    tags="",
-):
-    """Generate the node assets html code.
+def angular_assets(package, _type="js"):
+    """Generate HTML tags from an Angular application's generated index.html.
 
-    :param package: The node package path relative to node_modules.
-    :param patters: list of glob bash like partterns.
-    "param _type: string one of ['js', 'css'].
-    "param tags: additional script, link, html tags such as 'defer', etc.
-    "return" html link, script code
+    Reads the build-tool generated index.html as the single source of truth,
+    avoiding any coupling to Angular's internal output format or file naming.
+
+    :param package: The Angular package path relative to node_modules.
+    :param _type: one of 'js', 'css', 'modulepreload'.
+    :return: html tags extracted from the Angular index.html
     """
     package_path = os.path.join(current_app.static_folder, "node_modules", package)
+    index_path = os.path.join(package_path, "index.html")
+    try:
+        with open(index_path, encoding="utf-8") as f:
+            content = f.read()
+    except OSError as error:
+        current_app.logger.warning("angular_assets: unable to read %s (%s)", index_path, error)
+        content = ""
 
-    def to_html(value):
-        value = re.sub(r"(.*?)\/static", "/static", value)
-        # default: js
-        html_code = f'<script {tags} src="{value}"></script>'
-        # styles
-        if _type == "css":
-            html_code = f'<link {tags} href="{value}" rel="stylesheet">'
-        return html_code
+    tag_patterns = {
+        "css": r'<link\b[^>]*\brel="stylesheet"[^>]*>',
+        "modulepreload": r'<link\b[^>]*\brel="modulepreload"[^>]*>',
+        "js": r'<script\b[^>]*\btype="module"[^>]*></script>',
+    }
+    static_base = f"/static/node_modules/{package}/"
 
-    output_files = []
-    for pattern in patterns:
-        files = glob.glob(os.path.join(package_path, pattern))
-        output_files.extend([to_html(v) for v in files])
+    def normalize_url(tag):
+        def fix(m):
+            attr, url = m.group(1), m.group(2)
+            if url.startswith("/static/") and "browser/" in url:
+                # Correct absolute URLs whose package path may differ from the
+                # installed location (e.g. wrong --deploy-url in the Angular build).
+                url = static_base + url.split("browser/", 1)[1]
+            elif not url.startswith(("/", "http")):
+                # Relative URL: prefix with the correct static base.
+                url = static_base + url
+            return f'{attr}="{url}"'
+
+        return re.sub(r'(href|src)="([^"]+)"', fix, tag)
+
+    pattern = tag_patterns.get(_type)
+    if pattern is None:
+        current_app.logger.warning("angular_assets: unsupported type '%s' for package '%s'", _type, package)
+        tags = []
+    else:
+        tags = [normalize_url(t) for t in re.findall(pattern, content)]
 
     class HTMLSafe:
         def __html__():
-            return Markup("\n".join(output_files))
+            return Markup("\n".join(tags))
 
     return HTMLSafe
 

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -313,7 +313,8 @@
 
 {%- block javascript %}
   {{ super() }}
-  {{ node_assets('@rero/rero-ils-ui/dist/public-holdings-items/browser', tags='type="module"') }}
+  {{ angular_assets('@rero/rero-ils-ui/dist/public-holdings-items/browser', 'modulepreload') }}
+  {{ angular_assets('@rero/rero-ils-ui/dist/public-holdings-items/browser', 'js') }}
   {% if viewcode | babeltheque_enabled_view and isbn is not none %}
     <script type="text/javascript" src="https://www.babelio.com/bw_330.js"></script>
   {% endif %}

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -44,12 +44,12 @@ from redis import Redis
 
 from rero_ils.filter import (
     address_block,
+    angular_assets,
     empty_data,
     format_date_filter,
     get_record_by_ref,
     jsondumps,
     message_filter,
-    node_assets,
     text_to_id,
     to_pretty_json,
     translate,
@@ -199,7 +199,7 @@ class REROILSAPP:
             # register filters
             app.add_template_filter(get_record_by_ref)
             app.add_template_filter(format_date_filter, name="format_date")
-            app.add_template_global(node_assets)
+            app.add_template_global(angular_assets)
             app.add_template_filter(to_pretty_json, name="tojson_pretty")
             app.add_template_filter(text_to_id)
             app.add_template_filter(jsondumps)

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -24,5 +24,6 @@
 
 {%- block javascript %}
 {{ super() }}
-{{ node_assets('@rero/rero-ils-ui/dist/public-patron-profile/browser', tags='type="module"') }}
+{{ angular_assets('@rero/rero-ils-ui/dist/public-patron-profile/browser', 'modulepreload') }}
+{{ angular_assets('@rero/rero-ils-ui/dist/public-patron-profile/browser', 'js') }}
 {%- endblock javascript %}

--- a/rero_ils/theme/templates/rero_ils/javascript.html
+++ b/rero_ils/theme/templates/rero_ils/javascript.html
@@ -18,5 +18,6 @@
 #}
 {%- block javascript %}
 {{ webpack['reroils_public.js']}}
-{{ node_assets('@rero/rero-ils-ui/dist/search-bar/browser', tags='type="module"') }}
+{{ angular_assets('@rero/rero-ils-ui/dist/search-bar/browser', 'modulepreload') }}
+{{ angular_assets('@rero/rero-ils-ui/dist/search-bar/browser', 'js') }}
 {%- endblock javascript %}

--- a/rero_ils/theme/templates/rero_ils/page.html
+++ b/rero_ils/theme/templates/rero_ils/page.html
@@ -67,9 +67,10 @@
     {%- block header %}{% endblock header %}
     {%- block css %}
       <style>
-        @layer bootstrap, babel, theme, rero-ils-ui, primeng;
+        @layer bootstrap, babel, theme, base, rero-ils-ui, primeng, utilities;
       </style>
-      {{ node_assets('@rero/rero-ils-ui/dist/public-search/browser', ['styles-*.css'], 'css') }}
+      <style type="text/css" data-primeng-style-id="layer-order"></style>
+      {{ angular_assets('@rero/rero-ils-ui/dist/public-search/browser', 'css') }}
       {{ webpack['global.css'] }}
       {% if config.get('RERO_ILS_PERSONALIZED_CSS_BY_VIEW') %}
        <link

--- a/rero_ils/theme/templates/rero_ils/professional.html
+++ b/rero_ils/theme/templates/rero_ils/professional.html
@@ -26,17 +26,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base href="/professional" />
     {% include 'rero_ils/_favicon.html' %}
-    <style>
-      @layer theme, base, primeng, utilities;
-    </style>
-
-    {{ node_assets('@rero/rero-ils-ui/dist/admin/browser', ['styles-*.css'], 'css') }}
-    {{ node_assets('@rero/rero-ils-ui/dist/admin/browser', ['styles-*.css'], 'css', 'media="print" onload="this.media=\'all\'"') }}
+    {{ angular_assets('@rero/rero-ils-ui/dist/admin/browser', 'css') }}
 </head>
 
 <body>
-    <admin-root />
-    {{ node_assets('@rero/rero-ils-ui/dist/admin/browser', tags='type="module"') }}
+    <admin-root></admin-root>
+    {{ angular_assets('@rero/rero-ils-ui/dist/admin/browser', 'modulepreload') }}
+    {{ angular_assets('@rero/rero-ils-ui/dist/admin/browser', 'js') }}
 </body>
 
 </html>

--- a/rero_ils/theme/templates/rero_ils/search.html
+++ b/rero_ils/theme/templates/rero_ils/search.html
@@ -26,5 +26,6 @@
 
 {%- block javascript %}
 {{ webpack['reroils_public.js']}}
-{{ node_assets('@rero/rero-ils-ui/dist/public-search/browser', tags='type="module"') }}
+{{ angular_assets('@rero/rero-ils-ui/dist/public-search/browser', 'modulepreload') }}
+{{ angular_assets('@rero/rero-ils-ui/dist/public-search/browser', 'js') }}
 {%- endblock javascript %}

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -128,7 +128,7 @@ then
   info_msg "Install RERO-ILS-UI from tgz: ${tgz_file}"
   npm install --no-save --only=prod --no-fund --no-audit  "${tgz_file}" --prefix "${static_folder}"
 else
-  npm install --no-save --only=prod --no-fund --no-audit  @rero/rero-ils-ui@19.3.0 --prefix "${static_folder}"
+  npm install --no-save --only=prod --no-fund --no-audit  @rero/rero-ils-ui@21.0.0 --prefix "${static_folder}"
 fi
 
 # build the web assets


### PR DESCRIPTION
Replace the glob-based node_assets Jinja helper with angular_assets, which
reads CSS, JS module scripts and modulepreload hints directly from each
Angular app's generated index.html. This decouples the Flask templates from
Angular's internal output format and file naming conventions.

