### PR TITLE
fix(acquisitions): fix order data inconsistencies

### DIFF
--- a/rero_ils/modules/acquisition/acq_order_lines/api.py
+++ b/rero_ils/modules/acquisition/acq_order_lines/api.py
@@ -66,10 +66,14 @@ class AcqOrderLine(AcquisitionIlsRecord):
     def extended_validation(self, **kwargs):
         """Add additional record validation.
 
-        :return: False if
-            - notes array has multiple notes with same type
-            - an update would leave the line non-cancelled while its document
-              has been deleted
+        :return: ``True`` if valid, otherwise an error message string when:
+            - the notes array has several notes of the same type;
+            - an update leaves the line active (not cancelled) while its
+              document has been deleted;
+            - the related order status forbids the operation: a line may be
+              created only on a PENDING or CANCELLED order, and updated also on
+              an ORDERED or PARTIALLY_RECEIVED one (plus RECEIVED when the
+              update cancels the line).
         """
         # NOTES fields testing
         note_types = [note.get("type") for note in self.get("notes", [])]
@@ -94,8 +98,17 @@ class AcqOrderLine(AcquisitionIlsRecord):
                 AcqOrderStatus.ORDERED,
                 AcqOrderStatus.PARTIALLY_RECEIVED,
             ]
+            # Cancelling a line is always valid, even when it makes the order
+            # fully received (e.g. cancelling its last non-received line). The
+            # REST layer commits and reindexes the record, then re-validates it,
+            # so the order may already report RECEIVED by the time we get here.
+            # The permission (checked once, on the prior status) is the real
+            # gate; a direct cancel on an already-received order is blocked there.
+            # This overlap between validators/permissions will be addressed in a future refactor.
+            if self.get("is_cancelled"):
+                valid_statuses.append(AcqOrderStatus.RECEIVED)
         if order_status not in valid_statuses:
-            return _("Cannot create an order line with an order with a wrong status.")
+            return _("Cannot save an order line for an order with a wrong status.")
         return True
 
     @classmethod

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -278,6 +278,26 @@ class REROILSAPP:
                 ), 409
             return e.get_response()
 
+        # Acquisition item responses can't be safely browser-cached: their ETag/Last-Modified track only the record's
+        # own `revision_id`/`updated`, but the response also depends on *related* records. Serialized fields computed
+        # at dump time (an order's `account_statement`/`status`, a receipt's totals, an account's balances) go stale
+        # without the ETag changing, so a conditional GET returns 304 with an outdated body (e.g. a provisional total
+        # stuck at 0, greying out the "Place order" button). The stale ETag also breaks editing: the editor reuses it
+        # as the `If-Match` precondition on save, so a line loaded from cache fails to save once its revision moved.
+        # Send `Cache-Control: no-store` so the browser always refetches a fresh body and ETag.
+        @app.after_request
+        def prevent_stale_computed_record_cache(response):
+            """Disable browser caching for acquisition records with related data."""
+            if request.endpoint in {
+                "invenio_records_rest.acor_item",  # acquisition orders
+                "invenio_records_rest.acol_item",  # acquisition order lines
+                "invenio_records_rest.acre_item",  # acquisition receipts
+                "invenio_records_rest.acrl_item",  # acquisition receipt lines
+                "invenio_records_rest.acac_item",  # acquisition accounts
+            }:
+                response.headers["Cache-Control"] = "no-store"
+            return response
+
     @staticmethod
     def register_import_api_blueprint(app):
         """Imports blueprints initialization."""

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2025-03-31 15:43+0000\n"
 "Last-Translator: Maher Asaad Baker <maher.asaad.baker@gmail.com>\n"
 "Language: ar\n"
@@ -31,35 +31,35 @@ msgstr "كلمتي المرور ليستا متطابقتين."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "INVALID_USER_OR_PASSWORD"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "الفرنسية"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "الألمانية"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "الايطالية"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "أهلًا وسهلًا"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "إعادة تعيين الكلمة السرية لمعرّف RERO ID"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "تم إعادة تعيين كلمة مرور معرف RERO الخاص بك"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -69,283 +69,284 @@ msgstr ""
 "اسم المستخدم يجب أن يبدأ بحرف أو رقم، ويجب أن يتكون من ثلاثة أحرف على "
 "الأقل، ويجب أن يحتوي فقط على أحرف أبجدية رقمية وشرطات وعلامات سفلية."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "الكتالوج العالمي"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "متصل"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "غير_متصل"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "الموضوع"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "استحواذ"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "معرف"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "تصنبف المستند"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "\""
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "اللغة"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "الشبكة"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "المكتبة"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "الموقع"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "الحالة"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "النوع"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr ""
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr ""
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr ""
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr ""
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr ""
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr ""
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr ""
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr ""
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr ""
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr ""
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr ""
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr ""
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr ""
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr ""
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr ""
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr ""
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr ""
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr ""
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr ""
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr ""
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr ""
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "مهام"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "المدينة"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr ""
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr ""
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "الميزانية"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr ""
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr ""
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr ""
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr ""
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr ""
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr ""
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "المصادر"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "الرؤية"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "معلّم"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr ""
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "حالة الإعارة"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "الطالب"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr ""
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr ""
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr ""
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr ""
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr ""
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr ""
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr ""
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr ""
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -365,36 +366,36 @@ msgstr ""
 msgid "Title"
 msgstr "العنوان"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr ""
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 #, fuzzy
 msgid "Contribution"
 msgstr "توزيع"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "البلد"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr ""
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr ""
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -403,15 +404,15 @@ msgstr ""
 msgid "Identifier"
 msgstr "معرف"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr ""
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr ""
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -419,14 +420,14 @@ msgstr ""
 msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "الموضوع"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -435,32 +436,32 @@ msgstr "الموضوع"
 msgid "Call number"
 msgstr "رقم استدعاء"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr ""
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr ""
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr ""
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr ""
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr ""
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr ""
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr ""
 
@@ -2456,17 +2457,17 @@ msgstr "العملة"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "تصنيف"
@@ -4576,7 +4577,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4618,7 +4619,7 @@ msgstr "رقم الحساب"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4776,19 +4777,19 @@ msgstr "URI للشبكة"
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7869,8 +7870,8 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr ""
 
@@ -10388,7 +10389,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "يوجد تصنيف نسخة آخر في هذه الشبكة"
 
@@ -10836,7 +10837,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "رمز"
@@ -10850,7 +10851,7 @@ msgid "Name of the library."
 msgstr "إسم المكتبة"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "عنوان"
 
@@ -10908,13 +10909,13 @@ msgid "Communication language"
 msgstr "لغة التواصل"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 #, fuzzy
 msgid "Online harvested sources"
 msgstr "مصدر مباشر محصود"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 #, fuzzy
 msgid "Online harvested sources as configured in ebooks server."
 msgstr "مصدر مباشر محصود كما تم اعداده للكتاب الالكتروني"
@@ -11627,157 +11628,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "ID للشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "عنوان الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "كود الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "ال ID الحالي للميزانية"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "ال ID الحالي لميزانية الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "العملة الافتراضية"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "عملة الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12502,8 +12503,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12514,36 +12515,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12559,144 +12560,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -12982,7 +12983,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -12992,7 +12993,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -13112,7 +13113,7 @@ msgstr "تسجيل الدخول"
 msgid "or"
 msgstr "أو"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr ""
 
@@ -13223,4 +13224,7 @@ msgstr ""
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr "تمت إعادة تعيين كلمتك السرية بنجاح."
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2026-06-23 11:31+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
 "Language: de\n"
@@ -37,35 +37,35 @@ msgstr "Die 2 Passwörter sind nicht identisch."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "Ungültiger Benutzer oder Passwort"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Französisch"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Deutsch"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Italienisch"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "Zurücksetzung des RERO ID Passworts"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "Ihr RERO ID-Passwort wurde zurückgesetzt"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -76,283 +76,284 @@ msgstr ""
 "mindestens drei Zeichen lang sein und darf nur alphanumerische Zeichen, "
 "Bindestriche und Unterstriche enthalten."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Globaler Katalog"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "Online"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "nicht online"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "Autor"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "Thema"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "Erwerbung"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr "new_acquisition"
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "Identifikatoren"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "Dokumenttyp"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "Dokument-Untertyp"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "Sprache"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "Bibliothek"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "Standort"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "Status"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "Genre, Form"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "Zielgruppe"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "Jahr"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr "Fiktionangabe"
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "Exemplartyp"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "Temporäre Exemplartyp"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "Temporärer Standort"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "Lieferant"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr "Status der Lieferung (ODER)"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "Anzahl der Ansprüche"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr "Datum der Anspruch"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "Aktuelle Anfragen"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "Besitzende Bibliothek"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "Standort"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "Abholbibliothek"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "Abholort"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "Bibliothek der Transaktion"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "Standort der Transaktion"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "Verspätungsstatus"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "Kundentyp"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "Ablaufdatum der Bestellung"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "Enddatum"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "Status ausschließen"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "Rollen"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "Stadt"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "gesperrt"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "abgelaufen"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr "nicht abgelaufen"
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "Budget"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "Konto"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "Bestellungsdatum"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "Empfangsdatum"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "Ressource Typ"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "Typ"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "Quellekatalog"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "Quellen"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "Sichtbarkeit"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "Dozent"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr "Status der Bestellung"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "Ausleihstatus"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "Besteller"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "Kategorie"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "Indikator"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "Frequenz"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "Aktiv"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "Dies ist eine TEST-VERSION."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "Produktion-Website öffnen."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "enthält"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "Phrase"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -372,35 +373,35 @@ msgstr "Phrase"
 msgid "Title"
 msgstr "Titel"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Verantwortlichkeitsangabe"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Beitrag"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Land"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "Kanton"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "Veröffentlichungsangabe"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "Gesamttitelangabe"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -409,15 +410,15 @@ msgstr "Gesamttitelangabe"
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -425,14 +426,14 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Genre, Form"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Thema"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -441,32 +442,32 @@ msgstr "Thema"
 msgid "Call number"
 msgstr "Signatur"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Lokale felder (Dockument)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Lokale Felder (Bestände)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Lokale Felder (Exemplare)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Klassifikation"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "RDA Inhaltstyp"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "RDA Medientyp"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "RDA Datenträgertyp"
 
@@ -2461,17 +2462,17 @@ msgstr "Währung"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Typ"
@@ -4576,7 +4577,7 @@ msgstr "Ein Posten im Budget, dem ein Betrag zugewiesen werden kann."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4618,7 +4619,7 @@ msgstr "ID des Kontos"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4780,24 +4781,24 @@ msgstr "URI der Organisation"
 msgid "%"
 msgstr "%"
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr "Muss nicht mehrere Noten des gleichen Typen enthalten."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 "Eine aktive Bestellzeile für eine gelöschte Bestellung kann nicht "
 "gespeichert werden."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
-"Es ist nicht möglich, eine Zeile zu einer Bestellung mit falschem Status "
-"hinzuzufügen."
+"Es ist nicht möglich, eine Bestellzeile für eine Bestellung mit falschem "
+"Status zu speichern."
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
 msgid "Cannot link to an harvested document"
@@ -7890,8 +7891,8 @@ msgstr "Lese-/Verständnisniveau"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "Wert"
 
@@ -10399,7 +10400,7 @@ msgstr "Nein"
 msgid "Yes"
 msgstr "Ja"
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "Ein anderer Online-Exemplartyp existiert bereits in dieser Organisation"
 
@@ -10853,7 +10854,7 @@ msgstr "Informationen zur Rechnungsstellung"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Code"
@@ -10867,7 +10868,7 @@ msgid "Name of the library."
 msgstr "Name der Bibliothek."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Adresse"
 
@@ -10924,12 +10925,12 @@ msgid "Communication language"
 msgstr "Kommunikationssprache"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr "Online gesammelte Quellen"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr "Online gesammelte Quellen, wie im Ebook-Server eingestellt."
 
@@ -11641,47 +11642,47 @@ msgstr ""
 "Ein Netzwerk, in dem mehrere Bibliotheken zusammenarbeiten und Daten über"
 " Kunden, Exemplare usw. teilen."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "ID der Organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr "Name der Organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "Einrichtungsadresse."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "Organisationscode."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "Aktuelle ID des Budgets"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "Die ID des aktuellen Budgets der Organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "Standardwährung"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "Die Standardwährung der Organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr "Sammlung in der öffentlichen Oberfläche aktiviert"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr "Konfiguration der Löschung inaktiver Kunden"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
@@ -11691,11 +11692,11 @@ msgstr ""
 "Sie dieses Feld, wenn Sie keine automatische Löschung von Kundenkonten "
 "wünschen."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr "Ungültigkeitsbegrenzung (Jahre)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
@@ -11703,11 +11704,11 @@ msgstr ""
 "Nur Kunden, deren Ablaufdatum älter als die angegebene Jahresanzahl ist, "
 "werden gelöscht."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr "Inaktivitätsbegrenzung (Jahre)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
@@ -11715,64 +11716,64 @@ msgstr ""
 "Nur Kunden löschen, deren letzter Login länger als die angegebene Anzahl "
 "Jahre zurückliegt."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr "Ausgeschlossene Kundentypen"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 "Liste der Kundentyp-PIDs, die von der automatischen Löschung "
 "ausgeschlossen werden."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr "Startseite"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr "Konfiguration der öffentlichen Startseite."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr "Slogan"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr "Text des Banners der öffentlichen Startseite."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr "Pro Sprache ist nur ein Wert erlaubt."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr "Placeholder"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr "Platzhaltertext im Suchfeld der öffentlichen Startseite."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr "Blöcke"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr "HTML-Inhalt der Homepage-Blöcke."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr "Links Block"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
@@ -11780,18 +11781,18 @@ msgstr ""
 "HTML-Inhalt des linken Homepage-Blocks. Auf Mobilgeräten wird dieser "
 "Block zuerst angezeigt."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr "HTML"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr "Mittelblock"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
@@ -11799,12 +11800,12 @@ msgstr ""
 "HTML-Inhalt des mittleren Homepage-Blocks. Auf Mobilgeräten wird dieser "
 "Block als zweiter angezeigt."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr "Rechts Block"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12550,8 +12551,8 @@ msgid "Catalog"
 msgstr "Katalog"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr "Indikator"
 
@@ -12562,36 +12563,36 @@ msgstr "Anzahl der Dokumente"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr "Verteilungen"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr "Erstellungsmonat"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr "Erstellungsjahr"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr "Besitzende Bibliothek"
 
@@ -12607,77 +12608,77 @@ msgstr "Anzahl der Bestände (Serien)"
 msgid "Number of items"
 msgstr "Anzahl der Exemplare"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr "Besitzende Standort"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr "Typ (Standard/Lieferung)"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr "Anzahl der gelöschten Exemplare"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr "Monat der Aktion"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr "Jahr der Aktion"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr "Bibliothek des Operators"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr "Ausleihe"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr "Anzahl der Fernleihbestellungen"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr "Anzahl der Rückgaben"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr "Anzahl der Ausleihen"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr "Anzahl der Verlängerungen"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr "Anzahl der Bestellungen"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr "Anzahl der validierten Bestellungen"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr "Benutzerverwaltung"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr "Anzahl der Kunden"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr "Anzahl der aktiven Kunden"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr "Verteilungen"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
@@ -12685,11 +12686,11 @@ msgstr ""
 "Bis zu zwei Filter, um die Daten in der erzeugten Tabelle zu verteilen. "
 "Der erste Wert verteilt nach Zeilen, der zweite nach Spalten."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr "Zeitraum"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
@@ -12700,57 +12701,57 @@ msgstr ""
 "leer, um die Daten nicht zu filtern. Beispiel: Bearbeiten Sie die Anzahl "
 "der Ausleihen, die im letzten Monat vergeben wurden."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr "Monat"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr "Monat der Transaktion"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr "Jahr der Transaktion"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr "Alter des Kunden"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr "Postleitzahl des Kunden"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr "lokale Codes des Kunden"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr "Transaktionskanal"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr "Geschlecht"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr "Postleitzahl"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr "lokale Codes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr "Geburtsjahr"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr "Rolle"
 
@@ -13032,8 +13033,8 @@ msgstr "Nur ein Kontakt pro Typ ist erlaubt."
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
-msgstr "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
+msgstr "<i class=\"fa fa-phone\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
@@ -13042,8 +13043,8 @@ msgstr "<i class=\"fa fa-user\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
-msgstr "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
+msgstr "<i class=\"fa fa-globe\"></i>"
 
 #: rero_ils/theme/menus.py:38
 msgid "My Account"
@@ -13166,7 +13167,7 @@ msgstr "Anmelden"
 msgid "or"
 msgstr "oder"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "Was suchen Sie?"
 

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2026-06-23 11:31+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
 "Language: en\n"
@@ -37,35 +37,35 @@ msgstr "The two passwords are not identical."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "Invalid user or password"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "French"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "German"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Italian"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Welcome"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "RERO ID password reset"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "Your RERO ID password has been reset"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -76,283 +76,284 @@ msgstr ""
 "characters long and only contain alphanumeric characters, dashes and "
 "underscores."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Global catalog"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "online"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "not online"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "author"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "subject"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "acquisition"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr "new_acquisition"
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "identifiers"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "document type"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "document subtype"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "language"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "organisation"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "library"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "location"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "genre, form"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "intended audience"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "year"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr "fiction statement"
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "Item type"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "Temporary item type"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "Temporary location"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "Vendor"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr "Issue status (OR)"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "Number of claims"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr "Claim date"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "Current requests"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "owning library"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "location"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "pickup location"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "pickup location"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "transaction library"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "transaction location"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "late status"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "patron type"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "request expiry date"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "end date"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "exclude status"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "roles"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "city"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "blocked"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "expired"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr "not expired"
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "account"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "order date"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "receipt date"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "resource type"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "type"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "source catalog"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "sources"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "visibility"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "teacher"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr "Request status"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "loan status"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "requester"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "category"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "indicator"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "frequency"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "active"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "This is a TEST VERSION."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "Go to the production site."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "contains"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "phrase"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -372,35 +373,35 @@ msgstr "phrase"
 msgid "Title"
 msgstr "Title"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Responsibility statement"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contribution"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Country"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "Canton"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "Provision activity statement"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "Series statement"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -409,15 +410,15 @@ msgstr "Series statement"
 msgid "Identifier"
 msgstr "Identifier"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -425,14 +426,14 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Genre, form"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Subject"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -441,32 +442,32 @@ msgstr "Subject"
 msgid "Call number"
 msgstr "Call number"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Local fields (document)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Local fields (holdings)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Local fields (items)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Classification"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "RDA content type"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "RDA media type"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "RDA carrier type"
 
@@ -2461,17 +2462,17 @@ msgstr "Currency"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Type"
@@ -4576,7 +4577,7 @@ msgstr "Budget category to which an amount can be allocated."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4618,7 +4619,7 @@ msgstr "Account ID"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4780,20 +4781,20 @@ msgstr "Organisation URI"
 msgid "%"
 msgstr "%"
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr "Cannot have multiple notes of the same type."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr "Cannot save an active order line for a deleted document."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
-msgstr "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
+msgstr "Cannot save an order line for an order with a wrong status."
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
 msgid "Cannot link to an harvested document"
@@ -7855,8 +7856,8 @@ msgstr "Understanding level"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "value"
 
@@ -10341,7 +10342,7 @@ msgstr "No"
 msgid "Yes"
 msgstr "Yes"
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "Another online item type exists in this organisation"
 
@@ -10788,7 +10789,7 @@ msgstr "Billing information"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Code"
@@ -10802,7 +10803,7 @@ msgid "Name of the library."
 msgstr "Name of the library."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Address"
 
@@ -10859,12 +10860,12 @@ msgid "Communication language"
 msgstr "Communication language"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr "Online harvested sources"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr "Online harvested sources as configured in ebook server."
 
@@ -11566,47 +11567,47 @@ msgstr ""
 "Usually a network of several libraries sharing data for patrons, items, "
 "etc."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "Organisation ID"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr "Name of the organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "Address of the organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "Code of the organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "Current ID of the budget"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "The ID of the current budget of the organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "Default currency"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "The default currency of the organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr "Collection enabled on public view"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr "Patron cleanup configuration"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
@@ -11616,11 +11617,11 @@ msgstr ""
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr "Expiration threshold (years)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
@@ -11628,11 +11629,11 @@ msgstr ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr "Inactivity threshold (years)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
@@ -11640,62 +11641,62 @@ msgstr ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr "Excluded patron types"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr "List of patron type PIDs to exclude from automatic deletion."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr "Homepage"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr "Configuration for the public homepage."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr "Slogan"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr "Text displayed on the public homepage banner."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr "Only one value per language is allowed."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr "Placeholder"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr "Placeholder text displayed in the public homepage search box."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr "Blocks"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr "HTML content displayed in the homepage blocks."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr "Left block"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
@@ -11703,18 +11704,18 @@ msgstr ""
 "HTML content displayed in the left homepage block. Will also be the "
 "second block displayed on mobile."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr "HTML"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr "Center block"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
@@ -11722,12 +11723,12 @@ msgstr ""
 "HTML content displayed in the center homepage block. Will also be the "
 "first block displayed on mobile."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr "Right block"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12458,8 +12459,8 @@ msgid "Catalog"
 msgstr "Catalog"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr "Indicator"
 
@@ -12470,36 +12471,36 @@ msgstr "Number of documents"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr "distributions"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr "creation month"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr "creation year"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr "owning library"
 
@@ -12515,77 +12516,77 @@ msgstr "Number of serial holdings"
 msgid "Number of items"
 msgstr "Number of items"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr "owning location"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr "type (standard/issue)"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr "Number of deleted items"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr "action month"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr "action year"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr "operator library"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr "Circulation"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr "Number of ILL requests"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr "Number of checkins"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr "Number of checkouts"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr "Number of renewals"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr "Number of requests"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr "Number of validated requests"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr "User management"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr "Number of patrons"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr "Number of active patrons"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr "Distributions"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
@@ -12593,11 +12594,11 @@ msgstr ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr "Period"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
@@ -12607,57 +12608,57 @@ msgstr ""
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr "month"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr "transaction month"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr "transaction year"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr "patron age"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr "patron postal code"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr "patron local codes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr "transaction channel"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr "gender"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr "postal code"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr "local codes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr "birth year"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr "role"
 
@@ -12935,8 +12936,8 @@ msgstr "Only one contact per type is allowed."
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
-msgstr "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
+msgstr "<i class=\"fa fa-phone\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
@@ -12945,8 +12946,8 @@ msgstr "<i class=\"fa fa-user\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
-msgstr "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
+msgstr "<i class=\"fa fa-globe\"></i>"
 
 #: rero_ils/theme/menus.py:38
 msgid "My Account"
@@ -13065,7 +13066,7 @@ msgstr "Log in"
 msgid "or"
 msgstr "or"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "What are you looking for?"
 

--- a/rero_ils/translations/eo/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/eo/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.0.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2021-06-09 13:00+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: eo\n"
@@ -27,35 +27,35 @@ msgstr ""
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr ""
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Franca"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Germana"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Itala"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr ""
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr ""
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr ""
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -63,296 +63,297 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr ""
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr ""
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr ""
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "aŭtoro"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "temo"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 #, fuzzy
 msgid "identifiers"
 msgstr "Identigiloj"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "tipo de dokumento"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "subtipo de dokumento"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "lingvo"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "organizaĵo"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "biblioteko"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "loko"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "stato"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr ""
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr ""
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 #, fuzzy
 msgid "year"
 msgstr "Jaro"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "tipo de ero"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 #, fuzzy
 msgid "temporary_item_type"
 msgstr "tipo de ero"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 #, fuzzy
 msgid "temporary_location"
 msgstr "interbiblioteka prunto"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr ""
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr ""
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr ""
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr ""
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr ""
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 #, fuzzy
 msgid "owner_library"
 msgstr "biblioteko"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 #, fuzzy
 msgid "owner_location"
 msgstr "loko"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 #, fuzzy
 msgid "pickup_library"
 msgstr "biblioteko"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 #, fuzzy
 msgid "pickup_location"
 msgstr "Loko de ricevo"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr ""
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 #, fuzzy
 msgid "transaction_location"
 msgstr "Komunika kanalo"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 #, fuzzy
 msgid "misc_status"
 msgstr "stato de problemo"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "tipo de bibliotekano"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 #, fuzzy
 msgid "request_expire_date"
 msgstr "Petinto"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 #, fuzzy
 msgid "end_date"
 msgstr "Fina dato"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 #, fuzzy
 msgid "exclude_status"
 msgstr "stato de problemo"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "roloj"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "urbo"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr ""
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr ""
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "buĝeto"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr ""
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr ""
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr ""
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr ""
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "tipo"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr ""
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "fontoj"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "videbleco"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "instruisto"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr ""
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "Stato de prunto"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "Petinto"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr ""
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr ""
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr ""
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr ""
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr ""
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr ""
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr ""
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr ""
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -372,35 +373,35 @@ msgstr ""
 msgid "Title"
 msgstr "Titolo"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr ""
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Kontribuo"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Lando"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr ""
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr ""
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -409,15 +410,15 @@ msgstr ""
 msgid "Identifier"
 msgstr "Identigilo"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr ""
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr ""
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -425,14 +426,14 @@ msgstr ""
 msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Temo"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -441,32 +442,32 @@ msgstr "Temo"
 msgid "Call number"
 msgstr "Klasifika numero"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr ""
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr ""
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr ""
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr ""
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr ""
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr ""
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr ""
 
@@ -2463,17 +2464,17 @@ msgstr "Valuto"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Tipo"
@@ -4578,7 +4579,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4620,7 +4621,7 @@ msgstr "Identigilo de konto"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4778,19 +4779,19 @@ msgstr "URI de organizaĵo"
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7752,8 +7753,8 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr ""
 
@@ -10182,7 +10183,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr ""
 
@@ -10614,7 +10615,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Kodo"
@@ -10628,7 +10629,7 @@ msgid "Name of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Adreso"
 
@@ -10685,12 +10686,12 @@ msgid "Communication language"
 msgstr "Komunika lingvo"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 
@@ -11384,157 +11385,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12229,8 +12230,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12241,36 +12242,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12286,144 +12287,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -12693,7 +12694,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -12703,7 +12704,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -12821,7 +12822,7 @@ msgstr "Saluti"
 msgid "or"
 msgstr "aŭ"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr ""
 
@@ -12929,4 +12930,7 @@ msgstr ""
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr ""
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2024-03-26 11:02+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
 "Language: es\n"
@@ -32,35 +32,35 @@ msgstr "Las 2 contraseñas no son idénticas."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "Usuario o contraseña no válido"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Francés"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Alemán"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Italiano"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO-ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Bienvenido"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "Restablecimiento de la contraseña del RERO ID"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "Se ha restablecido la contraseña de su identificador de RERO"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -68,283 +68,284 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Catálogo colectivo"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "en línea"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "no en línea"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "autor"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "sujeto"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "adquisición"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr "Novedades"
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "identificadores"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "tipo de documento"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "Subtipo de documento"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "idioma"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "organización"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "ubicación"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "estado"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "género, forma"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "público destinatario"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "año"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "Tipo de ejemplar"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "Tipo de ejemplar temporal"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "Ubicación temporal"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "proveedor"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr "Estado de fascículo (O)"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "Número de reclamaciones"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr "Fecha de reclamación"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "Nbre reservación"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "biblioteca titular"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "ubicación"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "lugar de recogida"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "lugar de recogida"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "biblioteca de transacción"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "ubicación de la transacción"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "estado de retraso"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "Tipo de usuario"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "expiración de la reservación"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "fecha de fin"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "excluir estado"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "funcciones"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "ciudad"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "bloqueado"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "caducado"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "presupuesto"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "cuenta"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "fecha del pedido"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "fecha de recepción"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "tipo de recurso"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "tipo"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "fuente de catálogo"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "fuentes"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "visibilidad"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "profesor"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr "estado de la solicitud"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "Estado_de préstamo"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "solicitante"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "categoría"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "indicador"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "frecuencia"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "activo"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "Esta es una VERSIÓN DE TEST."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "Ir al sitio de producción."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "contiene"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "frase"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -364,35 +365,35 @@ msgstr "frase"
 msgid "Title"
 msgstr "Título"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Declaración de responsabilidad"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contribución"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "País"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "Cantón"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "Información de la publicación"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "Mención de la serie"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -401,15 +402,15 @@ msgstr "Mención de la serie"
 msgid "Identifier"
 msgstr "Identificador"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -417,14 +418,14 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Género, forma"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Sujeto"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -433,32 +434,32 @@ msgstr "Sujeto"
 msgid "Call number"
 msgstr "Número de clasificación"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Campos locales (documento)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Campos locales (acciones)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Campos locales (ejemplos)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Clasificación"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "Tipo de contenido RDA"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "Tipo de medio RDA"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "Tipo de soporte RDA"
 
@@ -2453,17 +2454,17 @@ msgstr "Moneda"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Tipo"
@@ -4568,7 +4569,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4610,7 +4611,7 @@ msgstr "Mi cuenta"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4772,19 +4773,19 @@ msgstr "URI de la organización"
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7851,8 +7852,8 @@ msgstr "Nivel de lectura/comprensión"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "valor"
 
@@ -10352,7 +10353,7 @@ msgstr "No"
 msgid "Yes"
 msgstr "Sí"
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "Existe otro tipo de ejemplar en línea en esta organización"
 
@@ -10800,7 +10801,7 @@ msgstr "Información sobre facturación"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Código"
@@ -10814,7 +10815,7 @@ msgid "Name of the library."
 msgstr "Nombre de la biblioteca."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Dirección"
 
@@ -10871,12 +10872,12 @@ msgid "Communication language"
 msgstr "Lenguaje de comunicación"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr "Fuentes recolectadas en línea"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 "Fuentes recolectadas en línea según lo configurado en el servidor de "
@@ -11579,157 +11580,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "ID de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "Dirección de la organización."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "Código de la organización."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "ID actual del presupuesto"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "El ID del presupuesto actual de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "La moneda por defecto"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "La moneda por defecto de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr "Colección habilitada en la vista pública"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12448,8 +12449,8 @@ msgid "Catalog"
 msgstr "Catálogo"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr "Indicador"
 
@@ -12460,36 +12461,36 @@ msgstr "Número de documentos"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr "distribuciones"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr "Mes de creación"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr "Año de creación"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr "Biblioteca titular"
 
@@ -12505,77 +12506,77 @@ msgstr "Número de explotaciones en serie"
 msgid "Number of items"
 msgstr "Número de elementos"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr "localización titular"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr "Tipo (estándar/edición)"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr "Número de elementos borrados"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr "mes de la operación"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr "año de la operación"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr "biblioteca del operador"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr "Circulación"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr "Número de solicitudes por enfermedad"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr "Número de devoluciones"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr "Número de préstamos"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr "Número de extensiones"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr "Número de ordenes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr "Número de solicitudes validadas"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr "Gestión de usuarios"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr "Número de clientes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr "Número de clientes activos"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr "Distribuciones"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
@@ -12583,11 +12584,11 @@ msgstr ""
 "Hasta 2 filtros para distribuir datos en la tabla generada. El primer "
 "valor se divide por fila, el segundo por columna."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr "Período"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
@@ -12598,57 +12599,57 @@ msgstr ""
 "filtrar los datos. Ejemplo: procesa el número de préstamos realizados "
 "durante el último mes."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr "mes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr "Mes de transacción"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr "Año de transacción"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr "Edad del cliente"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr "código postal del lector"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr "Canal de la transacción"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr "género"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr "Código Postal"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr "Año de nacimiento"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr "rol"
 
@@ -12922,7 +12923,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -12932,7 +12933,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -13054,7 +13055,7 @@ msgstr "Conectarse"
 msgid "or"
 msgstr "o"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "¿Qué busca?"
 
@@ -13166,4 +13167,7 @@ msgstr "Su biblioteca"
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr "Se ha restablecido su contraseña correctamente."
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2026-06-23 11:31+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
 "Language: fr\n"
@@ -40,35 +40,35 @@ msgstr "Les deux mots de passe ne sont pas identiques."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "Utilisateur ou mot de passe invalide"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Français"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Allemand"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Italien"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "Réinitialiser le mot de passe du RERO ID"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "Le mot de passe de votre compte RERO ID a été réinitialisé"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -79,283 +79,284 @@ msgstr ""
 "comporter au moins trois caractères et ne contenir que des caractères "
 "alphanumériques, des tirets et des traits de soulignement."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Catalogue collectif"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "en ligne"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "pas en ligne"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "auteur"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "sujet"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "acquisition"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr "Nouvelle acquisition"
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "Identifiants"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "type de document"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "sous-type de document"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "langue"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "organisation"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "bibliothèque"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "localisation"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "statut"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "genre, forme"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "public cible"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "année"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr "mention de fiction"
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "type d'exemplaire"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "Type d'exemplaire temporaire"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "localisation temporaire"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "fournisseur"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr "statut du fascicule (OU)"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "nombre de réclamations"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr "date de réclamation"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "nbre demandes"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "bibliothèque propriétaire"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "localisation"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "lieu de retrait"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "lieu de retrait"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "bibliothèque de transaction"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "localisation de transaction"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "statut de retard"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "type de lecteur"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "expiration de la demande"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "date d'échéance"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "exclure statut"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "rôles"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "ville"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "bloqué"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "expiré"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr "non expiré"
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "compte"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "date de commande"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "date de réception"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "type de ressource"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "type"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "catalogue source"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "sources"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "visibilité"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "professeur"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr "statut de la demande"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "statut de prêt"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "demandeur"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "catégorie"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "indicateur"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "périodicité"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "active"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "Ceci est une VERSION DE TEST."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "Aller au site de production."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "contient"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "phrase"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -375,35 +376,35 @@ msgstr "phrase"
 msgid "Title"
 msgstr "Titre"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Mention de responsabilité"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contribution"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Pays"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "Canton"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "Mention de publication"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "Mention de collection"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -412,15 +413,15 @@ msgstr "Mention de collection"
 msgid "Identifier"
 msgstr "Identifiant"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -428,14 +429,14 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Genre, forme"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Sujet"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -444,32 +445,32 @@ msgstr "Sujet"
 msgid "Call number"
 msgstr "Cote"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Champs locaux (document)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Champs locaux (états de collection)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Champs locaux (exemplaires)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Classification"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "Type de contenu RDA"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "Type de média RDA"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "Type de support RDA"
 
@@ -2464,17 +2465,17 @@ msgstr "Devise"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Type"
@@ -4579,7 +4580,7 @@ msgstr "Poste au budget auquel on peut allouer un montant."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4621,7 +4622,7 @@ msgstr "PID du compte"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4783,22 +4784,22 @@ msgstr "URI de l'organisation"
 msgid "%"
 msgstr "%"
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr "Impossible d'avoir plusieurs notes du même type."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 "Impossible d'enregistrer une ligne de commande active pour un document "
 "supprimé."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
-msgstr "Impossible d'ajouter une ligne sur une commande ayant le mauvais statut."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
+msgstr "Impossible d'enregistrer une ligne de commande pour une commande ayant le mauvais statut."
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
 msgid "Cannot link to an harvested document"
@@ -7887,8 +7888,8 @@ msgstr "Niveau de lecture/compréhension"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "valeur"
 
@@ -10403,7 +10404,7 @@ msgstr "Non"
 msgid "Yes"
 msgstr "Oui"
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "Un autre type d'exemplaire \"en ligne\" existe dans cette organisation"
 
@@ -10862,7 +10863,7 @@ msgstr "Informations sur la facturation"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Code"
@@ -10876,7 +10877,7 @@ msgid "Name of the library."
 msgstr "Nom de la bibliothèque."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Adresse"
 
@@ -10933,12 +10934,12 @@ msgid "Communication language"
 msgstr "Langue de communication"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr "Sources pour moissonnage en ligne"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 "Sources pour le moissonnage en ligne, tel que configuré dans le serveur "
@@ -11648,47 +11649,47 @@ msgstr ""
 "Habituellement un réseau regroupant plusieurs bibliothèques et partageant"
 " des données de lecteurs, d'exemplaires, etc."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "ID de l'organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr "Nom de l'organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "Adresse de l'organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "Code de l'organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "ID actuel du budget"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "L'ID du budget actuel de l'organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "Devise par défaut"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "La devise par défaut de l'organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr "Collection activée en vue publique"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr "Configuration du nettoyage des lecteurs inactifs"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
@@ -11698,11 +11699,11 @@ msgstr ""
 "inactifs. Supprimez ce champ si vous ne voulez aucune suppression "
 "automatique des lecteurs."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr "Limite d'expiration (années)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
@@ -11710,12 +11711,11 @@ msgstr ""
 "Ne supprimer que les lecteurs dont la date d'expiration est plus ancienne"
 " que le nombre d'années indiqué."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
-msgstr ""
-"Limite d'inactivité (années)"
+msgstr "Limite d'inactivité (années)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
@@ -11723,66 +11723,66 @@ msgstr ""
 "Supprimer uniquement les lecteurs dont la dernière connexion remonte à "
 "plus du nombre d'années indiqué."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr "Types de lecteurs exclus"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 "Liste de PID des types de lecteurs à exclure de la suppression "
 "automatique."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr "Page d'accueil"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr "Configuration de la page d'accueil publique."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr "Slogan"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr "Texte affiché sur la bannière de la page d'accueil publique."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr "Une seule valeur par langue est autorisée."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr "Placeholder"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 "Texte d'espace réservé affiché dans le champ de recherche de la page "
 "d'accueil publique."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr "Blocs"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr "Contenu HTML affiché dans les blocs de la page d'accueil."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr "Bloc gauche"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
@@ -11790,18 +11790,18 @@ msgstr ""
 "Contenu HTML affiché dans le bloc gauche de la page d'accueil. Sur "
 "mobile, ce bloc s'affiche en premier."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr "HTML"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr "Bloc du milieu"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
@@ -11809,12 +11809,12 @@ msgstr ""
 "Contenu HTML affiché dans le bloc central de la page d'accueil. Sur "
 "mobile, ce bloc s'affiche en deuxième."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr "Bloc droit"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12552,8 +12552,8 @@ msgid "Catalog"
 msgstr "Catalogue"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr "Indicateur"
 
@@ -12564,36 +12564,36 @@ msgstr "Nombre de documents"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr "distributions"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr "mois de création"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr "année de création"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr "bibliothèque propriétaire"
 
@@ -12609,77 +12609,77 @@ msgstr "Nombre d'états de collection (publications en série)"
 msgid "Number of items"
 msgstr "Nombre d'exemplaires"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr "localisation propriétaire"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr "type (standard/fascicule)"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr "Nombre d'exemplaires supprimés"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr "mois de l'opération"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr "année de l'opération"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr "bibliothèque de l'opérateur"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr "Prêt"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr "Nombre de demandes PEB"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr "Nombre de retours"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr "Nombre de prêts"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr "Nombre de prolongations"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr "Nombre de demandes"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr "Nombre de demandes validées"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr "Gestion des utilisateurs"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr "Nombre de lecteurs"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr "Nombre de lecteurs actifs"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr "Distributions"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
@@ -12687,11 +12687,11 @@ msgstr ""
 "Jusqu'à 2 filtres pour distribuer les données dans le tableau généré. La "
 "première valeur répartit par ligne, la seconde répartit par colonne."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr "Période"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
@@ -12702,57 +12702,57 @@ msgstr ""
 "pas filtrer les données. Exemple : traiter le nombre de prêts effectués "
 "au cours du dernier mois."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr "mois"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr "mois de transaction"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr "année de transaction"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr "âge du lecteur"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr "code postal du lecteur"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr "codes locaux du lecteur"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr "canal de transaction"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr "genre"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr "code postal"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr "codes locaux"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr "année de naissance"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr "rôle"
 
@@ -13039,8 +13039,8 @@ msgstr "Un seul contact de chaque type est autorisé."
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
-msgstr "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
+msgstr "<i class=\"fa fa-phone\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
@@ -13049,8 +13049,8 @@ msgstr "<i class=\"fa fa-user\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
-msgstr "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
+msgstr "<i class=\"fa fa-globe\"></i>"
 
 #: rero_ils/theme/menus.py:38
 msgid "My Account"
@@ -13175,7 +13175,7 @@ msgstr "S'identifier"
 msgid "or"
 msgstr "ou"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "Que cherchez-vous ?"
 

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2026-06-23 11:31+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
 "Language: it\n"
@@ -38,35 +38,35 @@ msgstr "Le due password non sono identiche."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "utente o password non validi"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Francese"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Tedesco"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Italiano"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Benvenuto"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "Reimpostazione della password RERO ID"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "La sua password è stata reimposta"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -77,283 +77,284 @@ msgstr ""
 "almeno tre caratteri e contenere solo caratteri alfanumerici, trattini e "
 "underscore."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Catalogo globale"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "online"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "non online"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "autore"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "soggetto"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "acquisizione"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr "new_acquisition"
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "identificatori"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "tipo di documento"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "sottotipo di documento"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "lingua"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "organizzazione"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "localizzazione"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "statuto"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "genere, forma"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "destinatari presunti"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "anno"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr "formulazione di narrativa"
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "Tipo di esemplare"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "Tipo di esemplare temporaneo"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "Localizzazione temporanea"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "fornitore"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr "Statuto del fascicolo (O)"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "Numero di reclami"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr "Data de reclamo"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "Richieste attuali"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "biblioteca proprietaria"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "localizzazione"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "punto di ritiro"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "punto di ritiro"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "biblioteca della transazione"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "localizzazione della transazione"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "stato di ritardo"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "Tipo di lettore"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "data di scadenza della richiesta"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "data di fine"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "escludere lo stato"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "ruoli"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "città"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "bloccato"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "scaduto"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr "non scaduto"
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "bilancio"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "account"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "data dell'ordine"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "data della ricezione"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "tipo di risorsa"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "tipo"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "catalogo fonti"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "fonti"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "visibilità"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "insegnante"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr "statuto della richiesta"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "Stato del prestito"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "Richiedente"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "categoria"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "indicatore"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "periodicità"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "attiva"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "Questa è una VERSIONE TEST."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "Aprire il sito di produzione."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "contiene"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "frase"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -373,35 +374,35 @@ msgstr "frase"
 msgid "Title"
 msgstr "Titolo"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Formulazione di responsabilità"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Contributo"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Paese"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "Cantone"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "Formulazione di pubblicazione"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "Formulazione di serie"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -410,15 +411,15 @@ msgstr "Formulazione di serie"
 msgid "Identifier"
 msgstr "identificatore"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -426,14 +427,14 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Genere, forma"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Soggetto"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -442,32 +443,32 @@ msgstr "Soggetto"
 msgid "Call number"
 msgstr "Segnatura"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Campi locali (documento)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Campi locali (posseduti)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Campi locali (esemplari)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Classificazione"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "Tipo di contenuto RDA"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "Tipo di media RDA"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "Tipo di supporto RDA"
 
@@ -2462,17 +2463,17 @@ msgstr "Valuta"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Tipo"
@@ -4577,7 +4578,7 @@ msgstr "Categoria di bilancio alla quale è possibile assegnare un importo."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4619,7 +4620,7 @@ msgstr "ID del conto"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4781,22 +4782,22 @@ msgstr "URI dell'organizzazione"
 msgid "%"
 msgstr "%"
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr "Non può avere più note dello stesso tipo."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 "Non è possibile salvare una riga d'ordine attiva relativa a un documento "
 "eliminato."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
-msgstr "Impossibile aggiungere una riga a un ordine con stato errato."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
+msgstr "Impossibile salvare una riga d'ordine per un ordine con stato errato."
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
 msgid "Cannot link to an harvested document"
@@ -7873,8 +7874,8 @@ msgstr "Livello di lettura/comprensione"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "valore"
 
@@ -10382,7 +10383,7 @@ msgstr "No"
 msgid "Yes"
 msgstr "Sì"
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "Un'altro tipo di esemplare online esiste in questa organizzazione"
 
@@ -10842,7 +10843,7 @@ msgstr "Informazioni di fatturazione"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Codice"
@@ -10856,7 +10857,7 @@ msgid "Name of the library."
 msgstr "Nome della biblioteca."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Indirizzo"
 
@@ -10913,12 +10914,12 @@ msgid "Communication language"
 msgstr "Lingua di comunicazione"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr "Fonti raccolte online"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr "Fonti raccolte online, come configurate nel server di ebooks."
 
@@ -11628,47 +11629,47 @@ msgstr ""
 "Di solito una rete di diverse biblioteche che condividono dati relativi "
 "agli lettori, agli esemplari, ecc."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "Ente ID"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr "Nome dell'organizzazione."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "Indirizzo dell'organizzazione."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "Codice dell'organizzazione."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "Attuale ID del bilancio"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "L'ID del attuale bilancio dell'organizzazione"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "Valuta predefinita"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "La valuta predefinita dell'organizzazione"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr "Collezione abilitata nell'interfaccia pubblica"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr "Configurazione della rimozione dei lettori inattivi"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
@@ -11678,11 +11679,11 @@ msgstr ""
 "inattivi. Eliminare questo campo se non si desidera che gli account "
 "utente vengano eliminati automaticamente."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr "Soglia di scadenza (anni)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
@@ -11690,11 +11691,11 @@ msgstr ""
 "Eliminare solo i lettori la cui data di scadenza è precedente al numero "
 "di anni indicato."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr "Limite di inattività (anni)"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
@@ -11702,66 +11703,66 @@ msgstr ""
 "Eliminare solo gli lettori il cui ultimo accesso è avvenuto più di questo"
 " numero di anni fa."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr "Tipi di lettorri esclusi"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 "Elenco dei PID di tipi di lettori da escludere dall'eliminazione "
 "automatica."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr "Homepage"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr "Configurazione della pagina iniziale pubblica."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr "Slogan"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr "Testo visualizzato sul banner della pagina iniziale pubblica."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr "È consentito un solo valore per lingua."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr "Placeholder"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 "Testo segnaposto visualizzato nel campo di ricerca della pagina iniziale "
 "pubblica."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr "Blocci"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr "Contenuto HTML visualizzato nei blocchi della pagina iniziale."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr "Blocco sinistro"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
@@ -11769,18 +11770,18 @@ msgstr ""
 "Contenuto HTML visualizzato nel blocco sinistro della pagina iniziale. Su"
 " dispositivi mobili, questo blocco viene visualizzato per primo."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr "HTML"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr "Blocco centrale"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
@@ -11788,12 +11789,12 @@ msgstr ""
 "Contenuto HTML visualizzato nel blocco centrale della pagina iniziale. Su"
 " dispositivi mobili, questo blocco viene visualizzato per secondo."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr "Blocco destro"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12531,8 +12532,8 @@ msgid "Catalog"
 msgstr "Catalogo"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr "Indicatore"
 
@@ -12543,36 +12544,36 @@ msgstr "Numero di documenti"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr "distribuzioni"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr "mese della creazione"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr "anno di creazione"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr "biblioteca proprietaria"
 
@@ -12588,77 +12589,77 @@ msgstr "Numero di posseduti (seriali)"
 msgid "Number of items"
 msgstr "Numero di esemplari"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr "localizzazione proprietaria"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr "tipo (standard/fascicolo)"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr "Numero di esemplari eliminati"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr "mese di azione"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr "anno di azione"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr "biblioteca dell'operatore"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr "Prestito"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr "Numero di richieste di prestito interbibliotecario"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr "Numero di ritorni"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr "Numero di prestiti"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr "Numero di proroghe"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr "Numero di richieste"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr "Numero di richieste convalidate"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr "Gestione utente"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr "Numero di lettori"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr "Numero di lettori attivi"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr "Distribuzioni"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
@@ -12666,11 +12667,11 @@ msgstr ""
 "Fino a 2 filtri per distribuire i dati nella tabella generata. Il primo "
 "valore divide per riga, il secondo per colonna."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr "Periodo"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
@@ -12681,57 +12682,57 @@ msgstr ""
 "filtrare i dati. Esempio: elaborare il numero di prestiti effettuati "
 "nell'ultimo mese."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr "mese"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr "mese di transazione"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr "anno di transazione"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr "età del lettore"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr "codice postale del lettore"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr "codici locali del lettore"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr "canale di transazione"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr "genere"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr "codice postale"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr "codici locali"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr "anno di nascita"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr "ruolo"
 
@@ -13016,8 +13017,8 @@ msgstr "È consentito solo un contatto per tipo."
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
-msgstr "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
+msgstr "<i class=\"fa fa-phone\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
@@ -13026,8 +13027,8 @@ msgstr "<i class=\"fa fa-user\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
-msgstr "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
+msgstr "<i class=\"fa fa-globe\"></i>"
 
 #: rero_ils/theme/menus.py:38
 msgid "My Account"
@@ -13150,7 +13151,7 @@ msgstr "Autentificarsi"
 msgid "or"
 msgstr "o"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "Cosa stai cercando?"
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RERO_ILS VERSION\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,35 +25,35 @@ msgstr ""
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr ""
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr ""
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr ""
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr ""
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr ""
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr ""
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr ""
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr ""
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -61,283 +61,284 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr ""
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr ""
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr ""
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr ""
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr ""
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr ""
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr ""
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr ""
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr ""
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr ""
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr ""
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr ""
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr ""
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr ""
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr ""
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr ""
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr ""
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr ""
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr ""
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr ""
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr ""
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr ""
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr ""
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr ""
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr ""
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr ""
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr ""
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr ""
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr ""
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr ""
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr ""
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr ""
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr ""
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr ""
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr ""
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr ""
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr ""
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr ""
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr ""
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr ""
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr ""
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr ""
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr ""
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr ""
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr ""
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr ""
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr ""
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr ""
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr ""
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr ""
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr ""
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr ""
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr ""
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr ""
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr ""
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr ""
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr ""
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr ""
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr ""
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -357,35 +358,35 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr ""
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr ""
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr ""
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr ""
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr ""
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -394,15 +395,15 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr ""
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr ""
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -410,14 +411,14 @@ msgstr ""
 msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr ""
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -426,32 +427,32 @@ msgstr ""
 msgid "Call number"
 msgstr ""
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr ""
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr ""
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr ""
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr ""
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr ""
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr ""
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr ""
 
@@ -2446,17 +2447,17 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr ""
@@ -4561,7 +4562,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4603,7 +4604,7 @@ msgstr ""
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4761,19 +4762,19 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7733,8 +7734,8 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr ""
 
@@ -10157,7 +10158,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr ""
 
@@ -10588,7 +10589,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr ""
@@ -10602,7 +10603,7 @@ msgid "Name of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr ""
 
@@ -10659,12 +10660,12 @@ msgid "Communication language"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 
@@ -11351,157 +11352,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12196,8 +12197,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12208,36 +12209,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12253,144 +12254,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -12657,7 +12658,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -12667,7 +12668,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -12785,7 +12786,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr ""
 

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2024-02-23 17:02+0000\n"
 "Last-Translator: LievenSmets <lievensmets@me.com>\n"
 "Language: nl\n"
@@ -31,35 +31,35 @@ msgstr "Beide wachtwoorden zijn niet gelijk."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "ONGELDIGE_GEBRUIKER_OF_WACHTWOORD"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Frans"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Duits"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Italiaans"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Welkom"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "RERO ID wachtwoord bijwerken"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "Uw RERO ID-wachtwoord werd bijgewerkt"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -67,285 +67,286 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Globale catalogus"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "Online"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "niet_online"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "auteur"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "onderwerp"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "aanschaf"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 #, fuzzy
 msgid "new_acquisition"
 msgstr "Aankoopvoorwaarden"
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "identificatiecode"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "type van document"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "Subtype van document"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "taal"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "organisatie"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "bibliotheek"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "plaats"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "genreVorm"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "beoogdPubliek"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "jaar"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "Item type"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "tijdelijk_item_type"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "tijdelijke_locatie"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "verkoper"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr ""
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "claims_aantal"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr ""
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "huidige_aanvragen"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "eigenaar_bibliotheek"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "eigenaar_plaats"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "afhaalpunt"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "afhaallocatie"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "transactie_bibliotheek"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "transactie_plaats"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "diverse_status"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "gebruikers_type"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "aanvraag_vervaldatum"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 #, fuzzy
 msgid "end_date"
 msgstr "Einddatum"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "verwijderen_status"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "rollen"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "stad"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "geblokkeerd"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "vervallen"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "account"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "bestelling_datum"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "ontvangst_datum"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "bron_type"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "type"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "bron_catalogus"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "bronnen"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "zichtbaarheid"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "Leeraar"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr ""
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "ontlening_status"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "aanvrager"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "categorie"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "indicator"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "frequentie"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "actief"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "Dit is een TEST VERSIE"
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "Ga naar de productie site."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "bevat"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "zin"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -365,35 +366,35 @@ msgstr "zin"
 msgid "Title"
 msgstr "Titel"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Verantwoordelijkheidsverklaring"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Bijdrage"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Land"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "Kanton"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr ""
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -402,15 +403,15 @@ msgstr ""
 msgid "Identifier"
 msgstr "Identificator"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -418,14 +419,14 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Genre,Vorm"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -434,32 +435,32 @@ msgstr "Onderwerp"
 msgid "Call number"
 msgstr "Telefoon"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Lokale velden (document)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Lokale velden (bijhouding)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Lokale velden (items)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Classificatie"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "RDA inhoudstype"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "RDA mediatye"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "RDA dragertype"
 
@@ -2463,17 +2464,17 @@ msgstr "Valuta"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Type"
@@ -4578,7 +4579,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4620,7 +4621,7 @@ msgstr "Account ID"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4778,19 +4779,19 @@ msgstr "URI van de organisatie"
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7896,8 +7897,8 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr ""
 
@@ -10448,7 +10449,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "Een ander online itemtype bestaat in deze organisatie "
 
@@ -10896,7 +10897,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "Code"
@@ -10910,7 +10911,7 @@ msgid "Name of the library."
 msgstr "Naam van de bibliotheek."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "Adres"
 
@@ -10968,13 +10969,13 @@ msgid "Communication language"
 msgstr "Communicatietaal"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 #, fuzzy
 msgid "Online harvested sources"
 msgstr "Online geoogste bron"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 #, fuzzy
 msgid "Online harvested sources as configured in ebooks server."
 msgstr "Online geoogste bron zoals geconfigureerd in de ebookserver."
@@ -11693,157 +11694,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "Organisatie ID"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "Adres van de organisatie."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "Code van de organisatie."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "Huidige ID van de begroting"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "ID van de huidige begroting van de organisatie"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "Standaardvaluta"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "De standaardvaluta van de organisatie"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12576,8 +12577,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12588,36 +12589,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12633,144 +12634,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -13060,7 +13061,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -13070,7 +13071,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -13190,7 +13191,7 @@ msgstr "Aanmelden"
 msgid "or"
 msgstr "of"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr ""
 
@@ -13301,4 +13302,7 @@ msgstr ""
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr ""
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/rero_ils/translations/ru/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ru/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2022-01-21 16:53+0000\n"
 "Last-Translator: lushnikov3d37b9a0863842c1 <pavel.lushnikov@gmail.com>\n"
 "Language: ru\n"
@@ -24,35 +24,35 @@ msgstr ""
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr ""
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "Французский"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "Немецкий"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "Итальянский"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr ""
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "Сброс пароля"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "Ваш пароль был сброшен"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -60,294 +60,295 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "Общий каталог"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr ""
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr ""
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "автор"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "тема"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr ""
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "тип_документа"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "подтип_документа"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "язык"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "организация"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "библиотека"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "место хранения"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "статус"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr ""
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr ""
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr ""
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr ""
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr ""
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 #, fuzzy
 msgid "temporary_location"
 msgstr "место хранения"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr ""
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr ""
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr ""
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr ""
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr ""
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 #, fuzzy
 msgid "owner_library"
 msgstr "библиотека"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 #, fuzzy
 msgid "owner_location"
 msgstr "место хранения"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 #, fuzzy
 msgid "pickup_library"
 msgstr "библиотека"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 #, fuzzy
 msgid "pickup_location"
 msgstr "место хранения"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr ""
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 #, fuzzy
 msgid "transaction_location"
 msgstr "место хранения"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 #, fuzzy
 msgid "misc_status"
 msgstr "статус"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "категории_читателей"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 #, fuzzy
 msgid "request_expire_date"
 msgstr "заявитель"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 #, fuzzy
 msgid "end_date"
 msgstr "дата_заказа"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 #, fuzzy
 msgid "exclude_status"
 msgstr "статус_выдачи"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr ""
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr ""
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr ""
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "бюджет"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "учетная запись"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "дата_заказа"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "дата_чека"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr ""
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "тип"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr ""
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "источники"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "доступность отображения"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "преподаватель"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr ""
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "статус_выдачи"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "заявитель"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr ""
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr ""
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr ""
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr ""
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 #, fuzzy
 msgid "This is a TEST VERSION."
 msgstr "Тестовая версия"
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr ""
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr ""
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr ""
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -367,35 +368,35 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr ""
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr ""
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr ""
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr ""
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr ""
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -404,15 +405,15 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr ""
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr ""
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -420,14 +421,14 @@ msgstr ""
 msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr ""
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -436,32 +437,32 @@ msgstr ""
 msgid "Call number"
 msgstr ""
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr ""
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr ""
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr ""
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr ""
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr ""
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr ""
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr ""
 
@@ -2457,17 +2458,17 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr ""
@@ -4573,7 +4574,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4615,7 +4616,7 @@ msgstr ""
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4773,19 +4774,19 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7746,8 +7747,8 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr ""
 
@@ -10171,7 +10172,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr ""
 
@@ -10602,7 +10603,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr ""
@@ -10616,7 +10617,7 @@ msgid "Name of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr ""
 
@@ -10673,12 +10674,12 @@ msgid "Communication language"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 
@@ -11366,157 +11367,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12211,8 +12212,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12223,36 +12224,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12268,144 +12269,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -12672,7 +12673,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -12682,7 +12683,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -12800,7 +12801,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr ""
 
@@ -12908,4 +12909,7 @@ msgstr ""
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr ""
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/rero_ils/translations/ta/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ta/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.24.1\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2025-08-30 18:01+0000\n"
 "Last-Translator: தமிழ்நேரம் <anishprabu.t@gmail.com>\n"
 "Language: ta\n"
@@ -27,35 +27,35 @@ msgstr "2 கடவுச்சொற்கள் ஒரே மாதிரி�
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "தவறான_பயனர்_அல்லது_கடவுச்சொல்"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "பிரஞ்சு"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "செர்மன்"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "இத்தாலிய"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "ரீரோ-ஐஎல்சு"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "வரவேற்கிறோம்"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "ரீரோ ஐடி கடவுச்சொல் மீட்டமைப்பு"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "உங்கள் ரீரோ ஐடி கடவுச்சொல் மீட்டமைக்கப்பட்டுள்ளது"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -67,283 +67,284 @@ msgstr ""
 "எழுத்துக்கள், கோடுகள் மற்றும் அடிக்கோடிட்டுக் காட்டுதல் மட்டுமே இருக்க "
 "வேண்டும்."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr "உலகளாவிய பட்டியல்"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr "இணைப்பில்"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr "இணையம்_இல்லா"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "நூலாசிரியர்"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "பொருள்"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr "கையகப்படுத்தல்"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr "அடையாளங்காட்டிகள்"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "ஆவணம்_வகை"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "ஆவணம்_துணைவகை"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "மொழி"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "அமைப்பு"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "நூலகம்"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "இடம்"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "நிலை"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 msgid "genreForm"
 msgstr "வகை வடிவம்"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 msgid "intendedAudience"
 msgstr "நோக்கம்"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 msgid "year"
 msgstr "ஆண்டு"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr "கற்பனை_அறிக்கை"
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "உருப்படி_வகை"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 msgid "temporary_item_type"
 msgstr "தற்காலிக_உருப்படி_வகை"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 msgid "temporary_location"
 msgstr "தற்காலிக_இடம்"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "விற்பனையாளர்"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr "அல்லது_பிழை_நிலை"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr "உரிமைகோரல்_எண்ணிக்கை"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr "உரிமைகோரல்_தேதி"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "நடப்பு_கோரிக்கை"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 msgid "owner_library"
 msgstr "உரிமையாளர்_நூலகம்"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 msgid "owner_location"
 msgstr "உரிமையாளர்_இடம்"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 msgid "pickup_library"
 msgstr "எடுக்கும்_நூலகம்"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "எடுக்கும்_இடம்"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr "பரிவர்த்தனை_நூலகம்"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 msgid "transaction_location"
 msgstr "பரிவர்த்தனை_இடம்"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 msgid "misc_status"
 msgstr "மற்ற_நிலை"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "புரவலர்_வகை"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "request_expire_date"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "கடைசி_நாள்"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 msgid "exclude_status"
 msgstr "விலக்கு_நிலை"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "பாத்திரங்கள்"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "நகரம்"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr "தடுக்கப்பட்டது"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr "காலாவதியான"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "நிதிதிட்டம்"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr "கணக்கு"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "order_date"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr "இரசீது_தேதி"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "resource_type"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "வகை"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "மூல அட்டவணை"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "மூலங்கள்"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 msgid "visibility"
 msgstr "விழிமை"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "ஆசிரியர்"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr "request_status"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "கடன்_நிலை"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "கோரிக்கை"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "வகை"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr "காட்டொளி"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr "நிகழ்வெண்"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr "செயலில்"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 msgid "This is a TEST VERSION."
 msgstr "இது ஒரு சோதனை பதிப்பு."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 msgid "Go to the production site."
 msgstr "விளைவாக்கம் தளத்திற்குச் செல்."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "கொண்டுள்ளது"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr "சொற்றொடர்"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -363,35 +364,35 @@ msgstr "சொற்றொடர்"
 msgid "Title"
 msgstr "தலைப்பு"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "பொறுப்பு அறிக்கை"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "பங்களிப்பு"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "நாடு"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr "கேன்டன்"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "வழங்கல் செயல்பாட்டு அறிக்கை"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "தொடர் அறிக்கை"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -400,15 +401,15 @@ msgstr "தொடர் அறிக்கை"
 msgid "Identifier"
 msgstr "அடையாளங்காட்டி"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "Issn"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -416,14 +417,14 @@ msgstr "Issn"
 msgid "Genre, form"
 msgstr "வகை, வடிவம்"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr "பொருள்"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -432,32 +433,32 @@ msgstr "பொருள்"
 msgid "Call number"
 msgstr "அழைப்பு எண்"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "உள்ளக புலங்கள் (ஆவணம்)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "உள்ளக புலங்கள் (ஓல்டிங்ச்)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "உள்ளக புலங்கள் (உருப்படிகள்)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "வகைப்பாடு"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "RDA உள்ளடக்க வகை"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "ஆர்டிஏ மீடியா வகை"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "ஆர்டிஏ கேரியர் வகை"
 
@@ -2452,17 +2453,17 @@ msgstr "நாணயம்"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "வகை"
@@ -4567,7 +4568,7 @@ msgstr "ஒரு தொகையை ஒதுக்கக்கூடிய ப
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4609,7 +4610,7 @@ msgstr "கணக்கு ஐடி"
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4771,19 +4772,19 @@ msgstr "அமைப்பு யூரி"
 msgid "%"
 msgstr "%"
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7862,8 +7863,8 @@ msgstr "புரிந்துகொள்ளும் நிலை"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "மதிப்பு"
 
@@ -10370,7 +10371,7 @@ msgstr "இல்லை"
 msgid "Yes"
 msgstr "ஆம்"
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr "இந்த நிறுவனத்தில் மற்றொரு நிகழ்நிலை உருப்படி வகை உள்ளது"
 
@@ -10824,7 +10825,7 @@ msgstr "பட்டியலிடல் செய்தி"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr "குறியீடு"
@@ -10838,7 +10839,7 @@ msgid "Name of the library."
 msgstr "நூலகத்தின் பெயர்."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr "முகவரி"
 
@@ -10895,12 +10896,12 @@ msgid "Communication language"
 msgstr "தொடர்பு மொழி"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr "நிகழ்நிலை அறுவடை ஆதாரங்கள்"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr "நிகழ்நிலை அறுவடை ஆதாரங்கள் மின்புத்தக சேவையகத்தில் கட்டமைக்கப்பட்டுள்ளன."
 
@@ -11610,157 +11611,157 @@ msgstr ""
 "வழக்கமாக பல நூலகங்களின் பிணையம் புரவலர்கள், உருப்படிகள் போன்றவற்றிற்கான "
 "தரவைப் பகிரும் பிணையம்."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr "அமைப்பு ஐடி"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr "அமைப்பின் பெயர்."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr "அமைப்பின் முகவரி."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr "அமைப்பின் குறியீடு."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr "பட்செட்டின் தற்போதைய ஐடி"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr "அமைப்பின் தற்போதைய பட்செட்டின் ஐடி"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr "இயல்புநிலை நாணயம்"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr "அமைப்பின் இயல்புநிலை நாணயம்"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr "பொது பார்வையில் சேகரிப்பு இயக்கப்பட்டது"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12487,8 +12488,8 @@ msgid "Catalog"
 msgstr "பட்டியல்"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr "காட்டொளி"
 
@@ -12499,36 +12500,36 @@ msgstr "ஆவணங்களின் எண்ணிக்கை"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr "வழங்கல்"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr "created_month"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr "உருவாக்கப்பட்டது_இயர்"
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr "சொந்த_ லைப்ரரி"
 
@@ -12544,77 +12545,77 @@ msgstr "தொடர் இருப்புகளின் எண்ணிக�
 msgid "Number of items"
 msgstr "பொருட்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr "சொந்த_ லோகேசன்"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr "வகை (நிலையான/வெளியீடு)"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr "நீக்கப்பட்ட பொருட்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr "action_month"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr "Action_year"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr "ஆபரேட்டர்_லிபிரரி"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr "சுற்றோட்டம்"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr "தவறான கோரிக்கைகளின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr "செக்கின்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr "புதுப்பித்தல்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr "புதுப்பித்தல்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr "கோரிக்கைகளின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr "சரிபார்க்கப்பட்ட கோரிக்கைகளின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr "பயனர் மேலாண்மை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr "புரவலர்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr "செயலில் உள்ள புரவலர்களின் எண்ணிக்கை"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr "வழங்கல்"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
@@ -12622,11 +12623,11 @@ msgstr ""
 "உருவாக்கப்பட்ட அட்டவணையில் தரவை விநியோகிக்க 2 வடிப்பான்கள் வரை. முதல் "
 "மதிப்பு கோடுகள்; இரண்டாவது மதிப்பு நெடுவரிசைகள்."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr "காலசுழற்சி"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
@@ -12637,57 +12638,57 @@ msgstr ""
 "விடவும். எடுத்துக்காட்டு: கடந்த மாதத்தில் நிகழ்த்தப்பட்ட "
 "புதுப்பித்தல்களின் எண்ணிக்கையை செயலாக்கவும்."
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr "மாதம்"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr "பரிவர்த்தனை_ மாத"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr "பரிவர்த்தனை_ ஆண்டு"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr "உதவி"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr "batron_postal_code"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr "பரிவர்த்தனை_சானல்"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr "பாலினம்"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr "அஞ்சல் குறியீடு"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr "பிறப்பு_ ஆண்டு"
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr "பங்கு"
 
@@ -12965,8 +12966,8 @@ msgstr "ஒரு வகைக்கு ஒரு தொடர்பு மட�
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
-msgstr "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
+msgstr "<i class=\"fa fa-phone\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
@@ -12975,8 +12976,8 @@ msgstr "<i class=\"fa fa-user\"></i>"
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
-msgstr "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
+msgstr "<i class=\"fa fa-globe\"></i>"
 
 #: rero_ils/theme/menus.py:38
 msgid "My Account"
@@ -13101,7 +13102,7 @@ msgstr "புகுபதிகை"
 msgid "or"
 msgstr "அல்லது"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "நீங்கள் எதைத் தேடுகிறீர்கள்?"
 
@@ -13213,4 +13214,7 @@ msgstr "உங்கள் நூலகம்"
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr "உங்கள் கடவுச்சொல் வெற்றிகரமாக மீட்டமைக்கப்பட்டுள்ளது."
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/rero_ils/translations/uk/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RERO_ILS VERSION\n"
 "Report-Msgid-Bugs-To: pascal.repond@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2026-04-08 08:09+0000\n"
 "Last-Translator: Галина Нежурбіда <nezhga29@gmail.com>\n"
 "Language: uk\n"
@@ -29,42 +29,42 @@ msgstr "Ці два паролі не однакові."
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr "НЕДІЙСНИЙ_КОРИСТУВАЧ_АБО_ПАРОЛЬ"
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 #, fuzzy
 msgid "French"
 msgstr "Французька"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 #, fuzzy
 msgid "German"
 msgstr "Німецька"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 #, fuzzy
 msgid "Italian"
 msgstr "Італійська"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 #, fuzzy
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 #, fuzzy
 msgid "Welcome"
 msgstr "Ласкаво просимо"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 #, fuzzy
 msgid "RERO ID password reset"
 msgstr "Скидання пароля RERO ID"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 #, fuzzy
 msgid "Your RERO ID password has been reset"
 msgstr "Ваш пароль RERO ID скинуто"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 #, fuzzy
 msgid ""
@@ -76,329 +76,330 @@ msgstr ""
 "щонайменше з трьох символів і містити лише літери, цифри, дефіси або "
 "символи підкреслення."
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 #, fuzzy
 msgid "Global catalog"
 msgstr "Глобальний каталог"
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 #, fuzzy
 msgid "online"
 msgstr "онлайн"
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 #, fuzzy
 msgid "not_online"
 msgstr "not_online"
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 #, fuzzy
 msgid "author"
 msgstr "автор"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 #, fuzzy
 msgid "subject"
 msgstr "предмет"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 #, fuzzy
 msgid "acquisition"
 msgstr "комплектування"
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 #, fuzzy
 msgid "identifiers"
 msgstr "ідентифікатори"
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 #, fuzzy
 msgid "document_type"
 msgstr "тип_документа"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 #, fuzzy
 msgid "document_subtype"
 msgstr "підтип_документа"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 #, fuzzy
 msgid "language"
 msgstr "мова"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "організація"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 #, fuzzy
 msgid "library"
 msgstr "бібліотека"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 #, fuzzy
 msgid "location"
 msgstr "місце знаходження"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 #, fuzzy
 msgid "status"
 msgstr "статус"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 #, fuzzy
 msgid "genreForm"
 msgstr "genreForm"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 #, fuzzy
 msgid "intendedAudience"
 msgstr "цільоваАудиторія"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 #, fuzzy
 msgid "year"
 msgstr "рік"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 #, fuzzy
 msgid "fiction_statement"
 msgstr "fiction_statement"
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 #, fuzzy
 msgid "item_type"
 msgstr "item_type"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 #, fuzzy
 msgid "temporary_item_type"
 msgstr "temporary_item_type"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 #, fuzzy
 msgid "temporary_location"
 msgstr "тимчасове_місцезнаходження"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 #, fuzzy
 msgid "vendor"
 msgstr "постачальник"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 #, fuzzy
 msgid "or_issue_status"
 msgstr "or_issue_status"
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 #, fuzzy
 msgid "claims_count"
 msgstr "claims_count"
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 #, fuzzy
 msgid "claims_date"
 msgstr "дата_претензій"
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 msgid "current_requests"
 msgstr "поточні_запити"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 #, fuzzy
 msgid "owner_library"
 msgstr "owner_library"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 #, fuzzy
 msgid "owner_location"
 msgstr "owner_location"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 #, fuzzy
 msgid "pickup_library"
 msgstr "пункт_видачі"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 msgid "pickup_location"
 msgstr "місце_отримання"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 #, fuzzy
 msgid "transaction_library"
 msgstr "transaction_library"
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 #, fuzzy
 msgid "transaction_location"
 msgstr "transaction_location"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 #, fuzzy
 msgid "misc_status"
 msgstr "стан_виконання"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 #, fuzzy
 msgid "patron_type"
 msgstr "категорія_читачів"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 msgid "request_expire_date"
 msgstr "термін дії запиту/Дата замовлення/кінцева дата бронювання"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 msgid "end_date"
 msgstr "кінцева_дата"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 #, fuzzy
 msgid "exclude_status"
 msgstr "статус_виключення"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "ролі/функції"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "місто"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 #, fuzzy
 msgid "blocked"
 msgstr "заблоковано"
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 #, fuzzy
 msgid "expired"
 msgstr "закінчився"
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr "термін дії не закінчився"
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "бюджет"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 #, fuzzy
 msgid "account"
 msgstr "обліковий запис"
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr "дата_замовлення"
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 #, fuzzy
 msgid "receipt_date"
 msgstr "дата _отримання"
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr "тип_ресурсів"
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 msgid "type"
 msgstr "тип"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr "source_каталог"
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 #, fuzzy
 msgid "sources"
 msgstr "джерела"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 #, fuzzy
 msgid "visibility"
 msgstr "видимість"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "вчитель"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 #, fuzzy
 msgid "request_status"
 msgstr "статус_запиту"
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "статус_виданого_документа/статус_позики"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 #, fuzzy
 msgid "requester"
 msgstr "запитувач/читач"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr "категорія"
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 #, fuzzy
 msgid "indicator"
 msgstr "індикатор"
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 #, fuzzy
 msgid "frequency"
 msgstr "періодичність"
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 #, fuzzy
 msgid "active"
 msgstr "дійсний"
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 #, fuzzy
 msgid "This is a TEST VERSION."
 msgstr "Це ТЕСТОВА ВЕРСІЯ."
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 #, fuzzy
 msgid "Go to the production site."
 msgstr "Перейдіть на сайт продукту."
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr "містить"
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 #, fuzzy
 msgid "phrase"
 msgstr "фраза"
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -418,36 +419,36 @@ msgstr "фраза"
 msgid "Title"
 msgstr "Назва"
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr "Застереження/Заява про відповідальність"
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr "Внесок"
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr "Країна"
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 #, fuzzy
 msgid "Canton"
 msgstr "Кантон"
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr "Повідомлення про публікацію/Звіт про діяльність з надання послуг"
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr "Відомості про серію"
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -456,15 +457,15 @@ msgstr "Відомості про серію"
 msgid "Identifier"
 msgstr "Ідентифікатор"
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr "ISBN"
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr "ISSN"
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -473,7 +474,7 @@ msgstr "ISSN"
 msgid "Genre, form"
 msgstr "Жанр, форма"
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
@@ -481,7 +482,7 @@ msgstr "Жанр, форма"
 msgid "Subject"
 msgstr "Предмет/тема"
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -491,32 +492,32 @@ msgstr "Предмет/тема"
 msgid "Call number"
 msgstr "Телефон"
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr "Локальні поля (документ)"
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr "Локальні поля (фонди)"
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr "Локальні поля (примірники)"
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr "Класифікація"
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr "Тип вмісту RDA"
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr "Медіатип RDA"
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr "Тип фізичного носія RDA"
 
@@ -2588,17 +2589,17 @@ msgstr "Валюта"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "Тип"
@@ -4712,7 +4713,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4755,7 +4756,7 @@ msgstr ""
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4929,21 +4930,21 @@ msgstr "URI організації"
 msgid "%"
 msgstr "%"
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr "Не можна мати кілька нотаток одного типу."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 #, fuzzy
 msgid "Cannot save an active order line for a deleted document."
 msgstr "Неможливо зберегти активний рядок замовлення для видаленого документа."
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
 #, fuzzy
-msgid "Cannot create an order line with an order with a wrong status."
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 "Неможливо створити рядок замовлення якщо замовлення із неправильним "
 "статусом."
@@ -8133,8 +8134,8 @@ msgstr "рівень_розуміння"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 #, fuzzy
 msgid "value"
 msgstr "значення"
@@ -10694,7 +10695,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr ""
 
@@ -11125,7 +11126,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr ""
@@ -11139,7 +11140,7 @@ msgid "Name of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr ""
 
@@ -11196,12 +11197,12 @@ msgid "Communication language"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 
@@ -11888,157 +11889,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12733,8 +12734,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12745,36 +12746,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12790,144 +12791,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -13198,7 +13199,7 @@ msgstr "Дозволено лише один контакт для кожног�
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -13208,7 +13209,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -13352,7 +13353,7 @@ msgstr "Увійти в систему"
 msgid "or"
 msgstr "або"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 #, fuzzy
 msgid "What are you looking for?"
 msgstr "Що Ви шукаєте?"

--- a/rero_ils/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 1.5.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2026-06-23 13:57+0200\n"
+"POT-Creation-Date: 2026-07-02 12:17+0200\n"
 "PO-Revision-Date: 2021-12-25 09:52+0000\n"
 "Last-Translator: Sam Tse <codefzer@gmail.com>\n"
 "Language: zh_Hant\n"
@@ -27,35 +27,35 @@ msgstr ""
 msgid "INVALID_USER_OR_PASSWORD"
 msgstr ""
 
-#: rero_ils/config.py:202
+#: rero_ils/config.py:201
 msgid "French"
 msgstr "法文"
 
-#: rero_ils/config.py:203
+#: rero_ils/config.py:202
 msgid "German"
 msgstr "德文"
 
-#: rero_ils/config.py:204
+#: rero_ils/config.py:203
 msgid "Italian"
 msgstr "意大利文"
 
-#: rero_ils/config.py:245 rero_ils/config.py:249
+#: rero_ils/config.py:244 rero_ils/config.py:248
 msgid "rero-ils"
 msgstr "RERO ILS"
 
-#: rero_ils/config.py:290
+#: rero_ils/config.py:289
 msgid "Welcome"
 msgstr "歡迎"
 
-#: rero_ils/config.py:292
+#: rero_ils/config.py:291
 msgid "RERO ID password reset"
 msgstr "RERO ID密碼重置"
 
-#: rero_ils/config.py:293
+#: rero_ils/config.py:292
 msgid "Your RERO ID password has been reset"
 msgstr "您的 RERO ID 密碼已重置"
 
-#: rero_ils/config.py:319
+#: rero_ils/config.py:318
 #: rero_ils/modules/users/jsonschemas/users/user-v0.0.1.json:128
 msgid ""
 "Username must start with a letter or a number, be at least three "
@@ -63,302 +63,303 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: rero_ils/config.py:2002
+#: rero_ils/config.py:2001
 #: rero_ils/theme/templates/rero_ils/_frontpage_organisation_link.html:17
 msgid "Global catalog"
 msgstr ""
 
-#: rero_ils/config.py:2189
+#: rero_ils/config.py:2188
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:86
 msgid "online"
 msgstr ""
 
-#: rero_ils/config.py:2196
+#: rero_ils/config.py:2195
 msgid "not_online"
 msgstr ""
 
-#: rero_ils/config.py:2199
+#: rero_ils/config.py:2198
 msgid "author"
 msgstr "作者"
 
-#: rero_ils/config.py:2200 rero_ils/config.py:2617
+#: rero_ils/config.py:2199 rero_ils/config.py:2616
 msgid "subject"
 msgstr "主題"
 
-#: rero_ils/config.py:2202
+#: rero_ils/config.py:2201
 msgid "acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2205
+#: rero_ils/config.py:2204
 msgid "new_acquisition"
 msgstr ""
 
-#: rero_ils/config.py:2206
+#: rero_ils/config.py:2205
 msgid "identifiers"
 msgstr ""
 
-#: rero_ils/config.py:2209 rero_ils/config.py:2210 rero_ils/config.py:2286
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:373
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:949
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1025
+#: rero_ils/config.py:2208 rero_ils/config.py:2209 rero_ils/config.py:2285
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:374
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:954
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1030
 msgid "document_type"
 msgstr "文檔類型"
 
-#: rero_ils/config.py:2211 rero_ils/config.py:2287
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:377
+#: rero_ils/config.py:2210 rero_ils/config.py:2286
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:378
 msgid "document_subtype"
 msgstr "文檔子類型"
 
-#: rero_ils/config.py:2213
+#: rero_ils/config.py:2212
 msgid "language"
 msgstr "語言"
 
-#: rero_ils/config.py:2214 rero_ils/config.py:2215
+#: rero_ils/config.py:2213 rero_ils/config.py:2214
 msgid "organisation"
 msgstr "機構"
 
-#: rero_ils/config.py:2216 rero_ils/config.py:2288 rero_ils/config.py:2451
-#: rero_ils/config.py:2488 rero_ils/config.py:2616 rero_ils/config.py:2660
-#: rero_ils/config.py:2766
+#: rero_ils/config.py:2215 rero_ils/config.py:2287 rero_ils/config.py:2450
+#: rero_ils/config.py:2487 rero_ils/config.py:2615 rero_ils/config.py:2659
+#: rero_ils/config.py:2765
 msgid "library"
 msgstr "圖書館"
 
-#: rero_ils/config.py:2217 rero_ils/config.py:2289
+#: rero_ils/config.py:2216 rero_ils/config.py:2288
 msgid "location"
 msgstr "位置"
 
-#: rero_ils/config.py:2219 rero_ils/config.py:2293 rero_ils/config.py:2375
-#: rero_ils/config.py:2502 rero_ils/modules/migrations/views.py:74
+#: rero_ils/config.py:2218 rero_ils/config.py:2292 rero_ils/config.py:2374
+#: rero_ils/config.py:2501 rero_ils/modules/migrations/views.py:74
 msgid "status"
 msgstr "狀態"
 
-#: rero_ils/config.py:2220
+#: rero_ils/config.py:2219
 #, fuzzy
 msgid "genreForm"
 msgstr "體裁、形式"
 
-#: rero_ils/config.py:2221
+#: rero_ils/config.py:2220
 #, fuzzy
 msgid "intendedAudience"
 msgstr "目標受眾"
 
-#: rero_ils/config.py:2222
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:875
+#: rero_ils/config.py:2221
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:880
 #, fuzzy
 msgid "year"
 msgstr "親愛的"
 
-#: rero_ils/config.py:2223
+#: rero_ils/config.py:2222
 msgid "fiction_statement"
 msgstr ""
 
-#: rero_ils/config.py:2290
+#: rero_ils/config.py:2289
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:382
 msgid "item_type"
 msgstr "資料類型"
 
-#: rero_ils/config.py:2291
+#: rero_ils/config.py:2290
 #, fuzzy
 msgid "temporary_item_type"
 msgstr "資料類型"
 
-#: rero_ils/config.py:2292
+#: rero_ils/config.py:2291
 #, fuzzy
 msgid "temporary_location"
 msgstr "位置"
 
-#: rero_ils/config.py:2294 rero_ils/config.py:2489
+#: rero_ils/config.py:2293 rero_ils/config.py:2488
 msgid "vendor"
 msgstr "供應商"
 
-#: rero_ils/config.py:2295
+#: rero_ils/config.py:2294
 msgid "or_issue_status"
 msgstr ""
 
-#: rero_ils/config.py:2298
+#: rero_ils/config.py:2297
 msgid "claims_count"
 msgstr ""
 
-#: rero_ils/config.py:2299
+#: rero_ils/config.py:2298
 msgid "claims_date"
 msgstr ""
 
-#: rero_ils/config.py:2303
+#: rero_ils/config.py:2302
 #, fuzzy
 msgid "current_requests"
 msgstr "請求"
 
-#: rero_ils/config.py:2369
+#: rero_ils/config.py:2368
 #, fuzzy
 msgid "owner_library"
 msgstr "您的圖書館"
 
-#: rero_ils/config.py:2370
+#: rero_ils/config.py:2369
 #, fuzzy
 msgid "owner_location"
 msgstr "位置"
 
-#: rero_ils/config.py:2371
+#: rero_ils/config.py:2370
 #, fuzzy
 msgid "pickup_library"
 msgstr "圖書館"
 
-#: rero_ils/config.py:2372
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:564
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1033
+#: rero_ils/config.py:2371
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:569
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1038
 #, fuzzy
 msgid "pickup_location"
 msgstr "是取件地點"
 
-#: rero_ils/config.py:2373
+#: rero_ils/config.py:2372
 msgid "transaction_library"
 msgstr ""
 
-#: rero_ils/config.py:2374
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:929
+#: rero_ils/config.py:2373
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:934
 #, fuzzy
 msgid "transaction_location"
 msgstr "位置"
 
-#: rero_ils/config.py:2376
+#: rero_ils/config.py:2375
 #, fuzzy
 msgid "misc_status"
 msgstr "現況"
 
-#: rero_ils/config.py:2377 rero_ils/config.py:2425
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:933
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1009
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1082
+#: rero_ils/config.py:2376 rero_ils/config.py:2424
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:938
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1014
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1087
 msgid "patron_type"
 msgstr "讀者類型"
 
-#: rero_ils/config.py:2378
+#: rero_ils/config.py:2377
 #, fuzzy
 msgid "request_expire_date"
 msgstr "用戶請求"
 
-#: rero_ils/config.py:2382
+#: rero_ils/config.py:2381
 #, fuzzy
 msgid "end_date"
 msgstr "結束日期"
 
-#: rero_ils/config.py:2386
+#: rero_ils/config.py:2385
 #, fuzzy
 msgid "exclude_status"
 msgstr "現況"
 
-#: rero_ils/config.py:2423
+#: rero_ils/config.py:2422
 msgid "roles"
 msgstr "用戶角色"
 
-#: rero_ils/config.py:2424
+#: rero_ils/config.py:2423
 msgid "city"
 msgstr "城市"
 
-#: rero_ils/config.py:2426
+#: rero_ils/config.py:2425
 msgid "blocked"
 msgstr ""
 
-#: rero_ils/config.py:2427
+#: rero_ils/config.py:2426
 msgid "expired"
 msgstr ""
 
-#: rero_ils/config.py:2428
+#: rero_ils/config.py:2427
 msgid "not_expired"
 msgstr ""
 
-#: rero_ils/config.py:2452 rero_ils/config.py:2491
+#: rero_ils/config.py:2451 rero_ils/config.py:2490
 msgid "budget"
 msgstr "預算"
 
-#: rero_ils/config.py:2490
+#: rero_ils/config.py:2489
 msgid "account"
 msgstr ""
 
-#: rero_ils/config.py:2492
+#: rero_ils/config.py:2491
 msgid "order_date"
 msgstr ""
 
-#: rero_ils/config.py:2496
+#: rero_ils/config.py:2495
 msgid "receipt_date"
 msgstr ""
 
-#: rero_ils/config.py:2516
+#: rero_ils/config.py:2515
 msgid "resource_type"
 msgstr ""
 
-#: rero_ils/config.py:2517 rero_ils/config.py:2528 rero_ils/config.py:2540
-#: rero_ils/config.py:2567 rero_ils/config.py:2615
+#: rero_ils/config.py:2516 rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2566 rero_ils/config.py:2614
 #, fuzzy
 msgid "type"
 msgstr "類型"
 
-#: rero_ils/config.py:2518
+#: rero_ils/config.py:2517
 msgid "source_catalog"
 msgstr ""
 
-#: rero_ils/config.py:2527 rero_ils/config.py:2539
+#: rero_ils/config.py:2526 rero_ils/config.py:2538
 msgid "sources"
 msgstr "來源"
 
-#: rero_ils/config.py:2568
+#: rero_ils/config.py:2567
 #, fuzzy
 msgid "visibility"
 msgstr "可見性"
 
-#: rero_ils/config.py:2618
+#: rero_ils/config.py:2617
 msgid "teacher"
 msgstr "教師"
 
-#: rero_ils/config.py:2657
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:568
+#: rero_ils/config.py:2656
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:573
 msgid "request_status"
 msgstr ""
 
-#: rero_ils/config.py:2658
+#: rero_ils/config.py:2657
 msgid "loan_status"
 msgstr "館藏現況"
 
-#: rero_ils/config.py:2659
+#: rero_ils/config.py:2658
 msgid "requester"
 msgstr "用戶請求"
 
-#: rero_ils/config.py:2763
+#: rero_ils/config.py:2762
 msgid "category"
 msgstr ""
 
-#: rero_ils/config.py:2764
+#: rero_ils/config.py:2763
 msgid "indicator"
 msgstr ""
 
-#: rero_ils/config.py:2765
+#: rero_ils/config.py:2764
 msgid "frequency"
 msgstr ""
 
-#: rero_ils/config.py:2767
+#: rero_ils/config.py:2766
 msgid "active"
 msgstr ""
 
-#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:69
+#: rero_ils/config.py:3502 rero_ils/manual_translations.txt:69
 #: rero_ils/theme/templates/rero_ils/header.html:89
 #, fuzzy
 msgid "This is a TEST VERSION."
 msgstr "測試版"
 
-#: rero_ils/config.py:3504 rero_ils/manual_translations.txt:70
+#: rero_ils/config.py:3503 rero_ils/manual_translations.txt:70
 #: rero_ils/theme/templates/rero_ils/header.html:91
 #, fuzzy
 msgid "Go to the production site."
 msgstr "位置編碼"
 
-#: rero_ils/config.py:4231
+#: rero_ils/config.py:4230
 msgid "contains"
 msgstr ""
 
-#: rero_ils/config.py:4233
+#: rero_ils/config.py:4232
 msgid "phrase"
 msgstr ""
 
-#: rero_ils/config.py:4239
+#: rero_ils/config.py:4238
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:65
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:22
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:26
@@ -378,35 +379,35 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: rero_ils/config.py:4245
+#: rero_ils/config.py:4244
 msgid "Responsibility statement"
 msgstr ""
 
-#: rero_ils/config.py:4251
+#: rero_ils/config.py:4250
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:3
 #: rero_ils/modules/documents/jsonschemas/documents/document_contribution-v0.0.1.json:8
 msgid "Contribution"
 msgstr ""
 
-#: rero_ils/config.py:4257 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
+#: rero_ils/config.py:4256 rero_ils/jsonschemas/common/countries-v0.0.1.json:3
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:354
 msgid "Country"
 msgstr ""
 
-#: rero_ils/config.py:4263
+#: rero_ils/config.py:4262
 msgid "Canton"
 msgstr ""
 
-#: rero_ils/config.py:4269
+#: rero_ils/config.py:4268
 msgid "Provision activity statement"
 msgstr ""
 
-#: rero_ils/config.py:4275
+#: rero_ils/config.py:4274
 #: rero_ils/modules/documents/jsonschemas/documents/document_series-v0.0.1.json:3
 msgid "Series statement"
 msgstr ""
 
-#: rero_ils/config.py:4281 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
+#: rero_ils/config.py:4280 rero_ils/jsonschemas/common/identifier-v0.0.1.json:3
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:52
 #: rero_ils/modules/documents/jsonschemas/documents/document_identified_by-v0.0.1.json:7
 #: rero_ils/modules/entities/templates/rero_ils/entity_local.html:43
@@ -415,15 +416,15 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: rero_ils/config.py:4287
+#: rero_ils/config.py:4286
 msgid "ISBN"
 msgstr ""
 
-#: rero_ils/config.py:4293
+#: rero_ils/config.py:4292
 msgid "ISSN"
 msgstr ""
 
-#: rero_ils/config.py:4299
+#: rero_ils/config.py:4298
 #: rero_ils/modules/documents/jsonschemas/documents/document_entity_local-v0.0.1.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form-v0.0.1.json:8
 #: rero_ils/modules/documents/jsonschemas/documents/document_genre_form_link-v0.0.1.json:14
@@ -431,14 +432,14 @@ msgstr ""
 msgid "Genre, form"
 msgstr ""
 
-#: rero_ils/config.py:4305
+#: rero_ils/config.py:4304
 #: rero_ils/modules/collections/jsonschemas/collections/collection-v0.0.1.json:141
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects-v0.0.1.json:9
 #: rero_ils/modules/documents/jsonschemas/documents/document_subjects_entity_link-v0.0.1.json:15
 msgid "Subject"
 msgstr ""
 
-#: rero_ils/config.py:4311
+#: rero_ils/config.py:4310
 #: rero_ils/modules/collections/templates/rero_ils/detailed_view_collections.html:78
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:54
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:74
@@ -447,32 +448,32 @@ msgstr ""
 msgid "Call number"
 msgstr ""
 
-#: rero_ils/config.py:4317
+#: rero_ils/config.py:4316
 msgid "Local fields (document)"
 msgstr ""
 
-#: rero_ils/config.py:4323
+#: rero_ils/config.py:4322
 msgid "Local fields (holdings)"
 msgstr ""
 
-#: rero_ils/config.py:4329
+#: rero_ils/config.py:4328
 msgid "Local fields (items)"
 msgstr ""
 
-#: rero_ils/config.py:4335
+#: rero_ils/config.py:4334
 #: rero_ils/modules/documents/jsonschemas/documents/document_classification-v0.0.1.json:7
 msgid "Classification"
 msgstr ""
 
-#: rero_ils/config.py:4341
+#: rero_ils/config.py:4340
 msgid "RDA content type"
 msgstr ""
 
-#: rero_ils/config.py:4347
+#: rero_ils/config.py:4346
 msgid "RDA media type"
 msgstr ""
 
-#: rero_ils/config.py:4353
+#: rero_ils/config.py:4352
 msgid "RDA carrier type"
 msgstr ""
 
@@ -2483,17 +2484,17 @@ msgstr "貨幣"
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:189
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:260
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:326
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:413
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:492
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:520
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:592
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:625
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:658
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:691
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:724
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:761
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:789
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:820
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:418
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:497
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:525
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:597
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:630
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:663
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:696
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:729
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:766
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:794
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:825
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:98
 msgid "Type"
 msgstr "類型"
@@ -4597,7 +4598,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:31
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:133
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:15
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:20
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:23
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:16
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:22
@@ -4639,7 +4640,7 @@ msgstr ""
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:219
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:60
 #: rero_ils/modules/operation_logs/jsonschemas/operation_logs/operation_log-v0.0.1.json:419
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:30
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:33
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:37
 #: rero_ils/modules/templates/jsonschemas/templates/template-v0.0.1.json:36
@@ -4797,19 +4798,19 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:77
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:81
 #: rero_ils/modules/acquisition/acq_orders/api.py:88
 #: rero_ils/modules/holdings/api.py:173 rero_ils/modules/ill_requests/api.py:89
 #: rero_ils/modules/items/api/record.py:92
 msgid "Cannot have multiple notes of the same type."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:83
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:87
 msgid "Cannot save an active order line for a deleted document."
 msgstr ""
 
-#: rero_ils/modules/acquisition/acq_order_lines/api.py:98
-msgid "Cannot create an order line with an order with a wrong status."
+#: rero_ils/modules/acquisition/acq_order_lines/api.py:111
+msgid "Cannot save an order line for an order with a wrong status."
 msgstr ""
 
 #: rero_ils/modules/acquisition/acq_order_lines/extensions.py:56
@@ -7841,8 +7842,8 @@ msgstr "程度"
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:405
 #: rero_ils/modules/documents/jsonschemas/documents/document_intended_audience-v0.0.1.json:490
 #: rero_ils/modules/documents/jsonschemas/documents/document_summary-v0.0.1.json:32
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:156
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:218
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:168
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:230
 msgid "value"
 msgstr "值"
 
@@ -10276,7 +10277,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:63
+#: rero_ils/modules/item_types/api.py:72
 msgid "Another online item type exists in this organisation"
 msgstr ""
 
@@ -10708,7 +10709,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:214
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:41
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:42
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:61
 msgid "Code"
 msgstr ""
@@ -10722,7 +10723,7 @@ msgid "Name of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:225
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:36
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Address"
 msgstr ""
 
@@ -10779,12 +10780,12 @@ msgid "Communication language"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:497
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:59
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:62
 msgid "Online harvested sources"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:498
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:60
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:63
 msgid "Online harvested sources as configured in ebooks server."
 msgstr ""
 
@@ -11478,157 +11479,157 @@ msgid ""
 "etc."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:26
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Organisation ID"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:31
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:37
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Address of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:43
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "Code of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:48
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "Current ID of the budget"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:49
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
 msgid "The ID of the current budget of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Default currency"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:54
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "The default currency of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:70
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:73
 msgid "Collection enabled on public view"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:75
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:78
 msgid "Patron cleanup configuration"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:76
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:79
 msgid ""
 "Configuration for the automatic deletion of inactive patron profiles. "
 "Delete the field if you never want the patrons to be deleted "
 "automatically."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:90
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:93
 msgid "Expiration threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:91
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:94
 msgid ""
 "Only delete patrons whose expiration_date is older than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:96
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:99
 msgid "Inactivity threshold (years)"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:97
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:100
 msgid ""
 "Only delete patrons whose user last logged in more than this many years "
 "ago."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:102
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:105
 msgid "Excluded patron types"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:103
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:106
 msgid "List of patron type PIDs to exclude from automatic deletion."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:124
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:127
 msgid "Homepage"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:126
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:129
 msgid "Configuration for the public homepage."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:135
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:141
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:147
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:153
 msgid "Slogan"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:137
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:150
 msgid "Text displayed on the public homepage banner."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:189
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:251
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:325
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:388
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:451
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:201
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:263
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:337
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:400
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:463
 msgid "Only one value per language is allowed."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:197
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:203
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:209
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:215
 msgid "Placeholder"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:199
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:212
 msgid "Placeholder text displayed in the public homepage search box."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:259
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:271
 msgid "Blocks"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:261
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:273
 msgid "HTML content displayed in the homepage blocks."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:270
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:276
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:282
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:288
 msgid "Left block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:272
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:285
 msgid ""
 "HTML content displayed in the left homepage block. Will also be the first"
 " block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:291
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:354
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:417
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:303
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:366
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:429
 msgid "HTML"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:333
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:339
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:345
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:351
 msgid "Center block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:335
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:348
 msgid ""
 "HTML content displayed in the center homepage block. Will also be the "
 "second block displayed on mobile."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:396
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:402
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:408
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:414
 msgid "Right block"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:398
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:411
 msgid ""
 "HTML content displayed in the right homepage block. Will also be the "
 "third block displayed on mobile."
@@ -12332,8 +12333,8 @@ msgid "Catalog"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:174
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:505
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:774
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:510
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:779
 msgid "Indicator"
 msgstr ""
 
@@ -12344,36 +12345,36 @@ msgstr ""
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:208
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:279
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:345
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:432
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:539
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:889
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:969
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1049
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:437
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:544
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:894
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:974
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1054
 msgid "distributions"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:225
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:295
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:365
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:556
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1070
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:366
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:561
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1075
 msgid "created_month"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:229
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:299
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:369
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:560
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1074
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:370
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:565
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1079
 msgid "created_year"
 msgstr ""
 
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:233
 #: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:303
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:381
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:457
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:921
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1001
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:386
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:462
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:926
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1006
 msgid "owning_library"
 msgstr ""
 
@@ -12389,144 +12390,144 @@ msgstr ""
 msgid "Number of items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:385
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:925
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1005
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:390
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:930
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1010
 msgid "owning_location"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:389
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:394
 msgid "type (standard/issue)"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:410
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:415
 msgid "Number of deleted items"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:449
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:454
 msgid "action_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:453
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:458
 msgid "action_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:461
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:466
 msgid "operator_library"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:489
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:494
 msgid "Circulation"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:517
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:522
 msgid "Number of ill requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:589
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:594
 msgid "Number of checkins"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:622
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:627
 msgid "Number of checkouts"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:655
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:660
 msgid "Number of renewals"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:688
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:693
 msgid "Number of requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:721
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:726
 msgid "Number of validated requests"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:758
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:763
 msgid "User management"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:786
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:791
 msgid "Number of patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:817
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:822
 msgid "Number of active patrons"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:849
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:854
 msgid "Distributions"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:850
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:855
 msgid ""
 "Up to 2 filters by which to distribute the data in the generated tables. "
 "The first value is the lines; the second value is the columns."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:858
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:863
 msgid "Period"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:859
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:864
 msgid ""
 "The time range to filter the data relevant to a specific period: latest "
 "month or latest year. Leave empty to not filter the data. Example: "
 "process the number of checkouts performed in the last month."
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:871
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:876
 msgid "month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:913
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:993
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:918
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:998
 msgid "transaction_month"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:917
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:997
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:922
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1002
 msgid "transaction_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:937
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1013
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:942
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1018
 msgid "patron_age"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:941
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1017
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:946
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1022
 msgid "patron_postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:945
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1021
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:950
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1026
 msgid "patron_local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:953
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1029
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:958
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1034
 msgid "transaction_channel"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1078
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1083
 msgid "gender"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1086
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1091
 msgid "postal_code"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1090
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1095
 msgid "local_codes"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1094
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1099
 msgid "birth_year"
 msgstr ""
 
-#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1098
+#: rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json:1103
 msgid "role"
 msgstr ""
 
@@ -12796,7 +12797,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-globe\"></i>"
+msgid "<i class=\"fa fa-phone\"></i>"
 msgstr ""
 
 #. Line unknown
@@ -12806,7 +12807,7 @@ msgstr ""
 
 #. Line unknown
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:1
-msgid "<i class=\"fa fa-phone\"></i>"
+msgid "<i class=\"fa fa-globe\"></i>"
 msgstr ""
 
 #: rero_ils/theme/menus.py:38
@@ -12924,7 +12925,7 @@ msgstr "登錄"
 msgid "or"
 msgstr "或"
 
-#: rero_ils/theme/templates/rero_ils/frontpage.html:38
+#: rero_ils/theme/templates/rero_ils/frontpage.html:36
 msgid "What are you looking for?"
 msgstr "你在找什麼？"
 
@@ -13032,4 +13033,7 @@ msgstr "您的圖書館"
 #: rero_ils/theme/templates/security/email/reset_notice.html:9
 msgid "Your password has been successfully reset."
 msgstr "您的密碼已成功重置。"
+
+#~ msgid "Cannot create an order line with an order with a wrong status."
+#~ msgstr ""
 

--- a/tests/api/acq_orders/test_acq_orders_rest.py
+++ b/tests/api/acq_orders/test_acq_orders_rest.py
@@ -75,6 +75,38 @@ def test_acq_order_get(client, acq_order_fiction_martigny):
     "invenio_records_rest.views.verify_record_permission",
     mock.MagicMock(return_value=VerifyRecordPermissionPatch),
 )
+def test_acq_computed_records_are_not_cacheable(
+    client,
+    acq_order_fiction_martigny,
+    acq_order_line_fiction_martigny,
+    acq_receipt_fiction_martigny,
+    acq_receipt_line_1_fiction_martigny,
+    acq_account_fiction_martigny,
+):
+    """Test acquisition item responses with related data disable caching.
+
+    Their body and ETag depend on related records (financial totals,
+    statuses, budget state), so a conditional 304 would serve a stale body
+    and a stale ETag (the latter breaking the editor's If-Match on save).
+    The responses must be `no-store` while keeping the ETag for updates.
+    """
+    for endpoint, record in [
+        ("invenio_records_rest.acor_item", acq_order_fiction_martigny),
+        ("invenio_records_rest.acol_item", acq_order_line_fiction_martigny),
+        ("invenio_records_rest.acre_item", acq_receipt_fiction_martigny),
+        ("invenio_records_rest.acrl_item", acq_receipt_line_1_fiction_martigny),
+        ("invenio_records_rest.acac_item", acq_account_fiction_martigny),
+    ]:
+        res = client.get(url_for(endpoint, pid_value=record.pid))
+        assert res.status_code == 200
+        assert res.headers["Cache-Control"] == "no-store"
+        assert "ETag" in res.headers
+
+
+@mock.patch(
+    "invenio_records_rest.views.verify_record_permission",
+    mock.MagicMock(return_value=VerifyRecordPermissionPatch),
+)
 def test_acq_orders_post_put_delete(
     client,
     org_martigny,

--- a/tests/ui/acq_order_lines/test_acq_order_lines_api.py
+++ b/tests/ui/acq_order_lines/test_acq_order_lines_api.py
@@ -5,11 +5,13 @@
 """Acquisition order lines API tests."""
 
 from copy import deepcopy
+from unittest import mock
 
 import pytest
 from jsonschema import ValidationError
 
 from rero_ils.modules.acquisition.acq_order_lines.api import AcqOrderLine
+from rero_ils.modules.acquisition.acq_orders.models import AcqOrderStatus
 from rero_ils.modules.utils import get_ref_for_pid
 
 
@@ -40,3 +42,18 @@ def test_order_line_validation_extension(acq_order_line_fiction_martigny_data, a
     with pytest.raises(ValidationError) as error:
         AcqOrderLine.create(test_data, delete_pid=True)
     assert "Cannot link to an harvested document" in str(error.value)
+
+
+def test_order_line_cancel_on_received_order(acq_order_line_fiction_martigny):
+    """Test cancelling a line is valid even when the order became received."""
+    order_line = acq_order_line_fiction_martigny
+    with mock.patch(
+        "rero_ils.modules.acquisition.acq_orders.api.AcqOrder.get_status_by_pid",
+        mock.MagicMock(return_value=AcqOrderStatus.RECEIVED),
+    ):
+        order_line["is_cancelled"] = True
+        assert order_line.extended_validation() is True
+
+        # a non-cancelling update on a received order is still rejected
+        order_line["is_cancelled"] = False
+        assert isinstance(order_line.extended_validation(), str)


### PR DESCRIPTION
## Summary

Two independent fixes for acquisition orders, both surfaced while editing or cancelling order lines on partially received orders. A deeper follow-up is tracked in #4152.

## 1. Stale browser cache on acquisition records

Acquisition item responses depend on *related* records, but their `ETag`/`Last-Modified` only track the record's own `revision_id`. So a conditional `GET` can return `304` with a stale representation:

- Computed display fields (`account_statement`, `status`, account balances) show outdated values — e.g. an order's provisional total stayed `0` after lines were added, greying out the **Place order** button.
- The stale `ETag` breaks editing — the editor reuses it as the `If-Match` precondition on save, so a line loaded from cache fails to save.

**Fix:** send `Cache-Control: no-store` on the acquisition item endpoints (`acor`, `acol`, `acre`, `acrl`, `acac`) so the browser always refetches a fresh body and ETag. The ETag is kept intact for optimistic concurrency on updates.

## 2. Cannot cancel the last non-received line of a partially received order

Cancelling the last non-received line makes the order fully received. Because the REST `PUT` calls the record's overridden `update()` (which commits and reindexes) and then invenio commits again, `extended_validation` re-runs against the already-reindexed state, sees `received`, and rejects it with "wrong status" — even though the cancellation had already persisted (line cancelled, but an error was shown).

**Fix:** accept `RECEIVED` in `extended_validation` when the line is being cancelled — a cancellation is always valid, and the update permission (evaluated once on the prior status) remains the real gate. Also clarified the validation docstring (it omitted the status check and claimed a `False` return) and reworded the message to "save" instead of "create"; translated the new string in en/fr/de/it.
