### PR TITLE
fix(documents): allow delete for rolled-over orders

### DIFF
--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -14,6 +14,7 @@ from invenio_circulation.search.api import search_by_pid
 from invenio_search import current_search_client
 from jsonschema.exceptions import ValidationError
 
+from rero_ils.modules.acquisition.acq_accounts.api import AcqAccountsSearch
 from rero_ils.modules.acquisition.acq_order_lines.api import AcqOrderLinesSearch
 from rero_ils.modules.acquisition.acq_order_lines.models import AcqOrderLineStatus
 from rero_ils.modules.api import IlsRecord, IlsRecordsIndexer, IlsRecordsSearch
@@ -303,6 +304,7 @@ class Document(IlsRecord):
         )
         file_query = self.get_records_files_query().source()
 
+        # Order lines block a document deletion only if their status is open AND the linked budget is active.
         acq_order_lines_query = (
             AcqOrderLinesSearch()
             .filter("term", document__pid=self.pid)
@@ -311,6 +313,21 @@ class Document(IlsRecord):
                 status=[AcqOrderLineStatus.APPROVED, AcqOrderLineStatus.ORDERED, AcqOrderLineStatus.PARTIALLY_RECEIVED],
             )
         )
+        # keep only order lines whose related budget is still active
+        account_pids = {hit.acq_account.pid for hit in acq_order_lines_query.source(["acq_account"]).scan()}
+        active_account_pids = (
+            [
+                hit.pid
+                for hit in AcqAccountsSearch()
+                .filter("terms", pid=list(account_pids))
+                .filter("term", is_active=True)
+                .source(["pid"])
+                .scan()
+            ]
+            if account_pids
+            else []
+        )
+        acq_order_lines_query = acq_order_lines_query.filter("terms", acq_account__pid=active_account_pids)
         local_fields_query = LocalFieldsSearch().get_local_fields(self.provider.pid_type, self.pid)
 
         relation_types = {

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -10,6 +10,8 @@ import pytest
 from invenio_db import db
 from jsonschema.exceptions import ValidationError
 
+from rero_ils.modules.acquisition.acq_accounts.api import AcqAccountsSearch
+from rero_ils.modules.acquisition.budgets.api import Budget
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.documents.api import (
     Document,
@@ -219,6 +221,40 @@ def test_document_can_delete_with_loans(client, item_lib_martigny, loan_pending_
     assert not can
     assert reasons["links"]["items"]
     assert reasons["links"]["loans"]
+
+
+def test_document_can_delete_with_rolled_over_order_line(
+    document,
+    acq_order_line_fiction_martigny,
+    acq_account_fiction_martigny,
+    budget_2020_martigny,
+):
+    """Test an inactive budget order line does not block document deletion."""
+    # while the budget is active, the open order line blocks the deletion
+    assert budget_2020_martigny.is_active
+    can, reasons = document.can_delete
+    assert not can
+    assert reasons["links"]["acq_order_lines"]
+
+    # simulate a rollover: deactivate the budget. The order line keeps its
+    # open status but must no longer be a reason to keep the document.
+    budget = Budget.get_record_by_pid(budget_2020_martigny.pid)
+    budget_data = deepcopy(budget)
+    try:
+        budget_data["is_active"] = False
+        budget.update(budget_data, dbcommit=True, reindex=True)
+        acq_account_fiction_martigny.reindex()
+        AcqAccountsSearch.flush_and_refresh()
+
+        assert "acq_order_lines" not in document.get_links_to_me()
+        assert "acq_order_lines" not in document.get_links_to_me(get_pids=True)
+    finally:
+        # restore the budget active state for the following tests
+        budget_data["is_active"] = True
+        budget.update(budget_data, dbcommit=True, reindex=True)
+        acq_account_fiction_martigny.reindex()
+        AcqAccountsSearch.flush_and_refresh()
+    assert document.get_links_to_me()["acq_order_lines"] == reasons["links"]["acq_order_lines"]
 
 
 def test_document_contribution_resolve_exception(search_clear, db, mef_agents_url, document_data_ref):


### PR DESCRIPTION
At rollover, orders of the deactivated budget keep their open status, so a document linked only to those lines could never be deleted. Ignore order lines whose account belongs to an inactive budget when computing the document deletion blockers.

* Filter open order lines on their account `is_active` flag, reusing the account index already kept in sync with the budget.