### PR TITLE
fix(thumbnails): normalize thumbnail size in exhibition/courses

### DIFF
--- a/rero_ils/theme/assets/scss/rero_ils/thumbnail.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/thumbnail.scss
@@ -19,7 +19,7 @@
 
 
 figure#thumbnail .thumb {
-  max-width: 160px;
+  width: 96px;
   figcaption {
     overflow-wrap: anywhere;
   }
@@ -27,16 +27,6 @@ figure#thumbnail .thumb {
 
 figure#thumbnail .figure-caption {
   line-height: 1.2em;
-}
-
-// Tablets
-@include media-breakpoint-between(sm, md) {
-  figure#thumbnail .thumb {
-    max-width: 100px;
-    figcaption {
-      overflow-wrap: anywhere;
-    }
-  }
 }
 
 @include media-breakpoint-down(sm) {


### PR DESCRIPTION
Fixed the thumbnail inconsistent size issue in the exhibition/courses page. 

in `thumbnail.scss`, 

- changed width to 96px, to be consistent with the documents list page
- did not use max-width because some images were smaller than 96px
- removed the tablet rule since 100px is bigger than 96px. The base rule can handle that case.


May close #4099 