### PR TITLE
fix(docker): raise Elasticsearch mem_limit to avoid OOM kills

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -77,7 +77,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 1g
+    mem_limit: 3g
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
Raise the Elasticsearch container `mem_limit` from 1g to 3g in `docker-services.yml`, used for both local dev and CI.

As modules and indices were added over releases, it seems ES's memory footprint outgrew the original 1g limit. It showed up as slow setups and a sluggish server; sometimes even ES crashes and restarts (`Connection refused` locally, random ES timeouts in CI).

3g gives ES enough headroom above its real footprint (~1.1g) while staying safe on the CI runner.