### PR TITLE
fix(cli): make index date filters UTC-aware

### DIFF
--- a/rero_ils/modules/cli/index.py
+++ b/rero_ils/modules/cli/index.py
@@ -6,6 +6,7 @@
 
 import json
 import sys
+from datetime import UTC
 
 import click
 import dateparser
@@ -152,9 +153,15 @@ def reindex(pid_types, from_date, until_date, direct, queue):
                         .order_by(model_cls.created)
                     )
                     if from_date:
-                        query = query.filter(model_cls.updated > dateparser.parse(from_date))
+                        dt = dateparser.parse(from_date)
+                        if dt:
+                            dt = dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+                            query = query.filter(model_cls.updated > dt)
                     if until_date:
-                        query = query.filter(model_cls.updated <= dateparser.parse(until_date))
+                        dt = dateparser.parse(until_date)
+                        if dt:
+                            dt = dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+                            query = query.filter(model_cls.updated <= dt)
             else:
                 query = (
                     PersistentIdentifier.query.filter_by(object_type="rec", status=PIDStatus.REGISTERED)


### PR DESCRIPTION
After the invenio-db alembic migration (66db9c49c699), the `created` and `updated` columns on `records_metadata` are now `UTCDateTime` (timezone-aware). Comparing them against naive datetimes from `dateparser.parse()` raises a TypeError in SQLAlchemy.

* replace `dateparser.parse(from_date)` with UTC-aware equivalent
* replace `dateparser.parse(until_date)` with UTC-aware equivalent