### PR TITLE
fix: return 400 instead of 500 on invalid requests

### DIFF
--- a/rero_ils/modules/documents/query.py
+++ b/rero_ils/modules/documents/query.py
@@ -8,7 +8,7 @@ import re
 from datetime import datetime
 
 from elasticsearch_dsl import Q
-from flask import request
+from flask import abort, request
 
 
 def acquisition_filter():
@@ -45,10 +45,13 @@ def acquisition_filter():
             # NG-Core's widget for a date range sends timestamps
             # We transform the timestamp into a date
             values = dict(zip(["from", "to"], range_values.split("--")))
-            if "from" in values:
-                values["from"] = datetime.fromtimestamp(float(values["from"]) / 1000).strftime("%Y-%m-%d")
-            if "to" in values:
-                values["to"] = datetime.fromtimestamp(float(values["to"]) / 1000).strftime("%Y-%m-%d")
+            try:
+                if "from" in values:
+                    values["from"] = datetime.fromtimestamp(float(values["from"]) / 1000).strftime("%Y-%m-%d")
+                if "to" in values:
+                    values["to"] = datetime.fromtimestamp(float(values["to"]) / 1000).strftime("%Y-%m-%d")
+            except ValueError, OverflowError, OSError:
+                abort(400, description="Invalid 'new_acquisition' timestamp range")
         else:
             values = dict(zip(["from", "to"], range_values.split(":")))
         range_acquisition_dates = {"lte": values.get("to") or "now/d"}

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -203,7 +203,9 @@ class REROILSAPP:
     def init_app(self, app):
         """Flask application initialization."""
         Bootstrap4(app)
-        Wiki(app)
+        # Only register the wiki on the UI app to avoid ``BuildError`` when trying to reach it from the API.
+        if app.static_folder is not None:
+            Wiki(app)
         NormalizerStopWords(app)
         self.init_config(app)
         app.extensions["rero-ils"] = self

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 
 from dateutil.relativedelta import relativedelta
 from elasticsearch_dsl.query import Q
-from flask import current_app, request
+from flask import abort, current_app, request
 from flask import request as flask_request
 from invenio_i18n.ext import current_i18n
 from invenio_records_rest.errors import InvalidQueryRESTError
@@ -268,7 +268,11 @@ def view_search_collection_factory(self, search, query_parser=None):
         org = Organisation.get_record_by_viewcode(view)
         search = search.filter("term", organisation__pid=org["pid"])
     if published := request.args.get("published"):
-        search = search.filter("term", published=bool(int(published)))
+        try:
+            published = bool(int(published))
+        except ValueError:
+            abort(400, description="Invalid 'published' value")
+        search = search.filter("term", published=published)
 
     return search, urlkwargs
 

--- a/tests/api/collections/test_collections_rest.py
+++ b/tests/api/collections/test_collections_rest.py
@@ -52,6 +52,11 @@ def test_collections_facets(client, rero_json_header, coll_martigny_1):
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
 
+    # malformed 'published' value must return a clean 400, not a 500
+    list_url = url_for("invenio_records_rest.coll_list", published="foo")
+    res = client.get(list_url, headers=rero_json_header)
+    assert res.status_code == 400
+
 
 def test_collection_enrich_data(
     client,

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -227,6 +227,15 @@ def test_documents_newacq_filters(
     data = get_json(res)
     assert data["hits"]["total"]["value"] == 1
 
+    # malformed timestamp range must return a clean 400 Bad Request
+    doc_list = url_for(
+        "invenio_records_rest.doc_list",
+        view="global",
+        new_acquisition="foo--bar",
+    )
+    res = client.get(doc_list, headers=rero_json_header)
+    assert res.status_code == 400
+
 
 @mock.patch(
     "invenio_records_rest.views.verify_record_permission",

--- a/tests/api/test_commons_api.py
+++ b/tests/api/test_commons_api.py
@@ -203,6 +203,12 @@ def test_proxy(mock_get, client):
     assert response.status_code == 418
 
 
+def test_wiki_not_registered_on_api_app(app, client):
+    """Test the wiki is not served by the API app."""
+    assert "wiki.page" not in app.view_functions
+    assert client.get("/help/home/").status_code == 404
+
+
 def test_boosting_fields(app):
     """Test the boosting configuration."""
     # the configuration should exists


### PR DESCRIPTION
Handle three previously-uncaught cases that produced HTTP 500 responses:

- serve the wiki only on the UI app; the API app has no `static` endpoint, so rendering a wiki page (e.g. /api/help/home/) raised a BuildError
- malformed `new_acquisition` timestamp range on the documents search
- malformed `published` value on the collections search