### PR TITLE
fix(search): allow Lucene/MARC special chars in query strings

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -4074,6 +4074,17 @@ SIP2_SUMMARY_FIELDS = {
 # OAuth base template
 OAUTH2SERVER_COVER_TEMPLATE = "rero_ils/oauth/base.html"
 
+# Extend the oauthlib allowed character set for Lucene query syntax.
+# Characters that commonly appear unencoded in query strings:
+#   $  - MARC subfield codes ($a, $b, ...)
+#   [] - inclusive range queries (date:[x TO y])
+#   {} - exclusive range queries (date:{x TO y})
+#   ^  - boost factor (term^2)
+#   "  - phrase queries ("exact phrase")
+#   |  - OR operator (||)
+#   '  - apostrophe in text queries (O'Brien); also in oauthlib's own default
+OAUTH2SERVER_ALLOWED_URLENCODE_CHARACTERS = "=&;:%+~,*@!()/?$'[]{}^\"|"
+
 # STOP WORDS
 # Disregarded articles for sorting processes
 # ==========

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -225,3 +225,45 @@ def test_documents_search(client, doc_title_travailleurs, doc_title_travailleuse
     res = client.get(list_url)
     hits = get_json(res)["hits"]
     assert hits["total"]["value"] != 0
+
+
+@mock.patch(
+    "invenio_records_rest.views.verify_record_permission",
+    mock.MagicMock(return_value=VerifyRecordPermissionPatch),
+)
+def test_search_special_chars_not_rejected(client):
+    """Test that Lucene and MARC special chars in query strings return 200.
+
+    OAUTH2SERVER_ALLOWED_URLENCODE_CHARACTERS extends the oauthlib default so
+    that characters valid per RFC 3986 in query strings are not rejected with
+    a 400 by the OAuth middleware.  Spaces must still be encoded as %20.
+    """
+    base_url = url_for("invenio_records_rest.doc_list")
+
+    # $ — MARC subfield codes ($a, $b, $c); unencoded by Angular's HttpClient
+    res = client.get(f"{base_url}?q=local_fields.fields.field_1:$a%20test%20$b%202026")
+    assert res.status_code == 200
+
+    # [] — Lucene inclusive range query
+    res = client.get(f"{base_url}?q=date:[2024-01-01%20TO%202024-12-31]")
+    assert res.status_code == 200
+
+    # {{}} — Lucene exclusive range query
+    res = client.get(f"{base_url}?q=date:{{2024-01-01%20TO%202024-12-31}}")
+    assert res.status_code == 200
+
+    # ^ — Lucene boost factor
+    res = client.get(f"{base_url}?q=title:test^2")
+    assert res.status_code == 200
+
+    # " — Lucene phrase query (unencoded double quote)
+    res = client.get(f'{base_url}?q=title:"exact%20phrase"')
+    assert res.status_code == 200
+
+    # || — Lucene OR operator
+    res = client.get(f"{base_url}?q=(title:foo)||(title:bar)")
+    assert res.status_code == 200
+
+    # ' — apostrophe in text values (e.g. O'Brien)
+    res = client.get(f"{base_url}?q=author:O'Brien")
+    assert res.status_code == 200


### PR DESCRIPTION
Extends OAUTH2SERVER_ALLOWED_URLENCODE_CHARACTERS to include $, ', [],
{}, ^, " and | so that these characters—commonly sent unencoded by
Angular's HttpClient in Lucene query strings—are no longer rejected with
a 400 by the OAuth middleware.

* Closes #4170.
* Closes #3713.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
