### PR TITLE
fix(homepage): do not display "None" for orgs without a placeholder

### DIFF
--- a/rero_ils/modules/organisations/extensions.py
+++ b/rero_ils/modules/organisations/extensions.py
@@ -4,9 +4,13 @@
 """Organisation record extensions."""
 
 from invenio_records.extensions import RecordExtension
-from marshmallow_utils.html import sanitize_html
+from marshmallow_utils.html import ALLOWED_HTML_ATTRS, sanitize_html
 
 from .cache import delete_homepage_organisation_cache
+
+# Allow the ``class`` attribute on every tag so the Bootstrap utility classes
+# used in the homepage blocks (list-unstyled, text-center, ...) are preserved.
+HOMEPAGE_ALLOWED_ATTRS = {**ALLOWED_HTML_ATTRS, "*": ["class"]}
 
 
 class OrganisationHomepageSanitizerExtension(RecordExtension):
@@ -32,4 +36,4 @@ class OrganisationHomepageSanitizerExtension(RecordExtension):
         for position in ("left", "center", "right"):
             for entry in blocks.get(position, []):
                 if "value" in entry:
-                    entry["value"] = sanitize_html(entry["value"])
+                    entry["value"] = sanitize_html(entry["value"], attrs=HOMEPAGE_ALLOWED_ATTRS)

--- a/rero_ils/theme/templates/rero_ils/frontpage.html
+++ b/rero_ils/theme/templates/rero_ils/frontpage.html
@@ -33,7 +33,7 @@
     <div class="rero-search-bar">
       <div class="container">
         <main-search-bar
-          placeholder="{{ (_('What are you looking for?') if not view_organisation else placeholder) }}"
+          placeholder="{{ (_('What are you looking for?') if not view_organisation else placeholder if placeholder) }}"
           viewcode="{{ viewcode or config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE }}"
           inputstyleclass="ui:md:text-xl ui:w-full"
           styleclass="ui:w-full"


### PR DESCRIPTION
Second commit: fix(homepage): allow class attributes in the HTML blocks. Otherwise, the class used in the organisation data are sanitized and the render is not the same.