### PR TITLE
fix(ext): return 409 on concurrent PUT instead of 500

### DIFF
--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -22,7 +22,7 @@ import logging
 
 import jinja2
 from elasticsearch_dsl import connections
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
 from flask_bootstrap import Bootstrap4
 from flask_login import current_user
 from flask_login.signals import user_loaded_from_cookie, user_logged_in, user_logged_out
@@ -31,16 +31,18 @@ from flask_wiki import Wiki
 from invenio_base.signals import app_loaded
 from invenio_base.utils import obj_or_import_string
 from invenio_circulation.signals import loan_state_changed
+from invenio_db import db
 from invenio_indexer.signals import before_record_index
 from invenio_records.signals import (
     after_record_insert,
     after_record_update,
     before_record_update,
 )
-from invenio_records_rest.errors import JSONSchemaValidationError
+from invenio_records_rest.errors import JSONSchemaValidationError, PIDResolveRESTError
 from invenio_search import current_search_client
 from jsonschema.exceptions import ValidationError
 from redis import Redis
+from sqlalchemy.orm.exc import StaleDataError
 
 from rero_ils.filter import (
     address_block,
@@ -243,6 +245,52 @@ class REROILSAPP:
             search_trace_logger.addHandler(handler)
         app_loaded.connect(set_boosting_query_fields)
         connections.add_connection("default", current_search_client)
+
+        # TODO: Temporary workaround for nginx gzip + invenio-rest ETag interaction.
+        # nginx converts strong ETags ("N") to weak ETags (W/"N") when gzip is applied to
+        # a response, which is correct per RFC 7232 (byte content changes after compression).
+        # invenio-rest's check_etag() uses strong comparison only: when If-Match contains
+        # W/"N", as_set(include_weak=False) returns an empty set and the check is silently
+        # skipped, allowing any PUT to succeed regardless of the If-Match value.
+        # The proper fix belongs in invenio-rest: check_etag() should handle weak ETags in
+        # If-Match (either reject with 412 or accept with weak comparison).
+        # Track upstream: https://github.com/inveniosoftware/invenio-rest
+        @app.before_request
+        def normalize_weak_etags_in_if_match():
+            """Strip W/ prefix from ETags in If-Match to restore strong ETag semantics."""
+            if_match = request.environ.get("HTTP_IF_MATCH", "")
+            if if_match:
+                request.environ["HTTP_IF_MATCH"] = if_match.replace('W/"', '"')
+
+        # TODO: Temporary workaround for concurrent PUT requests (e.g. double-click on save).
+        # StaleDataError is raised by SQLAlchemy optimistic locking (version_id_col on
+        # RecordMetadata) when two requests read the same revision and both try to commit.
+        # The proper fix belongs in invenio-records-rest (and invenio-records-resources):
+        # the put() handler should catch StaleDataError and return 409 itself.
+        # Track upstream: https://github.com/inveniosoftware/invenio-records-rest
+        @app.errorhandler(StaleDataError)
+        def handle_concurrent_update(e):
+            """Return 409 when two concurrent requests update the same record."""
+            db.session.rollback()
+            return jsonify(
+                status=409,
+                message="A conflict happened while processing the request. The resource might have been modified while the request was being processed.",
+            ), 409
+
+        # invenio-records-rest's pass_record decorator wraps the entire PUT handler in a
+        # try/except SQLAlchemyError, which intercepts StaleDataError before it can reach
+        # handle_concurrent_update above and re-raises it as PIDResolveRESTError (500).
+        # We catch PIDResolveRESTError here and check the exception chain to detect this case.
+        @app.errorhandler(PIDResolveRESTError)
+        def handle_pid_resolve_concurrent(e):
+            """Return 409 when PIDResolveRESTError wraps a concurrent update conflict."""
+            if isinstance(e.__context__, StaleDataError):
+                db.session.rollback()
+                return jsonify(
+                    status=409,
+                    message="A conflict happened while processing the request. The resource might have been modified while the request was being processed.",
+                ), 409
+            return e.get_response()
 
     @staticmethod
     def register_import_api_blueprint(app):

--- a/tests/api/test_concurrent_updates.py
+++ b/tests/api/test_concurrent_updates.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019-2026 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for concurrent record update protection via ETag / If-Match.
+
+These tests verify observable HTTP behaviour (status codes, response bodies) and
+pass regardless of whether the protection is implemented via workarounds in
+ext.py or via upstream fixes in invenio-records-rest / invenio-rest.
+"""
+
+import json
+from unittest.mock import patch
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from sqlalchemy.orm.exc import StaleDataError
+
+from tests.utils import get_json
+
+
+def test_concurrent_put_through_records_rest_returns_409(client, librarian_martigny, patron_martigny, json_header):
+    """Concurrent PUT through invenio-records-rest must return 409.
+
+    Patches db.session.commit to raise StaleDataError, simulating the optimistic
+    locking failure that SQLAlchemy raises when two concurrent sessions try to
+    commit the same record revision. This exercises the full invenio-records-rest
+    PUT code path and verifies that the 409 response is produced.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_martigny.pid)
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)["metadata"]
+
+    with patch("invenio_db.db.session.commit", side_effect=StaleDataError()):
+        res = client.put(item_url, data=json.dumps(data), headers=json_header)
+        assert res.status_code == 409
+        assert res.get_json() == {
+            "status": 409,
+            "message": "A conflict happened while processing the request. The resource might have been modified while the request was being processed.",
+        }
+
+
+def test_sequential_updates_without_etag_succeed(client, librarian_martigny, patron_martigny, json_header):
+    """Sequential PUTs without If-Match must both succeed.
+
+    Without concurrent requests there is no version conflict, so two
+    sequential PUTs without If-Match must each return 200 and advance
+    the ETag independently.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_martigny.pid)
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    etag = res.headers["ETag"]
+    data = get_json(res)["metadata"]
+
+    # First PUT — must succeed and advance the revision
+    res = client.put(item_url, data=json.dumps(data), headers=json_header)
+    assert res.status_code == 200
+    assert res.headers["ETag"] != etag
+
+    # Second PUT — must also succeed (sequential, no real concurrency)
+    etag = res.headers["ETag"]
+    res = client.put(item_url, data=json.dumps(data), headers=json_header)
+    assert res.status_code == 200
+    assert res.headers["ETag"] != etag
+
+
+def test_weak_etag_matching_current_revision_succeeds(client, librarian_martigny, patron_martigny, json_header):
+    """PUT with a weak If-Match matching the current revision must succeed.
+
+    nginx converts strong ETags ("N") to weak ETags (W/"N") when applying gzip
+    compression (RFC 7232 §2.1). The server must accept weak ETags in If-Match
+    and succeed when the version matches.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_martigny.pid)
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    # Simulate nginx gzip: convert strong ETag "N" to weak W/"N"
+    weak_etag = f"W/{res.headers['ETag']}"
+    data = get_json(res)["metadata"]
+
+    res = client.put(item_url, data=json.dumps(data), headers=[*json_header, ("If-Match", weak_etag)])
+    assert res.status_code == 200
+
+
+def test_weak_etag_stale_revision_returns_412(client, librarian_martigny, patron_martigny, json_header):
+    """PUT with a stale weak If-Match must be rejected with 412.
+
+    After a first PUT advances the revision, a second PUT carrying the original
+    weak ETag (W/"N") must fail with 412 — the server must check weak ETags
+    in If-Match against the current revision, not silently bypass the check.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_martigny.pid)
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    # Simulate nginx gzip: convert strong ETag "N" to weak W/"N"
+    weak_etag = f"W/{res.headers['ETag']}"
+    data = get_json(res)["metadata"]
+
+    headers_with_weak_etag = [*json_header, ("If-Match", weak_etag)]
+
+    # First PUT with the correct weak ETag — must succeed and advance the revision
+    res = client.put(item_url, data=json.dumps(data), headers=headers_with_weak_etag)
+    assert res.status_code == 200
+
+    # Second PUT with the now-stale weak ETag — must be rejected
+    res = client.put(item_url, data=json.dumps(data), headers=headers_with_weak_etag)
+    assert res.status_code == 412
+    assert res.get_json() == {
+        "status": 412,
+        "message": "The precondition on the request for the URL failed positive evaluation.",
+    }
+
+
+def test_etag_prevents_stale_concurrent_update(client, librarian_martigny, patron_martigny, json_header):
+    """Second PUT with a stale ETag must be rejected with 412.
+
+    Simulates a double-click or two concurrent saves by sending two PUT
+    requests carrying the same If-Match value. After the first PUT commits,
+    the record revision advances and the second PUT must fail with 412
+    Precondition Failed rather than silently overwriting or returning 500.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_martigny.pid)
+
+    # Capture the current ETag from a GET
+    res = client.get(item_url)
+    assert res.status_code == 200
+    etag = res.headers["ETag"]
+    data = get_json(res)["metadata"]
+
+    headers_with_etag = [*json_header, ("If-Match", etag)]
+
+    # First PUT with the correct ETag — must succeed and advance the revision
+    res = client.put(item_url, data=json.dumps(data), headers=headers_with_etag)
+    assert res.status_code == 200
+    assert res.headers["ETag"] != etag
+
+    # Second PUT with the now-stale ETag — must be rejected
+    res = client.put(item_url, data=json.dumps(data), headers=headers_with_etag)
+    assert res.status_code == 412
+    assert res.get_json() == {
+        "status": 412,
+        "message": "The precondition on the request for the URL failed positive evaluation.",
+    }


### PR DESCRIPTION
SQLAlchemy optimistic locking raises StaleDataError when two requests
try to commit the same record revision. invenio-records-rest's pass_record
decorator intercepts this as PIDResolveRESTError before app-level handlers
can catch it. Two error handlers are registered as a temporary workaround
until a fix lands upstream in invenio-records-rest.

- Closes https://github.com/rero/rero-ils/issues/3652.

Depends on https://github.com/rero/rero-ils-ui/pull/1476

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
