### PR TITLE
fix(facet-count): count library facets by document

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2114,38 +2114,27 @@ RECORDS_REST_FACETS = dict(
                     bool=dict()
                 ),
                 aggs=dict(
-                    nested_holdings=dict(
-                        nested=dict(
-                            path="nested_holdings"
-                        ),
-                        aggs=dict(
-                            organisation=dict(
-                                terms=dict(
-                                    field="nested_holdings.organisation.organisation_pid",
-                                    size=DOCUMENTS_AGGREGATION_SIZE,
-                                    min_doc_count=0,
-                                ),
-                                aggs=dict(
-                                    library=dict(
-                                        terms=dict(
-                                            field="nested_holdings.organisation.library_pid",
-                                            size=50,
-                                            min_doc_count=0,
-                                        ),
-                                        aggs=dict(
-                                            location=dict(
-                                                terms=dict(
-                                                    field="nested_holdings.location.pid",
-                                                    size=100,
-                                                    min_doc_count=0,
-                                                )
-                                            )
-                                        )
-                                    )
-                                )
-                            )
+                    organisation=dict(
+                        terms=dict(
+                            field="organisation_library_location.organisation",
+                            size=DOCUMENTS_AGGREGATION_SIZE,
+                            min_doc_count=0,
                         )
-                    )
+                    ),
+                    library=dict(
+                        terms=dict(
+                            field="organisation_library_location.library",
+                            size=50,
+                            min_doc_count=0,
+                        )
+                    ),
+                    location=dict(
+                        terms=dict(
+                            field="organisation_library_location.location",
+                            size=100,
+                            min_doc_count=0,
+                        )
+                    ),
                 )
             ),
             status=dict(

--- a/rero_ils/facets.py
+++ b/rero_ils/facets.py
@@ -67,6 +67,15 @@ def default_facets_factory(search, index):
             (facet_body.get(k)["field"] for k in ["terms", "date_histogram"] if k in facet_body),
             None,
         )
+        if not facet_field and index == "documents" and facet_name == "organisation":
+            facet_field = next(
+                (
+                    body.get("terms", {}).get("field")
+                    for body in facet_body.get("aggs", {}).values()
+                    if body.get("terms", {}).get("field")
+                ),
+                None,
+            )
         facet_filter = None
         if facet_field:
             # get DSL expression of post_filters,
@@ -77,7 +86,13 @@ def default_facets_factory(search, index):
 
         # Check if 'filter' is defined into the facet configuration. If yes,
         # then add this filter to the facet filter previously created.
-        if "filter" in facet_body:
+        if index == "documents" and facet_name == "organisation" and "filter" in facet_body:
+            agg_filter = obj_or_import_string(facet_body["filter"])
+            if callable(agg_filter):
+                agg_filter = agg_filter(search, urlkwargs)
+            facet_body["filter"] = (facet_filter & Q(agg_filter) if facet_filter else Q(agg_filter)).to_dict()
+            facet_filter = None
+        elif "filter" in facet_body:
             agg_filter = obj_or_import_string(facet_body.pop("filter"))
             if callable(agg_filter):
                 agg_filter = agg_filter(search, urlkwargs)

--- a/rero_ils/modules/documents/dumpers/indexer.py
+++ b/rero_ils/modules/documents/dumpers/indexer.py
@@ -25,13 +25,22 @@ class IndexerDumper(Dumper):
         from rero_ils.modules.items.models import ItemNoteTypes
 
         holdings = []
+        organisations = set()
+        libraries = set()
+        locations = set()
         search_holdings = HoldingsSearch().filter("term", document__pid=record["pid"]).source().scan()
         for holding in search_holdings:
             holding = holding.to_dict()
+            organisation_pid = holding["organisation"]["pid"]
+            library_pid = holding["library"]["pid"]
+            location_pid = holding["location"]["pid"]
+            organisations.add(organisation_pid)
+            libraries.add(f"{organisation_pid}|{library_pid}")
+            locations.add(f"{organisation_pid}|{library_pid}|{location_pid}")
             hold_data = {
                 "pid": holding["pid"],
                 "location": {
-                    "pid": holding["location"]["pid"],
+                    "pid": location_pid,
                 },
                 "circulation_category": [
                     {
@@ -39,8 +48,8 @@ class IndexerDumper(Dumper):
                     }
                 ],
                 "organisation": {
-                    "organisation_pid": holding["organisation"]["pid"],
-                    "library_pid": holding["library"]["pid"],
+                    "organisation_pid": organisation_pid,
+                    "library_pid": library_pid,
                 },
                 "holdings_type": holding["holdings_type"],
             }
@@ -86,9 +95,9 @@ class IndexerDumper(Dumper):
                 #   'nested' structure.
                 if acq_date := item.get("acquisition_date"):
                     item_data["acquisition"] = {
-                        "organisation_pid": holding["organisation"]["pid"],
-                        "library_pid": holding["library"]["pid"],
-                        "location_pid": holding["location"]["pid"],
+                        "organisation_pid": organisation_pid,
+                        "library_pid": library_pid,
+                        "location_pid": location_pid,
                         "date": acq_date,
                     }
                 if public_notes_content := [
@@ -101,6 +110,11 @@ class IndexerDumper(Dumper):
         if holdings:
             data["holdings"] = holdings
             data["nested_holdings"] = holdings
+            data["organisation_library_location"] = {
+                "organisation": sorted(organisations),
+                "library": sorted(libraries),
+                "location": sorted(locations),
+            }
 
     @staticmethod
     def _process_identifiers(record, data):

--- a/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v7/documents/document-v0.0.1.json
@@ -52,6 +52,20 @@
       "location_pid": {
         "type": "keyword"
       },
+      "organisation_library_location": {
+        "type": "object",
+        "properties": {
+          "organisation": {
+            "type": "keyword"
+          },
+          "library": {
+            "type": "keyword"
+          },
+          "location": {
+            "type": "keyword"
+          }
+        }
+      },
       "files": {
         "type": "object",
         "properties": {

--- a/rero_ils/modules/documents/serializers/json.py
+++ b/rero_ils/modules/documents/serializers/json.py
@@ -32,6 +32,50 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
     """Serializer for RERO-ILS `Document` records as JSON."""
 
     @staticmethod
+    def _new_terms_aggregation(buckets=None):
+        """Build a terms aggregation result."""
+        return {
+            "buckets": buckets or [],
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+        }
+
+    @classmethod
+    def _build_organisation_aggregation(cls, aggregation):
+        """Build the organisation aggregation from indexed location paths."""
+        organisations = {
+            bucket["key"]: {
+                **bucket,
+                "library": cls._new_terms_aggregation(),
+            }
+            for bucket in aggregation.get("organisation", {}).get("buckets", [])
+        }
+        libraries = {}
+        for bucket in aggregation.get("library", {}).get("buckets", []):
+            org_pid, library_pid = bucket["key"].split("|", 1)
+            if org_pid not in organisations:
+                continue
+            library_bucket = {
+                **bucket,
+                "key": library_pid,
+                "location": cls._new_terms_aggregation(),
+            }
+            organisations[org_pid]["library"]["buckets"].append(library_bucket)
+            libraries[(org_pid, library_pid)] = library_bucket
+
+        for bucket in aggregation.get("location", {}).get("buckets", []):
+            org_pid, library_pid, location_pid = bucket["key"].split("|", 2)
+            if library_bucket := libraries.get((org_pid, library_pid)):
+                library_bucket["location"]["buckets"].append(
+                    {
+                        **bucket,
+                        "key": location_pid,
+                    }
+                )
+
+        return cls._new_terms_aggregation(list(organisations.values()))
+
+    @staticmethod
     def _get_view_information():
         """Get the `view_id` and `view_code` to use to build response."""
         view_id = None
@@ -41,7 +85,7 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
         return view_id, view_code
 
     def preprocess_record(self, pid, record, links_factory=None, **kwargs):
-        """Prepare a record and persistent identifier for serialization."""
+        """Prepare a record and persistent identifier for serialization"""
         rec = record
 
         # TODO: uses dumpers
@@ -144,17 +188,19 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
                     "max": extract_acquisition_date("date_max", datetime.now().strftime("%Y-%m-%d")),
                 },
             }
-        # organisation aggregation is a nested aggregation, we need to
-        # remove this useless level.
+        # Build the public organisation/library/location facet shape from the
+        # internal aggregation representation.
         if aggr_by_org := aggregations.pop("organisation", None):
             if aggr_by_org.get("nested_holdings"):
                 aggregations["organisation"] = aggr_by_org["nested_holdings"]["organisation"]
+            elif "organisation" in aggr_by_org:
+                aggregations["organisation"] = self._build_organisation_aggregation(aggr_by_org)
             else:
                 aggregations["organisation"] = aggr_by_org
 
         if aggr_org := aggregations.get("organisation", {}).get("buckets", []):
-            # nested aggregation, we need to filter empty buckets
-            aggr_org = filter(lambda agg: agg["doc_count"] > 0, aggr_org)
+            aggr_org = list(filter(lambda agg: agg["doc_count"] > 0, aggr_org))
+            aggregations["organisation"]["buckets"] = aggr_org
             # load all organisations, libraries and locations in cache
             # to avoid multiple queries
             self.load_all(
@@ -166,7 +212,6 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
             # organisation. We can filter the organisation aggregation to keep
             # only this value
             if view_code != GLOBAL_VIEW_CODE:
-                # nested aggregation, we need to filter empty buckets
                 aggr_org = list(filter(lambda term: term["key"] == view_id, aggr_org))
                 aggregations["organisation"]["buckets"] = aggr_org
             for org in aggr_org:
@@ -176,7 +221,6 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
                 for lib_term in org["library"].get("buckets", []):
                     # add aggregation name
                     lib_term["name"] = self.get_resource(LibrariesSearch(), lib_term["key"])["name"]
-                    # nested aggregation, we need to filter empty buckets
                     lib_term["location"]["buckets"] = list(
                         filter(lambda agg: agg["doc_count"] > 0, lib_term["location"]["buckets"])
                     )

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -343,7 +343,7 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
 
     assert aggs["organisation"]["buckets"] == [
         {
-            "doc_count": 2,
+            "doc_count": 1,
             "key": "org1",
             "library": {
                 "buckets": [
@@ -384,7 +384,7 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
 
     assert aggs["organisation"]["buckets"] == [
         {
-            "doc_count": 2,
+            "doc_count": 1,
             "key": "org1",
             "library": {
                 "buckets": [
@@ -423,51 +423,7 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
     data = get_json(res)
     aggs = data["aggregations"]
 
-    assert aggs["organisation"]["buckets"] == [
-        {
-            "doc_count": 0,
-            "key": "org1",
-            "library": {
-                "buckets": [
-                    {
-                        "doc_count": 0,
-                        "key": "lib1",
-                        "location": {
-                            "buckets": [
-                                {"doc_count": 0, "key": "loc1"},
-                                {
-                                    "doc_count": 0,
-                                    "key": "loc3",
-                                },
-                            ],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
-                        },
-                    },
-                    {
-                        "doc_count": 0,
-                        "key": "lib2",
-                        "location": {
-                            "buckets": [
-                                {
-                                    "doc_count": 0,
-                                    "key": "loc1",
-                                },
-                                {
-                                    "doc_count": 0,
-                                    "key": "loc3",
-                                },
-                            ],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
-                        },
-                    },
-                ],
-                "doc_count_error_upper_bound": 0,
-                "sum_other_doc_count": 0,
-            },
-        }
-    ]
+    assert aggs["organisation"]["buckets"] == []
 
 
 @mock.patch(

--- a/tests/unit/documents/test_document_organisation_facets.py
+++ b/tests/unit/documents/test_document_organisation_facets.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Document organisation facet tests."""
+
+from rero_ils.modules.documents.serializers.json import DocumentJSONSerializer
+
+
+def test_build_organisation_aggregation_from_location_paths():
+    """Build organisation aggregation without creating invalid children."""
+    aggregation = {
+        "organisation": {
+            "buckets": [
+                {"key": "org1", "doc_count": 2},
+                {"key": "org2", "doc_count": 1},
+            ]
+        },
+        "library": {
+            "buckets": [
+                {"key": "org1|lib1", "doc_count": 2},
+                {"key": "org1|lib2", "doc_count": 1},
+                {"key": "org2|lib3", "doc_count": 1},
+            ]
+        },
+        "location": {
+            "buckets": [
+                {"key": "org1|lib1|loc1", "doc_count": 2},
+                {"key": "org1|lib2|loc2", "doc_count": 1},
+                {"key": "org2|lib3|loc3", "doc_count": 1},
+            ]
+        },
+    }
+
+    result = DocumentJSONSerializer._build_organisation_aggregation(aggregation)
+
+    assert result["buckets"] == [
+        {
+            "key": "org1",
+            "doc_count": 2,
+            "library": {
+                "buckets": [
+                    {
+                        "key": "lib1",
+                        "doc_count": 2,
+                        "location": {
+                            "buckets": [{"key": "loc1", "doc_count": 2}],
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                        },
+                    },
+                    {
+                        "key": "lib2",
+                        "doc_count": 1,
+                        "location": {
+                            "buckets": [{"key": "loc2", "doc_count": 1}],
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                        },
+                    },
+                ],
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+            },
+        },
+        {
+            "key": "org2",
+            "doc_count": 1,
+            "library": {
+                "buckets": [
+                    {
+                        "key": "lib3",
+                        "doc_count": 1,
+                        "location": {
+                            "buckets": [{"key": "loc3", "doc_count": 1}],
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                        },
+                    }
+                ],
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+            },
+        },
+    ]


### PR DESCRIPTION
* Replaces nested facet aggregations with indexed organisation library location paths.
* Stores unique pid combinations in organisation_library_location.
* Uses those paths to count documents instead of holdings.
* Rebuilds the same facet tree for the UI.
* Replaces https://github.com/rero/rero-ils-ui/pull/1508 and https://github.com/rero/ng-core/pull/831.
* Closes #4003

Note: this change adds new indexed fields for document facet counts. Existing records need to be reindexed for the corrected organisation/library/location counts to be available.
