### PR TITLE
fix(entities): link MEF by identifier, not type

### DIFF
--- a/rero_ils/modules/entities/remote_entities/cli.py
+++ b/rero_ils/modules/entities/remote_entities/cli.py
@@ -101,22 +101,42 @@ def sync_errors(clear, verbose):
 @click.option("-l", "--log-dir", default=None)
 @with_appcontext
 def replace_identified_by_cli(field, dry_run, verbose, log_dir):
-    """Replace identifiedBy with $ref."""
+    """Replace local identifiedBy entities with MEF $ref links.
+
+    Runs :class:`ReplaceIdentifiedBy` over each requested field (all fields by
+    default) and prints a per-field summary: changed, not found, RERO only,
+    type mismatch and type-not-allowed counts. With -v, also lists the
+    offending identifiers.
+    Use -n/--dry-run to report without modifying any document.
+    """
     for parent in field or ReplaceIdentifiedBy.fields:
         replace_identified_by = ReplaceIdentifiedBy(field=parent, verbose=verbose, dry_run=dry_run, log_dir=log_dir)
         changed, not_found, rero_only = replace_identified_by.run()
+        type_mismatch = sum(len(values) for values in replace_identified_by.type_mismatch.values())
+        type_not_allowed = sum(len(values) for values in replace_identified_by.type_not_allowed.values())
         click.secho(
-            f"{parent:<12} | Changed: {changed} | Not found: {not_found} | RERO only: {rero_only}",
+            f"{parent:<12} | Changed: {changed} | Not found: {not_found} | RERO only: {rero_only} | "
+            f"Type mismatch: {type_mismatch} | Type not allowed: {type_not_allowed}",
             fg="green",
         )
         if verbose:
-            if replace_identified_by._error_count(replace_identified_by.not_found):
+            if replace_identified_by.not_found:
                 click.secho("Not found:", fg="yellow")
                 for etype, values in replace_identified_by.not_found.items():
                     for pid, data in values.items():
                         click.echo(f"\t{etype} {pid}: {data}")
-            if replace_identified_by._error_count(replace_identified_by.rero_only):
+            if replace_identified_by.rero_only:
                 click.secho("RERO only:", fg="yellow")
                 for etype, values in replace_identified_by.rero_only.items():
                     for pid, data in values.items():
-                        click.echo(f"\t{pid}: {data}")
+                        click.echo(f"\t{etype} {pid}: {data}")
+            if replace_identified_by.type_mismatch:
+                click.secho("Type mismatch:", fg="yellow")
+                for etype, values in replace_identified_by.type_mismatch.items():
+                    for pid, data in values.items():
+                        click.echo(f"\t{etype} {pid}: {data}")
+            if replace_identified_by.type_not_allowed:
+                click.secho("Type not allowed:", fg="red")
+                for etype, values in replace_identified_by.type_not_allowed.items():
+                    for pid, data in values.items():
+                        click.echo(f"\t{etype} {pid}: {data}")

--- a/rero_ils/modules/entities/remote_entities/permissions.py
+++ b/rero_ils/modules/entities/remote_entities/permissions.py
@@ -13,7 +13,7 @@ class RemoteEntityPermissionPolicy(RecordPermissionPolicy):
     """Entity Permission Policy used by the CRUD operations.
 
     Only search and read is allowed for all users.
-    Other operations are denied far anybody.
+    Other operations are denied for anybody.
     """
 
     can_search = [AnyUser()]

--- a/rero_ils/modules/entities/remote_entities/proxy.py
+++ b/rero_ils/modules/entities/remote_entities/proxy.py
@@ -102,6 +102,10 @@ class MEFProxyMixin:
         "Transfer-Encoding".upper(),
         "Connection".upper(),
     ]
+    # Only content-negotiation headers are relayed to the remote MEF server:
+    # forwarding cookies or other RERO-ILS-specific headers to an external
+    # server would leak them for no benefit to the search itself.
+    forwarded_headers = ["accept", "accept-language"]
     mef_entrypoint = None  # Must be overridden by subclasses
 
     def __init__(self, *args):
@@ -119,15 +123,14 @@ class MEFProxyMixin:
         :returns: the remote MEF response matching the search term
         :rtype: flask.Response
         """
-        # Call the remote MEF server removing the 'Host' headers from initial
-        # request to avoid security problems.
-        request_headers = {key: value for key, value in request.headers if key != "Host"}
+        # Only relay a small allowlist of headers to the remote MEF server;
+        # cookies and other RERO-ILS-specific headers are not forwarded.
+        request_headers = {key: value for key, value in request.headers if key.lower() in self.forwarded_headers}
         response = requests.request(
             method=request.method,
             url=self._build_url(term),
             headers=request_headers,
             data=request.get_data(),
-            cookies=request.cookies,
             allow_redirects=True,
         )
 
@@ -176,6 +179,20 @@ class MEFProxyMixin:
                 filter_value = _build_filter_value(value)
                 query_params.append(f"{key}:{filter_value}")
         return query_params
+
+    def _type_query_param(self):
+        """Build the `(type:X OR type:Y)` query filter from `self.entity_types`.
+
+        :returns: the type filter query param, or `None` if no entity type is set.
+        :rtype: str
+        """
+        if not self.entity_types:
+            return None
+        ent_types = []
+        for _type in self.entity_types:
+            _type = _type.replace(":", "\\:")
+            ent_types.append(f"type:{_type}")
+        return f"({' OR '.join(ent_types)})"
 
     def _build_url(self, term):
         """Build the HTTP query to call to search on MEF authority system.
@@ -226,12 +243,8 @@ class MefAgentsProxy(MEFProxyMixin):
         :rtype: list<str>
         """
         params = super()._get_query_params(term)
-        if self.entity_types:
-            ent_types = []
-            for _type in self.entity_types:
-                _type = _type.replace(":", "\\:")
-                ent_types.append(f"type:{_type}")
-            params += [f"({' OR '.join(ent_types)})"]
+        if type_query := self._type_query_param():
+            params.append(type_query)
         return params
 
     def _post_process_result_hit(self, hit):
@@ -271,26 +284,9 @@ class MefConceptsProxy(MEFProxyMixin):
         :rtype: list<str>
         """
         params = super()._get_query_params(term)
-        if self.entity_types:
-            ent_types = []
-            for _type in self.entity_types:
-                _type = _type.replace(":", "\\:")
-                ent_types.append(f"type:{_type}")
-            params += [f"({' OR '.join(ent_types)})"]
+        if type_query := self._type_query_param():
+            params.append(type_query)
         return params
-
-    def _post_process_result_hit(self, hit):
-        """Modify a MEF hit response to return a standardized hit.
-
-        The modification to do on an 'Agent' hit are :
-          - for each used sources: (TODO :: Need MEF correction)
-            - add a `type` field
-
-        :param hit: an elasticSearch hit already parsed as a dictionary.
-        """
-        if not (metadata := hit.get("metadata", {})):
-            return
-        super()._post_process_result_hit(hit)
 
 
 class MefConceptsGenreFormProxy(MefConceptsProxy):

--- a/rero_ils/modules/entities/remote_entities/replace.py
+++ b/rero_ils/modules/entities/remote_entities/replace.py
@@ -19,37 +19,63 @@ from rero_ils.modules.utils import set_timestamp as utils_set_timestamp
 from ..logger import create_logger
 from .api import RemoteEntity
 
+# (connect, read) timeout in seconds for each MEF request, so a stalled
+# connection cannot hang the whole run scan.
+MEF_REQUEST_TIMEOUT = (5, 60)
+
 
 class ReplaceIdentifiedBy:
-    """Entity replace identifiedBy with $ref.
+    """Replace a document's ``identifiedBy`` entities with a MEF ``$ref``.
 
-    Usage example:
-    replace_identified_by = ReplaceIdentifiedBy(
-        field='contribution',
-        dry_run=True,
-        verbose=True
-    )
-    changed, not_found rero_only = replace_identified_by.run()
-    # changed: count of changed identifiedBy
-    # not_found: count of not found identifiedBy
-    # rero_only: count of identifiedBy with RERO reference
-    #            (therefore not changed).
+    For a given field (``contribution``, ``subjects`` or ``genreForm``), every
+    entity still described by a local ``identifiedBy`` is looked up on the MEF
+    server; when a match is found the entity is rewritten as a ``$ref`` to the
+    MEF record. The identifier alone is authoritative — a wrong local type does
+    not prevent linking.
+
+    Outcomes are accumulated in per-entity-type dicts for reporting:
+
+    * ``not_found``: the identifier was not found on any allowed MEF family.
+    * ``rero_only``: found, but the MEF record exposes only a RERO source
+      (nothing to link to); also gates retries for the same identifier.
+    * ``type_mismatch``: (``contribution`` only) linked, but the MEF type
+      differs from the document's — still a valid contribution type, flagged
+      for review.
+    * ``type_not_allowed``: the MEF type cannot appear in this field at all
+      (e.g. a contribution resolving to a ``bf:Topic``) — refused, not linked,
+      logged as an error.
+
+    Usage example::
+
+        replace = ReplaceIdentifiedBy(field="contribution", dry_run=True, verbose=True)
+        changed, not_found, rero_only = replace.run()
     """
 
     fields = ("contribution", "subjects", "genreForm")
+    # MEF families allowed for each field, per the document JSON schema.
+    field_mef_types = {
+        "contribution": ("agents",),
+        "subjects": ("agents", "concepts", "places"),
+        "genreForm": ("concepts",),
+    }
     timestamp_name = "replace_identified_by"
 
     def __init__(self, field, dry_run=False, verbose=False, log_dir=None):
-        """Constructor.
+        """Initialize the replacer for a single document field.
 
-        :param field: field type [contribution, subjects, genreForm]
-        :param dry_run: bool - if true the data are not modified
-        :param verbose: bool or integer - verbose level
+        :param field: the field to process: contribution, subjects or genreForm.
+        :param dry_run: when True, resolve and report but do not write changes.
+        :param verbose: verbosity level (bool or integer).
+        :param log_dir: directory for the ``replace_identifiedby.log`` file;
+            when omitted, logs go to the default location.
         """
         self.field = field
         self.dry_run = dry_run
         self.verbose = verbose
         self.entity_types = current_app.config["RERO_ILS_ENTITY_TYPES"]
+        # Entity types allowed in this field, per RERO_ILS_ENTITIES_TYPES_FIELDS.
+        types_fields = current_app.config["RERO_ILS_ENTITIES_TYPES_FIELDS"]
+        self.allowed_entity_types = {entity_type for entity_type, fields in types_fields.items() if field in fields}
         self.logger = create_logger(
             name="ReplaceIdentifiedBy",
             file_name="replace_identifiedby.log",
@@ -59,35 +85,68 @@ class ReplaceIdentifiedBy:
         self.changed = 0
         self.rero_only = {}
         self.not_found = {}
+        self.type_mismatch = {}
+        self.type_not_allowed = {}
 
     def _get_base_url(self, entity_type):
-        """Get MEF base URL."""
+        """Return the MEF base URL for a MEF family.
+
+        :param entity_type: MEF family (agents, concepts, places).
+        :returns: the base URL for that family.
+        :raises KeyError: when no base URL is configured for the family.
+        """
         if base_url := get_mef_url(entity_type):
             return base_url
         raise KeyError(f"Unable to find MEF base url for {entity_type}")
 
     def _get_latest(self, entity_type, source, pid):
-        """Query the MEF server to retrieve the last MEF for a given entity id.
+        """Fetch the latest MEF record for a source identifier.
 
-        :param source: (string) the entity source such as `idref`, `gnd`
-        :param pid: (string) the entity identifier.
-        :returns: dictionary representing the MEF record.
-        :rtype: dictionary.
+        :param entity_type: MEF family (agents, concepts, places).
+        :param source: the identifier source, such as `idref` or `gnd`.
+        :param pid: the identifier value in that source.
+        :returns: the MEF record, or an empty dict on any non-OK response.
         """
         url = f"{self._get_base_url(entity_type)}/mef/latest/{source}:{pid}"
-        res = requests_retry_session().get(url)
+        res = requests_retry_session().get(url, timeout=MEF_REQUEST_TIMEOUT)
         if res.status_code == requests.codes.ok:
             return res.json()
-        self.logger.warning(f"Problem get {url}: {res.status_code}")
+        self.logger.warning("Problem get %s: %s", url, res.status_code)
         return {}
 
-    def _find_other_source(self, source, mef_data):
-        """Find other soure.
+    def _get_latest_for_field(self, doc_entity_type, source, pid):
+        """Query the MEF families allowed for the current field.
 
-        If source is 'rero' try to find other source in mef_data.
-        :params source: source type
-        :params mef_data: mef data to find other source
-        :returns: found source and source pid
+        The MEF family implied by the document's local type is tried first,
+        then the field's other allowed families, so a wrong local type does
+        not prevent finding the identifier: it alone is enough to link.
+
+        :param doc_entity_type: (string) the entity type declared in the document.
+        :param source: (string) the entity source such as `idref`, `gnd`.
+        :param pid: (string) the entity identifier.
+        :returns: (mef_type, mef_data) the family the record was found in and
+            the MEF record, or (None, {}) if not found in any allowed family.
+        """
+        guessed_mef_type = self.entity_types.get(doc_entity_type)
+        if guessed_mef_type is None:
+            # `doc_entity_type` has no MEF family at all (e.g. bf:Work): nothing to query.
+            return None, {}
+        allowed_mef_types = self.field_mef_types[self.field]
+        for mef_type in dict.fromkeys((guessed_mef_type, *allowed_mef_types)):
+            if mef_type in allowed_mef_types and (mef_data := self._get_latest(mef_type, source, pid)):
+                return mef_type, mef_data
+        return None, {}
+
+    def _find_other_source(self, source, mef_data):
+        """Pick the source to link to from a MEF record.
+
+        `idref`/`gnd` are linkable and returned as-is; a `rero` source is not
+        linkable, so the record is searched for an `idref` or `gnd` alternative.
+
+        :param source: the document's identifier source (idref, gnd or rero).
+        :param mef_data: the MEF record to inspect.
+        :returns: a (source, pid) tuple to link to, or (None, None) when the
+            record exposes no linkable source.
         """
         if source in ("idref", "gnd"):
             return source, mef_data[source]["pid"]
@@ -100,11 +159,10 @@ class ReplaceIdentifiedBy:
     @property
     def query(self):
         """Search query for documents with identifiedBy and entity types."""
-        entity_types = list(current_app.config["RERO_ILS_ENTITY_TYPES"].keys())
         return (
             DocumentsSearch()
             .filter("exists", field=f"{self.field}.entity.identifiedBy")
-            .filter({"terms": {f"{self.field}.entity.type": entity_types}})
+            .filter({"terms": {f"{self.field}.entity.type": list(self.allowed_entity_types)}})
         )
 
     def count(self):
@@ -126,74 +184,120 @@ class ReplaceIdentifiedBy:
                 # TODO: try to optimize with parent commit and reindex
                 #       bulk operation
                 RemoteEntity.create(data=new_mef_data, dbcommit=True, reindex=True)
-            self.logger.info(f"Create a new MEF {mef_type} record(pid: {mef_data['pid']})")
+            self.logger.info("Create a new MEF %s record(pid: %s)", mef_type, mef_data["pid"])
 
     def _do_entity(self, entity, doc_pid):
-        """Do entity.
+        """Resolve one entity and rewrite it as a MEF ``$ref`` when possible.
 
-        :param entity: entity to chnage.
-        :param doc_pid: document pid.
-        :returns: changed
+        Looks the entity's identifier up on the allowed MEF families and, on a
+        linkable match, replaces ``entity["entity"]`` in place with a ``$ref``.
+        Unresolved, RERO-only, type-mismatch and type-not-allowed outcomes are
+        recorded in the corresponding reporting dicts (see the class docstring).
+
+        :param entity: the field entry to process; mutated in place on success.
+        :param doc_pid: the document pid, used for logging.
+        :returns: True if the entity was linked, False/None otherwise (None when
+            skipped without a change, e.g. already-tried or type-not-allowed).
         """
         changed = False
         doc_entity_type = entity["entity"]["type"]
-        self.not_found.setdefault(doc_entity_type, {})
-        self.rero_only.setdefault(doc_entity_type, {})
-        if mef_type := self.entity_types.get(doc_entity_type):
-            source_pid = entity["entity"]["identifiedBy"]["value"]
-            source = entity["entity"]["identifiedBy"]["type"].lower()
-            identifier = f"{source}:{source_pid}"
-            if identifier in self.not_found[doc_entity_type] or identifier in self.rero_only[doc_entity_type]:
-                # MEF was not found previously. Do not try it again.
-                return None
-            if mef_data := self._get_latest(mef_type, source, source_pid):
-                new_source, new_source_pid = self._find_other_source(source=source, mef_data=mef_data)
-                if new_source:
-                    mef_entity_type = mef_data.get("type")
-                    # verify local and MEF type are the same
-                    if mef_entity_type == doc_entity_type:
-                        self._create_entity(mef_type, mef_data)
-                        authorized_access_point = entity["entity"]["authorized_access_point"]
-                        mef_authorized_access_point = mef_data[new_source]["authorized_access_point"]
-                        self.logger.info(
-                            f"Replace document:{doc_pid} "
-                            f'{self.field} "{authorized_access_point}" - '
-                            f"({mef_type}:{mef_data['pid']}) "
-                            f"{new_source}:{new_source_pid} "
-                            f'"{mef_authorized_access_point}"'
-                        )
-                        entity["entity"] = {
-                            "$ref": (f"{self._get_base_url(mef_type)}/{new_source}/{new_source_pid}"),
-                            "pid": mef_data["pid"],
-                        }
-                        changed = True
-                    else:
-                        authorized_access_point = mef_data.get(source, {}).get("authorized_access_point")
-                        info = f'{doc_entity_type} != {mef_entity_type} : "{authorized_access_point}"'
-                        self.rero_only[doc_entity_type][identifier] = info
-                        self.logger.warning(f"Type differ:{doc_pid} {self.field} - ({mef_type}) {identifier} {info}")
-                else:
-                    authorized_access_point = mef_data.get(source, {}).get("authorized_access_point")
-                    info = f"{authorized_access_point}"
-                    self.rero_only[doc_entity_type][identifier] = info
-                    self.logger.info(
-                        f"No other source found for document:{doc_pid} "
-                        f"{self.field} - ({mef_type}|{doc_entity_type}) "
-                        f'{identifier} "{info}"'
+        source_pid = entity["entity"]["identifiedBy"]["value"]
+        source = entity["entity"]["identifiedBy"]["type"].lower()
+        identifier = f"{source}:{source_pid}"
+        if (
+            identifier in self.not_found.get(doc_entity_type, {})
+            or identifier in self.rero_only.get(doc_entity_type, {})
+            or identifier in self.type_not_allowed.get(doc_entity_type, {})
+        ):
+            # Already resolved to a deterministic no-link outcome; don't query
+            # MEF again. (type_mismatch is excluded: those entities DO link, so
+            # a later document sharing the identifier must still be replaced.)
+            return None
+        mef_type, mef_data = self._get_latest_for_field(doc_entity_type, source, source_pid)
+        if mef_data:
+            new_source, new_source_pid = self._find_other_source(source=source, mef_data=mef_data)
+            if new_source:
+                mef_entity_type = mef_data.get("type")
+                source_authorized_access_point = mef_data.get(source, {}).get("authorized_access_point")
+                if mef_entity_type and mef_entity_type not in self.allowed_entity_types:
+                    # The identifier resolves to an entity whose type cannot appear
+                    # in this field (e.g. a contribution pointing to a bf:Topic):
+                    # do not link it — a wrong-typed $ref would be invalid data.
+                    info = (
+                        f"{doc_entity_type} -> {mef_entity_type} not allowed "
+                        f'for {self.field} : "{source_authorized_access_point}"'
+                    )
+                    self.type_not_allowed.setdefault(doc_entity_type, {})[identifier] = info
+                    self.logger.error(
+                        "Type not allowed:%s %s - (%s) %s %s", doc_pid, self.field, mef_type, identifier, info
+                    )
+                    return None
+                self._create_entity(mef_type, mef_data)
+                authorized_access_point = entity["entity"]["authorized_access_point"]
+                mef_authorized_access_point = mef_data[new_source]["authorized_access_point"]
+                self.logger.info(
+                    'Replace document:%s %s "%s" - (%s:%s) %s:%s "%s"',
+                    doc_pid,
+                    self.field,
+                    authorized_access_point,
+                    mef_type,
+                    mef_data["pid"],
+                    new_source,
+                    new_source_pid,
+                    mef_authorized_access_point,
+                )
+                entity["entity"] = {
+                    "$ref": (f"{self._get_base_url(mef_type)}/{new_source}/{new_source_pid}"),
+                    "pid": mef_data["pid"],
+                }
+                changed = True
+                # the identifier alone is enough to link the entity; on
+                # `contribution` a type mismatch (within the allowed types) is
+                # still flagged for review. Kept separate from `rero_only`,
+                # which also gates retries: this entity was successfully
+                # replaced, so it must not block a later document sharing the
+                # same identifier.
+                if self.field == "contribution" and mef_entity_type != doc_entity_type:
+                    info = f'{doc_entity_type} != {mef_entity_type} : "{source_authorized_access_point}"'
+                    self.type_mismatch.setdefault(doc_entity_type, {})[identifier] = info
+                    self.logger.warning(
+                        "Type differ:%s %s - (%s) %s %s", doc_pid, self.field, mef_type, identifier, info
                     )
             else:
-                authorized_access_point = entity["entity"]["authorized_access_point"]
+                authorized_access_point = mef_data.get(source, {}).get("authorized_access_point")
                 info = f"{authorized_access_point}"
-                self.not_found[doc_entity_type][identifier] = info
-                self.logger.info(f'No MEF found for document:{doc_pid}  - ({mef_type}) {identifier} "{info}"')
-        self.not_found = {k: v for k, v in self.not_found.items() if v}
-        self.rero_only = {k: v for k, v in self.rero_only.items() if v}
+                self.rero_only.setdefault(doc_entity_type, {})[identifier] = info
+                self.logger.info(
+                    'No other source found for document:%s %s - (%s|%s) %s "%s"',
+                    doc_pid,
+                    self.field,
+                    mef_type,
+                    doc_entity_type,
+                    identifier,
+                    info,
+                )
+        else:
+            authorized_access_point = entity["entity"]["authorized_access_point"]
+            info = f"{authorized_access_point}"
+            self.not_found.setdefault(doc_entity_type, {})[identifier] = info
+            self.logger.info(
+                'No MEF found for document:%s  - (%s) %s "%s"',
+                doc_pid,
+                doc_entity_type,
+                identifier,
+                info,
+            )
         return changed
 
     def _replace_entities_in_document(self, doc_id):
-        """Replace identifiedBy with $ref.
+        """Replace every resolvable ``identifiedBy`` entity in one document.
 
-        :param doc_id: (string) document id
+        A failure on a single entity is logged and skipped so it never aborts
+        the rest of the document.
+
+        :param doc_id: the document record id (uuid).
+        :returns: the mutated document when at least one entity changed, else
+            None (nothing to persist).
         """
         changed = False
         with contextlib.suppress(NoResultFound):
@@ -206,21 +310,37 @@ class ReplaceIdentifiedBy:
                 try:
                     changed = self._do_entity(entity, doc.pid) or changed
                 except Exception as err:
-                    self.logger.error(f'Error document:{doc.pid} {entity} {err}"')
+                    self.logger.error("Error document:%s %s %s", doc.pid, entity, err)
             if changed:
                 return doc
         return None
 
     def _error_count(self, counter_dict):
-        """Summ of error count."""
+        """Sum the entries across a per-entity-type reporting dict.
+
+        :param counter_dict: a ``{entity_type: {identifier: info}}`` dict.
+        :returns: the total number of identifiers recorded in it.
+        """
         return sum(len(values) for values in counter_dict.values())
 
     def run(self):
-        """Replace identifiedBy with $ref."""
+        """Process the whole field: resolve and persist every document.
+
+        Scans documents that still carry an ``identifiedBy`` for the field,
+        rewrites resolvable entities as ``$ref`` (unless dry-run), and records
+        the run in the timestamp store.
+
+        ``type_mismatch`` and ``type_not_allowed`` counts are not in this tuple;
+        they are exposed via the same-named attributes and the timestamp payload.
+
+        :returns: a (changed, not_found, rero_only) tuple of counts.
+        """
         self.changed = 0
         self.not_found = {}
         self.rero_only = {}
-        self.logger.info(f"Found {self.field} identifiedBy: {self.count()}")
+        self.type_mismatch = {}
+        self.type_not_allowed = {}
+        self.logger.info("Found %s identifiedBy: %s", self.field, self.count())
         query = self.query.params(preserve_order=True).sort({"_created": {"order": "asc"}}).source(["pid", self.field])
         for hit in list(query.scan()):
             if doc := self._replace_entities_in_document(hit.meta.id):
@@ -241,21 +361,22 @@ class ReplaceIdentifiedBy:
         return data or {}
 
     def set_timestamp(self):
-        """Set time stamp.
+        """Record per-field outcome counts in the timestamp store.
 
-        Dictionary with entity type and count of changed, not found and
-        `rero` only records.
-        * not found: no entity was found.
-        * rero only: entity was found but has only `rero` as source.
+        Each outcome is reported under its own key so none is absorbed into
+        another:
+        * not found: the identifier was not found on any allowed MEF family.
+        * rero only: found, but the MEF record exposes only a `rero` source.
+        * type mismatch: linked, but the MEF type differs (contribution only).
+        * type not allowed: the MEF type cannot appear in this field (refused).
         """
         data = self.get_timestamp()
-        # Count of changed, not found and rero only records.
-        # not found: no entity was found.
-        # rero only: entity was found but has only `rero` as source.
         data[self.field] = {
             "changed": self.changed,
             "not found": self._error_count(self.not_found),
             "rero only": self._error_count(self.rero_only),
+            "type mismatch": self._error_count(self.type_mismatch),
+            "type not allowed": self._error_count(self.type_not_allowed),
             "time": datetime.now(UTC),
         }
         utils_set_timestamp(self.timestamp_name, **data)

--- a/rero_ils/modules/entities/remote_entities/sync.py
+++ b/rero_ils/modules/entities/remote_entities/sync.py
@@ -85,7 +85,7 @@ class SyncEntity:
             ignore_order=True,
         )
         if diff:
-            self.logger.debug(f"Entity differs: {entity1['pid']}, {entity2['pid']}", diff)
+            self.logger.debug("Entity differs: %s, %s: %s", entity1["pid"], entity2["pid"], diff)
             return True
         return False
 
@@ -106,7 +106,7 @@ class SyncEntity:
         res = requests_retry_session().get(url)
         if res.status_code == requests.codes.ok:
             return res.json()
-        self.logger.debug(f"Problem get {url}: {res.status_code}")
+        self.logger.debug("Problem get %s: %s", url, res.status_code)
         return {}
 
     def _update_entities_in_document(self, doc_pid, pids_to_replace):
@@ -129,7 +129,7 @@ class SyncEntity:
                 entity["entity"] for entity in doc.get(field, []) if entity.get("entity", {}).get("$ref")
             ]
         if not remote_entities:
-            self.logger.debug(f"No entity to update for document {doc.pid}")
+            self.logger.debug("No entity to update for document %s", doc.pid)
 
         # update the $ref entity URL and MEF pid
         for mef_url, (old_pid, new_pid) in pids_to_replace.items():
@@ -137,10 +137,12 @@ class SyncEntity:
             new_entity_url = f"{mef_url}/{new_pid}"
             entities_to_update = filter(lambda c: c.get("$ref") == old_entity_url, remote_entities)
             for entity in entities_to_update:
-                if old_entity_url != new_entity_url:
-                    self.logger.info(
-                        f"Entitiy URL changed from {old_entity_url} to {new_entity_url} for document {doc.pid}"
-                    )
+                self.logger.info(
+                    "Entity URL changed from %s to %s for document %s",
+                    old_entity_url,
+                    new_entity_url,
+                    doc.pid,
+                )
                 # update the entity URL
                 entity["$ref"] = new_entity_url
         # in any case we update the doc as the mef pid can be changed
@@ -161,7 +163,7 @@ class SyncEntity:
         if not from_date and self.from_date:
             from_date = self.from_date
         if from_date:
-            self.logger.info(f"Get records updated after: {from_date}")
+            self.logger.info("Get records updated after: %s", from_date)
 
         def get_mef_pids(search_query, chunk_size=1000):
             """Get the identifiers from search index.
@@ -174,7 +176,7 @@ class SyncEntity:
             The scroll is done using the slice scroll feature:
             https://www.elastic.co/guide/en/elasticsearch/reference/8.5/paginate-search-results.html#slice-scroll
             """
-            self.logger.info(f"Processing: {total} MEF records")
+            self.logger.info("Processing: %s MEF records", total)
             if total > 2 * chunk_size:
                 n_part = int(total / chunk_size)
                 for i in range(n_part):
@@ -222,7 +224,7 @@ class SyncEntity:
                                 n_provided += 1
                                 yield hit.get("pid")
                 finally:
-                    self.logger.info(f"Processed {n_provided} records.")
+                    self.logger.info("Processed %s records.", n_provided)
 
             if total:
                 return (
@@ -233,10 +235,16 @@ class SyncEntity:
         # considers all MEF pids
         return get_mef_pids(search_query), total
 
-    def sync_record(self, pid):
+    #: maximum recursion depth for `sync_record`, as a safety net against a
+    #: pathological MEF pid cycle (e.g. A's latest is B, B's latest is A).
+    max_recursion_depth = 10
+
+    def sync_record(self, pid, _depth=0):
         """Sync a MEF record.
 
         :param pid: (string) the MEF identifier.
+        :param _depth: (int) current recursion depth. Used internally to
+            guard against MEF pid cycles; callers should not pass it.
         :returns: the number of updated document, true if the MEF record
             has been update, true if an error occurs.
         :rtype: integer, boolean, x.
@@ -247,10 +255,13 @@ class SyncEntity:
         doc_updated = set()
         updated = error = False
         try:
+            if _depth > self.max_recursion_depth:
+                raise RuntimeError(f"MEF record(pid: {pid}): recursion depth exceeded, possible MEF pid cycle")
+
             if not (entity := RemoteEntity.get_record_by_pid(pid)):
                 raise RecordNotFound(RemoteEntity, pid)
 
-            self.logger.debug(f"Processing {entity['type']} MEF(pid: {pid})")
+            self.logger.debug("Processing %s MEF(pid: %s)", entity["type"], pid)
             # iterate over all entity sources: rero, gnd, idref
             pids_to_replace = {}
             for source in entity["sources"]:
@@ -279,16 +290,22 @@ class SyncEntity:
 
                     if old_mef_pid != new_mef_pid:
                         self.logger.info(
-                            f"MEF pid has changed from {entity.type} "
-                            f"{old_mef_pid} to {new_mef_pid} "
-                            f"for {source} (pid:{old_entity_pid})"
+                            "MEF pid has changed from %s %s to %s for %s (pid:%s)",
+                            entity.type,
+                            old_mef_pid,
+                            new_mef_pid,
+                            source,
+                            old_entity_pid,
                         )
                         if RemoteEntity.get_record_by_pid(new_mef_pid):
                             # update the new MEF - recursion
                             self.logger.info(
-                                f"{entity['type']} MEF(pid: {entity.pid}) recursion with (pid:{new_mef_pid})"
+                                "%s MEF(pid: %s) recursion with (pid:%s)",
+                                entity["type"],
+                                entity.pid,
+                                new_mef_pid,
                             )
-                            new_doc_updated, new_updated, new_error = self.sync_record(new_mef_pid)
+                            new_doc_updated, new_updated, new_error = self.sync_record(new_mef_pid, _depth + 1)
                             # TODO: find a better way
                             doc_updated.update(new_doc_updated)
                             updated = updated or new_updated
@@ -298,9 +315,9 @@ class SyncEntity:
                             if not self.dry_run:
                                 RemoteEntity.create(data=new_mef_data, dbcommit=True, reindex=True)
                                 RemoteEntitiesSearch.flush_and_refresh()
-                            self.logger.info(f"Create a new MEF {entity['type']} record(pid: {new_mef_pid})")
+                            self.logger.info("Create a new MEF %s record(pid: %s)", entity["type"], new_mef_pid)
                     # something changed, update the content
-                    self.logger.info(f"MEF {entity['type']} record(pid: {entity.pid}) content has been updated")
+                    self.logger.info("MEF %s record(pid: %s) content has been updated", entity["type"], entity.pid)
                     if not self.dry_run:
                         if old_mef_pid == new_mef_pid:
                             RemoteEntity.get_record(entity.id).replace(new_mef_data, dbcommit=True, reindex=True)
@@ -315,13 +332,18 @@ class SyncEntity:
             if updated:
                 # need to update each documents
                 doc_pids = entity.documents_pids()
-                self.logger.info(f"MEF {entity['type']} record(pid: {entity.pid})  try to update documents: {doc_pids}")
+                self.logger.info(
+                    "MEF %s record(pid: %s)  try to update documents: %s",
+                    entity["type"],
+                    entity.pid,
+                    doc_pids,
+                )
 
                 for doc_pid in doc_pids:
                     self._update_entities_in_document(doc_pid=doc_pid, pids_to_replace=pids_to_replace)
                 doc_updated = set(doc_pids)
         except Exception as err:
-            self.logger.error(f"ERROR: MEF record(pid: {pid}) -> {err!s}")
+            self.logger.error("ERROR: MEF record(pid: %s) -> %s", pid, err)
             error = True
             # uncomment to debug
             # raise
@@ -337,7 +359,7 @@ class SyncEntity:
 
     def end_sync(self, n_doc_updated, n_mef_updated, mef_errors):
         """Add logging and cache information about the ending process."""
-        self.logger.info(f"DONE: doc updated: {n_doc_updated}, mef updated: {n_mef_updated}.")
+        self.logger.info("DONE: doc updated: %s, mef updated: %s.", n_doc_updated, n_mef_updated)
         if self.dry_run:
             return
         errors = data.get("errors", []) if (data := get_timestamp("sync_entities")) else []
@@ -395,20 +417,21 @@ class SyncEntity:
             if not self.dry_run:
                 # remove from the database and the index: no tombstone
                 entity.delete(True, True, True)
-            self.logger.info(f"MEF {entity['type']} record(pid: {entity.pid}) has been deleted.")
+            self.logger.info("MEF %s record(pid: %s) has been deleted.", entity["type"], entity.pid)
             return True
         return False
 
     @classmethod
     def get_errors(cls):
         """Get all the MEF pids that causes an error."""
-        return get_timestamp("sync_entities").get("errors", [])
+        data = get_timestamp("sync_entities")
+        return data.get("errors", []) if data else []
 
     @classmethod
     def clear_errors(cls):
         """Removes errors in the cache information."""
         data = get_timestamp("sync_entities")
-        if data.get("errors"):
+        if data and data.get("errors"):
             data["errors"] = []
             set_timestamp("sync_entities", **data)
 
@@ -438,5 +461,5 @@ class SyncEntity:
             except Exception:
                 error_entities.append(pid)
             sys.stdout.flush()
-        self.logger.info(f"DONE: MEF deleted: {removed_entity_counter}")
+        self.logger.info("DONE: MEF deleted: %s", removed_entity_counter)
         return removed_entity_counter, error_entities

--- a/rero_ils/modules/entities/remote_entities/tasks.py
+++ b/rero_ils/modules/entities/remote_entities/tasks.py
@@ -52,7 +52,7 @@ def sync_entities(from_last_date=True, verbose=0, dry_run=False, in_memory=True)
 
 
 @shared_task(ignore_result=True)
-def replace_identified_by(fields=None, verbose=0, dry_run=False):
+def replace_identified_by(fields=None, verbose=False, dry_run=False):
     """Replace identifiedBy with $ref.
 
     :param fields: Entity type to replace (concepts, subjects, genreForm)
@@ -70,6 +70,8 @@ def replace_identified_by(fields=None, verbose=0, dry_run=False):
                 "changed": changed,
                 "not_found": not_found,
                 "rero_only": rero_only,
+                "type_not_allowed": sum(len(v) for v in replace.type_not_allowed.values()),
+                "type_mismatch": sum(len(v) for v in replace.type_mismatch.values()),
             }
         except Exception as err:
             result[field] = {"error": err}

--- a/rero_ils/modules/entities/remote_entities/utils.py
+++ b/rero_ils/modules/entities/remote_entities/utils.py
@@ -105,7 +105,12 @@ def get_mef_data_by_type(
             json_data = request.json()
             if hits := json_data.get("hits", {}):
                 # we got an search response
-                data = hits.get("hits", [None])[0].get("metadata", {})
+                if not (hit_list := hits.get("hits", [])):
+                    msg = f"MEF resolver: no result for {mef_url}"
+                    if verbose:
+                        current_app.logger.warning(msg)
+                    raise ValueError(msg)
+                data = hit_list[0].get("metadata", {})
             else:
                 # we got an DB response
                 data = json_data

--- a/tests/ui/entities/remote_entities/test_remote_entities_api.py
+++ b/tests/ui/entities/remote_entities/test_remote_entities_api.py
@@ -394,15 +394,233 @@ def test_replace_identified_by(
             mock_response(json_data=entity_topic_data_2),
         ],
     ):
+        # bf:Work has no MEF family at all: no MEF lookup is attempted for it, it's just not_found
         changed, not_found, rero_only = replace_identified_by.run()
         assert changed == 1
-        assert not_found == 0
+        assert not_found == 1
         assert rero_only == 3
         assert dict(sorted(replace_identified_by.rero_only.items())) == {
             "bf:Person": {"rero:A009963344": "Athenagoras (patriarche oecuménique ; 1)"},
             "bf:Topic": {"rero:A021039750": "Bases de données déductives"},
             "bf:Place": {"rero:A009975209": "Europe occidentale"},
         }
+        assert replace_identified_by.not_found == {
+            "bf:Work": {"rero:A001234567": "Bases de donnéesi (Voltenauer, Marc)"}
+        }
+
+
+def test_replace_identified_by_type_mismatch(app, entity_organisation, entity_organisation_data):
+    """A MEF type differing from the document should not block the $ref replace.
+
+    The identifier alone is enough to link the entity. Only for
+    `contribution` is the mismatch still flagged for the metadata admin.
+    """
+    log_path = tempfile.mkdtemp()
+    entity = {
+        "entity": {
+            "type": "bf:Person",
+            "authorized_access_point": "Some person",
+            "identifiedBy": {"type": "GND", "value": "1161956409"},
+        }
+    }
+
+    # subjects/genreForm: replaced, mismatch is not flagged
+    replace_identified_by = ReplaceIdentifiedBy(field="subjects", verbose=True, dry_run=False, log_dir=log_path)
+    with mock.patch("requests.Session.get", side_effect=[mock_response(json_data=entity_organisation_data)]):
+        changed = replace_identified_by._do_entity(deepcopy(entity), "doc_pid_test")
+    assert changed is True
+    assert replace_identified_by.rero_only == {}
+
+    # contribution: replaced, but mismatch is flagged for the metadata admin
+    replace_identified_by = ReplaceIdentifiedBy(field="contribution", verbose=True, dry_run=False, log_dir=log_path)
+    contribution_entity = deepcopy(entity)
+    with mock.patch("requests.Session.get", side_effect=[mock_response(json_data=entity_organisation_data)]):
+        changed = replace_identified_by._do_entity(contribution_entity, "doc_pid_test")
+    assert changed is True
+    assert contribution_entity["entity"]["$ref"] == "https://mef.rero.ch/api/agents/gnd/1161956409"
+    assert replace_identified_by.rero_only == {}
+    assert replace_identified_by.type_mismatch == {
+        "bf:Person": {
+            "gnd:1161956409": 'bf:Person != bf:Organisation : "Convegno internazionale di italianistica Craiova"'
+        }
+    }
+
+
+def test_replace_identified_by_type_mismatch_does_not_block_retry(app, entity_organisation, entity_organisation_data):
+    """A type-mismatch flag on one document must not block replacement for another.
+
+    `type_mismatch` (flagged for admin review) must stay independent from
+    `rero_only` (which also gates retries): a successfully replaced entity
+    must not silently block a later document sharing the same identifier.
+    """
+    log_path = tempfile.mkdtemp()
+    replace_identified_by = ReplaceIdentifiedBy(field="contribution", verbose=True, dry_run=False, log_dir=log_path)
+
+    def make_entity():
+        return {
+            "entity": {
+                "type": "bf:Person",
+                "authorized_access_point": "Some person",
+                "identifiedBy": {"type": "GND", "value": "1161956409"},
+            }
+        }
+
+    entity_doc1 = make_entity()
+    with mock.patch("requests.Session.get", side_effect=[mock_response(json_data=entity_organisation_data)]):
+        changed_doc1 = replace_identified_by._do_entity(entity_doc1, "doc_pid_1")
+    assert changed_doc1 is True
+    assert entity_doc1["entity"]["$ref"] == "https://mef.rero.ch/api/agents/gnd/1161956409"
+
+    # a second document sharing the same identifier must still be replaced,
+    # not skipped because the first one was already flagged in type_mismatch
+    entity_doc2 = make_entity()
+    with mock.patch("requests.Session.get", side_effect=[mock_response(json_data=entity_organisation_data)]):
+        changed_doc2 = replace_identified_by._do_entity(entity_doc2, "doc_pid_2")
+    assert changed_doc2 is True
+    assert entity_doc2["entity"]["$ref"] == "https://mef.rero.ch/api/agents/gnd/1161956409"
+
+
+def test_replace_identified_by_type_not_allowed(app):
+    """A resolved MEF type invalid for the field is logged as error and not linked.
+
+    Unlike a Person/Organisation mismatch (still linked, flagged as warning), a
+    resolved type that cannot appear in the field at all (e.g. a contribution
+    resolving to a bf:Topic) must be refused: no $ref is written.
+    """
+    log_path = tempfile.mkdtemp()
+    entity = {
+        "entity": {
+            "type": "bf:Person",
+            "authorized_access_point": "Some person",
+            "identifiedBy": {"type": "GND", "value": "1161956409"},
+        }
+    }
+    # The identifier resolves to a bf:Topic, which is not allowed in a contribution.
+    mef_data = {
+        "pid": "topic1",
+        "type": "bf:Topic",
+        "gnd": {"pid": "1161956409", "authorized_access_point": "Some topic"},
+    }
+    original = deepcopy(entity)
+
+    replace_identified_by = ReplaceIdentifiedBy(field="contribution", verbose=True, dry_run=False, log_dir=log_path)
+    with mock.patch("requests.Session.get", side_effect=[mock_response(json_data=mef_data)]):
+        changed = replace_identified_by._do_entity(entity, "doc_pid_test")
+
+    assert not changed
+    # entity left untouched — no $ref written
+    assert entity == original
+    assert replace_identified_by.type_mismatch == {}
+    assert replace_identified_by.type_not_allowed == {
+        "bf:Person": {"gnd:1161956409": 'bf:Person -> bf:Topic not allowed for contribution : "Some topic"'}
+    }
+
+
+def test_replace_identified_by_type_not_allowed_gates_retry(app):
+    """A type-not-allowed identifier must not be re-queried against MEF.
+
+    The outcome is deterministic per identifier, so a second document sharing
+    it is skipped without another MEF call.
+    """
+    log_path = tempfile.mkdtemp()
+
+    def make_entity():
+        return {
+            "entity": {
+                "type": "bf:Person",
+                "authorized_access_point": "Some person",
+                "identifiedBy": {"type": "GND", "value": "1161956409"},
+            }
+        }
+
+    mef_data = {
+        "pid": "topic1",
+        "type": "bf:Topic",
+        "gnd": {"pid": "1161956409", "authorized_access_point": "Some topic"},
+    }
+    replace_identified_by = ReplaceIdentifiedBy(field="contribution", verbose=True, dry_run=False, log_dir=log_path)
+
+    with mock.patch("requests.Session.get", return_value=mock_response(json_data=mef_data)) as mock_get:
+        replace_identified_by._do_entity(make_entity(), "doc_pid_1")
+        replace_identified_by._do_entity(make_entity(), "doc_pid_2")
+
+    # the second document is gated by the type_not_allowed cache — MEF hit once
+    assert mock_get.call_count == 1
+
+
+def test_replace_identified_by_timestamp_reports_each_outcome(app):
+    """set_timestamp records each outcome under its own key, without conflation.
+
+    `rero only` must not absorb the `type mismatch` count anymore; both, plus
+    `type not allowed`, are reported distinctly.
+    """
+    _SET_TS = "rero_ils.modules.entities.remote_entities.replace.utils_set_timestamp"
+    replace = ReplaceIdentifiedBy(field="contribution", verbose=True, dry_run=True, log_dir=tempfile.mkdtemp())
+    replace.changed = 5
+    replace.not_found = {"bf:Person": {"idref:1": "x"}}
+    replace.rero_only = {"bf:Person": {"rero:2": "x"}}
+    replace.type_mismatch = {"bf:Person": {"gnd:3": "x"}}
+    replace.type_not_allowed = {"bf:Person": {"gnd:4": "x"}}
+
+    with mock.patch(_SET_TS) as mock_set, mock.patch.object(replace, "get_timestamp", return_value={}):
+        replace.set_timestamp()
+
+    payload = mock_set.call_args.kwargs["contribution"]
+    assert payload["changed"] == 5
+    assert payload["not found"] == 1
+    assert payload["rero only"] == 1  # does NOT include the type mismatch
+    assert payload["type mismatch"] == 1
+    assert payload["type not allowed"] == 1
+
+
+def test_replace_identified_by_query_allowed_types(app):
+    """The document search query must use the full per-field allowed-type list.
+
+    `subjects` allows `bf:Work` (it has no MEF family, but is still a valid
+    local type per the document schema); a document whose only qualifying
+    subject is a `bf:Work` entry must still be selected for scanning.
+    `contribution` only allows agents (Person/Organisation): `bf:Work` and
+    `bf:Place` must not appear in its filter.
+    """
+    subjects_types = ReplaceIdentifiedBy(field="subjects").query.to_dict()
+    contribution_types = ReplaceIdentifiedBy(field="contribution").query.to_dict()
+
+    def terms_for(query_dict):
+        for clause in query_dict["query"]["bool"]["filter"]:
+            if "terms" in clause:
+                return next(iter(clause["terms"].values()))
+        return []
+
+    assert "bf:Work" in terms_for(subjects_types)
+    assert "bf:Work" not in terms_for(contribution_types)
+    assert "bf:Place" not in terms_for(contribution_types)
+
+
+def test_replace_identified_by_family_fallback(app, entity_person_all, entity_person_data_all):
+    """The MEF family implied by a wrong local type is not the only one tried.
+
+    `subjects` allows agents, concepts and places: if the identifier is not
+    found in the family the (here wrong) local type implies, the other
+    allowed families are tried before giving up.
+    """
+    log_path = tempfile.mkdtemp()
+    replace_identified_by = ReplaceIdentifiedBy(field="subjects", verbose=True, dry_run=False, log_dir=log_path)
+    entity = {
+        "entity": {
+            "type": "bf:Temporal",
+            "authorized_access_point": "Some temporal",
+            "identifiedBy": {"type": "RERO", "value": "A003633163"},
+        }
+    }
+    with mock.patch(
+        "requests.Session.get",
+        side_effect=[mock_response(status=404), mock_response(json_data=entity_person_data_all)],
+    ):
+        changed = replace_identified_by._do_entity(entity, "doc_pid_test")
+    assert changed is True
+    assert entity["entity"]["$ref"] == "https://mef.rero.ch/api/agents/idref/029314100"
+    assert replace_identified_by.rero_only == {}
+    assert replace_identified_by.not_found == {}
 
 
 def test_entity_get_record_by_ref(mef_agents_url, entity_person, entity_person_data_tmp):


### PR DESCRIPTION
* replace.py: identifier alone now links contribution/subjects/ genreForm entries to MEF; search falls back across every MEF family allowed for the field when the locally-declared type is wrong
* replace.py: contribution type mismatches are tracked in a new `type_mismatch` dict, no longer conflated with the `rero_only` retry cache, which was silently blocking later documents sharing the same identifier
* replace.py: document query now derives allowed entity types from `RERO_ILS_ENTITIES_TYPES_FIELDS`, so `bf:Work`-only subjects are no longer skipped from scanning
* sync.py: `sync_record` recursion is now capped to guard against a pathological MEF pid cycle; raises specific `RuntimeError`s instead of the bare `Exception` class
* utils.py: `get_mef_data_by_type` reports a clear "no result" error instead of a confusing IndexError-derived message
* proxy.py: `search()` no longer forwards cookies or arbitrary headers to the remote MEF server; deduplicated `_get_query_params` and removed a dead `_post_process_result_hit` override
* sync.py, replace.py: switched logging calls to lazy %-style formatting instead of f-strings
* cli.py: stopped reaching into a private method from outside the class
* Closes https://github.com/rero/rero-ils/issues/4135