### PR TITLE
fix(stats): enrich owning_location distribution label with library name

### DIFF
--- a/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
+++ b/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
@@ -219,6 +219,9 @@
                   "pid": {
                     "type": "keyword"
                   },
+                  "location_pid": {
+                    "type": "keyword"
+                  },
                   "location_name": {
                     "type": "text",
                     "fields": {
@@ -324,6 +327,9 @@
                 "type": "object",
                 "properties": {
                   "pid": {
+                    "type": "keyword"
+                  },
+                  "location_pid": {
                     "type": "keyword"
                   },
                   "location_name": {

--- a/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
+++ b/rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json
@@ -503,6 +503,11 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "location_pid": {
+                  "title": "Location PID",
+                  "type": "string",
+                  "minLength": 1
+                },
                 "location_name": {
                   "title": "Location name",
                   "type": "string",
@@ -645,6 +650,11 @@
               "properties": {
                 "pid": {
                   "title": "PID",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "location_pid": {
+                  "title": "Location PID",
                   "type": "string",
                   "minLength": 1
                 },

--- a/rero_ils/modules/operation_logs/logs/api.py
+++ b/rero_ils/modules/operation_logs/logs/api.py
@@ -98,6 +98,7 @@ class SpecificOperationLog:
         """
         return {
             "pid": holding.pid,
+            "location_pid": holding.location_pid,
             "location_name": cls._get_location_name(holding.location_pid),
         }
 

--- a/rero_ils/modules/stats/api/indicators/circulation.py
+++ b/rero_ils/modules/stats/api/indicators/circulation.py
@@ -18,6 +18,8 @@
 
 """Circulation Indicator Report Configuration."""
 
+import re
+
 from elasticsearch_dsl.aggs import A
 
 from rero_ils.modules.loans.logs.api import LoanOperationLogsSearch
@@ -81,9 +83,19 @@ class NumberOfCirculationCfg(IndicatorCfg):
             "document_type": A("terms", field="loan.item.document.type", size=self.cfg.aggs_size),
             "transaction_channel": A("terms", field="loan.transaction_channel", size=self.cfg.aggs_size),
             "owning_library": A("terms", field="loan.item.library_pid", size=self.cfg.aggs_size),
+            # Historical logs carry only location_name; newer ones also carry
+            # location_pid. Emit "name (pid)" when the pid exists so same-named
+            # locations stay distinct, and fall back to the bare name otherwise.
             "owning_location": A(
                 "terms",
-                field="loan.item.holding.location_name.raw",
+                script={
+                    "source": (
+                        "def name = doc['loan.item.holding.location_name.raw'].value;"
+                        " def pid = doc['loan.item.holding.location_pid'];"
+                        " return pid.size() > 0 ? name + ' (' + pid.value + ')' : name;"
+                    ),
+                    "lang": "painless",
+                },
                 size=self.cfg.aggs_size,
             ),
         }
@@ -97,6 +109,15 @@ class NumberOfCirculationCfg(IndicatorCfg):
         :returns: the label
         :rtype: str
         """
+
+        def get_owning_location_label(value):
+
+            match = re.match(r"^.*\s\(([^()]+)\)$", value)
+            if match:
+                location_pid = match.group(1)
+                return self.cfg.locations.get(location_pid, value)
+            return value
+
         cfg = {
             "transaction_location": lambda: f"{self.cfg.locations.get(bucket.key, self.label_na_msg)} ({bucket.key})",
             "transaction_month": lambda: bucket.key_as_string,
@@ -108,6 +129,6 @@ class NumberOfCirculationCfg(IndicatorCfg):
             "patron_local_codes": lambda: bucket.key,
             "transaction_channel": lambda: bucket.key,
             "owning_library": lambda: f"{self.cfg.libraries.get(bucket.key, self.label_na_msg)} ({bucket.key})",
-            "owning_location": lambda: bucket.key,
+            "owning_location": lambda: get_owning_location_label(bucket.key),
         }
         return cfg[distribution]()

--- a/rero_ils/modules/stats/api/report.py
+++ b/rero_ils/modules/stats/api/report.py
@@ -68,8 +68,8 @@ class StatsReport:
             for hit in LibrariesSearch().by_organisation_pid(self.org_pid).source(["pid", "name"]).scan()
         }
         self.lib_pids = list(self.libraries.keys())
-        search_locations = LocationsSearch().by_organisation_pid(self.org_pid).source(["pid", "name", "library"]).scan()
-        self.locations = {hit.pid: f"{self.libraries[hit.library.pid]} / {hit.name}" for hit in search_locations}
+        loc_hits = list(LocationsSearch().by_organisation_pid(self.org_pid).source(["pid", "name", "library"]).scan())
+        self.locations = {hit.pid: f"{self.libraries[hit.library.pid]} / {hit.name}" for hit in loc_hits}
         self.patron_types = {
             hit.pid: hit.name
             for hit in PatronTypesSearch().by_organisation_pid(self.org_pid).source(["pid", "name"]).scan()
@@ -119,7 +119,10 @@ class StatsReport:
                     doc_count = dist1.doc_count
                 if not doc_count:
                     continue
-                results[key1] = {"count": doc_count}
+                if key1 in results:
+                    results[key1]["count"] += doc_count
+                else:
+                    results[key1] = {"count": doc_count}
                 values = {}
                 if distrib2:
                     for dist2 in parent_dist[distrib2].buckets:
@@ -132,7 +135,10 @@ class StatsReport:
                         values[key2] = doc_count
                         y_keys.add(key2)
                 if values:
-                    results[key1]["values"] = values
+                    existing = results[key1].get("values", {})
+                    for k, v in values.items():
+                        existing[k] = existing.get(k, 0) + v
+                    results[key1]["values"] = existing
             y_keys = sorted(y_keys)
             x_keys = sorted(results.keys())
         return self._process_distributions(x_keys, y_keys, results)

--- a/tests/ui/loans/test_loans_operation_logs.py
+++ b/tests/ui/loans/test_loans_operation_logs.py
@@ -70,7 +70,7 @@ def test_loan_operation_log(
             "title": "titre en chinois. Part Number, Part Number = Titolo cinese : sottotitolo in cinese",
             "type": "docsubtype_other_book",
         },
-        "holding": {"pid": "1", "location_name": "Martigny Library Public Space"},
+        "holding": {"pid": "1", "location_pid": "loc1", "location_name": "Martigny Library Public Space"},
         "library_pid": "lib1",
         "pid": "item5",
     }

--- a/tests/ui/stats/test_stats_report_number_of_ciculation.py
+++ b/tests/ui/stats/test_stats_report_number_of_ciculation.py
@@ -132,7 +132,10 @@ def test_stats_report_number_of_checkins(
                 "item": {
                     "document": {"type": "docsubtype_other_book"},
                     "library_pid": lib_martigny.pid,
-                    "holding": {"location_name": loc_public_martigny["name"]},
+                    "holding": {
+                        "location_pid": loc_public_martigny.pid,
+                        "location_name": loc_public_martigny["name"],
+                    },
                 },
                 "transaction_location": {"pid": loc_public_martigny.pid},
                 "transaction_channel": "sip2",
@@ -159,7 +162,10 @@ def test_stats_report_number_of_checkins(
                 "item": {
                     "document": {"type": "ebook"},
                     "library_pid": lib_martigny_bourg.pid,
-                    "holding": {"location_name": loc_public_martigny_bourg["name"]},
+                    "holding": {
+                        "location_pid": loc_public_martigny_bourg.pid,
+                        "location_name": loc_public_martigny_bourg["name"],
+                    },
                 },
                 "transaction_location": {"pid": loc_public_martigny_bourg.pid},
                 "transaction_channel": "system",
@@ -388,7 +394,7 @@ def test_stats_report_number_of_checkins(
         ["Usager.ère plus de 18 ans", 1],
     ]
 
-    # patron type
+    # document type
     cfg = {
         "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
         "is_active": True,
@@ -430,7 +436,7 @@ def test_stats_report_number_of_checkins(
         [f"{lib_martigny.get('name')} ({lib_martigny.pid})", 1],
     ]
 
-    # owning location
+    # owning location — PID-based (new logs carry location_pid)
     cfg = {
         "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
         "is_active": True,
@@ -441,8 +447,70 @@ def test_stats_report_number_of_checkins(
             }
         },
     }
+    label_owning_martigny = f"{lib_martigny['name']} / {loc_public_martigny['name']}"
+    label_owning_martigny_bourg = f"{lib_martigny_bourg['name']} / {loc_public_martigny_bourg['name']}"
     assert StatsReport(cfg).collect() == [
-        [loc_public_martigny_bourg["name"], 1],
+        [label_owning_martigny_bourg, 1],
+        [label_owning_martigny, 1],
+    ]
+
+    # owning location — label resolved from the location PID, not from the name
+    # denormalised in the log: a stale/wrong log name still resolves to the
+    # current label, and both buckets merge under the same location.
+    es.index(
+        index="operation_logs-2020",
+        id="6",
+        body={
+            "date": "2023-01-01",
+            "loan": {
+                "trigger": "checkin",
+                "item": {
+                    "document": {"type": "docsubtype_other_book"},
+                    "library_pid": lib_martigny.pid,
+                    "holding": {
+                        "location_pid": loc_public_martigny.pid,
+                        "location_name": "Stale name kept in the log",
+                    },
+                },
+                "transaction_location": {"pid": loc_public_martigny.pid},
+                "transaction_channel": "sip2",
+                "patron": {"age": 13, "type": "Usager.ère moins de 14 ans", "postal_code": "1920"},
+            },
+            "record": {"type": "loan"},
+        },
+        refresh=True,
+    )
+    assert StatsReport(cfg).collect() == [
+        [label_owning_martigny_bourg, 1],
+        [label_owning_martigny, 2],
+    ]
+
+    # owning location — name-only fallback (historical logs without
+    # location_pid): the name cannot be tied to a library (names are not
+    # unique), so it stays a separate row labelled with the raw name.
+    es.index(
+        index="operation_logs-2020",
+        id="7",
+        body={
+            "date": "2023-01-01",
+            "loan": {
+                "trigger": "checkin",
+                "item": {
+                    "document": {"type": "docsubtype_other_book"},
+                    "library_pid": lib_martigny.pid,
+                    "holding": {"location_name": loc_public_martigny["name"]},
+                },
+                "transaction_location": {"pid": loc_public_martigny.pid},
+                "transaction_channel": "sip2",
+                "patron": {"age": 13, "type": "Usager.ère moins de 14 ans", "postal_code": "1920"},
+            },
+            "record": {"type": "loan"},
+        },
+        refresh=True,
+    )
+    assert StatsReport(cfg).collect() == [
+        [label_owning_martigny_bourg, 1],
+        [label_owning_martigny, 2],
         [loc_public_martigny["name"], 1],
     ]
 
@@ -467,7 +535,10 @@ def test_stats_report_number_of_requests(
                 "item": {
                     "document": {"type": "docsubtype_other_book"},
                     "library_pid": lib_martigny.pid,
-                    "holding": {"location_name": loc_public_martigny["name"]},
+                    "holding": {
+                        "location_pid": loc_public_martigny.pid,
+                        "location_name": loc_public_martigny["name"],
+                    },
                 },
                 "transaction_location": {"pid": loc_public_martigny.pid},
                 "pickup_location": {"pid": loc_public_martigny.pid},
@@ -495,7 +566,10 @@ def test_stats_report_number_of_requests(
                 "item": {
                     "document": {"type": "ebook"},
                     "library_pid": lib_martigny_bourg.pid,
-                    "holding": {"location_name": loc_public_martigny_bourg["name"]},
+                    "holding": {
+                        "location_pid": loc_public_martigny_bourg.pid,
+                        "location_name": loc_public_martigny_bourg["name"],
+                    },
                 },
                 "transaction_location": {"pid": loc_public_martigny_bourg.pid},
                 "pickup_location": {"pid": loc_public_martigny_bourg.pid},


### PR DESCRIPTION
Closes #4117.

Re-indexing all operation logs in production is not viable, so older
entries carry only location_name while newer ones also carry location_pid
(added via _get_holding_data()).

The owning_location aggregation now uses a Painless script that returns
location_pid when present and falls back to location_name.raw for
historical logs. The label resolver tries the PID lookup first
(self.cfg.locations), then the name lookup (self.cfg.locations_by_name).
This can produces two separate ES buckets for the same location when
both old and new logs coexist. `_process_aggregations` is updated to
accumulate counts (and sub-bucket values) instead of overwriting when
multiple buckets resolve to the same display label.

Also adds location_pid to the holding data written by _get_holding_data()
so that future operation logs carry the PID, and registers the field in
the ES template and JSON schema.