### PR TITLE
fix(files): read and write text as UTF-8 regardless of host locale

### DIFF
--- a/rero_ils/modules/documents/dumpers/indexer.py
+++ b/rero_ils/modules/documents/dumpers/indexer.py
@@ -225,7 +225,7 @@ class IndexerDumper(Dumper):
                     continue
                 if metadata.get("type") == "fulltext":
                     # get the fulltext
-                    full_text = file.get_stream("r").read()
+                    full_text = file.get_stream("rb").read().decode("utf-8")
                     full_text_size += len(full_text)
                     if full_text_size < full_text_size_max:
                         record_files_information.setdefault(metadata["fulltext_for"], {})["text"] = full_text


### PR DESCRIPTION
Reading the extracted fulltext with `get_stream("r")` used the host locale's default codec, raising UnicodeDecodeError on accented content (e.g. on a server with an ASCII locale) when indexing/displaying a document with files. Read it as bytes and decode UTF-8 explicitly.