### PR TITLE
feat(organisations): make patron_cleanup optional in the editor

### DIFF
--- a/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
+++ b/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
@@ -73,7 +73,7 @@
     },
     "patron_cleanup": {
       "title": "Patron cleanup configuration",
-      "description": "Configuration for the automatic deletion of inactive patron profiles.",
+      "description": "Configuration for the automatic deletion of inactive patron profiles. Delete the field if you never want the patrons to be deleted automatically.",
       "type": "object",
       "additionalProperties": false,
       "propertiesOrder": [
@@ -106,6 +106,16 @@
           "items": {
             "type": "string",
             "minLength": 1
+          }
+        }
+      },
+      "widget": {
+        "formlyConfig": {
+          "props": {
+            "hide": true,
+            "navigation": {
+              "essential": true
+            }
           }
         }
       }

--- a/tests/api/operation_logs/test_operation_logs_rest.py
+++ b/tests/api/operation_logs/test_operation_logs_rest.py
@@ -52,6 +52,7 @@ def test_operation_logs_permissions(
 ):
     """Test operation logs permissions."""
     item_list = url_for("invenio_records_rest.oplg_list")
+    OperationLogsSearch.flush_and_refresh()
 
     # Check access for librarian role
     login_user_via_session(client, librarian_martigny.user)


### PR DESCRIPTION
Add the formly `hide`/`navigation.essential` widget config so that patron_cleanup is rendered as an optional, addable/removable block. Its required sub-fields are then only enforced when the block is present.