### PR TITLE
feat(documents): link to pro view for librarians

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -16,8 +16,23 @@
 {%- endblock css %}
 
 {%- block body %}
-<header class="row py-2">
-    <a href="javascript:history.back()" class="col-12"><i class="fa-solid fa-arrow-left"></i> {{ _('Back') }}</a>
+<header class="d-flex align-items-center py-2">
+    <div class="flex-grow-1">
+      <a href="javascript:history.back()">
+        <i class="fa-solid fa-arrow-left"></i> {{ _('Back') }}
+      </a>
+    </div>
+    {% if current_librarian %}
+    <div>
+      <a
+        class="btn btn-outline-secondary"
+        href="/professional/records/documents/detail/{{ record.pid }}"
+      >
+        <i class="fa-solid fa-file-lines"></i>
+        {{ _('See in pro interface') }}
+      </a>
+    </div>
+    {% endif %}
 </header>
 <div class="row">
   {%- set icon_name = record | document_main_type(false) %}

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -13,7 +13,7 @@ from rero_ils.modules.entities.api import Entity
 from rero_ils.modules.entities.helpers import get_entity_record_from_data
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.organisations.api import Organisation
-from rero_ils.modules.patrons.api import current_patrons
+from rero_ils.modules.patrons.api import current_librarian, current_patrons
 from rero_ils.modules.utils import extracted_data_from_ref
 
 from .api import Document
@@ -75,6 +75,7 @@ def doc_item_view_method(pid, record, template=None, **kwargs):
         viewcode=viewcode,
         recordType="documents",
         current_patrons=current_patrons,
+        current_librarian=current_librarian,
         linked_documents_count=linked_documents_count,
     )
 


### PR DESCRIPTION
* Show a "See in pro interface" link in the header, visible only to users with a professional role (current_librarian).
* Pass current_librarian to the document detail template from doc_item_view_method.
* Closes #4173.