### PR TITLE
feat(exports): add XLSX exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ dependencies = [
     "flask-admin>=1.6.1",
     "invenio-sip2>=0.6.25",
     "markdown-captions>=2.1.2",
+    "xlsxwriter>=3.2.9",
 ]
 
 [dependency-groups]

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -833,11 +833,13 @@ RECORDS_REST_ENDPOINTS = dict(
             "json": "application/json",
             "rero": "application/rero+json",
             "csv": "text/csv",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         },
         search_serializers={
             "application/json": "rero_ils.modules.serializers:json_v1_search",
             "application/rero+json": "rero_ils.modules.items.serializers:json_item_search",
             "text/csv": "rero_ils.modules.items.serializers:csv_item_search",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "rero_ils.modules.items.serializers:xlsx_item_search",
         },
         list_route="/items/",
         record_loaders={
@@ -917,8 +919,13 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             "application/json": "rero_ils.modules.serializers:json_v1_response",
             "text/csv": "rero_ils.modules.stats.serializers:csv_v1_response",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "rero_ils.modules.stats.serializers:xlsx_v1_response",
         },
-        record_serializers_aliases={"json": "application/json", "csv": "text/csv"},
+        record_serializers_aliases={
+            "json": "application/json",
+            "csv": "text/csv",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
         search_serializers={
             "application/json": "rero_ils.modules.serializers:json_v1_search"
         },
@@ -3977,32 +3984,48 @@ RERO_INVENIO_BASE_EXPORT_REST_ENDPOINTS = dict(
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.acquisition.acq_accounts.serializers:csv_acq_account_search",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "rero_ils.modules.acquisition.acq_accounts.serializers:xlsx_acq_account_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={
+            "csv": "text/csv",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
     ),
     acq_order=dict(
         resource=RECORDS_REST_ENDPOINTS.get("acor"),
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.acquisition.acq_orders.serializers:csv_acor_search",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "rero_ils.modules.acquisition.acq_orders.serializers:xlsx_acor_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={
+            "csv": "text/csv",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
     ),
     loan=dict(
         resource=CIRCULATION_REST_ENDPOINTS.get("loanid"),
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.loans.serializers:csv_stream_search",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "rero_ils.modules.loans.serializers:xlsx_stream_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={
+            "csv": "text/csv",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
     ),
     patron_transaction_events=dict(
         resource=RECORDS_REST_ENDPOINTS.get("ptre"),
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.patron_transaction_events.serializers:csv_ptre_search",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "rero_ils.modules.patron_transaction_events.serializers:xlsx_ptre_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={
+            "csv": "text/csv",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
     ),
 )
 

--- a/rero_ils/modules/acquisition/acq_accounts/serializers/__init__.py
+++ b/rero_ils/modules/acquisition/acq_accounts/serializers/__init__.py
@@ -11,6 +11,7 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import csv_to_xlsx
 
 from .csv import AcqAccountCSVSerializer
 from .json import AcqAccountJSONSerializer
@@ -19,6 +20,7 @@ __all__ = [
     "csv_acq_account_search",
     "json_acq_account_response",
     "json_acq_account_search",
+    "xlsx_acq_account_search",
 ]
 
 """JSON v1 serializer."""
@@ -41,3 +43,10 @@ _csv = AcqAccountCSVSerializer(
 )
 
 csv_acq_account_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_prefix="export-accounts")
+xlsx_acq_account_search = search_responsify_file(
+    _csv,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    file_extension="xlsx",
+    file_prefix="export-accounts",
+    content_converter=csv_to_xlsx,
+)

--- a/rero_ils/modules/acquisition/acq_orders/serializers/__init__.py
+++ b/rero_ils/modules/acquisition/acq_orders/serializers/__init__.py
@@ -11,11 +11,12 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import csv_to_xlsx
 
 from .csv import AcqOrderCSVSerializer
 from .json import AcqOrderJSONSerializer
 
-__all__ = ["csv_acor_search", "json_acor_record", "json_acor_search"]
+__all__ = ["csv_acor_search", "json_acor_record", "json_acor_search", "xlsx_acor_search"]
 
 """JSON serializer."""
 _json = AcqOrderJSONSerializer(RecordSchemaJSONV1)
@@ -56,3 +57,10 @@ _csv = AcqOrderCSVSerializer(
 )
 
 csv_acor_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_prefix="export-orders")
+xlsx_acor_search = search_responsify_file(
+    _csv,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    file_extension="xlsx",
+    file_prefix="export-orders",
+    content_converter=csv_to_xlsx,
+)

--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -11,6 +11,7 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import csv_to_xlsx
 
 from .csv import ItemCSVSerializer
 from .json import ItemsJSONSerializer
@@ -94,6 +95,13 @@ _csv = ItemCSVSerializer(
 """CSV serializer."""
 csv_item_response = record_responsify(_csv, "text/csv")
 csv_item_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_suffix="inventory")
+xlsx_item_search = search_responsify_file(
+    _csv,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    file_extension="xlsx",
+    file_suffix="inventory",
+    content_converter=csv_to_xlsx,
+)
 
 """JSON serializer."""
 _json = ItemsJSONSerializer(RecordSchemaJSONV1)

--- a/rero_ils/modules/items/views/rest.py
+++ b/rero_ils/modules/items/views/rest.py
@@ -10,7 +10,7 @@ from invenio_rest import ContentNegotiatedMethodView
 
 from rero_ils.modules.decorators import check_logged_as_librarian
 from rero_ils.modules.items.api import ItemsSearch
-from rero_ils.modules.items.serializers import csv_item_search
+from rero_ils.modules.items.serializers import csv_item_search, xlsx_item_search
 from rero_ils.query import items_search_factory
 
 
@@ -25,10 +25,12 @@ class InventoryListResource(ContentNegotiatedMethodView):
             method_serializers={
                 "GET": {
                     "text/csv": csv_item_search,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": xlsx_item_search,
                 }
             },
             serializers_query_aliases={
                 "csv": "text/csv",
+                "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             },
             default_method_media_type={"GET": "text/csv"},
             default_media_type="text/csv",

--- a/rero_ils/modules/loans/serializers/__init__.py
+++ b/rero_ils/modules/loans/serializers/__init__.py
@@ -9,11 +9,12 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import csv_to_xlsx
 
 from .csv import LoanStreamedCSVSerializer
 from .json import LoanJSONSerializer
 
-__all__ = ["csv_stream_search", "json_loan_search"]
+__all__ = ["csv_stream_search", "json_loan_search", "xlsx_stream_search"]
 
 
 _json = LoanJSONSerializer(RecordSchemaJSONV1)
@@ -39,3 +40,10 @@ _streamed_csv = LoanStreamedCSVSerializer(
 
 json_loan_search = search_responsify(_json, "application/rero+json")
 csv_stream_search = search_responsify_file(_streamed_csv, "text/csv", file_extension="csv", file_prefix="export-loans")
+xlsx_stream_search = search_responsify_file(
+    _streamed_csv,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    file_extension="xlsx",
+    file_prefix="export-loans",
+    content_converter=csv_to_xlsx,
+)

--- a/rero_ils/modules/patron_transaction_events/serializers/__init__.py
+++ b/rero_ils/modules/patron_transaction_events/serializers/__init__.py
@@ -8,11 +8,12 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import csv_to_xlsx
 
 from .csv import PatronTransactionEventCSVSerializer
 from .json import PatronTransactionEventsJSONSerializer
 
-__all__ = ["csv_ptre_search", "json_ptre_search"]
+__all__ = ["csv_ptre_search", "json_ptre_search", "xlsx_ptre_search"]
 
 
 """JSON serializer."""
@@ -41,3 +42,10 @@ _csv = PatronTransactionEventCSVSerializer(
 )
 
 csv_ptre_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_prefix="export-fees")
+xlsx_ptre_search = search_responsify_file(
+    _csv,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    file_extension="xlsx",
+    file_prefix="export-fees",
+    content_converter=csv_to_xlsx,
+)

--- a/rero_ils/modules/serializers/response.py
+++ b/rero_ils/modules/serializers/response.py
@@ -65,12 +65,16 @@ def search_responsify(serializer, mimetype):
     return view
 
 
-def search_responsify_file(serializer, mimetype, file_extension, file_prefix=None, file_suffix=None):
+def search_responsify_file(
+    serializer, mimetype, file_extension, file_prefix=None, file_suffix=None, content_converter=None
+):
     """Create a Records-REST search result response serializer.
 
     :param serializer: Serializer instance.
     :param mimetype: MIME type of response.
     :param file_extension: File extension.
+    :param content_converter: Optional function used to convert the serialized
+        content before creating the response.
     :returns: Function that generates a record HTTP response.
     """
 
@@ -82,13 +86,17 @@ def search_responsify_file(serializer, mimetype, file_extension, file_prefix=Non
         links=None,
         item_links_factory=None,
     ):
+        content = serializer.serialize_search(
+            pid_fetcher,
+            search_result,
+            links=links,
+            item_links_factory=item_links_factory,
+        )
+        if content_converter:
+            content = content_converter(content)
+
         response = current_app.response_class(
-            serializer.serialize_search(
-                pid_fetcher,
-                search_result,
-                links=links,
-                item_links_factory=item_links_factory,
-            ),
+            content,
             mimetype=mimetype,
         )
         response.status_code = code

--- a/rero_ils/modules/serializers/utils.py
+++ b/rero_ils/modules/serializers/utils.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Serializer utilities."""
+
+import csv
+from dataclasses import dataclass
+from tempfile import TemporaryFile
+
+import xlsxwriter
+
+XLSX_MAX_ROWS = 1_048_576
+XLSX_MAX_COLUMNS = 16_384
+
+
+def _split_row(row):
+    """Split a CSV row into chunks that fit in an XLSX worksheet."""
+    for start in range(0, max(1, len(row)), XLSX_MAX_COLUMNS):
+        yield start // XLSX_MAX_COLUMNS, row[start : start + XLSX_MAX_COLUMNS]
+
+
+@dataclass
+class _WorksheetState:
+    """Track the data range written to a worksheet."""
+
+    worksheet: object
+    last_row: int = 0
+    last_column: int = -1
+
+    def write_row(self, row_index, row):
+        """Write a row and update the worksheet data range."""
+        if not 0 <= row_index < XLSX_MAX_ROWS or len(row) > XLSX_MAX_COLUMNS:
+            raise ValueError("XLSX worksheet limits exceeded")
+        if self.worksheet.write_row(row_index, 0, row) != 0:
+            raise RuntimeError("Unable to write XLSX row")
+
+        self.last_row = max(self.last_row, row_index)
+        self.last_column = max(self.last_column, len(row) - 1)
+
+    def add_autofilter(self):
+        """Add an AutoFilter when the worksheet contains data rows."""
+        if self.last_row > 0 and self.last_column >= 0:
+            self.worksheet.autofilter(
+                0,
+                0,
+                self.last_row,
+                self.last_column,
+            )
+
+
+class _XlsxWorksheetWriter:
+    """Write CSV rows across one or more XLSX worksheets."""
+
+    def __init__(self, workbook, header):
+        self.workbook = workbook
+        self.header = header
+        self.row_part = 0
+        self.active_worksheets = {}
+        self.created_worksheets = []
+        self.header_worksheet_count = sum(1 for _ in _split_row(header))
+        self.start_new_row_part()
+
+    def start_new_row_part(self):
+        """Start a worksheet group when the XLSX row limit is reached."""
+        self.row_part += 1
+        self.active_worksheets = {}
+        for column_part in range(self.header_worksheet_count):
+            self._get_worksheet(column_part)
+
+    def write_row(self, row_index, row):
+        """Write a CSV row across as many worksheets as necessary."""
+        for column_part, values in _split_row(row):
+            self._get_worksheet(column_part).write_row(row_index, values)
+
+    def add_autofilters(self):
+        """Add an AutoFilter to every worksheet containing data."""
+        for worksheet in self.created_worksheets:
+            worksheet.add_autofilter()
+
+    def _get_worksheet(self, column_part):
+        """Return the requested worksheet, creating it when necessary."""
+        if column_part not in self.active_worksheets:
+            suffix = f"-{column_part + 1}" if column_part else ""
+            worksheet = self.workbook.add_worksheet(f"Export {self.row_part}{suffix}")
+            worksheet.freeze_panes(1, 0)
+
+            start = column_part * XLSX_MAX_COLUMNS
+            header = self.header[start : start + XLSX_MAX_COLUMNS]
+            state = _WorksheetState(worksheet)
+            state.write_row(0, header)
+            self.active_worksheets[column_part] = state
+            self.created_worksheets.append(state)
+
+        return self.active_worksheets[column_part]
+
+
+def _write_csv_to_worksheets(workbook, csv_rows):
+    """Write CSV rows across worksheets without dropping values."""
+    reader = iter(csv.reader(csv_rows))
+    header = next(reader, None)
+    if header is None:
+        workbook.add_worksheet("Export 1")
+        return
+
+    worksheets = _XlsxWorksheetWriter(workbook, header)
+    row_index = 1
+
+    for row in reader:
+        if row_index == XLSX_MAX_ROWS:
+            worksheets.start_new_row_part()
+            row_index = 1
+
+        worksheets.write_row(row_index, row)
+        row_index += 1
+
+    worksheets.add_autofilters()
+
+
+def csv_to_xlsx(csv_rows):
+    """Convert CSV content to XLSX without changing its values."""
+    with TemporaryFile() as output:
+        workbook = xlsxwriter.Workbook(
+            output,
+            {
+                "constant_memory": True,
+                "strings_to_formulas": False,
+                "strings_to_urls": False,
+            },
+        )
+        _write_csv_to_worksheets(workbook, csv_rows)
+
+        workbook.close()
+        output.seek(0)
+        return output.read()

--- a/rero_ils/modules/stats/serializers.py
+++ b/rero_ils/modules/stats/serializers.py
@@ -9,6 +9,8 @@ from flask import current_app
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 from invenio_records_rest.serializers.response import add_link_header
 
+from rero_ils.modules.serializers.utils import csv_to_xlsx
+
 from .models import StatType
 
 
@@ -118,19 +120,26 @@ csv_v1 = StatCSVSerializer()
 """CSV serializer."""
 
 
-def record_responsify(serializer, mimetype):
+def record_responsify(serializer, mimetype, file_extension, content_converter=None):
     """Create a Records-REST response serializer.
 
     This function is the same as the `invenio-records-rest`, but it adds an
     header to change the download file name.
     :param serializer: Serializer instance.
     :param mimetype: MIME type of response.
+    :param file_extension: Extension of the downloaded file.
+    :param content_converter: Optional function used to convert the serialized
+        content before creating the response.
     :returns: Function that generates a record HTTP response.
     """
 
     def view(pid, record, code=200, headers=None, links_factory=None):
+        content = serializer.serialize(pid, record, links_factory=links_factory)
+        if content_converter:
+            content = content_converter(content)
+
         response = current_app.response_class(
-            serializer.serialize(pid, record, links_factory=links_factory),
+            content,
             mimetype=mimetype,
         )
         response.status_code = code
@@ -142,7 +151,7 @@ def record_responsify(serializer, mimetype):
 
         # set the output filename
         date = record.created.isoformat()
-        filename = f"stats-{date}.csv"
+        filename = f"stats-{date}.{file_extension}"
         if not response.headers.get("Content-Disposition"):
             response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
 
@@ -154,4 +163,10 @@ def record_responsify(serializer, mimetype):
     return view
 
 
-csv_v1_response = record_responsify(csv_v1, "text/csv")
+csv_v1_response = record_responsify(csv_v1, "text/csv", "csv")
+xlsx_v1_response = record_responsify(
+    csv_v1,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "xlsx",
+    content_converter=csv_to_xlsx,
+)

--- a/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
+++ b/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
@@ -9,7 +9,8 @@
     {% set values = record['values']|sort_dict_by_library %}
     <div class="ml-5 mr-5 mt-2 mb-4">
       {%- if record.pid %}
-        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=xlsx" role="button">XLSX</a>
+        <a class="btn btn-primary float-right mr-1" href="/api/stats/{{record.pid}}?format=csv" role="button">CSV</a>
       {%- endif %}
       {%- if 'date_range' in record and 'from' in record.date_range %}
         {% set stat_name = record.date_range.to|yearmonthfilter+
@@ -56,7 +57,8 @@
   {%- else %}
     <div class="ml-5 mr-5 mt-2 mb-4">
       {%- if record.pid %}
-        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=xlsx" role="button">XLSX</a>
+        <a class="btn btn-primary float-right mr-1" href="/api/stats/{{record.pid}}?format=csv" role="button">CSV</a>
       {%- endif %}
       {%- if 'date_range' in record and 'from' in record.date_range %}
         {% set stat_name = record.date_range.to|yearmonthfilter+

--- a/rero_ils/modules/stats/templates/rero_ils/stats_list.html
+++ b/rero_ils/modules/stats/templates/rero_ils/stats_list.html
@@ -30,7 +30,10 @@
           {{rec._source._created | format_date}}
         {% endif %}
       </a>
-      <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+      <span>
+        <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=csv" role="button">CSV</a>
+        <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=xlsx" role="button">XLSX</a>
+      </span>
     </span>
     {%- endfor %}
   </div>
@@ -57,14 +60,18 @@
     <tr>
       <td class="col-xs-12">
         <a href="{{url_for('invenio_records_ui.stats', pid_value=rec._source.pid)}}">{{_('View statistics')}}</a>
-        <a class="btn btn-outline-secondary float-right" href="/api/stats/{{rec._source.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+        <a class="btn btn-outline-secondary float-right" href="/api/stats/{{rec._source.pid}}?format=xlsx" role="button">XLSX</a>
+        <a class="btn btn-outline-secondary float-right mr-1" href="/api/stats/{{rec._source.pid}}?format=csv" role="button">CSV</a>
       </td>
     </tr>
     <tr>
       <td>{{_('Loans of the transaction library by item location')}}
         <a class="btn btn-outline-secondary float-right"
-        href="{{url_for('stats.stats_librarian_queries', record_pid=rec._source.pid, query_id='loans_of_transaction_library_by_item_location')}}"
-        role="button"><i class="fa-solid fa-download"></i></a>
+        href="{{url_for('stats.stats_librarian_queries', record_pid=rec._source.pid, file_format='xlsx', query_id='loans_of_transaction_library_by_item_location')}}"
+        role="button">XLSX</a>
+        <a class="btn btn-outline-secondary float-right mr-1"
+        href="{{url_for('stats.stats_librarian_queries', record_pid=rec._source.pid, file_format='csv', query_id='loans_of_transaction_library_by_item_location')}}"
+        role="button">CSV</a>
       </td>
     </tr>
     {%- endfor %}

--- a/rero_ils/modules/stats/views.py
+++ b/rero_ils/modules/stats/views.py
@@ -13,6 +13,8 @@ import jinja2
 from elasticsearch_dsl import Q
 from flask import Blueprint, abort, make_response, render_template, request
 
+from rero_ils.modules.serializers.utils import csv_to_xlsx
+
 from .api.api import Stat, StatsSearch
 from .api.pricing import StatsForPricing
 from .models import StatType
@@ -80,13 +82,15 @@ def stats_librarian():
     return render_template("rero_ils/stats_list.html", records=hits["hits"]["hits"], type="librarian")
 
 
-@blueprint.route("/librarian/<record_pid>/csv")
+@blueprint.route("/librarian/<record_pid>/xlsx", defaults={"file_format": "xlsx"})
+@blueprint.route("/librarian/<record_pid>/csv", defaults={"file_format": "csv"})
 @check_logged_as_librarian
-def stats_librarian_queries(record_pid):
-    """Download specific statistic query into csv file.
+def stats_librarian_queries(record_pid, file_format):
+    """Download a specific statistic query as CSV or XLSX.
 
     :param record_pid: statistics pid
-    :return: response object, the csv file
+    :param file_format: output format
+    :return: response object containing the exported file
     """
     queries = ["loans_of_transaction_library_by_item_location"]
     query_id = request.args.get("query_id", None)
@@ -102,7 +106,7 @@ def stats_librarian_queries(record_pid):
 
     _from = record["date_range"]["from"].split("T")[0]
     _to = record["date_range"]["to"].split("T")[0]
-    filename = f"{query_id}_{_from}_{_to}.csv"
+    filename = f"{query_id}_{_from}_{_to}.{file_format}"
 
     data = StringIO()
     w = csv.writer(data)
@@ -136,9 +140,17 @@ def stats_librarian_queries(record_pid):
                         )
                     )
 
-    output = make_response(data.getvalue())
+    mimetype = "text/csv"
+    if file_format == "xlsx":
+        data.seek(0)
+        content = csv_to_xlsx(data)
+        mimetype = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    else:
+        content = data.getvalue()
+
+    output = make_response(content)
     output.headers["Content-Disposition"] = f"attachment; filename={filename}"
-    output.headers["Content-type"] = "text/csv"
+    output.headers["Content-type"] = mimetype
     return output
 
 

--- a/tests/api/acq_accounts/test_acq_accounts_serializers.py
+++ b/tests/api/acq_accounts/test_acq_accounts_serializers.py
@@ -7,7 +7,7 @@
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
-from tests.utils import get_csv
+from tests.utils import assert_xlsx_response, get_csv, parse_csv
 
 
 def test_csv_serializer(
@@ -36,3 +36,30 @@ def test_csv_serializer(
         '"account_current_encumbrance","account_current_expenditure",'
         '"account_available_balance"' in data
     )
+
+
+def test_xlsx_serializer(
+    client,
+    csv_header,
+    librarian_martigny,
+    acq_account_fiction_martigny,
+):
+    """Test XLSX formatter."""
+    login_user_via_session(client, librarian_martigny.user)
+
+    csv_url = url_for(
+        "api_exports.acq_account_export",
+        q=f"pid:{acq_account_fiction_martigny.pid}",
+    )
+    csv_rows = list(parse_csv(get_csv(client.get(csv_url, headers=csv_header))))
+
+    list_url = url_for(
+        "api_exports.acq_account_export",
+        q=f"pid:{acq_account_fiction_martigny.pid}",
+        format="xlsx",
+    )
+    response = client.get(list_url)
+
+    xlsx_rows = assert_xlsx_response(response)
+    assert xlsx_rows[0] == csv_rows[0]
+    assert xlsx_rows[1][0] == csv_rows[1][0]

--- a/tests/api/acq_orders/test_acq_orders_serializers.py
+++ b/tests/api/acq_orders/test_acq_orders_serializers.py
@@ -11,7 +11,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 from rero_ils.modules.documents.api import DocumentsSearch
-from tests.utils import get_csv
+from tests.utils import assert_xlsx_response, get_csv, parse_csv
 
 
 def test_csv_serializer(
@@ -34,6 +34,7 @@ def test_csv_serializer(
     assert response.status_code == 200
     data = get_csv(response)
     assert data
+    csv_rows = list(parse_csv(data))
     assert (
         '"order_pid","order_reference","order_date","order_staff_note",'
         '"order_vendor_note","order_status","vendor_name",'
@@ -46,6 +47,15 @@ def test_csv_serializer(
         '"receipt_reference","received_quantity","received_amount",'
         '"receipt_date"' in data
     )
+
+    list_url = url_for(
+        "api_exports.acq_order_export",
+        q=f"pid:{acq_order_fiction_martigny.pid}",
+        format="xlsx",
+    )
+    xlsx_rows = assert_xlsx_response(client.get(list_url))
+    assert xlsx_rows[0] == csv_rows[0]
+    assert xlsx_rows[1][0] == csv_rows[1][0]
 
 
 def test_csv_serializer_missing_document(

--- a/tests/api/items/test_items_serializer.py
+++ b/tests/api/items/test_items_serializer.py
@@ -6,7 +6,7 @@
 from flask import url_for
 
 from rero_ils.modules.utils import get_ref_for_pid
-from tests.utils import get_csv, login_user
+from tests.utils import assert_xlsx_response, get_csv, login_user, parse_csv
 
 
 def test_serializers(
@@ -61,6 +61,7 @@ def test_serializers(
     assert response.status_code == 200
     data = get_csv(response)
     assert data
+    csv_rows = list(parse_csv(data))
     fields = [
         "item_pid",
         "item_create_date",
@@ -134,6 +135,11 @@ def test_serializers(
     ]
     for field in fields:
         assert field in data
+
+    list_url = url_for("api_item.inventory_search", format="xlsx")
+    xlsx_rows = assert_xlsx_response(client.get(list_url))
+    assert xlsx_rows[0] == csv_rows[0]
+    assert xlsx_rows[1][csv_rows[0].index("item_pid")] == csv_rows[1][csv_rows[0].index("item_pid")]
 
     # test provisionActivity without type bf:Publication
     document["provisionActivity"][0]["type"] = "bf:Manufacture"

--- a/tests/api/stats/test_stats_rest.py
+++ b/tests/api/stats/test_stats_rest.py
@@ -8,7 +8,7 @@ from unittest import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
-from tests.utils import VerifyRecordPermissionPatch, get_csv, get_json, to_relative_url
+from tests.utils import VerifyRecordPermissionPatch, assert_xlsx_response, get_csv, get_json, parse_csv, to_relative_url
 
 
 @mock.patch(
@@ -48,6 +48,13 @@ def test_stats_get(client, stats, csv_header):
         "0,0,0,0,0,1,0,1,1,0,2,1,1,0,1,0,0\r\n"
         "0.000,lib4,Library of Sion,0,0,0,0,0,1,0,0,1,0,1,1,0,0,0,0,0\r\n"
     )
+
+    params = {"pid_value": stats.pid, "format": "xlsx"}
+    item_url = url_for("invenio_records_rest.stat_item", **params)
+    xlsx_rows = assert_xlsx_response(client.get(item_url))
+    csv_rows = list(parse_csv(data))
+    assert xlsx_rows[0] == csv_rows[0]
+    assert xlsx_rows[1][csv_rows[0].index("library id")] == csv_rows[1][csv_rows[0].index("library id")]
 
     list_url = url_for("invenio_records_rest.stat_list")
     res = client.get(list_url)
@@ -118,6 +125,13 @@ def test_stats_report_get(client, stats_report_martigny, csv_header):
     assert res.status_code == 200
     data = get_csv(res)
     assert data
+
+    params = {"pid_value": stats_report_martigny.pid, "format": "xlsx"}
+    item_url = url_for("invenio_records_rest.stat_item", **params)
+    xlsx_rows = assert_xlsx_response(client.get(item_url))
+    csv_rows = list(parse_csv(data))
+    assert xlsx_rows[0] == csv_rows[0]
+    assert xlsx_rows[1][0] == csv_rows[1][0]
     list_url = url_for("invenio_records_rest.stat_list")
     res = client.get(list_url)
     assert res.status_code == 200

--- a/tests/api/test_exports.py
+++ b/tests/api/test_exports.py
@@ -9,7 +9,7 @@ from invenio_accounts.testutils import login_user_via_session
 from invenio_db import db
 
 from rero_ils.modules.utils import get_ref_for_pid
-from tests.utils import get_csv, parse_csv
+from tests.utils import assert_xlsx_response, get_csv, parse_csv
 
 
 def test_loans_exports(app, client, librarian_martigny, loan_pending_martigny, loan2_validated_martigny):
@@ -46,6 +46,11 @@ def test_loans_exports(app, client, librarian_martigny, loan_pending_martigny, l
     ]
     assert all(field in header for field in header_columns)
     assert len(data) == 2
+
+    xlsx_url = url_for("api_exports.loan_export", format="xlsx")
+    xlsx_rows = assert_xlsx_response(client.get(xlsx_url))
+    assert xlsx_rows[0] == header
+    assert xlsx_rows[1][header.index("pid")] == data[0][header.index("pid")]
 
 
 def test_patron_transaction_events_exports(
@@ -113,3 +118,8 @@ def test_patron_transaction_events_exports(
     ]
     assert all(field in header for field in header_columns)
     assert len(data) == 1
+
+    xlsx_url = url_for("api_exports.patron_transaction_events_export", format="xlsx")
+    xlsx_rows = assert_xlsx_response(client.get(xlsx_url))
+    assert xlsx_rows[0] == header
+    assert xlsx_rows[1][header.index("category")] == data[0][header.index("category")]

--- a/tests/ui/stats/conftest.py
+++ b/tests/ui/stats/conftest.py
@@ -6,6 +6,7 @@
 import arrow
 import pytest
 
+from rero_ils.modules.stats.api.api import Stat
 from rero_ils.modules.stats.api.librarian import StatsForLibrarian
 from rero_ils.modules.stats.api.pricing import StatsForPricing
 
@@ -20,3 +21,22 @@ def stat_for_pricing(document, lib_martigny):
 def stat_for_librarian(document, lib_martigny):
     """Stats for Librarian."""
     yield StatsForLibrarian(to_date=arrow.utcnow())
+
+
+@pytest.fixture(scope="module")
+def stats_librarian(item_lib_martigny, item_lib_fully, item_lib_sion):
+    """Saved statistics record for librarian export views."""
+    stats_librarian = StatsForLibrarian()
+    date_range = {
+        "from": stats_librarian.date_range["gte"],
+        "to": stats_librarian.date_range["lte"],
+    }
+    yield Stat.create(
+        data={
+            "type": "librarian",
+            "date_range": date_range,
+            "values": stats_librarian.collect(),
+        },
+        dbcommit=True,
+        reindex=True,
+    )

--- a/tests/ui/stats/test_stats_views.py
+++ b/tests/ui/stats/test_stats_views.py
@@ -9,6 +9,8 @@ from unittest import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
+from tests.utils import assert_xlsx_response, get_csv, parse_csv
+
 
 def test_view_status(client, patron_martigny, librarian_martigny, system_librarian_martigny):
     """Test view status."""
@@ -55,3 +57,37 @@ def test_view_status(client, patron_martigny, librarian_martigny, system_librari
     with mock.patch("rero_ils.modules.stats.permissions.admin_permission", mock.MagicMock()):
         result = client.get(url_for("stats.stats_billing"))
         assert result.status_code == 200
+
+
+def test_stats_librarian_query_xlsx(client, stats_librarian, system_librarian_martigny):
+    """Test a librarian statistics query exported as XLSX."""
+    login_user_via_session(client, system_librarian_martigny.user)
+    url = url_for(
+        "stats.stats_librarian_queries",
+        record_pid=stats_librarian.pid,
+        file_format="xlsx",
+        query_id="loans_of_transaction_library_by_item_location",
+    )
+    xlsx_rows = assert_xlsx_response(client.get(url))
+    csv_url = url_for(
+        "stats.stats_librarian_queries",
+        record_pid=stats_librarian.pid,
+        file_format="csv",
+        query_id="loans_of_transaction_library_by_item_location",
+    )
+    csv_rows = list(parse_csv(get_csv(client.get(csv_url))))
+    assert xlsx_rows[0] == csv_rows[0]
+    assert xlsx_rows[1][0] == csv_rows[1][0]
+
+
+def test_stats_librarian_query_legacy_csv(client, stats_librarian, system_librarian_martigny):
+    """Test the legacy librarian statistics CSV URL."""
+    login_user_via_session(client, system_librarian_martigny.user)
+    response = client.get(
+        f"/stats/librarian/{stats_librarian.pid}/csv",
+        query_string={"query_id": "loans_of_transaction_library_by_item_location"},
+    )
+
+    assert response.status_code == 200
+    assert response.mimetype == "text/csv"
+    assert response.headers["Content-Disposition"].endswith(".csv")

--- a/tests/unit/test_serializer_utils.py
+++ b/tests/unit/test_serializer_utils.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests serializer utilities."""
+
+from io import BytesIO
+from zipfile import ZipFile
+
+from flask import Flask
+
+from rero_ils.modules.serializers import utils as serializer_utils
+from rero_ils.modules.serializers.response import search_responsify_file
+from rero_ils.modules.serializers.utils import csv_to_xlsx
+from tests.utils import assert_xlsx_response, parse_xlsx
+
+
+def _assert_xlsx_autofilter(xlsx, worksheet_index, cell_range):
+    """Assert the AutoFilter range of an XLSX worksheet."""
+    with ZipFile(BytesIO(xlsx)) as workbook:
+        worksheet = workbook.read(f"xl/worksheets/sheet{worksheet_index + 1}.xml")
+    assert f'<autoFilter ref="{cell_range}"/>'.encode() in worksheet
+
+
+def _assert_xlsx_frozen_header(xlsx, worksheet_index):
+    """Assert that an XLSX worksheet has a frozen header row."""
+    with ZipFile(BytesIO(xlsx)) as workbook:
+        worksheet = workbook.read(f"xl/worksheets/sheet{worksheet_index + 1}.xml")
+    assert b'ySplit="1"' in worksheet
+    assert b'state="frozen"' in worksheet
+
+
+def test_csv_to_xlsx():
+    """Test conversion of CSV content to an XLSX workbook."""
+    content = iter(['"first","second"\r\n', '"one","=literal"\r\n'])
+
+    xlsx = csv_to_xlsx(content)
+    rows = parse_xlsx(xlsx)
+
+    assert rows == [["first", "second"], ["one", "=literal"]]
+    _assert_xlsx_autofilter(xlsx, 0, "A1:B2")
+    _assert_xlsx_frozen_header(xlsx, 0)
+
+
+def test_csv_to_xlsx_multiple_worksheets(monkeypatch):
+    """Test that oversized CSV content is partitioned without data loss."""
+    monkeypatch.setattr(serializer_utils, "XLSX_MAX_ROWS", 3)
+    content = iter(['"header"\r\n', '"one"\r\n', '"two"\r\n', '"three"\r\n'])
+
+    xlsx = csv_to_xlsx(content)
+
+    assert parse_xlsx(xlsx) == [["header"], ["one"], ["two"]]
+    assert parse_xlsx(xlsx, worksheet_index=1) == [["header"], ["three"]]
+    _assert_xlsx_autofilter(xlsx, 0, "A1:A3")
+    _assert_xlsx_autofilter(xlsx, 1, "A1:A2")
+    _assert_xlsx_frozen_header(xlsx, 0)
+    _assert_xlsx_frozen_header(xlsx, 1)
+
+
+def test_csv_to_xlsx_multiple_column_worksheets(monkeypatch):
+    """Test that oversized CSV rows are partitioned without data loss."""
+    monkeypatch.setattr(serializer_utils, "XLSX_MAX_COLUMNS", 2)
+    content = iter(['"first","second","third"\r\n', '"one","two","three"\r\n'])
+
+    xlsx = csv_to_xlsx(content)
+
+    assert parse_xlsx(xlsx) == [["first", "second"], ["one", "two"]]
+    assert parse_xlsx(xlsx, worksheet_index=1) == [["third"], ["three"]]
+    _assert_xlsx_autofilter(xlsx, 0, "A1:B2")
+    _assert_xlsx_autofilter(xlsx, 1, "A1:A2")
+
+
+def test_search_responsify_file_with_converter():
+    """Test converting output from an existing search serializer."""
+
+    class CSVSerializer:
+        def serialize_search(self, *args, **kwargs):
+            return iter(['"first","second"\r\n', '"one","two"\r\n'])
+
+    view = search_responsify_file(
+        CSVSerializer(),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xlsx",
+        file_prefix="export",
+        content_converter=csv_to_xlsx,
+    )
+
+    app = Flask(__name__)
+    with app.app_context():
+        response = view(None, None)
+
+    assert assert_xlsx_response(response) == [["first", "second"], ["one", "two"]]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,10 @@ import csv
 import json
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
+from io import BytesIO
 from unittest.mock import MagicMock, Mock
+from xml.etree import ElementTree
+from zipfile import ZipFile
 
 import jsonref
 import xmltodict
@@ -90,6 +93,64 @@ def parse_csv(raw_data):
     """Parse CSV raw data into a iterable raw file."""
     content = StringIO(raw_data)
     return csv.reader(content)
+
+
+def parse_xlsx(raw_data, worksheet_index=0):
+    """Validate and parse rows from an XLSX worksheet."""
+    with ZipFile(BytesIO(raw_data)) as workbook:
+        filenames = set(workbook.namelist())
+        # Validate XLSX structure
+        assert "[Content_Types].xml" in filenames
+        assert "xl/workbook.xml" in filenames
+        worksheets = sorted(
+            filename for filename in filenames if filename.startswith("xl/worksheets/") and filename.endswith(".xml")
+        )
+        assert worksheets
+
+        # XLSX XML elements use this namespace, which ElementTree requires
+        # when searching for worksheet rows, cells, and values.
+        namespace = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+        shared_strings = []
+        if "xl/sharedStrings.xml" in filenames:
+            root = ElementTree.fromstring(workbook.read("xl/sharedStrings.xml"))
+            shared_strings = [
+                "".join(text.text or "" for text in item.iter(f"{namespace}t")) for item in root.iter(f"{namespace}si")
+            ]
+
+        # Parse the selected worksheet
+        root = ElementTree.fromstring(workbook.read(worksheets[worksheet_index]))
+        rows = []
+        for row in root.iter(f"{namespace}row"):
+            values = []
+            # Parse each cell in the row
+            for cell in row.findall(f"{namespace}c"):
+                column_name = cell.attrib["r"].rstrip("0123456789")
+                column_index = 0
+                # Convert column name (e.g., "A", "B", ..., "AA", "AB", ...) to a 1-based index
+                for character in column_name:
+                    column_index = column_index * 26 + ord(character) - ord("A") + 1
+                # Fill in missing values for empty cells
+                while len(values) < column_index - 1:
+                    values.append("")
+
+                if cell.attrib.get("t") == "inlineStr":
+                    value = "".join(text.text or "" for text in cell.iter(f"{namespace}t"))
+                else:
+                    value_node = cell.find(f"{namespace}v")
+                    value = value_node.text if value_node is not None else ""
+                    if cell.attrib.get("t") == "s":
+                        value = shared_strings[int(value)]
+                values.append(value)
+            rows.append(values)
+        return rows
+
+
+def assert_xlsx_response(response):
+    """Assert that a response contains a valid XLSX download."""
+    assert response.status_code == 200
+    assert response.mimetype == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert response.headers["Content-Disposition"].rstrip('"').endswith(".xlsx")
+    return parse_xlsx(response.data)
 
 
 def postdata(client, endpoint, data=None, headers=None, url_data=None, force_data_as_json=True):

--- a/uv.lock
+++ b/uv.lock
@@ -3679,6 +3679,7 @@ dependencies = [
     { name = "sqlalchemy-celery-beat" },
     { name = "unidecode" },
     { name = "urllib3" },
+    { name = "xlsxwriter" },
     { name = "xmltodict" },
 ]
 
@@ -3762,6 +3763,7 @@ requires-dist = [
     { name = "sqlalchemy-celery-beat", specifier = ">=0.8.3" },
     { name = "unidecode", specifier = ">=1.3.8" },
     { name = "urllib3", specifier = "<2.0.0" },
+    { name = "xlsxwriter", specifier = ">=3.2.9" },
     { name = "xmltodict" },
 ]
 
@@ -4622,6 +4624,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/2f/9e835c1ec678dcf4c450aabbeb28bc5681a3eab6e1eddcea209aa7970661/wtforms_components-0.11.0.tar.gz", hash = "sha256:ca94d60a6362c0e4b49d3d09d1eb1ddf5b26c99105a57397af313655f4447f7a", size = 25549, upload-time = "2024-11-15T13:43:16.244Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/1d/f8e8a73257e717e4070b5130105a328b1bc2902bcaca8ff64a1b60ce7380/WTForms_Components-0.11.0-py2.py3-none-any.whl", hash = "sha256:605762c32588a915b6411628d082799c6c741134fb961244a9bd8ed1686aef74", size = 14044, upload-time = "2024-11-15T13:43:14.519Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Adds XLSX downloads where CSV exports are available.
* Reuses existing CSV serializers to keep exported content identical.
* Converts serialized CSV output with XlsxWriter.
* Registers XLSX routes and MIME types.
* Closes #4168.