### PR TITLE
fix(stats): document owning_lib distribution also counts files

### DIFF
--- a/rero_ils/modules/stats/api/indicators/others.py
+++ b/rero_ils/modules/stats/api/indicators/others.py
@@ -39,7 +39,7 @@ class NumberOfDocumentsCfg(IndicatorCfg):
         cfg = {
             "owning_library": A(
                 "terms",
-                field="holdings.organisation.library_pid",
+                field="library_pid",
                 size=self.cfg.aggs_size,
                 include=self.cfg.lib_pids,
             ),


### PR DESCRIPTION
In stats, the indicator number of documents counts a document as belonging to a library if it is linked to a holdings or file for that library, but the distribution by owning_library only took holdings into account.

The owning_library distrib now correctly targets the field `library_pid`, which is a copy_to from the holdings, items, AND files.