### PR TITLE
fix(homepage-editor): add homepage mapping

### DIFF
--- a/rero_ils/modules/organisations/mappings/v7/organisations/organisation-v0.0.1.json
+++ b/rero_ils/modules/organisations/mappings/v7/organisations/organisation-v0.0.1.json
@@ -48,6 +48,10 @@
           }
         }
       },
+      "homepage": {
+        "type": "object",
+        "enabled": false
+      },
       "_created": {
         "type": "date"
       },


### PR DESCRIPTION
* Adds the homepage field to the ES mapping.
* Uses enabled and not index because homepage is an object.
* Omits child fields because enabled: false prevents ES from parsing or indexing them.