### PR TITLE
fix(theme): repair broken CSS files and demo assets

### DIFF
--- a/rero_ils/theme/static/css/rero_ils/wiki.css
+++ b/rero_ils/theme/static/css/rero_ils/wiki.css
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Fondation RERO+
-// SPDX-License-Identifier: AGPL-3.0-or-later
+/* SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later */
 
 figure {
   max-width: 85%;

--- a/rero_ils/theme/static/themes/css/aoste.css
+++ b/rero_ils/theme/static/themes/css/aoste.css
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Fondation RERO+
-// SPDX-License-Identifier: AGPL-3.0-or-later
+/* SPDX-FileCopyrightText: Fondation RERO+ */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 
 @layer bootstrap {
   body#view-aoste nav.rero-ils-header {
@@ -11,7 +11,7 @@
   }
   
   div#aoste-logo {
-    content: url('https://resources.rero.ch/ils/test/images/logo-aoste.svg');
+    content: url('/static/themes/images/logo-aoste.svg');
     max-height: 44px;
   }
   

--- a/rero_ils/theme/static/themes/css/fictive.css
+++ b/rero_ils/theme/static/themes/css/fictive.css
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Fondation RERO+
-// SPDX-License-Identifier: AGPL-3.0-or-later
+/* SPDX-FileCopyrightText: Fondation RERO+ */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 
 @layer bootstrap {
   body#view-fictive nav.rero-ils-header {
@@ -11,7 +11,7 @@
   }
   
   div#fictive-logo {
-    content: url('https://resources.rero.ch/ils/test/images/logo-fictive.svg');
+    content: url('/static/themes/images/logo-fictive.svg');
     max-height: 44px;
   }
   

--- a/rero_ils/theme/static/themes/css/global.css
+++ b/rero_ils/theme/static/themes/css/global.css
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Fondation RERO+
-// SPDX-License-Identifier: AGPL-3.0-or-later
+/* SPDX-FileCopyrightText: Fondation RERO+ */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 
 @layer bootstrap {
   body#view-global nav.rero-ils-header {
@@ -11,7 +11,7 @@
   }
   
   div#global-logo {
-    content: url('https://resources.rero.ch/bib/test/images/logo-global.svg');
+    content: url('/static/themes/images/logo-global.svg');
     min-height: 44px;
     max-height: 44px;
     min-width: 58px;

--- a/rero_ils/theme/static/themes/css/highlands.css
+++ b/rero_ils/theme/static/themes/css/highlands.css
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Fondation RERO+
-// SPDX-License-Identifier: AGPL-3.0-or-later
+/* SPDX-FileCopyrightText: Fondation RERO+ */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 
 @layer bootstrap {
   body#view-highlands nav.rero-ils-header {
@@ -11,7 +11,7 @@
   }
   
   div#highlands-logo {
-    content: url('https://resources.rero.ch/ils/test/images/logo-highlands.svg');
+    content: url('/static/themes/images/logo-highlands.svg');
     max-height: 44px;
   }
   


### PR DESCRIPTION
The per-organisation and wiki CSS files are served as raw static files but used SCSS-style `//` comments, which are invalid in plain CSS.

* Replace `//` comments with valid `/* */` CSS comments.
* Point the organisation logos to the local SVG assets under /static/themes/images/ instead of the remote resources.rero.ch CDN, as intended when the local assets were added.