### PR TITLE
feat(stats): add item_type distribution for number of items

### DIFF
--- a/rero_ils/modules/item_types/api.py
+++ b/rero_ils/modules/item_types/api.py
@@ -43,6 +43,15 @@ class ItemTypesSearch(IlsRecordsSearch):
 
         default_filter = None
 
+    def by_organisation_pid(self, organisation_pid):
+        """Build a search to get hits related to an organisation pid.
+
+        :param organisation_pid: string - the organisation pid to filter with
+        :returns: An ElasticSearch query to get hits related the entity.
+        :rtype: `elasticsearch_dsl.Search`
+        """
+        return self.filter("term", organisation__pid=organisation_pid)
+
 
 class ItemType(IlsRecord):
     """ItemType class."""

--- a/rero_ils/modules/stats/api/indicators/others.py
+++ b/rero_ils/modules/stats/api/indicators/others.py
@@ -176,6 +176,7 @@ class NumberOfItemsCfg(IndicatorCfg):
                 include=self.cfg.loc_pids,
             ),
             "type": A("terms", field="type", size=self.cfg.aggs_size),
+            "item_type": A("terms", field="item_type.pid", size=self.cfg.aggs_size),
             "document_type": A(
                 "terms",
                 field="document.document_type.main_type",
@@ -209,6 +210,7 @@ class NumberOfItemsCfg(IndicatorCfg):
             "owning_library": lambda: f"{self.cfg.libraries.get(bucket.key, self.label_na_msg)} ({bucket.key})",
             "owning_location": lambda: f"{self.cfg.locations.get(bucket.key, self.label_na_msg)} ({bucket.key})",
             "type": lambda: bucket.key,
+            "item_type": lambda: f"{self.cfg.item_types.get(bucket.key, self.label_na_msg)} ({bucket.key})",
             "document_type": lambda: bucket.key,
             "document_subtype": lambda: bucket.key,
             "created_month": lambda: bucket.key_as_string,

--- a/rero_ils/modules/stats/api/report.py
+++ b/rero_ils/modules/stats/api/report.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 
+from rero_ils.modules.item_types.api import ItemTypesSearch
 from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.patron_types.api import PatronTypesSearch
@@ -59,6 +60,10 @@ class StatsReport:
         self.patron_types = {
             hit.pid: hit.name
             for hit in PatronTypesSearch().by_organisation_pid(self.org_pid).source(["pid", "name"]).scan()
+        }
+        self.item_types = {
+            hit.pid: hit.name
+            for hit in ItemTypesSearch().by_organisation_pid(self.org_pid).source(["pid", "name"]).scan()
         }
 
         self.loc_pids = list(self.locations.keys())

--- a/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
+++ b/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
@@ -349,6 +349,7 @@
                               "created_year",
                               "document_type",
                               "document_subtype",
+                              "item_type",
                               "owning_library",
                               "owning_location",
                               "type"
@@ -375,6 +376,10 @@
                                   {
                                     "value": "document_subtype",
                                     "label": "document_subtype"
+                                  },
+                                  {
+                                    "value": "item_type",
+                                    "label": "item_type"
                                   },
                                   {
                                     "value": "owning_library",

--- a/tests/ui/stats/test_stats_report_n_items.py
+++ b/tests/ui/stats/test_stats_report_n_items.py
@@ -18,6 +18,8 @@ def test_stats_report_number_of_items(
     loc_restricted_martigny,
     loc_public_martigny_bourg,
     loc_public_sion,
+    item_type_standard_martigny,
+    item_type_on_site_martigny,
 ):
     """Test the number of items."""
     # no data
@@ -38,6 +40,7 @@ def test_stats_report_number_of_items(
             "organisation": {"pid": org_martigny.pid},
             "library": {"pid": lib_martigny.pid},
             "location": {"pid": loc_public_martigny.pid},
+            "item_type": {"pid": item_type_standard_martigny.pid},
             "document": {
                 "document_type": [
                     {
@@ -57,6 +60,7 @@ def test_stats_report_number_of_items(
             "organisation": {"pid": org_martigny.pid},
             "library": {"pid": lib_martigny.pid},
             "location": {"pid": loc_restricted_martigny.pid},
+            "item_type": {"pid": item_type_on_site_martigny.pid},
             "document": {
                 "document_type": [
                     {
@@ -76,6 +80,7 @@ def test_stats_report_number_of_items(
             "organisation": {"pid": org_martigny.pid},
             "library": {"pid": lib_martigny_bourg.pid},
             "location": {"pid": loc_public_martigny_bourg.pid},
+            "item_type": {"pid": item_type_standard_martigny.pid},
             "document": {
                 "document_type": [
                     {
@@ -272,3 +277,18 @@ def test_stats_report_number_of_items(
         },
     }
     assert StatsReport(cfg).collect() == [["docsubtype_other_book", 3]]
+
+    # item types
+    cfg = {
+        "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
+        "is_active": True,
+        "category": {"indicator": {"type": "number_of_items", "distributions": ["item_type"]}},
+    }
+    label_itty_standard = f"{item_type_standard_martigny['name']} ({item_type_standard_martigny.pid})"
+    label_itty_on_site = f"{item_type_on_site_martigny['name']} ({item_type_on_site_martigny.pid})"
+    assert StatsReport(cfg).collect() == sorted(
+        [
+            [label_itty_standard, 2],
+            [label_itty_on_site, 1],
+        ]
+    )

--- a/tests/ui/stats/test_stats_report_n_patrons.py
+++ b/tests/ui/stats/test_stats_report_n_patrons.py
@@ -107,6 +107,13 @@ def test_stats_report_number_of_patrons(
         "category": {"indicator": {"type": "number_of_patrons", "distributions": ["postal_code"]}},
     }
     assert StatsReport(cfg).collect() == [["1920", 2]]
+    # local codes
+    cfg = {
+        "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
+        "is_active": True,
+        "category": {"indicator": {"type": "number_of_patrons", "distributions": ["local_codes"]}},
+    }
+    assert StatsReport(cfg).collect() == [["code1", 1]]
     # role
     cfg = {
         "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},

--- a/tests/ui/stats/test_stats_report_number_of_ciculation.py
+++ b/tests/ui/stats/test_stats_report_number_of_ciculation.py
@@ -128,6 +128,7 @@ def test_stats_report_number_of_checkins(
                     "age": 13,
                     "type": "Usager.ère moins de 14 ans",
                     "postal_code": "1920",
+                    "local_codes": ["codeA"],
                 },
             },
             "record": {
@@ -158,6 +159,7 @@ def test_stats_report_number_of_checkins(
                     "age": 30,
                     "type": "Usager.ère plus de 18 ans",
                     "postal_code": "1930",
+                    "local_codes": ["codeB"],
                 },
             },
             "record": {
@@ -362,6 +364,19 @@ def test_stats_report_number_of_checkins(
         },
     }
     assert StatsReport(cfg).collect() == [["1920", 1], ["1930", 1]]
+
+    # local codes
+    cfg = {
+        "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
+        "is_active": True,
+        "category": {
+            "indicator": {
+                "type": "number_of_checkins",
+                "distributions": ["patron_local_codes"],
+            }
+        },
+    }
+    assert StatsReport(cfg).collect() == [["codeA", 1], ["codeB", 1]]
 
     # patron type
     cfg = {

--- a/tests/unit/test_stats_cfg_jsonschema.py
+++ b/tests/unit/test_stats_cfg_jsonschema.py
@@ -85,6 +85,7 @@ def test_valid_circulation_n_items(stats_cfg_schema):
         "document_type",
         "document_subtype",
         "type",
+        "item_type",
     ]:
         data["category"]["indicator"]["distributions"] = [dist]
         validate(data, stats_cfg_schema)
@@ -113,6 +114,7 @@ def test_valid_circulation_n_patrons(stats_cfg_schema):
         "created_month",
         "created_year",
         "postal_code",
+        "local_codes",
         "type",
         "gender",
         "birth_year",
@@ -147,6 +149,7 @@ def test_valid_circulation_n_active_patrons(stats_cfg_schema):
             "created_month",
             "created_year",
             "postal_code",
+            "local_codes",
             "type",
             "gender",
             "birth_year",
@@ -242,6 +245,7 @@ def test_valid_circulation_n_circulations(stats_cfg_schema):
                 "patron_type",
                 "patron_age",
                 "patron_postal_code",
+                "patron_local_codes",
                 "document_type",
                 "transaction_channel",
                 "owning_library",
@@ -281,6 +285,7 @@ def test_valid_circulation_n_requests(stats_cfg_schema):
                 "patron_type",
                 "patron_age",
                 "patron_postal_code",
+                "patron_local_codes",
                 "document_type",
                 "transaction_channel",
                 "owning_library",


### PR DESCRIPTION
Also add the test coverage that was missing for the patron local_codes distribution feature, both at the report level (number of patrons and circulation) and in the configuration JSON schema validation.

Closes #4143.