### PR TITLE
fix(acquisition): round monetary float arithmetic to 2 decimal places

### DIFF
--- a/rero_ils/modules/acquisition/acq_accounts/api.py
+++ b/rero_ils/modules/acquisition/acq_accounts/api.py
@@ -259,7 +259,7 @@ class AcqAccount(AcquisitionIlsRecord):
             rate = self.get("encumbrance_exceedance", 0)
         elif exceed_type == AcqAccountExceedanceType.EXPENDITURE:
             rate = self.get("expenditure_exceedance", 0)
-        return round(self["allocated_amount"] * rate) / 100
+        return round(self["allocated_amount"] * rate / 100, 2)
 
     def transfer_fund(self, target_account, amount):
         """Transfer funds between two accounts.

--- a/rero_ils/modules/acquisition/acq_accounts/listener.py
+++ b/rero_ils/modules/acquisition/acq_accounts/listener.py
@@ -50,13 +50,13 @@ def enrich_acq_account_data(
     json["encumbrance_amount"] = {
         "self": self_amount,
         "children": children_amount,
-        "total": self_amount + children_amount,
+        "total": round(self_amount + children_amount, 2),
     }
     (self_amount, children_amount) = account.expenditure_amount
     json["expenditure_amount"] = {
         "self": self_amount,
         "children": children_amount,
-        "total": self_amount + children_amount,
+        "total": round(self_amount + children_amount, 2),
     }
     (self_amount, total_amount) = account.remaining_balance
     json["remaining_balance"] = {"self": self_amount, "total": total_amount}

--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -148,7 +148,7 @@ class AcqOrderLine(AcquisitionIlsRecord):
     @classmethod
     def _build_total_amount(cls, data):
         """Build total amount for order line."""
-        data["total_amount"] = data["amount"] * data["quantity"]
+        data["total_amount"] = round(data["amount"] * data["quantity"], 2)
 
     # GETTER & SETTER =========================================================
     #   * Define some properties as shortcut to quickly access object attrs.

--- a/rero_ils/modules/acquisition/acq_order_lines/extensions.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/extensions.py
@@ -18,7 +18,7 @@ class AcqOrderLineValidationExtension(RecordExtension):
     def _check_balance(record):
         """Check if parent account balance has enough money."""
         # compute the total amount of the order line
-        record["total_amount"] = record["amount"] * record["quantity"] - record.get("discount_amount", 0)
+        record["total_amount"] = round(record["amount"] * record["quantity"] - record.get("discount_amount", 0), 2)
 
         original_record = record.__class__.get_record_by_pid(record.pid)
 

--- a/rero_ils/modules/acquisition/acq_order_lines/listener.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/listener.py
@@ -31,6 +31,6 @@ def enrich_acq_order_line_data(
             record = AcqOrderLine.get_record_by_pid(record.get("pid"))
         unreceived_quantity = record.unreceived_quantity
         # other dynamic keys
-        json["total_unreceived_amount"] = unreceived_quantity * record["amount"]
+        json["total_unreceived_amount"] = round(unreceived_quantity * record["amount"], 2)
         json["status"] = record.status
         json["received_quantity"] = record.received_quantity

--- a/tests/api/acquisition/test_acquisition_rollover.py
+++ b/tests/api/acquisition/test_acquisition_rollover.py
@@ -187,3 +187,78 @@ def test_rollover_misc_functions(client, acq_full_structure_a, org_martigny):
     process._abort_rollover("dummy errors")
     control_budget = Budget.get_record_by_pid(new_budget.pid)
     assert not control_budget
+
+
+def test_rollover_float_precision(client, lib_martigny, vendor_martigny, document, org_martigny):
+    """Test rollover succeeds when order line amount*quantity drifts in float arithmetic.
+
+    In Python, 1.1 * 3 = 3.3000000000000003. Without round(,2) in _build_total_amount
+    and _check_balance, the new order line's total_amount (3.3000000000000003) would
+    exceed the account's allocated_amount (3.3), raising ValidationError and aborting
+    the rollover.
+    """
+    org_ref = get_ref_for_pid("org", org_martigny.pid)
+    lib_ref = get_ref_for_pid("lib", lib_martigny.pid)
+    vendor_ref = get_ref_for_pid("vndr", vendor_martigny.pid)
+
+    logging_config = deepcopy(ROLLOVER_LOGGING_CONFIG)
+    logging_config["handlers"]["console"] = {"class": "logging.NullHandler"}
+    logging_config["handlers"]["file"] = {"class": "logging.NullHandler"}
+
+    # Budget sized exactly to round(1.1 * 3, 2) = 3.3
+    budget = _make_resource(
+        client,
+        "budg",
+        {
+            "name": "Float precision budget",
+            "start_date": "2022-01-01",
+            "end_date": "2022-12-31",
+            "is_active": True,
+            "organisation": {"$ref": org_ref},
+        },
+    )
+    account = _make_resource(
+        client,
+        "acac",
+        {
+            "name": "float_account",
+            "number": "FLT.0001.01",
+            "allocated_amount": 3.3,
+            "budget": {"$ref": get_ref_for_pid("budg", budget.pid)},
+            "library": {"$ref": lib_ref},
+        },
+    )
+    order = _make_resource(
+        client,
+        "acor",
+        {"vendor": {"$ref": vendor_ref}, "library": {"$ref": lib_ref}},
+    )
+    _make_resource(
+        client,
+        "acol",
+        {
+            "acq_account": {"$ref": get_ref_for_pid("acac", account.pid)},
+            "acq_order": {"$ref": get_ref_for_pid("acor", order.pid)},
+            "document": {"$ref": get_ref_for_pid("doc", document.pid)},
+            "quantity": 3,
+            "amount": 1.1,
+        },
+    )
+    dest_budget = _make_resource(
+        client,
+        "budg",
+        {
+            "name": "Float precision dest budget",
+            "start_date": "2023-01-01",
+            "end_date": "2023-12-31",
+            "is_active": False,
+            "organisation": {"$ref": org_ref},
+        },
+    )
+
+    # Without round(,2): 1.1*3 = 3.3000000000000003 > 3.3 → ValidationError
+    # With round(,2):    1.1*3 rounds to 3.3 <= 3.3    → success
+    rollover_process = AcqRollover(
+        budget, dest_budget, logging_config=logging_config, is_interactive=False, propagate_errors=True
+    )
+    rollover_process.run()

--- a/tests/ui/acq_accounts/test_acq_accounts_api.py
+++ b/tests/ui/acq_accounts/test_acq_accounts_api.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Acquisition account API tests."""
+
+from rero_ils.modules.acquisition.acq_accounts.models import AcqAccountExceedanceType
+
+
+def test_get_exceedance(acq_account_fiction_martigny):
+    """Test get_exceedance returns the correct percentage of the allocated amount."""
+    acac = acq_account_fiction_martigny
+    assert acac["allocated_amount"] == 15000
+
+    # No exceedance configured → 0 for both types
+    assert acac.get_exceedance(AcqAccountExceedanceType.ENCUMBRANCE) == 0
+    assert acac.get_exceedance(AcqAccountExceedanceType.EXPENDITURE) == 0
+
+    # 5% of 15000.00 = 750.0
+    acac["encumbrance_exceedance"] = 5
+    assert acac.get_exceedance(AcqAccountExceedanceType.ENCUMBRANCE) == 750.0
+    assert acac.get_exceedance(AcqAccountExceedanceType.EXPENDITURE) == 0
+
+    # 10% of 15000.00 = 1500.0
+    acac["expenditure_exceedance"] = 10
+    assert acac.get_exceedance(AcqAccountExceedanceType.EXPENDITURE) == 1500.0
+
+    # Fractional rate: 1.5% of 15000.00 = 225.0
+    acac["encumbrance_exceedance"] = 1.5
+    assert acac.get_exceedance(AcqAccountExceedanceType.ENCUMBRANCE) == 225.0
+
+    # Float precision: 7% of 1000.10 = 70.007 → rounds to 70.01
+    # Without round(,2) this would return 70.007 or drift further
+    acac["allocated_amount"] = 1000.10
+    acac["encumbrance_exceedance"] = 7
+    assert acac.get_exceedance(AcqAccountExceedanceType.ENCUMBRANCE) == 70.01
+
+    del acac["encumbrance_exceedance"]
+    del acac["expenditure_exceedance"]

--- a/tests/ui/acq_order_lines/test_acq_order_lines_api.py
+++ b/tests/ui/acq_order_lines/test_acq_order_lines_api.py
@@ -15,6 +15,18 @@ from rero_ils.modules.acquisition.acq_orders.models import AcqOrderStatus
 from rero_ils.modules.utils import get_ref_for_pid
 
 
+def test_build_total_amount():
+    """Total amount is amount * quantity, rounded to 2 decimal places."""
+    data = {"amount": 10.50, "quantity": 3}
+    AcqOrderLine._build_total_amount(data)
+    assert data["total_amount"] == 31.50
+
+    # Float drift: 0.1 * 3 in Python = 0.30000000000000004 without round
+    data = {"amount": 0.10, "quantity": 3}
+    AcqOrderLine._build_total_amount(data)
+    assert data["total_amount"] == 0.30
+
+
 def test_order_line_properties(
     acq_order_fiction_martigny,
     acq_order_line_fiction_martigny,


### PR DESCRIPTION
Float multiplication such as 1.1 * 3 = 3.3000000000000003 in Python caused the rollover to fail with a ValidationError when the computed total_amount exceeded the account's allocated_amount by a rounding artefact.

* round(amount * quantity, 2) in AcqOrderLine._build_total_amount
* round(amount * quantity - discount, 2) in _check_balance extension
* round(unreceived_quantity * amount, 2) in order line listener
* round(self_amount + children_amount, 2) for encumbrance and expenditure totals in account listener
* round(allocated_amount * rate / 100, 2) in AcqAccount.get_exceedance
* add test_build_total_amount verifying 0.1 * 3 rounds to 0.30
* add test_get_exceedance verifying 7% of 1000.10 rounds to 70.01
* add test_rollover_float_precision reproducing the exact rollover failure: account allocated_amount=3.3, order line amount=1.1 qty=3
* Closes #3998