### PR TITLE
feat(documents): flag incomplete indexing

### DIFF
--- a/rero_ils/modules/documents/dumpers/indexer.py
+++ b/rero_ils/modules/documents/dumpers/indexer.py
@@ -211,6 +211,7 @@ class IndexerDumper(Dumper):
         files = []
         full_text_size = 0
         full_text_size_max = current_app.config.get("RERO_ILS_FILES_FULL_TEXT_MAX", 10 * 1024 * 1024)
+        fulltext_indexing_incomplete = False
         for record_file in record.get_records_files():
             record_files_information = {}
             collections = record_file.get("metadata", {}).get("collections")
@@ -229,6 +230,8 @@ class IndexerDumper(Dumper):
                     full_text_size += len(full_text)
                     if full_text_size < full_text_size_max:
                         record_files_information.setdefault(metadata["fulltext_for"], {})["text"] = full_text
+                    else:
+                        fulltext_indexing_incomplete = True
                     continue
                 # other information from the main file
                 record_files_information.setdefault(file_name, {})["file_name"] = file_name
@@ -241,6 +244,7 @@ class IndexerDumper(Dumper):
             files += list(record_files_information.values())
         if files:
             data["files"] = files
+        data["fulltext_indexing_incomplete"] = fulltext_indexing_incomplete
 
     def dump(self, record, data):
         """Dump a document instance with basic document information's.

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -2397,6 +2397,9 @@
       "harvested": {
         "type": "boolean"
       },
+      "fulltext_indexing_incomplete": {
+        "type": "boolean"
+      },
       "isbn": {
         "type": "text",
         "analyzer": "identifier-analyzer",

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -13,6 +13,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 from rero_ils.modules.commons.identifiers import IdentifierType
 from rero_ils.modules.documents.api import Document, DocumentsSearch
+from rero_ils.modules.documents.dumpers import document_indexer_dumper
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.operation_logs.api import OperationLogsSearch
 from rero_ils.modules.utils import get_ref_for_pid
@@ -55,6 +56,7 @@ def test_documents_get(client, document_with_files):
         metadata.pop("nested_identifiers", None)
         metadata.pop("identifiedBy", None)
         metadata.pop("files", None)
+        metadata.pop("fulltext_indexing_incomplete", None)
         return metadata
 
     item_url = url_for("invenio_records_rest.doc_item", pid_value="doc1")
@@ -1050,6 +1052,7 @@ def test_document_fulltext(app, client, document_with_files, document_with_issn)
     assert hits["total"]["value"] == 1
     data = hits["hits"][0]["metadata"]
     assert data["pid"] == document_with_files.pid
+    assert data["fulltext_indexing_incomplete"] is False
     # the document index should contains files informations
     metadata_files = data["files"]
     # required fields
@@ -1095,3 +1098,15 @@ def test_document_fulltext(app, client, document_with_files, document_with_issn)
     res = client.get(list_url)
     hits = get_json(res)["hits"]
     assert hits["total"]["value"] == 1
+
+
+def test_document_fulltext_indexing_incomplete(app, document_with_files):
+    """Test the indicator for incomplete full-text indexing."""
+    full_text_size_max = app.config["RERO_ILS_FILES_FULL_TEXT_MAX"]
+    app.config["RERO_ILS_FILES_FULL_TEXT_MAX"] = 1
+    try:
+        data = document_with_files.dumps(document_indexer_dumper)
+        assert data["fulltext_indexing_incomplete"] is True
+        assert not [file["text"] for file in data["files"] if file.get("text")]
+    finally:
+        app.config["RERO_ILS_FILES_FULL_TEXT_MAX"] = full_text_size_max


### PR DESCRIPTION
* Adds indicator when attached file content exceeds the indexing limit.
* Closes #4071