### PR TITLE
fix(documents): count documents instead of holdings in org facet

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -2124,21 +2124,35 @@ RECORDS_REST_FACETS = dict(
                                     field="nested_holdings.organisation.organisation_pid",
                                     size=DOCUMENTS_AGGREGATION_SIZE,
                                     min_doc_count=0,
+                                    # count documents, not holdings, so the
+                                    # `size` cut keeps the buckets with the
+                                    # most documents (see `record_count` below)
+                                    order={"record_count": "desc"},
                                 ),
                                 aggs=dict(
+                                    # count documents, not holdings
+                                    record_count=dict(reverse_nested=dict()),
                                     library=dict(
                                         terms=dict(
                                             field="nested_holdings.organisation.library_pid",
-                                            size=50,
+                                            size=100,
                                             min_doc_count=0,
+                                            order={"record_count": "desc"},
                                         ),
                                         aggs=dict(
+                                            record_count=dict(reverse_nested=dict()),
                                             location=dict(
                                                 terms=dict(
                                                     field="nested_holdings.location.pid",
                                                     size=100,
                                                     min_doc_count=0,
-                                                )
+                                                    order={"record_count": "desc"},
+                                                ),
+                                                aggs=dict(
+                                                    record_count=dict(
+                                                        reverse_nested=dict()
+                                                    )
+                                                ),
                                             )
                                         )
                                     )

--- a/rero_ils/modules/documents/serializers/json.py
+++ b/rero_ils/modules/documents/serializers/json.py
@@ -28,6 +28,27 @@ from ..extensions import TitleExtension
 GLOBAL_VIEW_CODE = LocalProxy(lambda: current_app.config.get("RERO_ILS_SEARCH_GLOBAL_VIEW_CODE"))
 
 
+def _rewrite_nested_terms(terms):
+    """Rewrite a nested terms aggregation to expose root-document counts.
+
+    The nested holdings context counts holdings; the `record_count`
+    (reverse_nested) sub-aggregation gives the number of documents. Expose it
+    as `doc_count` on each bucket and drop empty buckets. The aggregation query
+    already orders buckets by descending document count (`order` on
+    `record_count`), so the buckets are not reordered.
+
+    The `sum_other_doc_count` and `doc_count_error_upper_bound` metadata still
+    describe the holdings-count terms aggregation and no longer match the
+    rewritten (document-count) buckets, so they are dropped.
+    """
+    for bucket in terms["buckets"]:
+        bucket["doc_count"] = bucket.pop("record_count")["doc_count"]
+    terms["buckets"] = [bucket for bucket in terms["buckets"] if bucket["doc_count"] > 0]
+    terms.pop("sum_other_doc_count", None)
+    terms.pop("doc_count_error_upper_bound", None)
+    return terms
+
+
 class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
     """Serializer for RERO-ILS `Document` records as JSON."""
 
@@ -152,9 +173,8 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
             else:
                 aggregations["organisation"] = aggr_by_org
 
-        if aggr_org := aggregations.get("organisation", {}).get("buckets", []):
-            # nested aggregation, we need to filter empty buckets
-            aggr_org = filter(lambda agg: agg["doc_count"] > 0, aggr_org)
+        organisation = aggregations.get("organisation", {})
+        if organisation.get("buckets"):
             # load all organisations, libraries and locations in cache
             # to avoid multiple queries
             self.load_all(
@@ -162,32 +182,31 @@ class DocumentJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
                 LibrariesSearch().source(["name", "pid"]),
                 LocationsSearch().source(["name", "pid"]),
             )
+            # expose document counts (reverse_nested) and prune empty buckets
+            _rewrite_nested_terms(organisation)
             # For a "local view", we only need the facet on the location
             # organisation. We can filter the organisation aggregation to keep
             # only this value
             if view_code != GLOBAL_VIEW_CODE:
-                # nested aggregation, we need to filter empty buckets
-                aggr_org = list(filter(lambda term: term["key"] == view_id, aggr_org))
-                aggregations["organisation"]["buckets"] = aggr_org
-            for org in aggr_org:
+                organisation["buckets"] = [term for term in organisation["buckets"] if term["key"] == view_id]
+            for org in organisation["buckets"]:
                 # add aggregation name
                 org["name"] = self.get_resource(OrganisationsSearch(), org["key"])["name"]
-                org["library"]["buckets"] = list(filter(lambda agg: agg["doc_count"] > 0, org["library"]["buckets"]))
-                for lib_term in org["library"].get("buckets", []):
+                _rewrite_nested_terms(org["library"])
+                for lib_term in org["library"]["buckets"]:
                     # add aggregation name
                     lib_term["name"] = self.get_resource(LibrariesSearch(), lib_term["key"])["name"]
-                    # nested aggregation, we need to filter empty buckets
-                    lib_term["location"]["buckets"] = list(
-                        filter(lambda agg: agg["doc_count"] > 0, lib_term["location"]["buckets"])
-                    )
-                    for loc_term in lib_term["location"].get("buckets", []):
+                    _rewrite_nested_terms(lib_term["location"])
+                    for loc_term in lib_term["location"]["buckets"]:
                         # add aggregation name
                         loc_term["name"] = self.get_resource(LocationsSearch(), loc_term["key"])["name"]
 
             # For a "local view", we replace the organisation aggregation by
             # a library aggregation containing only for the local organisation
             if view_code != GLOBAL_VIEW_CODE:
-                aggregations["library"] = aggr_org[0].get("library", {}) if aggr_org else {}
+                aggregations["library"] = (
+                    organisation["buckets"][0].get("library", {}) if organisation["buckets"] else {}
+                )
                 del aggregations["organisation"]
 
         super()._postprocess_search_aggregations(aggregations)

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -12,7 +12,8 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 from rero_ils.modules.commons.identifiers import IdentifierType
-from rero_ils.modules.documents.api import DocumentsSearch
+from rero_ils.modules.documents.api import Document, DocumentsSearch
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.operation_logs.api import OperationLogsSearch
 from rero_ils.modules.utils import get_ref_for_pid
 from tests.utils import (
@@ -394,9 +395,12 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
     data = get_json(res)
     aggs = data["aggregations"]
 
+    # the stale holdings-based terms metadata (`sum_other_doc_count`,
+    # `doc_count_error_upper_bound`) is dropped: it no longer matches the
+    # document counts exposed on the buckets.
     assert aggs["organisation"]["buckets"] == [
         {
-            "doc_count": 4,
+            "doc_count": 3,
             "key": "org1",
             "library": {
                 "buckets": [
@@ -405,8 +409,6 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
                         "key": "lib1",
                         "location": {
                             "buckets": [{"doc_count": 2, "key": "loc1", "name": "Martigny Library Public Space"}],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
                         },
                         "name": "Library of Martigny-ville",
                     },
@@ -415,14 +417,10 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
                         "key": "lib2",
                         "location": {
                             "buckets": [{"doc_count": 2, "key": "loc3", "name": "Saxon Library Public Space"}],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
                         },
                         "name": "Library of Saxon",
                     },
                 ],
-                "doc_count_error_upper_bound": 0,
-                "sum_other_doc_count": 0,
             },
             "name": "The district of Martigny Libraries",
         }
@@ -437,7 +435,7 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
 
     assert aggs["organisation"]["buckets"] == [
         {
-            "doc_count": 4,
+            "doc_count": 3,
             "key": "org1",
             "library": {
                 "buckets": [
@@ -446,8 +444,6 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
                         "key": "lib1",
                         "location": {
                             "buckets": [{"doc_count": 2, "key": "loc1", "name": "Martigny Library Public Space"}],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
                         },
                         "name": "Library of Martigny-ville",
                     },
@@ -456,14 +452,10 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
                         "key": "lib2",
                         "location": {
                             "buckets": [{"doc_count": 2, "key": "loc3", "name": "Saxon Library Public Space"}],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
                         },
                         "name": "Library of Saxon",
                     },
                 ],
-                "doc_count_error_upper_bound": 0,
-                "sum_other_doc_count": 0,
             },
             "name": "The district of Martigny Libraries",
         }
@@ -476,51 +468,118 @@ def test_documents_organisation_facets(client, document, item_lib_martigny, item
     data = get_json(res)
     aggs = data["aggregations"]
 
-    assert aggs["organisation"]["buckets"] == [
-        {
-            "doc_count": 0,
-            "key": "org1",
-            "library": {
-                "buckets": [
-                    {
-                        "doc_count": 0,
-                        "key": "lib1",
-                        "location": {
-                            "buckets": [
-                                {"doc_count": 0, "key": "loc1"},
-                                {
-                                    "doc_count": 0,
-                                    "key": "loc3",
-                                },
-                            ],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
-                        },
-                    },
-                    {
-                        "doc_count": 0,
-                        "key": "lib2",
-                        "location": {
-                            "buckets": [
-                                {
-                                    "doc_count": 0,
-                                    "key": "loc1",
-                                },
-                                {
-                                    "doc_count": 0,
-                                    "key": "loc3",
-                                },
-                            ],
-                            "doc_count_error_upper_bound": 0,
-                            "sum_other_doc_count": 0,
-                        },
-                    },
-                ],
-                "doc_count_error_upper_bound": 0,
-                "sum_other_doc_count": 0,
-            },
-        }
+    # no document matches `fiction`; every reverse_nested count is 0, so all
+    # buckets are pruned. `min_doc_count=0` still makes Elasticsearch emit the
+    # (empty) buckets, so the rewrite runs and drops the stale holdings-based
+    # terms metadata even for an empty result set.
+    assert aggs["organisation"]["buckets"] == []
+    assert "sum_other_doc_count" not in aggs["organisation"]
+    assert "doc_count_error_upper_bound" not in aggs["organisation"]
+
+
+def _facet_holding_data(document, location, item_type):
+    """Build minimal standard holding data (library/org come from location)."""
+    return {
+        "document": {"$ref": get_ref_for_pid("doc", document.pid)},
+        "circulation_category": {"$ref": get_ref_for_pid("itty", item_type.pid)},
+        "location": {"$ref": get_ref_for_pid("loc", location.pid)},
+        "holdings_type": "standard",
+    }
+
+
+@mock.patch(
+    "invenio_records_rest.views.verify_record_permission",
+    mock.MagicMock(return_value=VerifyRecordPermissionPatch),
+)
+def test_documents_organisation_facet_document_count_order(
+    client,
+    app,
+    rero_json_header,
+    org_sion,
+    lib_sion,
+    lib_aproz,
+    loc_public_sion,
+    loc_restricted_sion,
+    loc_online_sion,
+    loc_online_aproz,
+    item_type_internal_sion,
+    document_data,
+):
+    """Test the `size` cut keeps the buckets with the most documents.
+
+    The org/library/location facet runs on the `nested_holdings` nested field,
+    so Elasticsearch orders the terms buckets by holdings count. When the
+    number of buckets exceeds the aggregation `size`, a library (or location)
+    with many documents but few holdings could be dropped before the serializer
+    re-sorts. The terms aggregations must therefore order by `record_count`
+    (the document count) in the query itself.
+    """
+    # Two libraries of the same organisation:
+    #   * `lib_sion` gets 3 holdings, but all on a single document;
+    #   * `lib_aproz` gets 2 holdings, on two distinct documents.
+    # Elasticsearch orders terms by holdings count, so `lib_sion` (3 holdings)
+    # comes before `lib_aproz` (2 holdings) even though `lib_aproz` has more
+    # documents.
+    documents = [
+        Document.create(deepcopy(document_data), delete_pid=True, dbcommit=True, reindex=True) for _ in range(3)
     ]
+    doc_a, doc_b, doc_c = documents
+
+    holdings = [
+        Holding.create(
+            _facet_holding_data(doc_a, location, item_type_internal_sion), delete_pid=True, dbcommit=True, reindex=True
+        )
+        for location in (loc_public_sion, loc_restricted_sion, loc_online_sion)
+    ]
+    holdings += [
+        Holding.create(
+            _facet_holding_data(document, loc_online_aproz, item_type_internal_sion),
+            delete_pid=True,
+            dbcommit=True,
+            reindex=True,
+        )
+        for document in (doc_b, doc_c)
+    ]
+    HoldingsSearch.flush_and_refresh()
+    for document in documents:
+        document.reindex()
+    DocumentsSearch.flush_and_refresh()
+
+    try:
+        # Shrink the library `size` to 1: with two libraries, the size cut now
+        # keeps a single bucket, reproducing the "buckets exceed the limit"
+        # situation with a minimal dataset.
+        facets = deepcopy(app.config["RECORDS_REST_FACETS"])
+        library_agg = facets["documents"]["aggs"]["organisation"]["aggs"]["nested_holdings"]["aggs"]["organisation"][
+            "aggs"
+        ]["library"]
+        library_agg["terms"]["size"] = 1
+        with mock.patch.dict(app.config, {"RECORDS_REST_FACETS": facets}):
+            list_url = url_for("invenio_records_rest.doc_list", view="org2")
+            res = client.get(list_url, headers=rero_json_header)
+        aggs = get_json(res)["aggregations"]
+
+        # `lib_aproz` (2 documents) must survive the size cut; `lib_sion`
+        # (3 holdings but 1 document) must be dropped. Ordering by holdings
+        # count would keep `lib_sion` and lose `lib_aproz`.
+        library_buckets = aggs["library"]["buckets"]
+        assert [bucket["key"] for bucket in library_buckets] == [lib_aproz.pid]
+        assert library_buckets[0]["doc_count"] == 2
+        location_buckets = library_buckets[0]["location"]["buckets"]
+        assert [bucket["key"] for bucket in location_buckets] == [loc_online_aproz.pid]
+        assert location_buckets[0]["doc_count"] == 2
+        # the stale holdings-based terms metadata is dropped: here the size cut
+        # dropped `lib_sion`, so Elasticsearch reported a non-zero
+        # `sum_other_doc_count` (its 3 holdings) that no longer makes sense.
+        assert "sum_other_doc_count" not in aggs["library"]
+        assert "doc_count_error_upper_bound" not in aggs["library"]
+    finally:
+        for holding in holdings:
+            holding.delete(force=True, dbcommit=True, delindex=True)
+        HoldingsSearch.flush_and_refresh()
+        for document in documents:
+            document.delete(force=True, dbcommit=True, delindex=True)
+        DocumentsSearch.flush_and_refresh()
 
 
 @mock.patch(

--- a/tests/unit/documents/test_documents_serializers.py
+++ b/tests/unit/documents/test_documents_serializers.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Document serializers tests."""
+
+from rero_ils.modules.documents.serializers.json import _rewrite_nested_terms
+
+
+def test_rewrite_nested_terms():
+    """Test the holdings-to-documents facet terms rewrite.
+
+    The nested aggregation counts holdings; the `record_count`
+    (reverse_nested) sub-aggregation gives the document count. The rewrite
+    must expose it as `doc_count` and drop empty buckets, preserve the order
+    returned by Elasticsearch (the query orders terms by `record_count`, so
+    the rewrite must not reorder the buckets), and drop the stale
+    holdings-based terms metadata.
+    """
+    terms = {
+        "buckets": [
+            {"key": "lib1", "doc_count": 5, "record_count": {"doc_count": 2}},
+            {"key": "lib2", "doc_count": 3, "record_count": {"doc_count": 4}},
+            {"key": "lib3", "doc_count": 0, "record_count": {"doc_count": 0}},
+        ],
+        # holdings-based metadata: no longer matches the document counts
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 7,
+    }
+
+    # `doc_count` becomes the document count, `lib3` is pruned, the incoming
+    # order is kept (a document-count sort would move `lib2` first) and the
+    # stale (non-zero) holdings metadata is dropped.
+    assert _rewrite_nested_terms(terms) == {
+        "buckets": [
+            {"key": "lib1", "doc_count": 2},
+            {"key": "lib2", "doc_count": 4},
+        ],
+    }


### PR DESCRIPTION
The organisation -> library -> location facet is built on the
`nested_holdings` nested field, so terms sub-aggregations count holdings,
not documents: counts were inflated whenever a document had several
holdings in the same bucket.

Add a `reverse_nested` sub-aggregation (`record_count`) at each level to
count distinct parent documents, and expose it as `doc_count` in the
serializer. Buckets are also re-sorted by document count, since
Elasticsearch orders terms by holdings count and the displayed number is
now the document count.

* Closes #4003.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Ana Gomes <anagoncalves7@icloud.com>
