### PR TITLE
fix(acquisition): prevent CSV order export crash with deleted link

### DIFF
--- a/rero_ils/modules/acquisition/acq_orders/serializers/csv.py
+++ b/rero_ils/modules/acquisition/acq_orders/serializers/csv.py
@@ -204,7 +204,7 @@ class AcqOrderCSVSerializer(CSVSerializer):
                     csv_data = {k: order_data.get(f) for k, f in order_fields.items()}
 
                     # Update csv data with vendor
-                    csv_data["vendor_name"] = vendor_data.get("name")
+                    csv_data["vendor_name"] = vendor_data.get("name") if vendor_data else "unknown"
 
                     # extract order notes
                     order_notes = filter(
@@ -216,15 +216,19 @@ class AcqOrderCSVSerializer(CSVSerializer):
                         column_name = f"order_{note_type}"
                         csv_data[column_name] = note.get("content")
 
-                    # update csv data with document infos
-                    csv_data.update(documents.get(order_line["document"]["pid"]))
+                    # update csv data with document info
+                    if document := documents.get(order_line["document"]["pid"]):
+                        csv_data.update(document)
+                    else:
+                        csv_data["document_pid"] = order_line["document"]["pid"]
+                        csv_data["document_title"] = "unknown"
 
                     # update csv data with account infos
                     account = accounts.get(order_line["acq_account"]["pid"])
                     csv_data.update(
                         {
-                            "account_name": account.get("name"),
-                            "account_number": account.get("number"),
+                            "account_name": account.get("name") if account else "unknown",
+                            "account_number": account.get("number") if account else "unknown",
                         }
                     )
 

--- a/tests/api/acq_orders/test_acq_orders_serializers.py
+++ b/tests/api/acq_orders/test_acq_orders_serializers.py
@@ -4,9 +4,13 @@
 
 """Tests Serializers."""
 
+import csv
+from io import StringIO
+
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
+from rero_ils.modules.documents.api import DocumentsSearch
 from tests.utils import get_csv
 
 
@@ -42,3 +46,45 @@ def test_csv_serializer(
         '"receipt_reference","received_quantity","received_amount",'
         '"receipt_date"' in data
     )
+
+
+def test_csv_serializer_missing_document(
+    client,
+    csv_header,
+    librarian_martigny,
+    acq_account_fiction_martigny,
+    vendor_martigny,
+    acq_order_fiction_martigny,
+    acq_order_line_fiction_martigny,
+    acq_order_line2_fiction_martigny,
+    document,
+):
+    """Test CSV export keeps streaming when a linked document is missing.
+
+    A document may be deleted from the search index while still referenced by
+    a terminal order line. The export must export every order line instead of
+    crashing the stream, and display a placeholder for the missing document.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    order = acq_order_fiction_martigny
+
+    # Remove the document from the search index.
+    document.delete_from_index()
+    DocumentsSearch.flush_and_refresh()
+
+    try:
+        list_url = url_for("api_exports.acq_order_export", q=f"pid:{order.pid}")
+        response = client.get(list_url, headers=csv_header)
+        assert response.status_code == 200
+        rows = list(csv.DictReader(StringIO(get_csv(response))))
+    finally:
+        # Restore the shared module-scoped fixture for the other tests.
+        document.reindex()
+        DocumentsSearch.flush_and_refresh()
+
+    # Both order lines are still exported: the stream was not truncated.
+    order_rows = [row for row in rows if row["order_pid"] == order.pid]
+    assert len(order_rows) >= 2
+    for row in order_rows:
+        assert row["document_pid"] == document.pid
+        assert row["document_title"] == "unknown"


### PR DESCRIPTION
When serialising order lines, guard the document, vendor and account lookups with an "unknown" placeholder when the linked record is missing. This prevents incomplete CSV exports if a linked document was deleted, for example.