### PR TITLE
fix(tests): improve test suite quality 

### DIFF
--- a/tests/api/circulation/test_library_calendar_changes.py
+++ b/tests/api/circulation/test_library_calendar_changes.py
@@ -4,12 +4,10 @@
 
 """Test library calendar changes effects on related loans."""
 
-import time
-
 from invenio_accounts.testutils import login_user_via_session
 from invenio_cache import current_cache
 
-from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.api import Loan, LoansSearch
 from tests.utils import postdata
 
 
@@ -44,6 +42,7 @@ def test_library_calendar_changes(
     assert res.status_code == 200
     loan_pid = res.json["action_applied"]["checkout"]["pid"]
     loan = Loan.get_record_by_pid(loan_pid)
+    LoansSearch.flush_and_refresh()
 
     # TEST#1 :: Changes on an untracked field.
     #   Related loan shouldn't be updated
@@ -63,7 +62,6 @@ def test_library_calendar_changes(
     library["exception_dates"].append({"is_open": False, "title": "exception date", "start_date": loan.end_date[:10]})
     library = library.update(library, dbcommit=True, reindex=False)
 
-    time.sleep(5)  # TODO :: find a better way to detect task is finished.
     loan = Loan.get_record_by_pid(loan_pid)
     assert loan.end_date != initial_enddate
 

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -497,7 +497,6 @@ def test_documents_post_put_delete(client, document_chinese_data, json_header, r
     """Test record retrieval."""
     # Create record / POST
     item_url = url_for("invenio_records_rest.doc_item", pid_value="4")
-    list_url = url_for("invenio_records_rest.doc_list", q="pid:4")
 
     document_chinese_data["pid"] = "4"
     res, data = postdata(client, "invenio_records_rest.doc_list", document_chinese_data)

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -365,7 +365,6 @@ def test_items_receive(
     item_pid = item.pid
     patron_pid = patron_martigny.pid
     assert not item.patron_has_an_active_loan_on_item(patron_martigny)
-    location = loc_public_martigny
     # checkout
     res, data = postdata(
         client,
@@ -418,7 +417,6 @@ def test_items_no_extend(
     item = item_lib_martigny
     item_pid = item.pid
     patron_pid = patron_martigny.pid
-    location = loc_public_martigny
 
     # checkout
     res, data = postdata(

--- a/tests/api/items/test_items_rest_views.py
+++ b/tests/api/items/test_items_rest_views.py
@@ -4,7 +4,6 @@
 
 """Tests REST API items."""
 
-import time
 from unittest import mock
 
 from elasticsearch_dsl.search import Response
@@ -20,8 +19,7 @@ from tests.utils import get_json, postdata
 def test_item_stats_endpoint(item_at_desk_martigny_patron_and_loan_at_desk, client, librarian_martigny):
     """Test loan filter on stats endpoint with real data."""
     item, _, _ = item_at_desk_martigny_patron_and_loan_at_desk
-    StatsSearch.flush_and_refresh()
-    time.sleep(1)  # TODO :: find a better way to wait for stats.
+    OperationLogsSearch.flush_and_refresh()
     login_user_via_session(client, librarian_martigny.user)
     res = client.get(
         url_for(

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -68,13 +68,11 @@ def test_filtered_patrons_get(client, librarian_martigny, patron_martigny, libra
 def test_patron_has_valid_subscriptions(
     patron_type_grown_sion,
     patron_sion,
-    patron_sion_data,
     patron_type_adults_martigny,
     patron2_martigny,
     patron_type_youngsters_sion,
 ):
     """Test patron subscriptions."""
-    patron_sion = patron_sion
     patron_martigny = patron2_martigny
 
     # 'patron_type_adults_martigny' doesn't require any subscription

--- a/tests/api/patrons/test_patrons_tasks.py
+++ b/tests/api/patrons/test_patrons_tasks.py
@@ -70,7 +70,7 @@ def _clear_user_login(user):
     db.session.commit()
 
 
-def _create_throwaway_patron(app, data_tmp, suffix="1"):
+def _create_throwaway_patron(data_tmp, suffix="1"):
     """Create a throwaway patron for deletion tests.
 
     :param suffix: unique suffix for email/username/barcode.
@@ -246,7 +246,7 @@ def test_patron_meeting_all_criteria_is_deleted(
     app, org_martigny, roles, lib_martigny, patron_type_children_martigny, patron_martigny_data_tmp
 ):
     """Test that a patron meeting all deletion criteria is actually deleted."""
-    patron, user_id = _create_throwaway_patron(app, patron_martigny_data_tmp)
+    patron, user_id = _create_throwaway_patron(patron_martigny_data_tmp)
     pid = patron.pid
     config = {"expiration_years": 3, "inactivity_years": 3}
     _set_patron_cleanup_config(org_martigny, config)
@@ -266,7 +266,7 @@ def test_patron_with_never_logged_in_user_is_deleted(
     app, org_martigny, roles, lib_martigny, patron_type_children_martigny, patron_martigny_data_tmp
 ):
     """Test that patron with never-logged-in user is deleted (None login)."""
-    patron, user_id = _create_throwaway_patron(app, patron_martigny_data_tmp, suffix="2")
+    patron, user_id = _create_throwaway_patron(patron_martigny_data_tmp, suffix="2")
     pid = patron.pid
     config = {"expiration_years": 3, "inactivity_years": 3}
     _set_patron_cleanup_config(org_martigny, config)
@@ -286,7 +286,7 @@ def test_full_task_end_to_end(
     app, org_martigny, roles, lib_martigny, patron_type_children_martigny, patron_martigny_data_tmp
 ):
     """Test the full task_delete_inactive_patrons end-to-end."""
-    patron, user_id = _create_throwaway_patron(app, patron_martigny_data_tmp, suffix="3")
+    patron, user_id = _create_throwaway_patron(patron_martigny_data_tmp, suffix="3")
     pid = patron.pid
     config = {"expiration_years": 3, "inactivity_years": 3}
     _set_patron_cleanup_config(org_martigny, config)

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -28,16 +28,14 @@ def test_item_holding_document_availability(
     patron2_martigny,
     loc_public_saxon,
     circulation_policies,
-    ebook_1_data,
-    item_lib_martigny_data,
 ):
     """Test item, holding and document availability."""
-    assert item_availablity_status(client, item_lib_martigny.pid, librarian_martigny.user)
+    assert item_availability_status(client, item_lib_martigny.pid)
     assert item_lib_martigny.is_available()
     assert holding_lib_martigny.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == "standard"
     assert Document.is_available(document.pid, view_code="global")
-    assert document_availability_status(client, document.pid, librarian_martigny.user)
+    assert document_availability_status(client, document.pid)
 
     # login as patron
     with mock.patch("rero_ils.modules.patrons.api.current_patrons", [patron_martigny]):
@@ -62,12 +60,12 @@ def test_item_holding_document_availability(
     actions = data.get("action_applied")
     loan_pid = actions[LoanAction.REQUEST].get("pid")
     assert not item_lib_martigny.is_available()
-    assert not item_availablity_status(client, item_lib_martigny.pid, librarian_martigny.user)
+    assert not item_availability_status(client, item_lib_martigny.pid)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
     assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == "standard"
     assert Document.is_available(document.pid, "global")
-    assert document_availability_status(client, document.pid, librarian_martigny.user)
+    assert document_availability_status(client, document.pid)
 
     # validate request
     res, _ = postdata(
@@ -81,14 +79,12 @@ def test_item_holding_document_availability(
         },
     )
     assert res.status_code == 200
-    assert not item_lib_martigny.is_available()
-    assert not item_availablity_status(client, item_lib_martigny.pid, librarian_martigny.user)
-    assert not item_lib_martigny.is_available()
+    assert not item_availability_status(client, item_lib_martigny.pid)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
     assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == "standard"
     assert Document.is_available(document.pid, "global")
-    assert document_availability_status(client, document.pid, librarian_martigny.user)
+    assert document_availability_status(client, document.pid)
     login_user_via_session(client, librarian_saxon.user)
     # receive
     res, _ = postdata(
@@ -102,15 +98,14 @@ def test_item_holding_document_availability(
         },
     )
     assert res.status_code == 200
-    assert not item_lib_martigny.is_available()
-    assert not item_availablity_status(client, item_lib_martigny.pid, librarian_saxon.user)
+    assert not item_availability_status(client, item_lib_martigny.pid)
     item = Item.get_record_by_pid(item_lib_martigny.pid)
     assert not item.is_available()
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
     assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == "standard"
     assert Document.is_available(document.pid, "global")
-    assert document_availability_status(client, document.pid, librarian_martigny.user)
+    assert document_availability_status(client, document.pid)
     # checkout
     res, _ = postdata(
         client,
@@ -126,12 +121,12 @@ def test_item_holding_document_availability(
 
     item = Item.get_record_by_pid(item_lib_martigny.pid)
     assert not item.is_available()
-    assert not item_availablity_status(client, item.pid, librarian_martigny.user)
+    assert not item_availability_status(client, item.pid)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
     assert holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == "standard"
     assert Document.is_available(document.pid, "global")
-    assert document_availability_status(client, document.pid, librarian_martigny.user)
+    assert document_availability_status(client, document.pid)
 
     # masked item isn't.is_available()
     item["_masked"] = True
@@ -153,13 +148,7 @@ def test_item_holding_document_availability(
     data = get_json(res)
     assert not data.get("can_request")
 
-    end_date = item.get_item_end_date(time_format=None, language="en")
-
-    """
-    request second item with another patron and test document and holding
-    availability
-    """
-
+    # request second item with another patron and test document and holding availability
     # login as patron
     with mock.patch("rero_ils.modules.patrons.api.current_patrons", [patron_martigny]):
         login_user_via_session(client, patron2_martigny.user)
@@ -179,15 +168,15 @@ def test_item_holding_document_availability(
     )
     assert res.status_code == 200
     assert not item2_lib_martigny.is_available()
-    assert not item_availablity_status(client, item2_lib_martigny.pid, librarian_martigny.user)
+    assert not item_availability_status(client, item2_lib_martigny.pid)
     holding = Holding.get_record_by_pid(holding_lib_martigny.pid)
     assert not holding.is_available()
     assert holding_lib_martigny.get_holding_loan_conditions() == "standard"
     assert not Document.is_available(document.pid, "global")
-    assert not document_availability_status(client, document.pid, librarian_martigny.user)
+    assert not document_availability_status(client, document.pid)
 
 
-def item_availablity_status(client, pid, user):
+def item_availability_status(client, pid):
     """Returns item availability."""
     res = client.get(
         url_for(
@@ -200,7 +189,7 @@ def item_availablity_status(client, pid, user):
     return data.get("available")
 
 
-def document_availability_status(client, pid, user):
+def document_availability_status(client, pid):
     """Returns document availability."""
     res = client.get(url_for("api_documents.document_availability", pid=pid, view_code="global"))
     assert res.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,26 +60,39 @@ def search(appctx):
     should used the function-scoped :py:data:`search_clear` fixture to leave the
     indexes clean for the following tests.
     """
+    from elasticsearch.exceptions import NotFoundError as ESNotFoundError
+    from elasticsearch.exceptions import RequestError as ESRequestError
     from invenio_search import current_search, current_search_client
     from invenio_search.errors import IndexAlreadyExistsError
 
     try:
-        list(current_search.put_templates())
+        list(current_search.put_templates(ignore=[400]))
     except IndexAlreadyExistsError:
         current_search_client.indices.delete_template("*")
-        list(current_search.put_templates())
+        list(current_search.put_templates(ignore=[400]))
 
     try:
         list(current_search.create())
-    except IndexAlreadyExistsError:
+    except (IndexAlreadyExistsError, ESRequestError, ESNotFoundError) as error:
+        # Indices already exist from a previous interrupted run — wipe everything
+        # and recreate from scratch.
+        # current_search.delete() removes indices known to Invenio's registry;
+        # indices.delete(index="*") catches any leftover indices that were created
+        # outside the registry (e.g. by direct ES calls during a previous test run).
         list(current_search.delete(ignore=[404]))
+        current_search_client.indices.delete(index="*", ignore=[404])
+        current_search_client.indices.delete_template("*")
+        list(current_search.put_templates(ignore=[400]))
         list(current_search.create())
     current_search_client.indices.refresh()
 
     try:
         yield current_search_client
     finally:
-        current_search_client.indices.delete(index="*")
+        # Same two-step teardown: registry-aware delete first, then wildcard
+        # to ensure no stray indices leak between test modules.
+        list(current_search.delete(ignore=[404]))
+        current_search_client.indices.delete(index="*", ignore=[404])
         current_search_client.indices.delete_template("*")
 
 

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -3527,8 +3527,8 @@
       },
       {
         "entity": {
-          "$ref": "https://mef.rero.ch/api/concepts/idref/050394460",
-          "pid": "14650374"
+          "$ref": "https://mef.rero.ch/api/concepts/idref/030752787",
+          "pid": "14613205"
         }
       }
     ]

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -211,7 +211,7 @@ def export_document_data(data):
 
 
 @pytest.fixture(scope="module")
-def export_document(app, export_document_data):
+def export_document(app, entity_topic, export_document_data):
     """Load document record."""
     doc = Document.create(data=export_document_data, delete_pid=False, dbcommit=True, reindex=True)
     DocumentsSearch.flush_and_refresh()

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -56,7 +56,6 @@ def test_document_create_with_mef(
     mock_contributions_mef_get,
     app,
     document_data_ref,
-    document_data,
     entity_person_data,
     entity_person_response_data,
 ):
@@ -325,7 +324,7 @@ def test_document_indexing(document, export_document):
     document.update(document, dbcommit=True, reindex=True)
 
 
-def test_document_replace_refs(document, mef_agents_url):
+def test_document_replace_refs(document, entity_person, mef_agents_url):
     """Test document replace refs."""
     orig = deepcopy(document)
     data = document.replace_refs()

--- a/tests/ui/entities/local_entities/test_local_entities_api.py
+++ b/tests/ui/entities/local_entities/test_local_entities_api.py
@@ -4,9 +4,6 @@
 
 """Local entities record tests."""
 
-import time
-from datetime import timedelta
-
 from rero_ils.modules.documents.api import Document, DocumentsSearch
 from rero_ils.modules.utils import get_ref_for_pid
 
@@ -33,12 +30,7 @@ def test_local_entity_indexing(app, local_entity_person, document_data_tmp):
     original_access_point = entity["authorized_access_point"]
     entity["name"] = "my_local_access_point"
     entity = entity.update(entity, dbcommit=True, reindex=True, commit=True)
-    # updating related resource is an asynchronous task (to not block app if
-    # there are a lot of related resource). We need to wait to the end of the
-    # task to check id related resources are up-to-date.
-    delay = app.config.get("RERO_ILS_INDEXER_TASK_DELAY", 0) + timedelta(seconds=2)
-    time.sleep(delay.seconds)  # find a better way to detect task is finished.
-
+    # index_referenced_records runs synchronously via CELERY_TASK_ALWAYS_EAGER
     DocumentsSearch.flush_and_refresh()
     hit = DocumentsSearch().get_record_by_pid(doc.pid)
     assert any(


### PR DESCRIPTION
 fix(tests): improve test suite quality

    * fix typo `item_availability_status` (was misspelled)
    * remove unused `user` param from non-fixture helper functions
    * remove duplicate and redundant consecutive assertions
    * remove dead variable assignments (`location`, `list_url`, `end_date`)
    * replace mid-function string literals with proper `#` comments
    * remove unused `_data`-suffix fixture params (pure data, no side effects)
    * remove unused `app` param from `_create_throwaway_patron` helper
    * remove no-op self-assignment `patron_sion = patron_sion`