### PR TITLE
feat(patrons): add available languages to settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,25 @@ Each module has a `permissions.py` using `invenio-records-permissions`. Access i
 
 - Be clear and concise in the docstrings and do not over-comment the code.
 - Do not use Python type annotations (no `-> str`, `: str`, etc. in signatures).
-- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
+
+### Commit Messages
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org).
+
+Format: `<type>(<scope>): <subject>`
+
+Rules:
+- The subject line must not exceed 50 characters.
+- Body lines must not exceed 72 characters.
+- Use `*` for bullet points in the body, not `-`.
+- Use the imperative mood in the subject ("add", not "adds").
+- Do not end the subject line with a period.
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`,
+`perf`, `build`, `ci`
+
+Scope corresponds to the affected module under `rero_ils/modules/`
+(e.g. `patrons`, `items`, `loans`, `documents`).
 
 ### Translations
 

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -108,6 +108,8 @@ def logged_user():
         "settings": {
             "maxFilesCount": config.get("RERO_ILS_FILES_UI_MAX", 600),
             "language": current_i18n.locale.language,
+            "availableLanguages": [{"code": "en", "name": _("English")}]
+            + [{"code": code, "name": name} for code, name in config.get("I18N_LANGUAGES", [])],
             "globalView": config.get("RERO_ILS_SEARCH_GLOBAL_VIEW_CODE"),
             "baseUrl": get_base_url(),
             "agentLabelOrder": config.get("RERO_ILS_AGENTS_LABEL_ORDER", {}),
@@ -125,7 +127,8 @@ def logged_user():
 
     user = User.get_record(current_user.id).dumps_metadata()
     user["id"] = current_user.id
-    data = {**data, **user, "patrons": []}
+    data["user"] = user
+    data["patrons"] = []
     for patron in Patron.get_patrons_by_user(current_user):
         patron.pop("$schema", None)
         patron.pop("user_id", None)

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -27,12 +27,17 @@ def test_patrons_logged_user(client, librarian_martigny):
     res = client.get(url_for("patrons.logged_user", resolve=1))
     assert res.status_code == 200
     data = get_json(res)
-    assert data.get("first_name")
-    assert data.get("last_name")
+    assert data.get("user")
+    assert data.get("user", {}).get("id")
+    assert data.get("user", {}).get("first_name")
+    assert data.get("user", {}).get("last_name")
     assert data.get("patrons")
     assert data.get("settings")
     assert data.get("permissions")
     assert data.get("patrons")[0].get("organisation")
+    available_languages = data.get("settings").get("availableLanguages")
+    assert available_languages[0] == {"code": "en", "name": "English"}
+    assert {"code": "fr", "name": "French"} in available_languages
 
     class current_i18n:
         class locale:


### PR DESCRIPTION
* Expose the list of available UI languages in the logged-user endpoint so the frontend can build a language picker without needing a separate request.
* English is always prepended as the default entry; the rest comes from I18N_LANGUAGES in the app config.
* Restructure user data under a dedicated `user` key instead of spreading it directly into the response object.