### PR TITLE
build: update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -516,8 +516,32 @@ extend-exclude = ["config.py"]
 line-length = 120
 
 [tool.ruff.lint]
-extend-select = ["A", "C4", "INT", "ISC", "T20", "PIE", "Q", "RET", "SIM", "I", "N", "PERF", "W", "D", "F", "UP", "RUF"]
-ignore = ["A001", "A002", "D100", "D101", "D103", "D200", "D202", "D205", "D400", "D401", "F403", "F405", "F841", "INT001", "N801", "N802", "N803", "N806", "N811", "N818", "PERF203", "PERF401", "PERF402", "RUF001", "RUF012", "RUF018", "RUF059", "SIM102", "SIM113", "SIM115", "SIM117", "T201", "T203"]
+extend-select = ["A", "C4", "D", "F", "I", "INT", "ISC", "N", "PERF", "PIE", "Q", "RET", "RUF", "SIM", "T20", "UP", "W"]
+ignore = [
+    "A001",    # builtin-variable-shadowing
+    "A002",    # builtin-argument-shadowing
+    "BLE001",  # blind-except: catching `Exception` is deliberate around external services and harvesters
+    "D401",    # non-imperative-mood: docstring wording is left to the author
+    "DTZ",     # flake8-datetimez: naive dates are intentional (MARC dates, circulation dates, display)
+    "F403",    # undefined-local-with-import-star
+    "F841",    # unused-variable
+    "INT001",  # f-string-in-get-text-func-call
+    "N801",    # invalid-class-name
+    "N802",    # invalid-function-name: dojson handlers mirror the MARC field names
+    "N803",    # invalid-argument-name
+    "N806",    # non-lowercase-variable-in-function
+    "N818",    # error-suffix-on-exception-name
+    "PERF401", # manual-list-comprehension
+    "RUF012",  # mutable-class-default: Invenio base classes rely on mutable class attributes
+    "RUF059",  # unused-unpacked-variable
+    "SIM102",  # collapsible-if
+    "SIM115",  # open-file-with-context-handler
+    "T201",    # print
+]
+
+[tool.ruff.lint.per-file-ignores]
+# MARC transliteration fixtures deliberately mix Cyrillic and Latin look-alikes.
+"tests/**" = ["RUF001"]  # ambiguous-unicode-character-string
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/rero_ils/dojson/cli.py
+++ b/rero_ils/dojson/cli.py
@@ -17,9 +17,7 @@ def reverse():
     """Reverse the order of the data."""
 
     def processor(iterator):
-        items = []
-        for item in iterator:
-            items.append(item)
+        items = list(iterator)
         items.reverse()
         return items
 
@@ -35,11 +33,9 @@ def head(max):
     """Take only the first max items."""
 
     def processor(iterator):
-        n = 0
-        for item in iterator:
+        for n, item in enumerate(iterator):
             if n >= max:
-                raise StopIteration
-            n += 1
+                return
             yield item
 
     return processor

--- a/rero_ils/dojson/utils.py
+++ b/rero_ils/dojson/utils.py
@@ -417,7 +417,7 @@ def remove_trailing_punctuation(data, punctuation=",", spaced_punctuation=":;/-"
     return re.sub(rf"([{punctuation}]|\s+[{spaced_punctuation}])$", "", data.rstrip()).rstrip()
 
 
-def remove_special_characters(value, chars=["\u0098", "\u009c"]):
+def remove_special_characters(value, chars=("\u0098", "\u009c")):
     """Remove special characters from a string.
 
     :params value: string to clean.
@@ -452,8 +452,10 @@ def get_mef_link(bibid, reroid, entity_type, ids, key):
         entity_types = current_app.config.get("RERO_ILS_ENTITY_TYPES", {})
         mef_config = current_app.config.get("RERO_ILS_MEF_CONFIG")
     except Exception:
-        from rero_ils.config import RERO_ILS_ENTITY_TYPES as entity_types
-        from rero_ils.config import RERO_ILS_MEF_CONFIG as mef_config
+        from rero_ils.config import RERO_ILS_ENTITY_TYPES, RERO_ILS_MEF_CONFIG
+
+        entity_types = RERO_ILS_ENTITY_TYPES
+        mef_config = RERO_ILS_MEF_CONFIG
     entity_type = entity_types.get(entity_type)
     mef_url = mef_config.get(entity_type, {}).get("base_url")
     if not mef_url:
@@ -620,7 +622,7 @@ class BookFormatExtraction:
                 regexp = "|".join([regexp, self._specific_for_1248[value]])
             else:
                 additional = rf"[^\d]{value}mo|^{value}mo"
-                regexp = "|".join([regexp, additional])
+                regexp = f"{regexp}|{additional}"
             return f"({regexp})"
 
         def _populate_regexp():
@@ -888,17 +890,15 @@ class ReroIlsOverdo(Overdo):
         extent_and_physical_detail_str = "|".join(extent_and_physical_detail_data)
 
         color_content_set = set()
-        for key in _COLOR_CONTENT_REGEXP:
-            regexp = _COLOR_CONTENT_REGEXP[key]
+        for color_code, regexp in _COLOR_CONTENT_REGEXP.items():
             if regexp.search(physical_details_str):
-                color_content_set.add(key)
+                color_content_set.add(color_code)
         add_data_and_sort_list("colorContent", color_content_set, data)
 
         production_method_set = set()
-        for key in _PRODUCTION_METHOD_FROM_EXTENT_AND_PHYSICAL_DETAILS:
-            regexp = _PRODUCTION_METHOD_FROM_EXTENT_AND_PHYSICAL_DETAILS[key]
+        for method_code, regexp in _PRODUCTION_METHOD_FROM_EXTENT_AND_PHYSICAL_DETAILS.items():
             if regexp.search(extent_and_physical_detail_str):
-                production_method_set.add(key)
+                production_method_set.add(method_code)
 
         # extract build illustrativeContent data
         # remove 'couv. ill' and the extra '|' resulting of the remove
@@ -906,10 +906,9 @@ class ReroIlsOverdo(Overdo):
         physical_detail_ill_str = re.sub(r"\|\||^\||\|$", "", physical_detail_ill_str)
 
         illustration_set = set()
-        for key in _ILLUSTRATIVE_CONTENT_REGEXP:
-            regexp = _ILLUSTRATIVE_CONTENT_REGEXP[key]
+        for illustration_code, regexp in _ILLUSTRATIVE_CONTENT_REGEXP.items():
             if regexp.search(physical_detail_ill_str):
-                illustration_set.add(key)
+                illustration_set.add(illustration_code)
         add_data_and_sort_list("illustrativeContent", illustration_set, data)
 
         # remove 'rdapm:1005' if specific production_method exists
@@ -931,10 +930,8 @@ class ReroIlsOverdo(Overdo):
         subfield_code = self.extract_description_subfield["book_format"]
         for dimension in utils.force_list(value.get(subfield_code, [])):
             formats = tool.extract_book_formats_from(dimension)
-            for book_format in formats:
-                book_formats.append(book_format)
-            dim = remove_trailing_punctuation(data=dimension.rstrip(), punctuation="+,:;&.")
-            if dim:
+            book_formats.extend(iter(formats))
+            if dim := remove_trailing_punctuation(data=dimension.rstrip(), punctuation="+,:;&."):
                 add_data_and_sort_list("dimensions", utils.force_list(dim), data)
         add_data_and_sort_list("bookFormat", book_formats, data)
 
@@ -1093,8 +1090,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
             self.date = {"start_date": None}
             self.serial_type = ""
             self.is_top_level_record = False
-            fields_008 = self.get_fields(tag="008")
-            if fields_008:
+            if fields_008 := self.get_fields(tag="008"):
                 self.field_008_data = self.get_control_field_data(fields_008[0]).rstrip()
                 try:
                     self.serial_type = self.field_008_data[21]
@@ -1107,9 +1103,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
                     self.original_date_from_008 = self.date2_from_008
             self.admin_meta_data = {}
 
-            enc_level = ""
-            if self.leader:
-                enc_level = self.leader[17]  # LDR 17
+            enc_level = self.leader[17] if self.leader else ""
             if enc_level in _ENCODING_LEVEL_MAPPING:
                 encoding_level = _ENCODING_LEVEL_MAPPING[enc_level]
             else:
@@ -1130,21 +1124,20 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
             for field_019 in fields_019:
                 note = ""
                 for subfield_a in self.get_subfields(field_019, "a"):
-                    note += " | " + subfield_a
+                    note += f" | {subfield_a}"
                     if regexp.search(subfield_a):
                         self.is_top_level_record = True
                 for subfield_b in self.get_subfields(field_019, "b"):
                     note += " | " + subfield_b
                 for subfield_9 in self.get_subfields(field_019, "9"):
-                    note += " (" + subfield_9 + ")"
+                    note += f" ({subfield_9})"
                     break
                 if note:
                     notes_from_019_and_351.append(note[3:])
 
             fields_351 = self.get_fields(tag="351")
             for field_351 in fields_351:
-                note = " | ".join(self.get_subfields(field_351, "c"))
-                if note:
+                if note := " | ".join(self.get_subfields(field_351, "c")):
                     notes_from_019_and_351.append(note)
 
             if notes_from_019_and_351:
@@ -1164,14 +1157,10 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
                             self.rero_id,
                             subfield_b,
                         )
-                description_modifier = []
-                for subfield_d in self.get_subfields(field_040, "d"):
-                    description_modifier.append(subfield_d)
+                description_modifier = list(self.get_subfields(field_040, "d"))
                 if description_modifier:
                     self.admin_meta_data["descriptionModifier"] = description_modifier
-                description_conventions = []
-                for subfield_e in self.get_subfields(field_040, "e"):
-                    description_conventions.append(subfield_e)
+                description_conventions = list(self.get_subfields(field_040, "e"))
                 if description_conventions:
                     self.admin_meta_data["descriptionConventions"] = description_conventions
 
@@ -1202,7 +1191,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
                 f"{err} {traceback.format_exception_only}",
             )
             traceback.print_exc()
-            raise Exception(err)
+            raise
         return result
 
     def get_link_data(self, subfields_6_data):
@@ -1435,7 +1424,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
             languages = [self.lang_from_008, *self.langs_from_041_a, *self.langs_from_041_h]
             for lang in languages:
                 if lang in _LANGUAGES_SCRIPTS[script_code]:
-                    return "-".join([lang, script_code])
+                    return f"{lang}-{script_code}"
             error_print(
                 "WARNING LANGUAGE SCRIPTS:",
                 self.bib_id,
@@ -1448,7 +1437,7 @@ class ReroIlsMarc21Overdo(ReroIlsOverdo):
                 "041$h:",
                 self.langs_from_041_h,
             )
-        return "-".join(["und", script_code])
+        return f"und-{script_code}"
 
     def build_variant_title_data(self, string_set):
         """Build variant title data form fields 246.
@@ -1669,7 +1658,7 @@ class ReroIlsUnimarcOverdo(ReroIlsOverdo):
             if script_code in _LANGUAGES_SCRIPTS:
                 lang = self.lang_from_101
                 if lang in _LANGUAGES_SCRIPTS[script_code]:
-                    return "-".join([self.lang_from_101, script_code])
+                    return f"{self.lang_from_101}-{script_code}"
                 error_print(
                     "WARNING LANGUAGE SCRIPTS:",
                     self.bib_id,
@@ -1678,7 +1667,7 @@ class ReroIlsUnimarcOverdo(ReroIlsOverdo):
                     "101 $a or $g:",
                     f'"{self.lang_from_101}"',
                 )
-        return "-".join(["und", script_code])
+        return f"und-{script_code}"
 
     def get_alt_graphic_fields(self, tag=None):
         """Get all alternate graphic fields having the given tag value.
@@ -1850,10 +1839,9 @@ def extract_subtitle_and_parallel_titles_from_field_245_b(parallel_title_data, f
     data_lang_items = []
     if data_lang:
         data_lang_items = data_lang.split("=")
-    index = 0
     out_data_dict = {}
 
-    for data_std in data_std_items:
+    for index, data_std in enumerate(data_std_items):
         if index == 0 and not field_245_a_end_with_equal:
             if data_std.rstrip():
                 main_subtitle.append({"value": data_std.rstrip()})
@@ -1903,7 +1891,6 @@ def extract_subtitle_and_parallel_titles_from_field_245_b(parallel_title_data, f
                     out_data_dict["mainTitle"] = main_title
                 if subtitle:
                     out_data_dict["subtitle"] = subtitle
-        index += 1
         if out_data_dict:
             parallel_titles.append(out_data_dict)
     return main_subtitle, parallel_titles, pararalel_title_string_set
@@ -1932,8 +1919,7 @@ def build_responsibility_data(responsibility_data):
     data_lang_items = []
     if data_lang:
         data_lang_items = data_lang.split(";")
-    index = 0
-    for data_std in data_std_items:
+    for index, data_std in enumerate(data_std_items):
         out_data = []
         data_value = remove_trailing_punctuation(data_std.lstrip(), ",.", ":;/-=")
         if data_value:
@@ -1942,7 +1928,7 @@ def build_responsibility_data(responsibility_data):
                 try:
                     data_lang_value = remove_trailing_punctuation(data_lang_items[index].lstrip(), ",.", ":;/-=")
                     if not data_lang_value:
-                        raise Exception("missing data")
+                        raise ValueError("missing data")
                 except Exception:
                     data_lang_value = "[missing data]"
                 out_data.append({"value": data_lang_value, "language": lang})

--- a/rero_ils/facets.py
+++ b/rero_ils/facets.py
@@ -203,7 +203,7 @@ def _facet_filter(index, filters, filters_group, facet_name, facet_field):
             if filter_field != facet_field and _filter:
                 q &= _filter
 
-    for name_group, filters in filters_group.items():
-        if facet_name != name_group and filters:
-            q &= Q("bool", should=filters)
+    for name_group, group_filters in filters_group.items():
+        if facet_name != name_group and group_filters:
+            q &= Q("bool", should=group_filters)
     return q if q != Q() else None

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -378,10 +378,10 @@ class IlsRecord(Record):
             persistent_identifier.delete()
             if force:
                 db.session.delete(persistent_identifier)
-            self = super().delete(force=force)
+            record = super().delete(force=force)
             if dbcommit:
                 db.session.commit()
-            return self
+            return record
         raise IlsRecordError.NotDeleted()
 
     def update(self, data, commit=False, dbcommit=False, reindex=False):
@@ -429,10 +429,10 @@ class IlsRecord(Record):
         persistent_identifier = self.get_persistent_identifier(self.id)
         if persistent_identifier.is_deleted():
             raise IlsRecordError.Deleted()
-        self = super().revert(revision_id=revision_id)
+        record = super().revert(revision_id=revision_id)
         if reindex:
-            self.reindex(forceindex=False)
-        return self
+            record.reindex(forceindex=False)
+        return record
 
     def undelete(self, reindex=False):
         """Undelete the record."""
@@ -635,11 +635,12 @@ class IlsRecordsIndexer(RecordIndexer):
                 message.reject()
             except Exception:
                 message.reject()
-                current_app.logger.error(
-                    f"Failed to {payload['op']}"
-                    f" {payload.get('doc_type'), 'rec'} "
-                    f"{payload.get('pid')}:{payload.get('id')}",
-                    exc_info=True,
+                current_app.logger.exception(
+                    "Failed to %s %s %s:%s",
+                    payload["op"],
+                    payload.get("doc_type", "rec"),
+                    payload.get("pid"),
+                    payload.get("id"),
                 )
 
     def _index_action(self, payload):

--- a/rero_ils/modules/babel_extractors.py
+++ b/rero_ils/modules/babel_extractors.py
@@ -11,8 +11,10 @@ from flask_babel import gettext as _
 KEY_VAL_REGEX = re.compile(r'"(.*?)"\s*:\s*"(.*?)"')
 
 
-def translate(data, keys=["title"]):
+def translate(data, keys=None):
     """Translate strings in a data structure."""
+    if keys is None:
+        keys = ["title"]
     to_return = data
     if isinstance(data, dict):
         for k, v in six.iteritems(data):
@@ -26,8 +28,10 @@ def translate(data, keys=["title"]):
     return to_return
 
 
-def extract(fileobj, keys=["title"]):
+def extract(fileobj, keys=None):
     """Extract translation from a json file."""
+    if keys is None:
+        keys = ["title"]
     translations = []
     line = 1
 
@@ -44,8 +48,10 @@ def extract(fileobj, keys=["title"]):
     return translations
 
 
-def extract_array(fileobj, keys=["title"]):
+def extract_array(fileobj, keys=None):
     """Extract translation from a json file."""
+    if keys is None:
+        keys = ["title"]
     translations = []
     import json
 

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -402,7 +402,7 @@ class CircPolicy(IlsRecord):
         elif isinstance(record, Holding):
             record_circulation_category_pid = record.circulation_category_pid
         else:
-            raise Exception(
+            raise TypeError(
                 f"This resource cannot be \
                 requested : {record.__class__.__name__}"
             )

--- a/rero_ils/modules/cli/fixtures.py
+++ b/rero_ils/modules/cli/fixtures.py
@@ -329,8 +329,7 @@ def create_csv(record_type, json_file, output_directory, lazy, verbose, create_p
                         file_errors.write(",")
                     errors_count += 1
                     file_errors.write("\n")
-                    for line in json.dumps(record, indent=2).split("\n"):
-                        file_errors.write(f"  {line}\n")
+                    file_errors.writelines(f"  {line}\n" for line in json.dumps(record, indent=2).split("\n"))
 
         file_metadata.close()
         file_pids.close()
@@ -418,10 +417,8 @@ def bulk_save(pid_types, output_directory, deployment, verbose):
     with contextlib.suppress(OSError):
         os.remove(file_name_tmp_pidstore)
 
-    all_pid_types = []
     endpoints = current_app.config.get("RECORDS_REST_ENDPOINTS")
-    for endpoint in endpoints:
-        all_pid_types.append(endpoint)
+    all_pid_types = list(endpoints)
     if pid_types[0] == "all":
         pid_types = all_pid_types
 

--- a/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/jsontomarc21/model.py
@@ -865,7 +865,9 @@ class ToMarc21Overdo(Underdo):
         try:
             order = current_app.config.get("RERO_ILS_AGENTS_LABEL_ORDER", {})
         except RuntimeError:
-            from rero_ils.config import RERO_ILS_AGENTS_LABEL_ORDER as order
+            from rero_ils.config import RERO_ILS_AGENTS_LABEL_ORDER
+
+            order = RERO_ILS_AGENTS_LABEL_ORDER
         self.source_order = order.get(self.language, order.get(order.get("fallback", "en"), []))
 
         if with_holdings_items:
@@ -1046,7 +1048,6 @@ def reverse_identified_by(self, key, value):
             result["__order__"].append("q")
             result["q"] = qualifier
         self.append(("020__", utils.GroupableOrderedDict(result)))
-    return
 
 
 @to_marc21.over("245", "^title_responsibility")
@@ -1194,8 +1195,8 @@ def reverse_provision_activity(self, key, value):
         elif provision_activity_type == "bf:Production":
             ind2 = "0"
         result = {"$ind2": ind2}
-        for key, value in data.items():
-            result = add_values(result, key, value)
+        for data_key, data_value in data.items():
+            result = add_values(result, data_key, data_value)
         result["__order__"] = order
         return result
     return None

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/loc/model.py
@@ -363,7 +363,6 @@ def marc21_to_series(self, key, value):
                 series["seriesEnumeration"] = [{"value": "/".join(parts)}]
             self["seriesStatement"] = self.get("seriesStatement", [])
             self["seriesStatement"].append(series)
-    return
 
 
 @marc21.over("tableOfContents", "^505..")

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/rero/model.py
@@ -717,12 +717,12 @@ def marc21_to_classification(self, key, value):
         subdivision_subfield_codes_per_tag_980_2 = {"brp": {"d"}, "musg": {"d", "e"}}
         classification_type = None
         subdivision_subfield_codes = None
-        for key in classification_type_per_tag_980_2:
-            regexp = re.compile(rf"{key}", re.IGNORECASE)
+        for type_code, classification in classification_type_per_tag_980_2.items():
+            regexp = re.compile(rf"{type_code}", re.IGNORECASE)
             if regexp.search(subfield_2):
-                classification_type = classification_type_per_tag_980_2[key]
-                if key in subdivision_subfield_codes_per_tag_980_2:
-                    subdivision_subfield_codes = subdivision_subfield_codes_per_tag_980_2[key]
+                classification_type = classification
+                if type_code in subdivision_subfield_codes_per_tag_980_2:
+                    subdivision_subfield_codes = subdivision_subfield_codes_per_tag_980_2[type_code]
                 break
         return classification_type, subdivision_subfield_codes
 

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/utils.py
@@ -444,8 +444,8 @@ def do_abbreviated_title(data, marc21, key, value):
             title["subtitle"] = [{"value": subtitle}]
         for resp_tag in ["f", "g"]:
             if datas := utils.force_list(value.get(resp_tag)):
-                for data in datas:
-                    if responsibility := build_responsibility_data(data):
+                for resp_data in datas:
+                    if responsibility := build_responsibility_data(resp_data):
                         new_responsibility = data.get("responsibilityStatement", [])
                         for resp in responsibility:
                             new_responsibility.append(resp)
@@ -969,8 +969,7 @@ def do_intended_audience(data, value):
     intended_audience_set = set()
     for subfield_a in utils.force_list(value.get("a")):
         audiance_found = False
-        for audiance in _INTENDED_AUDIENCE_REGEXP:
-            regexp = _INTENDED_AUDIENCE_REGEXP[audiance]
+        for audiance, regexp in _INTENDED_AUDIENCE_REGEXP.items():
             if regexp.search(subfield_a):
                 intended_audience_set.add(audiance)
                 audiance_found = True
@@ -981,8 +980,7 @@ def do_intended_audience(data, value):
     for intended_audience_str in intended_audience_set:
         intended_audience = {}
         # get the audiance_type
-        for audiance_type in _INTENDED_AUDIENCE_TYPE_REGEXP:
-            regexp = _INTENDED_AUDIENCE_TYPE_REGEXP[audiance_type]
+        for audiance_type, regexp in _INTENDED_AUDIENCE_TYPE_REGEXP.items():
             if regexp.search(intended_audience_str):
                 intended_audience["audienceType"] = audiance_type
         if "audienceType" not in intended_audience:
@@ -1110,9 +1108,9 @@ def do_identified_by_from_field_024(data, marc21, key, value):
         elif subfield_2:
             identifier["value"] = subfield_a
             populate_acquisitionTerms_note_qualifier(identifier)
-            for pattern in subfield_2_regexp:
+            for pattern, identifier_data in subfield_2_regexp.items():
                 if re.search(pattern, subfield_2, re.IGNORECASE):
-                    identifier.update(subfield_2_regexp[pattern])
+                    identifier.update(identifier_data)
         else:  # without subfield $2
             ind1 = key[3]  # indicateur_1
             if ind1 in ("0", "1", "2", "3", "8"):

--- a/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
@@ -858,7 +858,6 @@ def unimarc_description(self, key, value):
     215 [$e repetitive]: accompanying material note
     """
     unimarc.extract_description_from_marc_field(key, value, self)
-    return
 
 
 @unimarc.over("series", "^225..")
@@ -954,10 +953,10 @@ def unimarc_identifier_isbn(self, key, value):
         identifiers.append(isbn)
 
     if value.get("z"):
-        for value in utils.force_list(value.get("z")):
+        for isbn_value in utils.force_list(value.get("z")):
             isbn = {
                 "type": "bf:Isbn",
-                "value": value.replace("-", ""),
+                "value": isbn_value.replace("-", ""),
                 "status": "invalid or cancelled",
             }
             identifiers.append(isbn)
@@ -1052,8 +1051,6 @@ def unimarc_notes(self, key, value):
     note: [300$a repetitive]
     """
     add_note({"noteType": "general", "label": value.get("a", "")}, self)
-
-    return
 
 
 @unimarc.over("subjects_imported", "^6((0[0-9])|(1[0-7]))..")

--- a/rero_ils/modules/documents/extensions/title.py
+++ b/rero_ils/modules/documents/extensions/title.py
@@ -49,7 +49,9 @@ class TitleExtension(RecordExtension):
                             return True
                         lang, _ = value.split("-")
                         # remove the latin form if a vernacular form exists
-                        return not value.endswith("-latn") or sum(v.startswith(f"{lang}-") for v in languages) <= 1
+                        return (
+                            not value.endswith("-latn") or sum(v.startswith(f"{lang}-") for v in languages) <= 1  # noqa: B023
+                        )
 
                     # list of selected language
                     filtered_languages = list(filter(filter_list, languages))

--- a/rero_ils/modules/documents/utils.py
+++ b/rero_ils/modules/documents/utils.py
@@ -104,8 +104,8 @@ def title_format_text_alternate_graphic(titles, responsabilities=None):
             responsibilities_text[language] = responsibility_text
 
     output = []
-    for language in altgr_titles:
-        altgr_text = ". ".join(altgr_titles[language])
+    for language, altgr_values in altgr_titles.items():
+        altgr_text = ". ".join(altgr_values)
         if language in parallel_titles:
             parallel_title_text = " = ".join(parallel_titles[language])
             altgr_text += " = " + str(parallel_title_text)

--- a/rero_ils/modules/entities/remote_entities/sync.py
+++ b/rero_ils/modules/entities/remote_entities/sync.py
@@ -258,7 +258,7 @@ class SyncEntity:
                 # MEF sever failed to retrieve the latest MEF record
                 # for the given entity
                 if not (mef_pid := mef.get("pid")):
-                    raise Exception(f"Error cannot get latest for {entity['type']} {source}:{entity[source]['pid']}")
+                    raise RuntimeError(f"Error cannot get latest for {entity['type']} {source}:{entity[source]['pid']}")
 
                 old_entity_pid = entity[source]["pid"]
                 new_entity_pid = mef[source]["pid"]

--- a/rero_ils/modules/holdings/api_views.py
+++ b/rero_ils/modules/holdings/api_views.py
@@ -50,8 +50,8 @@ def jsonify_error(func):
     def decorated_view(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (Unauthorized, NotFound) as error:
-            raise error
+        except Unauthorized, NotFound:
+            raise
         except (TemplateSyntaxError, UndefinedError) as error:
             return jsonify({"status": f"error: {error}"}), 400
         except Exception as error:
@@ -174,8 +174,8 @@ def do_holding_jsonify_action(func):
             abort(400, str(error))
         except CirculationException as error:
             abort(403, error.description or str(error))
-        except NotFound as error:
-            raise error
+        except NotFound:
+            raise
         except exceptions.RequestError as error:
             # missing required parameters
             return jsonify({"status": f"error: {error}"}), 400

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -872,7 +872,7 @@ class ItemCirculation(ItemRecord):
         # check if library exists
         lib = Library.get_record_by_pid(library_pid)
         if not lib:
-            raise Exception("Invalid Library PID")
+            raise ValueError("Invalid Library PID")
         # the '-' prefix means a desc order.
         sort_by = sort_by or "_created"
         order_by = "asc"

--- a/rero_ils/modules/items/cli.py
+++ b/rero_ils/modules/items/cli.py
@@ -149,14 +149,16 @@ def create_items(count, itemscount, missing, items_f, holdings_f):
 
     items = []
     holdings = []
-    with open(holdings_f, "w", encoding="utf-8") as holdings_file:
-        with open(items_f, "w", encoding="utf-8") as items_file:
-            for item, holding in generate(count, itemscount, missing):
-                items.append(item)
-                if holding:
-                    holdings.append(holding)
-            json.dump(items, indent=2, fp=items_file)
-            json.dump(holdings, indent=2, fp=holdings_file)
+    with (
+        open(holdings_f, "w", encoding="utf-8") as holdings_file,
+        open(items_f, "w", encoding="utf-8") as items_file,
+    ):
+        for item, holding in generate(count, itemscount, missing):
+            items.append(item)
+            if holding:
+                holdings.append(holding)
+        json.dump(items, indent=2, fp=items_file)
+        json.dump(holdings, indent=2, fp=holdings_file)
 
 
 def create_holding_record(holding_pid, location_pid, item_type_pid, document_pid):

--- a/rero_ils/modules/items/utils.py
+++ b/rero_ils/modules/items/utils.py
@@ -72,7 +72,7 @@ def exists_available_item(items=None):
         if isinstance(item, str):  # `item` seems to be an item pid
             item = Item.get_record_by_pid(item)
         if not isinstance(item, Item):
-            raise ValueError("All items should be Item resource.")
+            raise ValueError("All items should be Item resource.")  # noqa: TRY004
         if item.is_available():
             return True
     return False

--- a/rero_ils/modules/items/views/__init__.py
+++ b/rero_ils/modules/items/views/__init__.py
@@ -14,4 +14,4 @@ blueprints = [
     api_blueprint,
 ]
 
-__all__ = "api_blueprint"
+__all__ = ("api_blueprint",)

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -90,8 +90,8 @@ def jsonify_error(func):
     def decorated_view(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except NotFound as error:
-            raise error
+        except NotFound:
+            raise
         except Exception as error:
             # raise error
             current_app.logger.error(str(error))
@@ -229,8 +229,8 @@ def do_item_jsonify_action(func):
                 {"status": 403, "message": error.description or str(error)}, removed_temp_item_type_name
             )
             return jsonify(error_response), 403
-        except NotFound as error:
-            raise error
+        except NotFound:
+            raise
         except exceptions.RequestError as error:
             # missing required parameters
             return jsonify({"status": 400, "message": str(error)}), 400

--- a/rero_ils/modules/jsonresolver.py
+++ b/rero_ils/modules/jsonresolver.py
@@ -16,9 +16,9 @@ def resolve_json_refs(pid_type, pid):
     """
     try:
         persistent_id = PersistentIdentifier.get(pid_type, pid)
-    except Exception as error:
-        current_app.logger.error(f"Unable to resolve {pid_type} pid: {pid}")
-        raise error
+    except Exception:
+        current_app.logger.error("Unable to resolve %s pid: %s", pid_type, pid)
+        raise
 
     if persistent_id.is_redirected():
         persistent_id = persistent_id.get_redirect()

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -465,8 +465,8 @@ def get_random_librarian(patron):
         .source(["pid"])
         .scan()
     )
-    for patron in patrons:
-        return Patron.get_record_by_pid(patron.pid)
+    for professional in patrons:
+        return Patron.get_record_by_pid(professional.pid)
     return None
 
 

--- a/rero_ils/modules/loans/dumpers.py
+++ b/rero_ils/modules/loans/dumpers.py
@@ -30,7 +30,7 @@ class CirculationDumper(InvenioRecordsDumper):
         if ptrn_data := next(ptrn_query.scan(), None):
             data["patron"] = {}
             data["patron"]["barcode"] = ptrn_data.patron.barcode.pop()
-            data["patron"]["name"] = ", ".join((ptrn_data.last_name, ptrn_data.first_name))
+            data["patron"]["name"] = f"{ptrn_data.last_name}, {ptrn_data.first_name}"
 
         if record.get("pickup_location_pid"):
             location = Location.get_record_by_pid(record.get("pickup_location_pid"))

--- a/rero_ils/modules/loans/logs/api.py
+++ b/rero_ils/modules/loans/logs/api.py
@@ -111,6 +111,7 @@ class NoCirculationOperationLog(OperationLog, SpecificOperationLog):
     @classmethod
     def create(cls, scan, id_=None, index_refresh="false", **kwargs):
         """Create a new record instance and store it in search index.
+
         :param item_data: Dict with the item metadata.
         :param loan: Dict with the loan metadata.
         :param message: Message for item category.

--- a/rero_ils/modules/migrations/data/cli.py
+++ b/rero_ils/modules/migrations/data/cli.py
@@ -4,7 +4,7 @@
 """Command line interface for migration data record management."""
 
 import json
-from pprint import pprint
+from pprint import pformat
 from random import choice
 
 import click
@@ -79,7 +79,7 @@ def dedup(migration, id, dry_run, force):
                 )
                 for pid, json, score, detailed_score in candidates:
                     print(f"ILS pid: {pid}", f"{score:.2f}")
-                    pprint(detailed_score, indent=2)
+                    print(pformat(detailed_score, indent=2))
             else:
                 record.deduplication.candidates = [
                     DeduplicationCandidate(

--- a/rero_ils/modules/migrations/data/views.py
+++ b/rero_ils/modules/migrations/data/views.py
@@ -63,9 +63,7 @@ class MigrationDataListResource(ContentNegotiatedMethodView):
         """HTTP GET method."""
         from ..api import Migration
 
-        migration_id = flask_request.args.get("migration")
-
-        if migration_id:
+        if migration_id := flask_request.args.get("migration"):
             try:
                 migration = Migration.get(migration_id)
                 cls = migration.data_class
@@ -79,9 +77,9 @@ class MigrationDataListResource(ContentNegotiatedMethodView):
 
         # get request args
         size = int(flask_request.args.get("size", 10))
-        size = 0 if size < 0 else size
+        size = max(size, 0)
         page = int(flask_request.args.get("page", 1))
-        page = 1 if page < 1 else page
+        page = max(page, 1)
         query = flask_request.args.get("q")
 
         # base query and filter by organization
@@ -139,8 +137,7 @@ class MigrationDataResource(ContentNegotiatedMethodView):
         """Implement the GET."""
         from ..api import Migration
 
-        migration_id = flask_request.args.get("migration")
-        if migration_id:
+        if migration_id := flask_request.args.get("migration"):
             try:
                 migration = Migration.get(migration_id)
                 MigrationData = migration.data_class
@@ -181,10 +178,7 @@ class MigrationDataResource(ContentNegotiatedMethodView):
             migration_data = next(MigrationData.search(index="migration-data").filter("term", _id=id).scan())
             migration = Migration.get(migration_data.migration_id)
         migration_data.deduplication.ils_pid = ils_pid
-        if not ils_pid:
-            migration_data.deduplication.status = "no match"
-        else:
-            migration_data.deduplication.status = "match"
+        migration_data.deduplication.status = "match" if ils_pid else "no match"
         if candidates := body.get("candidates"):
             migration_data.deduplication.candidates = candidates
         if current_librarian:

--- a/rero_ils/modules/migrations/views.py
+++ b/rero_ils/modules/migrations/views.py
@@ -61,9 +61,9 @@ class MigrationsListResource(ContentNegotiatedMethodView):
     def get(self, **kwargs):
         """HTTP GET method."""
         size = int(flask_request.args.get("size", 10))
-        size = 0 if size < 0 else size
+        size = max(size, 0)
         page = int(flask_request.args.get("page", 1))
-        page = 1 if page < 1 else page
+        page = max(page, 1)
         query = flask_request.args.get("q")
 
         search = Migration.search()[(page - 1) * size : page * size].filter(

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -47,13 +47,12 @@ class Dispatcher:
         for notification in notifications:
             try:
                 cls._process_notification(notification, resend, aggregated)
-            except Exception as error:
+            except Exception:
                 errors += 1
-                current_app.logger.error(
-                    f"Notification has not be sent (pid: {notification.pid},"
-                    f" type: {notification['notification_type']}): "
-                    f"{error}",
-                    exc_info=True,
+                current_app.logger.exception(
+                    "Notification has not be sent (pid: %s, type: %s)",
+                    notification.pid,
+                    notification["notification_type"],
                     stack_info=True,
                 )
 

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -56,12 +56,8 @@ def create_notifications(types=None, tstamp=None, verbose=True):
                 logger.debug(f"* Loan#{loan.pid} is considered as 'due_soon'")
                 notifications = loan.create_notification(_type=NotificationType.DUE_SOON)
                 notification_counter[NotificationType.DUE_SOON] += len(notifications)
-            except Exception as error:
-                logger.error(
-                    f"Unable to create DUE_SOON notification :: {error}",
-                    exc_info=True,
-                    stack_info=True,
-                )
+            except Exception:
+                logger.exception("Unable to create DUE_SOON notification", stack_info=True)
         process_notifications(NotificationType.DUE_SOON)
     # OVERDUE NOTIFICATIONS
     if NotificationType.OVERDUE in types:
@@ -91,12 +87,8 @@ def create_notifications(types=None, tstamp=None, verbose=True):
                     else:
                         msg = f"  --> Overdue notification#{idx + 1} skipped :: already sent"
                         logger.debug(msg)
-                except Exception as error:
-                    logger.error(
-                        f"Unable to create OVERDUE notification :: {error}",
-                        exc_info=True,
-                        stack_info=True,
-                    )
+                except Exception:
+                    logger.exception("Unable to create OVERDUE notification", stack_info=True)
         process_notifications(NotificationType.OVERDUE)
     notification_sum = sum(notification_counter.values())
 

--- a/rero_ils/modules/operation_logs/api.py
+++ b/rero_ils/modules/operation_logs/api.py
@@ -149,7 +149,7 @@ class OperationLog(RecordBase):
             actions.append(action)
         n_succeed, errors = bulk(current_search_client, actions)
         if n_succeed != len(data):
-            raise Exception(f"search indexing Errors: {errors}")
+            raise RuntimeError(f"search indexing Errors: {errors}")
 
     @classmethod
     def get_record(cls, _id):
@@ -196,7 +196,7 @@ class OperationLog(RecordBase):
         )
 
         if result != "updated":
-            raise Exception("Operation log cannot be updated.")
+            raise RuntimeError("Operation log cannot be updated.")
 
     @property
     def id(self):

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -530,7 +530,7 @@ class Patron(IlsRecord):
         patrons = cls.get_patrons_by_user(user)
         librarians = list(filter(lambda p: p.is_professional_user, patrons))
         if len(librarians) > 1:
-            raise Exception(f"more than one librarian account for {user}")
+            raise RuntimeError(f"more than one librarian account for {user}")
         return librarians[0] if librarians else None
 
     @classmethod

--- a/rero_ils/modules/stats/api/indicators/base.py
+++ b/rero_ils/modules/stats/api/indicators/base.py
@@ -27,7 +27,6 @@ class IndicatorCfg:
         """
         raise NotImplementedError()
 
-    @property
     @abstractmethod
     def aggregation(self, distribution):
         """Search index Aggregation configuration to compute distributions.

--- a/rero_ils/modules/stats/tasks.py
+++ b/rero_ils/modules/stats/tasks.py
@@ -61,10 +61,6 @@ def collect_stats_reports(frequency="month"):
             values = stat_report.collect()
             report = stat_report.create_stat(values)
             to_return.append(report.pid)
-        except Exception as error:
-            logger.error(
-                f"Unable to generate report from config({pid}) :: {error}",
-                exc_info=True,
-                stack_info=True,
-            )
+        except Exception:
+            logger.exception("Unable to generate report from config(%s)", pid, stack_info=True)
     return to_return

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -43,6 +43,9 @@ from rero_ils.modules.providers import set_sequence
 # SEE: RECORDS_REFRESOLVER_STORE for more details
 refresolver_store = LocalProxy(lambda: current_app.extensions["rero-ils"].jsonschema_store)
 
+# Shared stateless decoder used as the default of `read_json_record`.
+_JSON_DECODER = JSONDecoder()
+
 
 def get_mef_url(entity_type):
     """Get the base MEF URL by entity type.
@@ -122,7 +125,7 @@ def date_string_to_utc(date):
     return parsed_date if parsed_date.tzinfo else parsed_date.replace(tzinfo=UTC)
 
 
-def read_json_record(json_file, buf_size=1024, decoder=JSONDecoder()):
+def read_json_record(json_file, buf_size=1024, decoder=_JSON_DECODER):
     """Read lasy json records from file.
 
     :param json_file: json file handle
@@ -837,8 +840,7 @@ def bulk_load_pids(pid_type, ids, bulk_count=0, verbose=True, reindex=False):
     with open(ids) as file:
         for line in file:
             pid = int(line)
-            if pid > max_pid:
-                max_pid = pid
+            max_pid = max(max_pid, pid)
     set_sequence(identifier)
 
 
@@ -887,13 +889,12 @@ def bulk_save_pidstore(pid_type, file_name, file_name_tmp, verbose=False):
             verbose=verbose,
         )
     # clean pid file
-    with open(file_name_tmp) as file_in:
-        with open(file_name, "w") as file_out:
-            count = 0
-            for line in file_in:
-                if pid_type in line:
-                    count += 1
-                    file_out.write(line)
+    with open(file_name_tmp) as file_in, open(file_name, "w") as file_out:
+        count = 0
+        for line in file_in:
+            if pid_type in line:
+                count += 1
+                file_out.write(line)
     return count
 
 
@@ -1065,7 +1066,7 @@ def truncate_string(str_input, max_length, ellipsis="..."):
     return str_input
 
 
-def draw_data_table(columns, rows=[], padding=""):
+def draw_data_table(columns, rows=None, padding=""):
     """Draw data as a table using ASCII characters.
 
     :param columns: the column headers. Each column is a tuple that must
@@ -1075,6 +1076,7 @@ def draw_data_table(columns, rows=[], padding=""):
         must define at most as much data as the number of columns.
     :param padding: the left padding to apply to each table line.
     """
+    rows = rows or []
 
     def table_header():
         column_lengths = [column[1] for column in columns]

--- a/rero_ils/modules/vendors/jsonresolver.py
+++ b/rero_ils/modules/vendors/jsonresolver.py
@@ -15,4 +15,4 @@ def vendor_resolver(pid):
     if persistent_id.status == PIDStatus.REGISTERED:
         return {"pid": persistent_id.pid_value}
     current_app.logger.error(f"Doc resolver error: /api/vendors/{pid} {persistent_id}")
-    raise Exception("unable to resolve")
+    raise RuntimeError("unable to resolve")

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -145,7 +145,6 @@ def bool_filter(field, **kwargs):
 
 def documents_search_factory(self, search, query_parser=None):
     """Search factory with view code parameter."""
-
     view = request.args.get("view")
     facets = request.args.get("facets", [])
     if facets:

--- a/rero_ils/theme/views.py
+++ b/rero_ils/theme/views.py
@@ -61,7 +61,7 @@ def check_organisation_viewcode(fn):
 @blueprint.route("/error")
 def error():
     """Error to generate exception for test purposes."""
-    raise Exception("this is an error for test purposes")
+    raise RuntimeError("this is an error for test purposes")
 
 
 @blueprint.route("/robots.txt")

--- a/tests/api/acq_accounts/test_acq_accounts_permissions.py
+++ b/tests/api/acq_accounts/test_acq_accounts_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests acquisition accounts permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -27,7 +29,6 @@ def test_acq_accounts_permissions(
     acq_account_fiction_sion,
 ):
     """Test acq_account permissions class."""
-
     # Anonymous user & Patron :: None action allowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/acq_accounts/test_acq_accounts_rest.py
+++ b/tests/api/acq_accounts/test_acq_accounts_rest.py
@@ -88,7 +88,6 @@ def test_acq_accounts_post_put_delete(
     client, lib_saxon, acq_account_books_saxon_data, budget_2020_martigny, json_header
 ):
     """Test record retrieval."""
-
     # TEST 1 :: Create record using POST API
     #   and check that the returned record matches the given data
     acc_data = deepcopy(acq_account_books_saxon_data)

--- a/tests/api/acq_accounts/test_acq_accounts_serializers.py
+++ b/tests/api/acq_accounts/test_acq_accounts_serializers.py
@@ -23,7 +23,7 @@ def test_csv_serializer(
     acq_receipt_line_1_fiction_martigny,
     acq_receipt_line_2_fiction_martigny,
 ):
-    """Test CSV formatter"""
+    """Test CSV formatter."""
     login_user_via_session(client, librarian_martigny.user)
     list_url = url_for("api_exports.acq_account_export", q=f"pid:{acq_account_fiction_martigny.pid}")
     response = client.get(list_url, headers=csv_header)

--- a/tests/api/acq_order_lines/test_acq_order_lines_permissions.py
+++ b/tests/api/acq_order_lines/test_acq_order_lines_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests acquisition order lines permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -29,7 +31,6 @@ def test_order_lines_permissions(
     acq_order_line_fiction_martigny,
 ):
     """Test order lines permissions class."""
-
     # Anonymous user & Patron :: None action allowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/acq_orders/test_acq_orders_permissions.py
+++ b/tests/api/acq_orders/test_acq_orders_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests acquisition orders permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -24,7 +26,6 @@ def test_orders_permissions(
     acq_order_fiction_martigny,
 ):
     """Test orders permissions class."""
-
     # Anonymous user & Patron :: None action allowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/acq_orders/test_acq_orders_serializers.py
+++ b/tests/api/acq_orders/test_acq_orders_serializers.py
@@ -27,7 +27,7 @@ def test_csv_serializer(
     acq_receipt_line_1_fiction_martigny,
     acq_receipt_line_2_fiction_martigny,
 ):
-    """Test CSV formatter"""
+    """Test CSV formatter."""
     login_user_via_session(client, librarian_martigny.user)
     list_url = url_for("api_exports.acq_order_export", q=f"pid:{acq_order_fiction_martigny.pid}")
     response = client.get(list_url, headers=csv_header)

--- a/tests/api/acq_receipt_lines/test_acq_receipt_lines_permissions.py
+++ b/tests/api/acq_receipt_lines/test_acq_receipt_lines_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests acquisition receipt lines permissions."""
+
 from unittest import mock
 
 from flask import current_app

--- a/tests/api/acq_receipts/test_acq_receipts_permissions.py
+++ b/tests/api/acq_receipts/test_acq_receipts_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests acquisition receipts permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -29,7 +31,6 @@ def test_receipts_permissions(
     acq_receipt_line_fiction_saxon,
 ):
     """Test receipt permissions class."""
-
     # Anonymous user & Patron :: None action allowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/acquisition/acq_utils.py
+++ b/tests/api/acquisition/acq_utils.py
@@ -28,7 +28,7 @@ def _make_resource(client, pid_type, input_data):
     res, data = postdata(client, url_alias, input_data)
     if res.status_code == 201:
         return record_class.get_record_by_pid(data["metadata"]["pid"])
-    raise Exception(data["message"])
+    raise AssertionError(data["message"])
 
 
 @mock.patch(

--- a/tests/api/acquisition/test_acquisition_dumpers.py
+++ b/tests/api/acquisition/test_acquisition_dumpers.py
@@ -13,7 +13,6 @@ def test_acquisition_dumpers(
     acq_order_line2_fiction_martigny,
 ):
     """Test acquisition dumpers."""
-
     # Test AcqOrderNotificationDumper. This will also test the
     #  * AcqOrderLineNotificationDumper
     #  * LibraryAcquisitionNotificationDumper

--- a/tests/api/acquisition/test_acquisition_rollover.py
+++ b/tests/api/acquisition/test_acquisition_rollover.py
@@ -27,7 +27,6 @@ from tests.api.acquisition.acq_utils import _make_resource
 
 def test_rollover_cli(client, acq_full_structure_a, org_martigny):
     """Test rollover script using the CLI command."""
-
     origin_budget = acq_full_structure_a
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/api/acquisition/test_acquisition_scenarios.py
+++ b/tests/api/acquisition/test_acquisition_scenarios.py
@@ -411,7 +411,6 @@ def test_acquisition_order(
     document,
 ):
     """Scenario to test orders creation."""
-
     login_user_via_session(client, librarian_martigny.user)
 
     # STEP 0 :: Create the account tree
@@ -573,7 +572,6 @@ def test_acquisition_order_line_account_changes(
     document,
 ):
     """Test validation behavior on if related account of order line changes."""
-
     # We will create an order line related to a first account (acc#A) ; then
     # we updated the related account (acc#B). We need to check if :
     #  - the destination account has enough balance to accept this order_line

--- a/tests/api/budgets/test_budgets_permissions.py
+++ b/tests/api/budgets/test_budgets_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests budgets permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user
@@ -12,7 +14,6 @@ from tests.utils import check_permission
 
 def test_budget_permissions(patron_martigny, librarian_martigny, budget_2018_martigny, budget_2020_sion):
     """Test budget permissions class."""
-
     # Anonymous user
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/circ_policies/test_circ_policies_permissions.py
+++ b/tests/api/circ_policies/test_circ_policies_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests circulation policies permissions."""
+
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security.utils import login_user

--- a/tests/api/circulation/test_actions_views_checkin.py
+++ b/tests/api/circulation/test_actions_views_checkin.py
@@ -123,7 +123,6 @@ def test_checkin_overdue_item(
     item_on_loan_martigny_patron_and_loan_on_loan,
 ):
     """Test a checkin for an overdue item with incremental fees."""
-
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
 
     # Update the circulation policy corresponding to the loan

--- a/tests/api/circulation/test_borrow_limits.py
+++ b/tests/api/circulation/test_borrow_limits.py
@@ -41,7 +41,6 @@ def test_checkout_library_limit(
     circ_policy_short_martigny,
 ):
     """Test checkout library limits."""
-
     patron = patron_martigny
     item2_original_data = deepcopy(item2_lib_martigny_data)
     item3_original_data = deepcopy(item3_lib_martigny_data)
@@ -240,7 +239,6 @@ def test_overdue_limit(
     loc_public_saxon,
 ):
     """Test overdue limit."""
-
     item = item_lib_martigny
     item_pid = item.pid
     patron_pid = patron_martigny.pid

--- a/tests/api/circulation/test_temporary_item_type.py
+++ b/tests/api/circulation/test_temporary_item_type.py
@@ -30,7 +30,7 @@ def test_checkout_temporary_item_type(
     circ_policy_short_martigny,
     circ_policy_default_martigny,
 ):
-    """Test checkout or item with temporary item_types"""
+    """Test checkout or item with temporary item_types."""
     login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
@@ -194,7 +194,6 @@ def test_checkin_remove_temporary_item_type_on_scan(
     item_type_on_site_martigny,
 ):
     """Test checkin removes temporary item type when remove_on_scan is enabled."""
-
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
 
@@ -257,7 +256,6 @@ def test_remove_temporary_item_type_on_scan_disabled(
     item_type_on_site_martigny,
 ):
     """Test that temporary item type is NOT removed when remove_on_scan is disabled."""
-
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
 
@@ -318,7 +316,6 @@ def test_no_circulation_action_remove_temporary_item_type_on_scan(
     item_type_on_site_martigny,
 ):
     """Test that temporary item type is removed even when no circulation action occurs."""
-
     item = item_lib_martigny
     assert item.status == ItemStatus.ON_SHELF
 
@@ -368,7 +365,6 @@ def test_circulation_exception_remove_temporary_item_type_on_scan(
     item_type_on_site_martigny,
 ):
     """Test that temporary item type is removed even when CirculationException occurs."""
-
     item = item_lib_martigny
     patron = patron_martigny
 

--- a/tests/api/collections/test_collections_api.py
+++ b/tests/api/collections/test_collections_api.py
@@ -8,7 +8,7 @@ from jsonschema.exceptions import ValidationError
 
 
 def test_get_items(item_lib_martigny, item2_lib_martigny, coll_martigny_1):
-    """Test get items for a collection"""
+    """Test get items for a collection."""
     # collection should have 2 items
     assert coll_martigny_1.get_items() == [item_lib_martigny, item2_lib_martigny]
 

--- a/tests/api/collections/test_collections_permissions.py
+++ b/tests/api/collections/test_collections_permissions.py
@@ -26,7 +26,6 @@ def test_collections_permissions(
     org_martigny,
 ):
     """Test collection permissions class."""
-
     # Anonymous user & Patron user
     #  - search/read any items are allowed.
     #  - create/update/delete operations are disallowed.

--- a/tests/api/documents/test_documents_files_rest.py
+++ b/tests/api/documents/test_documents_files_rest.py
@@ -19,7 +19,6 @@ def test_document_files(
     librarian_martigny,
 ):
     """Test document files."""
-
     list_url = url_for("invenio_records_rest.doc_list", q="_exists_:files")
     res = client.get(list_url)
     hits = get_json(res)["hits"]

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests documents permissions."""
+
 from unittest import mock
 
 from flask import current_app

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -34,7 +34,7 @@ def test_documents_get(client, document_with_files):
     document = document_with_files
 
     def clean_search_metadata(metadata):
-        """Clean contribution from authorized_access_point_"""
+        """Clean contribution from authorized_access_point_."""
         # Contributions, subject and genreForm are i18n indexed field, so it's
         # too complicated to compare it from original record. Just take the
         # data from original record ... not best, but not real alternatives.
@@ -118,6 +118,7 @@ def test_documents_newacq_filters(
     loc_public_saxon,
     item_lib_martigny_data,
 ):
+    """Test documents new acquisition filters."""
     login_user_via_session(client, system_librarian_martigny.user)
 
     def datetime_delta(**args):
@@ -654,10 +655,12 @@ def test_documents_post_put_delete(client, document_chinese_data, json_header, r
     assert data["metadata"]["title"] == expected_title
     assert data["metadata"]["ui_title_variants"] == ["Guojifa"]
     assert data["metadata"]["ui_title_altgr"] == [
-        "Guo ji fa : subtitle (Latin). Part Number (Latin), Part Name (Latin)"
-        " = International law (Latin) : Parallel Subtitle (Latin)."
-        " Parallel Part Number (Latin), Parallel Part Name (Latin)"
-        " = Parallel Title 2 (Latin) : Parallel Subtitle 2 (Latin)"
+        (
+            "Guo ji fa : subtitle (Latin). Part Number (Latin), Part Name (Latin)"
+            " = International law (Latin) : Parallel Subtitle (Latin)."
+            " Parallel Part Number (Latin), Parallel Part Name (Latin)"
+            " = Parallel Title 2 (Latin) : Parallel Subtitle 2 (Latin)"
+        )
     ]
     assert data["metadata"]["ui_responsibilities"] == [
         "梁西原著主编, 王献枢副主编",
@@ -864,9 +867,7 @@ def test_document_current_library_on_request_parameter(
     document,
     json_header,
 ):
-    """Test for library assignment if the current_library parameter
-    is present in the request.
-    """
+    """Test for library assignment if the current_library parameter is present in the request."""
     login_user_via_session(client, system_librarian_martigny.user)
 
     # Assign library pid with current_librarian information

--- a/tests/api/documents/test_export_serializers.py
+++ b/tests/api/documents/test_export_serializers.py
@@ -39,7 +39,7 @@ def test_json_export_serializers(client, export_json_header, document, export_do
     mock.MagicMock(return_value=VerifyRecordPermissionPatch),
 )
 def test_ris_serializer(client, ris_header, document, export_document):
-    """Test RIS formatter"""
+    """Test RIS formatter."""
     ris_tag = [
         "TY  -",
         "ID  -",

--- a/tests/api/entities/local_entities/test_local_entities_extensions.py
+++ b/tests/api/entities/local_entities/test_local_entities_extensions.py
@@ -16,7 +16,6 @@ def test_local_entities_authorized_access_point(
 
     dumped_record = local_entity_org.dumps()
     assert dumped_record["authorized_access_point"] == "Convegno internazionale di Italianistica"
-    #
     dumped_record = local_entity_org2.dumps()
     assert (
         dumped_record["authorized_access_point"] == "Catholic Church. Concilium Plenarium Americae "

--- a/tests/api/entities/local_entities/test_local_entities_permissions.py
+++ b/tests/api/entities/local_entities/test_local_entities_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests local entities permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security.utils import login_user

--- a/tests/api/entities/local_entities/test_local_entities_rest.py
+++ b/tests/api/entities/local_entities/test_local_entities_rest.py
@@ -178,8 +178,7 @@ def test_local_search_by_proxy(client, local_entity_genre_form, local_entity_org
     mock.MagicMock(return_value=VerifyRecordPermissionPatch),
 )
 def test_local_entities_resolve(client, mef_agents_url, local_entity_person, document):
-    """Test local entity resolver"""
-
+    """Test local entity resolver."""
     # LOCAL ENTITY RESOLVER ===================================================
     res = client.get(
         url_for(

--- a/tests/api/entities/remote_entities/test_remote_entities_permissions.py
+++ b/tests/api/entities/remote_entities/test_remote_entities_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests remote entities permissions."""
+
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security.utils import login_user

--- a/tests/api/entities/test_entities_search.py
+++ b/tests/api/entities/test_entities_search.py
@@ -16,7 +16,6 @@ from tests.utils import VerifyRecordPermissionPatch, get_json
 )
 def test_unified_entity_search(client, entity_person, local_entity_person, entity_organisation):
     """Test unified entity search queries."""
-
     # unified entity search
     list_url = url_for("invenio_records_rest.ent_list", q='"Loy, Georg"', simple="1")
     res = client.get(list_url)

--- a/tests/api/files/test_files_permissions.py
+++ b/tests/api/files/test_files_permissions.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests files permissions."""
+
 from unittest import mock
 
 from flask import current_app, url_for
@@ -99,7 +101,6 @@ def test_files_permissions(
     document_with_files,
 ):
     """Test files permissions."""
-
     # Anonymous user & Patron user
     #  - search/read any files are allowed.
     #  - create/update/delete operations are disallowed.

--- a/tests/api/holdings/test_holdings_permissions.py
+++ b/tests/api/holdings/test_holdings_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests holdings permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -27,7 +29,6 @@ def test_holdings_permissions(
     holding_lib_sion_w_patterns,
 ):
     """Test holdings permissions class."""
-
     # Anonymous user & Patron user
     #  - search/read any document are allowed.
     #  - create/update/delete operations are disallowed.

--- a/tests/api/holdings/test_holdings_rest.py
+++ b/tests/api/holdings/test_holdings_rest.py
@@ -175,7 +175,7 @@ def test_holding_request(
     lib_martigny,
     circ_policy_short_martigny,
 ):
-    """Test holding can be requested"""
+    """Test holding can be requested."""
     # test patron can request holding
     login_user_via_session(client, patron_martigny.user)
     patron = patron_martigny

--- a/tests/api/holdings/test_patterns.py
+++ b/tests/api/holdings/test_patterns.py
@@ -221,7 +221,7 @@ def test_pattern_validate_next_expected_date(
     json_header,
     holding_lib_sion_w_patterns_data,
 ):
-    """Test create holding with regular frequency and missing
+    """Test create holding with regular frequency and missing.
 
     the next_expected_date.
     """

--- a/tests/api/ill_requests/test_ill_requests_permissions.py
+++ b/tests/api/ill_requests/test_ill_requests_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests ILL requests permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user

--- a/tests/api/ill_requests/test_ill_requests_rest.py
+++ b/tests/api/ill_requests/test_ill_requests_rest.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from datetime import datetime
 from unittest import mock
 
-from dateutil.relativedelta import *
+from dateutil.relativedelta import relativedelta
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 

--- a/tests/api/item_types/test_item_types_permissions.py
+++ b/tests/api/item_types/test_item_types_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests item types permissions."""
+
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security.utils import login_user

--- a/tests/api/items/test_items_issue.py
+++ b/tests/api/items/test_items_issue.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests items issue."""
+
 from unittest import mock
 
 from flask import url_for
@@ -44,7 +46,6 @@ def _receive_regular_issue(client, holding):
 )
 def test_issues_permissions(client, holding_lib_martigny_w_patterns, librarian_martigny):
     """Test specific items issues permissions."""
-
     # receive a regular issue
     holding = holding_lib_martigny_w_patterns
     holding = Holding.get_record_by_pid(holding.pid)

--- a/tests/api/items/test_items_permissions.py
+++ b/tests/api/items/test_items_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests items permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -24,7 +26,6 @@ def test_items_permissions(
     item_lib_martigny,
 ):
     """Test item permissions class."""
-
     # Anonymous user & Patron user
     #  - search/read any items are allowed.
     #  - create/update/delete operations are disallowed.

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -38,7 +38,6 @@ def test_orphean_pids(
     json_header,
 ):
     """Test record retrieval."""
-
     item_data = item_lib_martigny_data_tmp
     item_data.pop("pid", None)
     item_data["foo"] = "foo"
@@ -201,7 +200,7 @@ def test_checkout_default_policy(
     json_header,
     circulation_policies,
 ):
-    """Test circ policy parameters"""
+    """Test circ policy parameters."""
     login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
@@ -257,7 +256,7 @@ def test_checkout_library_level_policy(
     json_header,
     circ_policy_short_martigny,
 ):
-    """Test circ policy parameters"""
+    """Test circ policy parameters."""
     login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
@@ -308,7 +307,7 @@ def test_checkout_organisation_policy(
     json_header,
     circ_policy_short_martigny,
 ):
-    """Test circ policy parameters"""
+    """Test circ policy parameters."""
     login_user_via_session(client, librarian_martigny.user)
     item = item_lib_martigny
     item_pid = item.pid
@@ -828,7 +827,6 @@ def test_local_fields_items_get(
 
 def test_items_notes(client, librarian_martigny, item_lib_martigny, json_header):
     """Test items notes."""
-
     item = item_lib_martigny
     login_user_via_session(client, librarian_martigny.user)
 
@@ -883,7 +881,6 @@ def test_requested_loans_to_validate(
     circulation_policies,
 ):
     """Test requested loans to validate."""
-
     holding_pid = item2_lib_martigny.holding_pid
     holding = Holding.get_record_by_pid(holding_pid)
     original_item = deepcopy(item2_lib_martigny)
@@ -1079,7 +1076,6 @@ def test_items_facets(
 
 def test_items_rest_api_sort(client, item_lib_martigny, item_lib_fully, rero_json_header, roles):
     """Test sorting option on `Item` REST API endpoints."""
-
     item_lib_fully["second_call_number"] = "second_call_number"
     item_lib_fully.update(item_lib_fully, dbcommit=True, reindex=True)
     ItemsSearch.flush_and_refresh()

--- a/tests/api/libraries/test_libraries_permissions.py
+++ b/tests/api/libraries/test_libraries_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests libraries permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -24,7 +26,6 @@ def test_library_permissions(
     lib_sion,
 ):
     """Test library permissions class."""
-
     # Anonymous user
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/loans/test_loans_permissions.py
+++ b/tests/api/loans/test_loans_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests loans permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user

--- a/tests/api/loans/test_loans_rest.py
+++ b/tests/api/loans/test_loans_rest.py
@@ -533,7 +533,6 @@ def test_timezone_due_date(
     lib_martigny,
 ):
     """Test that timezone affects due date regarding library location."""
-
     # Close the library all days. Except Monday.
     del lib_martigny["exception_dates"]
     lib_martigny["opening_hours"] = [

--- a/tests/api/loans/test_loans_utils.py
+++ b/tests/api/loans/test_loans_utils.py
@@ -15,7 +15,6 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 def test_loans_build_refs(item_lib_martigny, patron_martigny, document):
     """Test functions buildings refs."""
-
     # Create "virtual" Loan (not registered)
     loan = Loan(
         {

--- a/tests/api/local_fields/test_local_fields_permissions.py
+++ b/tests/api/local_fields/test_local_fields_permissions.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests local fields permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -21,7 +23,6 @@ def test_local_fields_permissions(
     local_field_sion,
 ):
     """Test item permissions class."""
-
     # Anonymous user & Patron user
     #  - search/read any local fields are allowed.
     #  - create/update/delete operations are disallowed.

--- a/tests/api/locations/test_locations_permissions.py
+++ b/tests/api/locations/test_locations_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests locations permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user
@@ -21,7 +23,6 @@ def test_location_permissions(
     loc_public_sion,
 ):
     """Test location permissions class."""
-
     # Anonymous user
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/locations/test_locations_rest.py
+++ b/tests/api/locations/test_locations_rest.py
@@ -17,7 +17,6 @@ from tests.utils import VerifyRecordPermissionPatch, get_json, postdata, to_rela
 
 def test_location_pickup_locations(locations, patron_martigny, patron_sion, loc_public_martigny, item2_lib_martigny):
     """Test for pickup locations."""
-
     # At the beginning, if we load all locations from fixtures, there are 4
     # pickup locations (loc1, loc3, loc5, loc7)
     pickup_locations = Location.get_pickup_location_pids()

--- a/tests/api/notifications/test_notifications_permissions.py
+++ b/tests/api/notifications/test_notifications_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests notifications permissions."""
+
 from unittest import mock
 
 from flask import current_app

--- a/tests/api/notifications/test_notifications_rest.py
+++ b/tests/api/notifications/test_notifications_rest.py
@@ -210,7 +210,6 @@ def test_notifications_get(client, notification_availability_martigny):
 )
 def test_notifications_post_put_delete(client, dummy_notification, loan_validated_martigny, json_header):
     """Test record delete and update."""
-
     record = deepcopy(dummy_notification)
     del record["pid"]
     loan_ref = get_ref_for_pid("loans", loan_validated_martigny.get("pid"))
@@ -388,6 +387,7 @@ def test_recall2_notifications(
     circulation_policies,
     mailbox,
 ):
+    """Test recall notification for a second request on a checked out item."""
     mailbox.clear()
     login_user_via_session(client, librarian_martigny.user)
     # - Create request for User#X
@@ -1246,7 +1246,6 @@ def test_reminder_notifications_after_extend(
     client,
 ):
     """Test any reminder notification could be resend after loan extension."""
-
     # STEP 1 - CREATE BASIC RESOURCES FOR THE TEST
     #   * Create a loan and update it to be considered as "due soon".
     #   * Run the `notification-creation` task to create a DUE_SOON
@@ -1349,4 +1348,5 @@ def test_reminder_notifications_after_extend(
 
 # should be at the end to avoid notifications in other tests
 def test_transaction_library_pid(notification_late_martigny, lib_martigny_data):
+    """Test the transaction library pid of a notification."""
     assert notification_late_martigny.transaction_library_pid == lib_martigny_data.get("pid")

--- a/tests/api/operation_logs/test_operation_logs_permissions.py
+++ b/tests/api/operation_logs/test_operation_logs_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests operation logs permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -16,7 +18,6 @@ from tests.utils import check_permission
 @mock.patch.object(Patron, "_extensions", [])
 def test_operation_logs_permissions(patron_martigny, operation_log, librarian_martigny):
     """Test item permissions class."""
-
     # Anonymous user & Patron user
     #  - search/read any items are allowed.
     #  - create/update/delete operations are disallowed.

--- a/tests/api/operation_logs/test_operation_logs_rest.py
+++ b/tests/api/operation_logs/test_operation_logs_rest.py
@@ -110,7 +110,6 @@ def test_operation_log_on_item(
     item_lib_martigny,
 ):
     """Test operation log on Item."""
-
     # STEP #1 : Create an item. This will generate an operation log
     item_data = deepcopy(item_lib_martigny_data_tmp)
     del item_data["pid"]
@@ -271,7 +270,6 @@ def test_operation_log_on_ill_request(client, ill_request_martigny, librarian_ma
 
 def test_operation_log_on_file(client, librarian_martigny, document, lib_martigny, file_location):
     """Test files operation log."""
-
     # get the op index
     fake_data = {"date": datetime.now().isoformat()}
     oplg_index = OperationLog.get_index(fake_data)

--- a/tests/api/organisations/test_organisations_permissions.py
+++ b/tests/api/organisations/test_organisations_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests organisations permissions."""
+
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user
@@ -59,7 +61,6 @@ def test_organisation_permissions(
     org_sion,
 ):
     """Test organisation permissions class."""
-
     permission_policy = OrganisationPermissionPolicy
 
     # Anonymous user

--- a/tests/api/patron_transaction_events/test_patron_transaction_events_permissions.py
+++ b/tests/api/patron_transaction_events/test_patron_transaction_events_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests patron transaction events permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -25,7 +27,6 @@ def test_ptre_permissions(
     patron_transaction_overdue_event_martigny,
 ):
     """Test patron transaction event permissions class."""
-
     ptre_martigny = patron_transaction_overdue_event_martigny
     ptre_saxon = patron_transaction_overdue_event_saxon
     ptre_sion = patron_transaction_overdue_event_sion

--- a/tests/api/patron_transactions/test_patron_transactions_permissions.py
+++ b/tests/api/patron_transactions/test_patron_transactions_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests patron transactions permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -25,7 +27,6 @@ def test_pttr_permissions(
     patron_transaction_overdue_martigny,
 ):
     """Test patron transaction permissions class."""
-
     pttr_martigny = patron_transaction_overdue_martigny
     pttr_saxon = patron_transaction_overdue_saxon
     pttr_sion = patron_transaction_overdue_sion

--- a/tests/api/patron_types/test_patron_types_permissions.py
+++ b/tests/api/patron_types/test_patron_types_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests patron types permissions."""
+
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security.utils import login_user
@@ -76,7 +78,6 @@ def test_patron_types_permissions(
     patron_type_youngsters_sion,
 ):
     """Test patron types permissions class."""
-
     permission_policy = PatronTypePermissionPolicy
 
     # Anonymous user

--- a/tests/api/patrons/test_patrons_blocked.py
+++ b/tests/api/patrons/test_patrons_blocked.py
@@ -56,6 +56,7 @@ def test_blocked_patron_cannot_request(
     patron3_martigny_blocked,
     circulation_policies,
 ):
+    """Test that a blocked patron cannot request an item."""
     login_user_via_session(client, librarian_martigny.user)
     res = client.get(
         url_for(

--- a/tests/api/patrons/test_patrons_marshmallow.py
+++ b/tests/api/patrons/test_patrons_marshmallow.py
@@ -17,7 +17,6 @@ from tests.utils import postdata
 
 def test_patrons_marshmallow_loaders(client, librarian_martigny, system_librarian_martigny_data_tmp, json_header):
     """Test marshmallow schema/restrictions for Patron resources."""
-
     # TEST#1 :: Use console to manage patron/role
     #   Using 'console' commands, no matter connected user, all operations are
     #   allowed on a Patron, even changes any roles.

--- a/tests/api/patrons/test_patrons_permissions.py
+++ b/tests/api/patrons/test_patrons_permissions.py
@@ -30,7 +30,6 @@ def test_patrons_permissions(
     lib_saxon,
 ):
     """Test patrons permissions class."""
-
     # Anonymous user & Patron user
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(PatronPermissionPolicy, {"search": False}, {})

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -436,7 +436,6 @@ def test_patron_messages(client, patron_martigny):
 
 def test_patron_info(app, client, patron_martigny, librarian_martigny):
     """Test patron info."""
-
     # All scopes
     scopes = [
         "fullname",

--- a/tests/api/selfcheck/test_admin.py
+++ b/tests/api/selfcheck/test_admin.py
@@ -28,20 +28,18 @@ def test_admin_view(app):
     with app.test_request_context():
         request_url = url_for("selfcheckterminal.index_view")
 
-    with app.app_context():
-        with app.test_client() as client:
-            res = client.get(request_url, follow_redirects=True)
-            assert res.status_code == 200
-            assert b"Name" in (res.get_data())
-            assert b"Access Token" in (res.get_data())
-            assert b"Organisation Pid" in (res.get_data())
-            assert b"Library Pid" in (res.get_data())
-            assert b"Location Pid" in (res.get_data())
+    with app.app_context(), app.test_client() as client:
+        res = client.get(request_url, follow_redirects=True)
+        assert res.status_code == 200
+        assert b"Name" in (res.get_data())
+        assert b"Access Token" in (res.get_data())
+        assert b"Organisation Pid" in (res.get_data())
+        assert b"Library Pid" in (res.get_data())
+        assert b"Location Pid" in (res.get_data())
 
 
 def test_admin_createuser(app, client, loc_public_martigny):
     """Test flask-admin user creation."""
-
     create_view_url = url_for("selfcheckterminal.create_view")
 
     # test required values

--- a/tests/api/selfcheck/test_models.py
+++ b/tests/api/selfcheck/test_models.py
@@ -13,7 +13,6 @@ from rero_ils.modules.selfcheck.models import SelfcheckTerminal
 
 def test_selfcheckuser(app):
     """Test SelfcheckUser model."""
-
     selfcheck_terminal = SelfcheckTerminal(
         name="selfcheck_test",
         access_token="UNACCESSTOKENDETEST",

--- a/tests/api/selfcheck/test_selfcheck.py
+++ b/tests/api/selfcheck/test_selfcheck.py
@@ -45,7 +45,6 @@ def test_invenio_sip2():
 
 def test_selfcheck_login(librarian_martigny, selfcheck_librarian_martigny):
     """Test selfcheck client login."""
-
     # test failed login
     response = selfcheck_login("invalid_user", "invalid_password", terminal_ip="127.0.0.1")
     assert not response
@@ -62,7 +61,6 @@ def test_selfcheck_login(librarian_martigny, selfcheck_librarian_martigny):
 
 def test_authorize_patron(selfcheck_patron_martigny, default_user_password):
     """Test authorize patron."""
-
     # try to authorize with wrong password
     response = authorize_patron(
         selfcheck_patron_martigny.get("patron", {}).get("barcode")[0],

--- a/tests/api/stats/test_stats_permissions.py
+++ b/tests/api/stats/test_stats_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests statistics permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user
@@ -12,7 +14,6 @@ from tests.utils import check_permission
 
 def test_stats_permissions(patron_martigny, stats_librarian, librarian_martigny, system_librarian_martigny):
     """Test stat permissions class."""
-
     # Anonymous user & Patron user :: all operation are disallowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/stats_cfg/test_stats_cfg_permissions.py
+++ b/tests/api/stats_cfg/test_stats_cfg_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests statistics configuration permissions."""
+
 from flask import current_app
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user
@@ -22,7 +24,6 @@ def test_stats_cfg_permissions(
     lib_saxon,
 ):
     """Test statistics configuration permissions class."""
-
     # Anonymous user & Patron user :: all operation are disallowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/api/templates/test_templates_marshmallow.py
+++ b/tests/api/templates/test_templates_marshmallow.py
@@ -22,7 +22,7 @@ from tests.utils import VerifyRecordPermissionPatch, login_user_via_session, pos
 def test_templates_marshmallow_loaders(
     client, system_librarian_martigny, templ_doc_public_martigny_data_tmp, json_header
 ):
-    """Test template marshmallow loaders"""
+    """Test template marshmallow loaders."""
     login_user_via_session(client, system_librarian_martigny.user)
     data = templ_doc_public_martigny_data_tmp
     del data["pid"]

--- a/tests/api/templates/test_templates_permissions.py
+++ b/tests/api/templates/test_templates_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests templates permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -27,7 +29,6 @@ def test_template_permissions(
     templ_doc_private_sion,
 ):
     """Test template permissions class."""
-
     # Anonymous user & Patron user
     #  - None operation are allowed
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())

--- a/tests/api/test_accounts_rest_auth.py
+++ b/tests/api/test_accounts_rest_auth.py
@@ -9,7 +9,6 @@ from invenio_accounts.testutils import login_user_via_session
 
 def test_disabled_endpoint(client, app, patron_martigny):
     """Test disabled endpoint."""
-
     ext = app.extensions["security"]
     ext.registerable = ext.changeable = ext.recoverable = ext.confirmable = True
 

--- a/tests/api/test_commons_api.py
+++ b/tests/api/test_commons_api.py
@@ -23,7 +23,7 @@ from tests.utils import get_json, mock_response, postdata
 
 
 def test_librarian_delete_permission_factory(client, librarian_fully, org_martigny, lib_martigny):
-    """Test librarian_delete_permission_factory"""
+    """Test librarian_delete_permission_factory."""
     login_user_via_session(client, librarian_fully.user)
     assert isinstance(librarian_delete_permission_factory(None, credentials_only=True), Permission)
     assert librarian_delete_permission_factory(org_martigny) is not None
@@ -111,7 +111,6 @@ def test_permission_exposition(app, db, client, system_librarian_martigny):
 
 def test_permission_management(client, system_librarian_martigny):
     """Test permission management."""
-
     # Test bad usage of the API
     #   1) Anonymous user can't manage permissions.
     #   2) try with bad payload data

--- a/tests/api/test_external_services.py
+++ b/tests/api/test_external_services.py
@@ -31,7 +31,6 @@ def test_documents_import_bnf_ean_no_permission(
     bnf_ean_any_123,
 ):
     """Test document import from bnf no permission."""
-
     mock_get.return_value = mock_response(content=bnf_ean_any_123)
     res = client.get(url_for("api_imports.import_bnf", q="ean:any:123", no_cache=1))
     assert res.status_code == 401
@@ -222,7 +221,6 @@ def test_documents_import_loc_isbn(
 @mock.patch("requests.get")
 def test_documents_import_loc_missing_id(mock_get, client, loc_without_010):
     """Test document import from LoC."""
-
     mock_get.return_value = mock_response(content=loc_without_010)
     results, status_code = LoCImport().search_records(
         what="test", relation="all", where="anywhere", max_results=100, no_cache=True

--- a/tests/api/test_pid_rest.py
+++ b/tests/api/test_pid_rest.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""API tests for PID and IlsRecords"""
+"""API tests for PID and IlsRecords."""
 
 from invenio_accounts.testutils import login_user_via_session
 
@@ -10,9 +10,13 @@ from tests.utils import postdata
 
 
 def test_ilsrecord_pid_after_validationerror(client, loc_online_martigny_data, librarian_martigny):
-    """Check PID before and after a ValidationError: it should be the same"""
+    """Check that a ValidationError leaves no record behind.
+
+    The pid minted for the rejected record is lost: the identifier tables
+    are backed by a database sequence, which a rollback does not rewind.
+    """
     loc = Location.create(loc_online_martigny_data, delete_pid=True)
-    next_pid = str(int(loc.pid) + 1)
+    skipped_pid = str(int(loc.pid) + 1)
 
     # post invalid data and post them
     login_user_via_session(client, librarian_martigny.user)
@@ -29,9 +33,9 @@ def test_ilsrecord_pid_after_validationerror(client, loc_online_martigny_data, l
     # check http status for invalid record
     assert res.status_code == 400
 
-    # the pid should be unchanged
-    loc.provider.identifier.query.first().recid == loc.pid
+    # no record has been created for the minted pid
+    assert Location.get_record_by_pid(skipped_pid) is None
 
     # check that we can create a new location
     loc2 = Location.create(loc_online_martigny_data, delete_pid=True)
-    loc2.pid == next_pid
+    assert int(loc2.pid) > int(loc.pid)

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -65,7 +65,6 @@ def test_patrons_permissions(
     librarian_sion,
 ):
     """Test permissions for patrons."""
-
     # simple librarian -----------------------------------------------
     login_user(client, librarian_martigny)
     # 1) should update and delete a librarian of the same library

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -16,7 +16,6 @@ from tests.utils import VerifyRecordPermissionPatch, get_json
 )
 def test_documents_search(client, doc_title_travailleurs, doc_title_travailleuses):
     """Test document search queries."""
-
     # phrase search
     list_url = url_for(
         "invenio_records_rest.doc_list",

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -348,7 +348,6 @@ def test_cached_serializers(
     loc_public_martigny_data,
 ):
     """Test cached serializers."""
-
     # Ensure than cache used in some serializer is reset each time we request
     # a new search result serialization.
     #

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -33,9 +33,7 @@ from rero_ils.modules.notifications.utils import (
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.patrons.listener import create_subscription_patron_transaction
 from rero_ils.modules.patrons.tasks import (
-    check_patron_types_and_add_subscriptions as check_patron_types_and_add_subscriptions,
-)
-from rero_ils.modules.patrons.tasks import (
+    check_patron_types_and_add_subscriptions,
     clean_obsolete_subscriptions,
     task_clear_and_renew_subscriptions,
 )
@@ -181,8 +179,6 @@ def test_notifications_task(
 
 def test_clear_and_renew_subscription(patron_type_grown_sion, patron_sion):
     """Test the `task patrons.tasks.clear_and_renew_subscription`."""
-    patron_sion = patron_sion
-
     # To test correctly all the code we need to disconnect the listener
     # `create_subscription_patron_transaction` method. Otherwise, the
     # first part of the task (clean_obsolete_subscriptions) will automatically
@@ -240,7 +236,7 @@ def test_clear_obsolete_temporary_item_type_and_location(
     loc_restricted_martigny,
     item2_lib_martigny,
 ):
-    """Test task test_clear_obsolete_temporary_item_type_and_location"""
+    """Test task test_clear_obsolete_temporary_item_type_and_location."""
     item = item_lib_martigny
     end_date = datetime.now() + timedelta(days=2)
     item["temporary_item_type"] = {

--- a/tests/api/test_translations.py
+++ b/tests/api/test_translations.py
@@ -10,7 +10,6 @@ from tests.utils import get_json
 
 def test_translations(client, app):
     """Test translations API."""
-
     for ln in app.extensions.get("invenio-i18n").get_languages():
         res = client.get(url_for("api_blueprint.translations", ln=ln[0]))
         assert res.status_code == 200
@@ -19,7 +18,6 @@ def test_translations(client, app):
 
 def test_translations_exceptions(client, app):
     """Test exceptions raised by translations API."""
-
     # Note : usage of type()
     #   the usage of `type` allow to create on the fly a class with only
     #   necessary attributes for the mock. In the Below case, we could replace

--- a/tests/api/vendors/test_vendors_permissions.py
+++ b/tests/api/vendors/test_vendors_permissions.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: UCLouvain
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests vendors permissions."""
+
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security.utils import login_user
@@ -65,7 +67,6 @@ def test_vendor_permissions(
     vendor_sion,
 ):
     """Test vendor permissions class."""
-
     # Anonymous user
     #   - all actions is denied
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())

--- a/tests/api_harvester/cantook/test_cantook_dojson.py
+++ b/tests/api_harvester/cantook/test_cantook_dojson.py
@@ -23,7 +23,6 @@ def clean_dict(data, keys=("$schema", "adminMetadata", "fiction_statement")):
 
 def test_trans_constants(app):
     """Test transformation constants."""
-
     data = {}
     transformation = Transformation(data=data, logger=None, verbose=False, transform=False)
     transformation.trans_constants()

--- a/tests/api_harvester/test_cli_api_harvester.py
+++ b/tests/api_harvester/test_cli_api_harvester.py
@@ -113,8 +113,10 @@ def test_cli(app, org_sion, lib_sion, loc_online_sion, item_type_online_sion):
         output = result.output.strip().split("\n")
         assert output == [
             "Harvest api: VS-CANTOOK",
-            "API page: 1 url: "
-            "https://mediatheque-valais.cantookstation.eu/v1/resources.json?start_at=1900-01-01T00:00:00&page=1",
+            (
+                "API page: 1 url: "
+                "https://mediatheque-valais.cantookstation.eu/v1/resources.json?start_at=1900-01-01T00:00:00&page=1"
+            ),
             "1: CANTOOK:mv-cantook cantook-immateriel.frO1109367 = CREATED",
             "2: CANTOOK:mv-cantook cantook-immateriel.frO1097420 = CREATED",
             "3: CANTOOK:mv-cantook cantook-feedhttps-www-feedbooks-com-item-6177668 = CREATED",
@@ -141,8 +143,10 @@ def test_cli(app, org_sion, lib_sion, loc_online_sion, item_type_online_sion):
         output = result.output.strip().split("\n")
         assert output == [
             "Harvest api: VS-CANTOOK",
-            "API page: 1 url: "
-            "https://mediatheque-valais.cantookstation.eu/v1/resources.json?start_at=1900-01-01T00:00:00&page=1",
+            (
+                "API page: 1 url: "
+                "https://mediatheque-valais.cantookstation.eu/v1/resources.json?start_at=1900-01-01T00:00:00&page=1"
+            ),
             "1: CANTOOK:mv-cantook cantook-immateriel.frO1109367 = DELETED",
             "2: CANTOOK:mv-cantook cantook-immateriel.frO1097420 = UPDATED",
             "3: CANTOOK:mv-cantook cantook-feedhttps-www-feedbooks-com-item-6177668 = DELETED",

--- a/tests/migrations/api/test_migrations_permissions.py
+++ b/tests/migrations/api/test_migrations_permissions.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+"""Tests migrations permissions."""
+
 from unittest import mock
 
 from flask import current_app
@@ -20,7 +22,6 @@ def test_migration_permissions(
     migration,
 ):
     """Test library permissions class."""
-
     # Anonymous user
     identity_changed.send(current_app._get_current_object(), identity=AnonymousIdentity())
     check_permission(

--- a/tests/migrations/ui/test_migration_data_api.py
+++ b/tests/migrations/ui/test_migration_data_api.py
@@ -11,7 +11,6 @@ from elasticsearch_dsl.exceptions import ValidationException
 
 def test_migration_data_create(migration, migration_xml_data, lib_martigny):
     """Test the migration creation."""
-
     raw = migration_xml_data.encode()
     data = {"raw": raw, "migration_id": migration.meta.id}
     MigrationData = migration.data_class

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -121,7 +121,7 @@ def test_circ_policy_extended_validation(
     circ_policy_short_martigny_data,
     circ_policy_default_sion_data,
 ):
-    """Test extended validation for circ policy"""
+    """Test extended validation for circ policy."""
     cipo_data = deepcopy(circ_policy_short_martigny_data)
     cipo_data["allow_requests"] = False
     cipo_data["pickup_hold_duration"] = 10

--- a/tests/ui/circulation/test_actions_checkout.py
+++ b/tests/ui/circulation/test_actions_checkout.py
@@ -29,7 +29,6 @@ def test_checkout_library_never_open(
     librarian_martigny,
 ):
     """Test checkout from a library without opening hours."""
-
     # Test checkout if library has no open days but has exception days/hours
     # in the past
     lib_martigny["opening_hours"] = [

--- a/tests/ui/circulation/test_actions_extend.py
+++ b/tests/ui/circulation/test_actions_extend.py
@@ -32,7 +32,6 @@ def test_fees_after_extend(
     circulation_policies,
 ):
     """Test fees calculation after extend on different location."""
-
     # STEP#1 :: CREATE A SPECIAL CIPO FOR NEXT EXTEND OPERATION
     item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
     checkout_cipo = get_circ_policy(loan)

--- a/tests/ui/circulation/test_loan_utils.py
+++ b/tests/ui/circulation/test_loan_utils.py
@@ -39,7 +39,7 @@ def test_loan_utils(
 
     # test that loan without an item may not move to the pending state
     del loan["item_pid"]
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017 - the circulation callbacks raise various types
         assert can_be_requested(loan)
 
     # test a pending loan will be attached at the right organisation and

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -259,7 +259,7 @@ def test_document_can_delete_with_rolled_over_order_line(
 def test_document_contribution_resolve_exception(search_clear, db, mef_agents_url, document_data_ref):
     """Test document contribution resolve."""
     document_data_ref["contribution"] = ([{"$ref": f"{mef_agents_url}/rero/XXXXXX"}],)
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017 - either a $ref resolution or a validation error
         Document.create(data=document_data_ref, delete_pid=False, dbcommit=True, reindex=True)
 
 
@@ -269,7 +269,7 @@ def test_document_create_invalid_data(search_clear, db, document_data):
     n_pids = DocumentIdentifier.query.count()
     data.pop("type")
     data.pop("pid")
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017 - either a $ref resolution or a validation error
         Document.create(data=data, delete_pid=True, dbcommit=True, reindex=True)
     db.session.rollback()
     assert DocumentIdentifier.query.count() == n_pids

--- a/tests/ui/documents/test_documents_filter.py
+++ b/tests/ui/documents/test_documents_filter.py
@@ -171,7 +171,6 @@ def test_main_title_text():
 
 def test_doc_entity_label_filter(entity_person, local_entity_person):
     """Test entity label filter."""
-
     # Remote entity
     remote_pid = entity_person["idref"]["pid"]
     data = {

--- a/tests/ui/entities/local_entities/test_local_entities_api.py
+++ b/tests/ui/entities/local_entities/test_local_entities_api.py
@@ -9,7 +9,7 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 
 def test_local_entity_properties(local_entity_person):
-    """Test local entity property"""
+    """Test local entity property."""
     assert local_entity_person.get_authorized_access_point(None) == local_entity_person["authorized_access_point"]
 
 

--- a/tests/ui/entities/local_entities/test_local_entities_dumpers.py
+++ b/tests/ui/entities/local_entities/test_local_entities_dumpers.py
@@ -9,7 +9,6 @@ from rero_ils.modules.entities.dumpers import document_dumper
 
 def test_local_entities_document_dumper(local_entity_person2):
     """Test document dumper."""
-
     dumped_record = local_entity_person2.dumps(dumper=document_dumper)
     authorized_access_point = "William III, King of England (1650-1702)"
     for field in [

--- a/tests/ui/entities/remote_entities/test_remote_entities_api.py
+++ b/tests/ui/entities/remote_entities/test_remote_entities_api.py
@@ -182,7 +182,6 @@ def test_sync_contribution(mock_get, app, mef_agents_url, entity_person_data_tmp
 
 @mock.patch("requests.Session.get")
 def test_sync_concept(mock_get, app, mef_concepts_url, entity_topic_data, document_data_subject_ref):
-    #
     """Test MEF agent synchronization."""
     # === setup
     log_path = tempfile.mkdtemp()

--- a/tests/ui/entities/test_entities_api.py
+++ b/tests/ui/entities/test_entities_api.py
@@ -14,17 +14,16 @@ from rero_ils.modules.utils import get_ref_for_pid
 
 def test_entities_properties(entity_person_data_tmp):
     """Test entity properties."""
-
     # These tests are only for code coverage
     entity = Entity(entity_person_data_tmp)
     with pytest.raises(NotImplementedError):
         entity.get_authorized_access_point(None)
     with pytest.raises(NotImplementedError):
-        entity.resource_type
+        entity.resource_type  # noqa: B018 - accessing the property is what raises
 
 
 def test_entities_helpers(local_entity_org):
-    """Test entity helpers"""
+    """Test entity helpers."""
     data = {"pid": "dummy"}
     with pytest.raises(RecordNotFound):
         get_entity_record_from_data(data)

--- a/tests/ui/entities/test_entities_ui.py
+++ b/tests/ui/entities/test_entities_ui.py
@@ -18,7 +18,6 @@ from rero_ils.modules.entities.views import (
 
 def test_view(client, entity_person, local_entity_person):
     """Entity detailed view test."""
-
     # Check unauthorized type value in url
     res = client.get(url_for("entities.entity_detailed_view", viewcode="global", type="foo", pid="foo"))
     assert res.status_code == 404
@@ -106,7 +105,6 @@ def test_sources_link(app):
 
 def test_search_link(app, entity_organisation, local_entity_org, entity_topic):
     """Search link test."""
-
     # test remote link
     link = search_link(entity_organisation)
     assert link == "contribution.entity.pids.rero:A027711299 OR subjects.entity.pids.rero:A027711299&simple=0"

--- a/tests/ui/holdings/test_holdings_item.py
+++ b/tests/ui/holdings/test_holdings_item.py
@@ -6,6 +6,7 @@
 from copy import deepcopy
 
 import pytest
+from werkzeug.exceptions import NotFound
 
 from rero_ils.modules.holdings.api import (
     Holding,
@@ -58,7 +59,7 @@ def test_holding_item_links(
     assert reasons["links"]["items"]
     # test loan conditions
     assert holding_loan_condition_filter(holding_lib_martigny.pid) == "standard"
-    with pytest.raises(Exception):
+    with pytest.raises(NotFound):
         assert holding_loan_condition_filter("no pid")
     holdings = get_holdings_by_document_item_type(document.pid, item_type_standard_martigny.pid)
     assert holding_lib_martigny.pid == holdings[1].get("pid")
@@ -97,7 +98,6 @@ def test_holding_delete_after_item_deletion(client, holding_lib_martigny, item_l
 
 def test_holding_delete_after_item_edition(client, holding_lib_saxon, item_lib_saxon, holding_lib_fully):
     """Test automatic holding delete after item edition."""
-
     item_lib_saxon["location"] = {"$ref": "https://bib.rero.ch/api/locations/loc5"}
 
     item_lib_saxon.update(item_lib_saxon, dbcommit=True, reindex=True)

--- a/tests/ui/holdings/test_holdings_patterns.py
+++ b/tests/ui/holdings/test_holdings_patterns.py
@@ -316,7 +316,7 @@ def test_holding_validate_next_expected_date(
     json_header,
     holding_lib_sion_w_patterns_data,
 ):
-    """Test create holding with regular frequency and missing
+    """Test create holding with regular frequency and missing.
 
     the next_expected_date.
     """
@@ -520,7 +520,6 @@ def test_intervals_and_expected_dates(holding_lib_martigny_w_patterns):
 
 def test_holding_notes(client, librarian_martigny, holding_lib_martigny_w_patterns, json_header):
     """Test holdings notes."""
-
     holding = holding_lib_martigny_w_patterns
     login_user_via_session(client, librarian_martigny.user)
 

--- a/tests/ui/item_types/test_item_types_api.py
+++ b/tests/ui/item_types/test_item_types_api.py
@@ -49,14 +49,14 @@ def test_item_type_get_pid_by_name(item_type_standard_martigny):
 
 
 def test_item_type_can_not_delete(item_type_standard_martigny, item_lib_martigny):
-    """Test item type cannot delete"""
+    """Test item type cannot delete."""
     can, reasons = item_type_standard_martigny.can_delete
     assert not can
     assert reasons["links"]["items"]
 
 
 def test_item_type_can_delete(app, item_type_data_tmp):
-    """Test item type can delete"""
+    """Test item type can delete."""
     itty = ItemType.create(item_type_data_tmp, delete_pid=True)
     can, reasons = itty.can_delete
     assert can

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -113,7 +113,7 @@ def test_item_extended_validation(client, holding_lib_martigny_w_patterns):
 def test_extended_validation_unique_barcode(
     item_lib_martigny, item_lib_fully, item_lib_martigny_data_tmp, lib_martigny
 ):
-    """Test that a barcode must be unique"""
+    """Test that a barcode must be unique."""
     # check that own barcode doesn't fail validation on item update
     assert item_lib_martigny.update(item_lib_martigny)
 
@@ -201,7 +201,6 @@ def test_items_availability(
     document,
 ):
     """Test availability for an item."""
-
     # Create a temporary item with correct data for the test
     item_data = deepcopy(item_lib_martigny_data_tmp)
     del item_data["pid"]

--- a/tests/ui/libraries/test_libraries_dumpers.py
+++ b/tests/ui/libraries/test_libraries_dumpers.py
@@ -15,7 +15,6 @@ from rero_ils.modules.libraries.dumpers import (
 
 def test_library_serial_dumpers(lib_martigny, lib_saxon):
     """Test serial library dumpers."""
-
     # Acquisition dumper
     dump_data = lib_martigny.dumps(LibraryAcquisitionNotificationDumper())
     assert dump_data["shipping_informations"]

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -97,7 +97,6 @@ def test_item_loans_default_duration(
     lib_martigny,
 ):
     """Test default loan duration."""
-
     # create a loan with request is easy
     item, actions = item_lib_martigny.request(
         pickup_location_pid=loc_public_martigny.pid,

--- a/tests/ui/locations/test_locations_other.py
+++ b/tests/ui/locations/test_locations_other.py
@@ -22,7 +22,6 @@ def test_location_get_all_pickup_locations(patron_martigny, loc_public_martigny,
 
 def test_location_get_links_to_me(loc_public_martigny, loc_public_sion, item_lib_martigny):
     """Test pickup locations retrieval."""
-
     assert loc_public_martigny.get_links_to_me() == {"items": 1, "holdings": 1}
     assert loc_public_martigny.get_links_to_me(get_pids=True) == {
         "items": ["item1"],

--- a/tests/ui/notifications/test_notifications_api.py
+++ b/tests/ui/notifications/test_notifications_api.py
@@ -36,6 +36,7 @@ def test_notification_organisation_pid(app, org_martigny, notification_availabil
 
 def test_notification_mail(notification_late_martigny, lib_martigny, mailbox):
     """Test notification creation.
+
     Patron communication channel is mail.
     """
     mailbox.clear()
@@ -47,6 +48,7 @@ def test_notification_mail(notification_late_martigny, lib_martigny, mailbox):
 
 def test_notification_email(notification_late_sion, patron_sion, mailbox):
     """Test overdue notification.
+
     Patron communication channel is email.
     """
     mailbox.clear()
@@ -56,6 +58,7 @@ def test_notification_email(notification_late_sion, patron_sion, mailbox):
 
 def test_notification_email_availability(notification_availability_sion, lib_sion, patron_sion, mailbox):
     """Test availability notification.
+
     Patron communication channel is email.
     """
     # test availability context fields
@@ -92,6 +95,7 @@ def test_notification_email_aggregated(
     mailbox,
 ):
     """Test availability notification.
+
     Patron communication channel is email.
     """
     mailbox.clear()
@@ -113,7 +117,6 @@ def test_notification_email_aggregated(
 
 def test_notification_properties(client, holding_lib_martigny_w_patterns):
     """Test notification properties."""
-
     record = CirculationNotification({})
     record.__class__ = CirculationNotification
     assert record.get_recipients("cc") == []

--- a/tests/ui/notifications/test_notifications_mapping.py
+++ b/tests/ui/notifications/test_notifications_mapping.py
@@ -11,7 +11,6 @@ from tests.utils import get_mapping
 
 def test_notification_search_mapping(dummy_notification, loan_validated_martigny):
     """Test notification search index mapping."""
-
     search = NotificationsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -156,7 +156,7 @@ def test_patron_extended_validation(
     patron_sion_data_tmp,
     loan_overdue_martigny,
 ):
-    """Test patron extended validation"""
+    """Test patron extended validation."""
     ds = app.extensions["invenio-accounts"].datastore
 
     # check that we cannot create a patron with an existing barcode
@@ -180,7 +180,8 @@ def test_patron_extended_validation(
     patron_sion_barcode = patron_sion["patron"]["barcode"]
     created_patron_sion = create_user_from_data(patron_sion_data_tmp)
     created_patron_sion["patron"]["barcode"] = [patron_martigny["patron"]["barcode"][0]]
-    assert (created_user := Patron.create(created_patron_sion, dbcommit=True, reindex=True, delete_pid=True))
+    created_user = Patron.create(created_patron_sion, dbcommit=True, reindex=True, delete_pid=True)
+    assert created_user
 
     # check that we can update a patron with existing barcode in another
     # organisation
@@ -315,7 +316,6 @@ def test_patron_properties(
     system_librarian_martigny,
 ):
     """Test patron properties methods."""
-
     # TEST `organisation.pid`
     search = PatronsSearch()
     librarian = next(search.filter("term", pid=librarian_martigny.pid).scan())
@@ -368,7 +368,6 @@ def test_user_librarian_can_delete(librarian_martigny):
 
 def test_get_patron_for_organisation(patron_martigny, patron_sion, org_martigny, org_sion):
     """Test get patron_pid for organisation."""
-
     pids = Patron.get_all_pids_for_organisation(org_martigny.pid)
     assert list(pids)
     pids = Patron.get_all_pids_for_organisation(org_sion.pid)

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -13,7 +13,6 @@ from tests.utils import get_json
 
 def test_patrons_logged_user(client, librarian_martigny):
     """Test logged user info API."""
-
     # No logged user (only settings are present)
     res = client.get(url_for("patrons.logged_user"))
     assert res.status_code == 200

--- a/tests/ui/stats/test_stats_librarian.py
+++ b/tests/ui/stats/test_stats_librarian.py
@@ -15,7 +15,6 @@ from rero_ils.modules.stats.api.librarian import StatsForLibrarian
 
 def test_stats_librarian_collect(stat_for_librarian):
     """Test the stat librarian collect keys."""
-
     assert list(stat_for_librarian.collect()[0].keys()) == [
         "library",
         "checkouts_for_transaction_library",

--- a/tests/ui/stats/test_stats_pricing.py
+++ b/tests/ui/stats/test_stats_pricing.py
@@ -17,7 +17,6 @@ from rero_ils.modules.stats.api.pricing import StatsForPricing
 
 def test_stats_pricing_collect(stat_for_pricing):
     """Test the stat pricing collect keys."""
-
     assert set(stat_for_pricing.collect()[0].keys()) == {
         "library",
         "number_of_docs_with_files",
@@ -87,9 +86,7 @@ def test_stats_pricing_number_of_order_lines(stat_for_pricing, acq_order_line_fi
 
 
 def test_stats_pricing_number_of_circ_operations(stat_for_pricing, loan_due_soon_martigny, lib_martigny):
-    """Test the number of circulation operation  during the specified
-    timeframe.
-    """
+    """Test the number of circulation operation  during the specified timeframe."""
     assert stat_for_pricing.number_of_circ_operations("foo", ItemCirculationAction.CHECKOUT) == 0
     assert stat_for_pricing.number_of_circ_operations(lib_martigny.pid, ItemCirculationAction.EXTEND) == 0
     assert stat_for_pricing.number_of_circ_operations(lib_martigny.pid, ItemCirculationAction.CHECKOUT) == 1
@@ -143,9 +140,7 @@ def test_stats_pricing_number_of_patrons(stat_for_pricing, patron_martigny):
 
 
 def test_stats_pricing_number_of_new_patrons(stat_for_pricing, patron_martigny):
-    """Test the number of new patrons for an organisation during the specified
-    timeframe.
-    """
+    """Test the number of new patrons for an organisation during the specified timeframe."""
     assert stat_for_pricing.number_of_patrons("foo") == 0
     # loans used in previous tests can adds some items
     assert stat_for_pricing.number_of_patrons(patron_martigny.organisation_pid) >= 1

--- a/tests/ui/stats_cfg/test_stats_cfg_api.py
+++ b/tests/ui/stats_cfg/test_stats_cfg_api.py
@@ -35,7 +35,6 @@ def test_stats_cfg_create(
 
 def test_stats_cfg_can_delete(stats_cfg_martigny):
     """Test statistics configuration can delete."""
-
     assert stats_cfg_martigny.get_links_to_me("stats_cfg1") == {}
 
     can, reasons = stats_cfg_martigny.can_delete

--- a/tests/ui/test_api.py
+++ b/tests/ui/test_api.py
@@ -102,7 +102,6 @@ class RecordTest(IlsRecord):
 
 def test_ilsrecord(app, search_default_index, ils_record, ils_record_2):
     """Test IlsRecord update."""
-
     # the created records will be accessible in all function of this test file
     record_1 = RecordTest.create(data=ils_record, dbcommit=True, reindex=True)
     assert record_1.pid == "ilsrecord_pid"
@@ -224,13 +223,15 @@ failed_pid_fetcher = partial(id_fetcher, provider=FailedPidProvider)
 
 
 class FailedIlsRecord(IlsRecord):
+    """Record class whose PID minting always fails."""
+
     minter = failed_pid_minter
     fetcher = failed_pid_fetcher
     provider = FailedPidProvider
 
 
 def test_ilsrecord_failed_pid(app, search_default_index, ils_record, ils_record_2):
-    """Test IlsRecord PID after validation failed"""
+    """Test IlsRecord PID after validation failed."""
     schema = {
         "type": "object",
         "properties": {

--- a/tests/ui/test_indexer_utils.py
+++ b/tests/ui/test_indexer_utils.py
@@ -15,7 +15,6 @@ from rero_ils.modules.libraries.api import LibrariesIndexer, LibrariesSearch
 
 def test_record_indexing(app, lib_martigny):
     """Test record indexing process."""
-
     # TEST#1 :: Test indexing without $ref replacement
     app.config["INDEXER_REPLACE_REFS"] = False
     lib_martigny.reindex()
@@ -41,7 +40,6 @@ def test_record_indexing(app, lib_martigny):
 
 def test_record_to_index(app):
     """Test the index name value from the JSONSchema."""
-
     # for documents
     assert (
         record_to_index({"$schema": "https://bib.rero.ch/schemas/documents/document-v0.0.1.json"})

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -36,7 +36,7 @@ def test_localized_label():
 
 def test_error(client):
     """Test error entrypoint."""
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         client.get(url_for("rero_ils.error"))
 
 
@@ -214,7 +214,6 @@ def test_google_analytics(client, app):
 
 def test_login(client, app, user_with_profile):
     """Testing the frontend login view."""
-
     ## bad password
     # be sure that no one is logged
     client.get(url_for_security("logout"))

--- a/tests/ui/users/test_forms.py
+++ b/tests/ui/users/test_forms.py
@@ -99,7 +99,6 @@ def test_reset_password_form(client, app):
     All validator tests are performed by the test_register_form (above).
     Here we only test that the validator is active on the field.
     """
-
     form_data = {"email": "foo@bar.com", "password": "123", "password_confirm": "123"}
     res = client.post(url_for("security.reset_password", token="123ab"), data=form_data)
     soup = BeautifulSoup(res.data, "html.parser")

--- a/tests/ui/users/test_users_ui.py
+++ b/tests/ui/users/test_users_ui.py
@@ -9,7 +9,6 @@ from invenio_accounts.testutils import login_user_via_session
 
 def test_users_not_authorized_access(client):
     """Test profile or change password if the user is not logged. Redirected to the login page."""
-
     res = client.get(url_for("patrons.profile", viewcode="global", path="user/edit"))
     assert res.status_code == 302
 
@@ -19,7 +18,6 @@ def test_users_not_authorized_access(client):
 
 def test_users_authorized_access(client, patron_martigny):
     """Test profile and change password if the user is logged."""
-
     login_user_via_session(client, patron_martigny.user)
     res = client.get(url_for("patrons.profile", viewcode="global", path="user/edit"))
     assert res.status_code == 200
@@ -30,7 +28,6 @@ def test_users_authorized_access(client, patron_martigny):
 
 def test_user_profile_authorization(app, client, librarian_martigny):
     """Test profile and change password with readonly config."""
-
     login_user_via_session(client, librarian_martigny.user)
     res = client.get(url_for("patrons.profile", viewcode="global"))
     assert res.status_code == 401
@@ -43,7 +40,6 @@ def test_user_profile_authorization(app, client, librarian_martigny):
 
 def test_users_readonly_not_authorized_access(app, client, patron_martigny):
     """Test profile and change password with readonly config."""
-
     app.config["RERO_ILS_PUBLIC_USERPROFILES_READONLY"] = True
     login_user_via_session(client, patron_martigny.user)
     res = client.get(url_for("patrons.profile", viewcode="global", path="user/edit"))

--- a/tests/ui/vendors/test_vendors_api.py
+++ b/tests/ui/vendors/test_vendors_api.py
@@ -9,7 +9,6 @@ from rero_ils.modules.vendors.models import VendorContactType, VendorNoteType
 
 def test_vendors_properties(vendor_martigny, vendor_sion):
     """Test vendor properties."""
-
     # NOTES -------------------------------------------------------------------
     assert vendor_martigny.get_note(VendorNoteType.CLAIM) is not None
     assert vendor_martigny.get_note(VendorNoteType.GENERAL) is None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -461,11 +461,13 @@ def mef_record_with_idref_gnd_rero_data():
             "authorized_access_point": "Congrès ouvrier français",
             "type": "bf:Organisation",
             "biographical_information": [
-                "L'ordre des formes exclues suit l'ordre chronologique des "
-                "publications et correspond à l'évolution historique "
-                "(Cf. la notice des congrès particuliers) On a gardé "
-                "volontairement la forme 'Congrès ouvrier français' "
-                "pour toute la série"
+                (
+                    "L'ordre des formes exclues suit l'ordre chronologique des "
+                    "publications et correspond à l'évolution historique "
+                    "(Cf. la notice des congrès particuliers) On a gardé "
+                    "volontairement la forme 'Congrès ouvrier français' "
+                    "pour toute la série"
+                )
             ],
             "conference": False,
             "country_associated": "fr",

--- a/tests/unit/documents/test_documents_api_cover.py
+++ b/tests/unit/documents/test_documents_api_cover.py
@@ -17,17 +17,20 @@ _StubDocument.cover = Document.cover
 
 
 def test_cover_returns_none_when_no_locators():
+    """Test cover without any electronic locator."""
     doc = _StubDocument()
     assert doc.cover == (None, None)
 
 
 def test_cover_returns_none_when_no_cover_image():
+    """Test cover without any cover image locator."""
     doc = _StubDocument()
     doc["electronicLocator"] = [{"content": "fullText", "type": "resource", "url": "https://example.com/full.pdf"}]
     assert doc.cover == (None, None)
 
 
 def test_cover_returns_url_and_provider():
+    """Test cover url and provider from the public note."""
     doc = _StubDocument()
     doc["electronicLocator"] = [
         {
@@ -43,6 +46,7 @@ def test_cover_returns_url_and_provider():
 
 
 def test_cover_returns_url_without_provider():
+    """Test cover url when no provider is given."""
     doc = _StubDocument()
     doc["electronicLocator"] = [{"content": "coverImage", "type": "relatedResource", "url": URL}]
     url, provider = doc.cover
@@ -51,6 +55,7 @@ def test_cover_returns_url_without_provider():
 
 
 def test_cover_ignores_non_related_resource():
+    """Test cover ignores locators that are not a related resource."""
     doc = _StubDocument()
     doc["electronicLocator"] = [{"content": "coverImage", "type": "resource", "url": URL}]
     assert doc.cover == (None, None)

--- a/tests/unit/documents/test_documents_dojson.py
+++ b/tests/unit/documents/test_documents_dojson.py
@@ -45,7 +45,6 @@ def test_marc21_to_type():
     $a: main_type
     $b: subtype
     """
-
     marc21xml = """
     <record>
         <leader>00501nam a2200133 a 4500</leader>
@@ -82,10 +81,7 @@ def test_marc21_to_type():
 
 
 def test_marc21_to_admin_metadata():
-    """
-    Test dojson marc21_to_admin_metadata (L34, L37, 45).
-    """
-
+    """Test dojson marc21_to_admin_metadata (L34, L37, 45)."""
     marc21xml = """
     <record>
         <leader>00501naa a2200133 a 4500</leader>
@@ -219,10 +215,7 @@ def test_marc21_to_admin_metadata():
 
 
 def test_marc21_to_mode_of_issuance():
-    """
-    Test dojson marc21_to_mode_issuance.
-    """
-
+    """Test dojson marc21_to_mode_issuance."""
     marc21xml = """
     <record>
         <leader>00501naa a2200133 a 4500</leader>
@@ -389,7 +382,6 @@ def test_marc21_to_mode_of_issuance():
 # pid: 001
 def test_marc21_to_pid():
     """Test dojson marc21pid."""
-
     marc21xml = """
     <record>
       <controlfield tag="001">
@@ -420,7 +412,6 @@ def test_marc21_to_title_245_with_sufield_c_having_square_bracket():
     - subfields 245 $c with '[]'
     - field 246 is not present
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -458,7 +449,6 @@ def test_marc21_to_title_245_with_two_246():
     - 2 fields 246 are present
     - field 880 exists for the field 245
     """
-
     marc21xml = """
     <record>
         <controlfield tag=
@@ -522,7 +512,6 @@ def test_marc21_to_title_245_without_246():
     - field 246 is not present
     - field 880 exists for the field 245
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -572,7 +561,6 @@ def test_marc21_to_title_245_with_part_without_246():
     - field 246 is not present
     - field 880 exists for the field 245
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -645,7 +633,6 @@ def test_marc21_to_title_with_multiple_parts():
     - subfields 245 $a without '='
     - field 246 is not present
     """
-
     marc21xml = """
     <record>
         <controlfield tag=
@@ -694,7 +681,6 @@ def test_marc21_to_title_245_and_246():
     - field 246 exists
     - field 880 exists for the field 245
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -752,7 +738,6 @@ def test_marc21_to_title_245_and_246_with_multiple_responsibilities():
     - field 246 exists
     - field 880 exists for the field 245
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -810,7 +795,6 @@ def test_marc21_to_title_with_variant_without_subtitle():
     - subfield 245 $a did not end with '='
     - field 246 with subfield $a $n $p
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -952,7 +936,6 @@ def test_marc21_to_title_245_with_parallel_title_and_246():
     - field 246 exists
     - field 880 exists for the field 245
     """
-
     marc21xml = """
     <record>
       <controlfield tag=
@@ -1199,7 +1182,6 @@ def test_marc21_to_contribution(mock_get, mef_agents_url):
 # Copyright Date: [264 _4 $c non repetitive]
 def test_marc21copyrightdate():
     """Test dojson Copyright Date."""
-
     marc21xml = """
     <record>
       <datafield tag="264" ind1=" " ind2="4">
@@ -1225,9 +1207,9 @@ def test_marc21copyrightdate():
 
 def test_marc21_to_provision_activity_manufacture_date():
     """Test dojson publication statement.
-    - 1 manufacture place and 1 agent, 1 manufacture date
-    """
 
+    - 1 manufacture place and 1 agent, 1 manufacture date.
+    """
     marc21xml = """
       <record>
         <controlfield tag=
@@ -1316,7 +1298,8 @@ def test_marc21_provisionActivity_without_264_with_752():
 
 def test_marc21_provisionActivity_with_original_date():
     """Test dojson publication statement.
-    - get original_date from 008 pos 11-14 if pos 6 = r
+
+    - get original_date from 008 pos 11-14 if pos 6 = r.
     """
     marc21xml = """
     <record>
@@ -1338,10 +1321,10 @@ def test_marc21_provisionActivity_with_original_date():
 
 def test_marc21_to_provision_activity_canton():
     """Test dojson publication statement.
-    - get canton from field 044
-    - 3 publication places and 3 agents from one field 264
-    """
 
+    - get canton from field 044
+    - 3 publication places and 3 agents from one field 264.
+    """
     marc21xml = """
       <record>
         <controlfield tag=
@@ -1425,9 +1408,9 @@ def test_marc21_to_provision_activity_canton():
 
 def test_marc21_to_provision_activity_obsolete_countries():
     """Test dojson publication statement.
+
     - convert country to correct code if encountering an obsolete code.
     """
-
     marc21xml = """
       <record>
         <controlfield tag=
@@ -1630,9 +1613,9 @@ def test_marc21_to_provision_activity_obsolete_countries():
 
 def test_marc21_to_provision_activity_1_place_2_agents():
     """Test dojson publication statement.
-    - 1 publication place and 2 agents from one field 264
-    """
 
+    - 1 publication place and 2 agents from one field 264.
+    """
     marc21xml = """
       <record>
         <controlfield tag=
@@ -1664,10 +1647,10 @@ def test_marc21_to_provision_activity_1_place_2_agents():
 
 def test_marc21_to_provision_activity_1_place_2_agents_with_one_752():
     """Test dojson publication statement.
-    - 1 publication place and 2 agents from one field 264
-    - 1 field 752
-    """
 
+    - 1 publication place and 2 agents from one field 264
+    - 1 field 752.
+    """
     marc21xml = """
       <record>
         <controlfield tag=
@@ -1709,10 +1692,10 @@ def test_marc21_to_provision_activity_1_place_2_agents_with_one_752():
 
 def test_marc21_to_provision_activity_1_place_2_agents_with_two_752():
     """Test dojson publication statement.
-    - 1 publication place and 2 agents from one field 264
-    - 2 field 752
-    """
 
+    - 1 publication place and 2 agents from one field 264
+    - 2 field 752.
+    """
     marc21xml = """
       <record>
         <controlfield tag=
@@ -1763,7 +1746,8 @@ def test_marc21_to_provision_activity_1_place_2_agents_with_two_752():
 
 def test_marc21_to_provision_activity_unknown_place_2_agents():
     """Test dojson publication statement.
-    - unknown place and 2 agents from one field 264
+
+    - unknown place and 2 agents from one field 264.
     """
     marc21xml = """
       <record>
@@ -1802,8 +1786,9 @@ def test_marc21_to_provision_activity_unknown_place_2_agents():
 
 def test_marc21_to_provision_activity_3_places_dann_2_agents():
     """Test dojson publication statement.
+
     - 3 places and 2 agents from one field 264
-    - 2 places with [dann] prefix
+    - 2 places with [dann] prefix.
     """
     marc21xml = """
       <record>
@@ -1841,9 +1826,9 @@ def test_marc21_to_provision_activity_3_places_dann_2_agents():
 
 def test_marc21_to_provision_activity_2_places_1_agent():
     """Test dojson publication statement.
-    - 2 publication places and 1 agents from one field 264
-    """
 
+    - 2 publication places and 1 agents from one field 264.
+    """
     marc21xml = """
       <record>
       <controlfield tag=
@@ -1878,8 +1863,9 @@ def test_marc21_to_provision_activity_2_places_1_agent():
 
 def test_marc21_to_provision_activity_1_place_1_agent_reprint_date():
     """Test dojson publication statement.
+
     - 1 place and 1 agent from one field 264
-    - reprint date in 008
+    - reprint date in 008.
     """
     marc21xml = """
       <record>
@@ -1917,8 +1903,9 @@ def test_marc21_to_provision_activity_1_place_1_agent_reprint_date():
 
 def test_marc21_to_provision_activity_1_place_1_agent_uncertain_date():
     """Test dojson publication statement.
+
     - 1 place and 1 agent from one field 264
-    - uncertain date
+    - uncertain date.
     """
     marc21xml = """
       <record>
@@ -1951,8 +1938,9 @@ def test_marc21_to_provision_activity_1_place_1_agent_uncertain_date():
 
 def test_marc21_to_provision_activity_1_place_1_agent_chi_hani():
     """Test dojson publication statement.
+
     - 1 place and 1 agent from one field 264
-    - extract data from the linked 880 from 3 fields 880
+    - extract data from the linked 880 from 3 fields 880.
     """
     marc21xml = """
       <record>
@@ -2084,8 +2072,9 @@ def test_marc21_to_provision_activity_1_place_1_agent_chi_hani():
 
 def test_marc21_to_edition_statement_one_field_250():
     """Test dojson edition statement.
+
     - 1 edition designation and 1 responsibility from field 250
-    - extract data from the linked 880 from field 880
+    - extract data from the linked 880 from field 880.
     """
     marc21xml = """
       <record>
@@ -2121,8 +2110,9 @@ def test_marc21_to_edition_statement_one_field_250():
 
 def test_marc21_to_edition_statement_two_fields_250():
     """Test dojson edition statement.
+
     - 2 edition designations and 2 responsibility from fields 250
-    - extract data from the linked 880 from 1 field 880
+    - extract data from the linked 880 from 1 field 880.
     """
     marc21xml = """
       <record>
@@ -2166,8 +2156,9 @@ def test_marc21_to_edition_statement_two_fields_250():
 
 def test_marc21_to_edition_statement_with_two_subfield_a():
     """Test dojson edition statement.
+
     - 1 field 250 with 2 subfield_a
-    - extract data from the linked 880 from 1 field 880
+    - extract data from the linked 880 from 1 field 880.
     """
     marc21xml = """
       <record>
@@ -2206,9 +2197,10 @@ def test_marc21_to_edition_statement_with_two_subfield_a():
 
 def test_marc21_to_edition_statement_with_one_bad_field_250():
     """Test dojson edition statement.
+
     - 3 fields 250, and one of them as bad subdields $x, $y
       and one as only $b
-    - extract data from the linked 880 from 1 field 880
+    - extract data from the linked 880 from 1 field 880.
     """
     marc21xml = """
       <record>
@@ -2253,8 +2245,9 @@ def test_marc21_to_edition_statement_with_one_bad_field_250():
 
 def test_marc21_to_provision_activity_1_place_1_agent_ara_arab():
     """Test dojson publication statement.
+
     - 1 place and 1 agent from one field 264
-    - extract data from the linked 880
+    - extract data from the linked 880.
     """
     marc21xml = """
       <record>
@@ -2317,8 +2310,9 @@ def test_marc21_to_provision_activity_1_place_1_agent_ara_arab():
 
 def test_marc21_to_provision_activity_2_places_2_agents_rus_cyrl():
     """Test dojson publication statement.
+
     - 2 places and 2 agents from one field 264
-    - extract data from the linked 880 from 3 fields 880
+    - extract data from the linked 880 from 3 fields 880.
     """
     marc21xml = """
       <record>
@@ -2410,7 +2404,8 @@ def test_marc21_to_provision_activity_2_places_2_agents_rus_cyrl():
 
 def test_marc21_to_provision_activity_exceptions(capsys):
     """Test dojson publication statement.
-    - exceptions
+
+    - exceptions.
     """
     marc21xml = """
       <record>
@@ -2479,7 +2474,6 @@ def test_marc21_to_provision_activity_exceptions(capsys):
 
 def test_marc21_to_physical_description_plano():
     """Test dojson extent, productionMethod."""
-
     marc21xml = """
     <record>
       <datafield tag="300" ind1=" " ind2=" ">
@@ -2501,7 +2495,6 @@ def test_marc21_to_physical_description_plano():
 
 def test_marc21_to_physical_description_with_material_note():
     """Test dojson extent, productionMethod, material note."""
-
     marc21xml = """
     <record>
       <datafield tag="300" ind1=" " ind2=" ">
@@ -2527,7 +2520,6 @@ def test_marc21_to_physical_description_with_material_note():
 
 def test_marc21_to_physical_description_with_material_note_plus():
     """Test dojson extent, productionMethod, material note with +."""
-
     marc21xml = """
     <record>
       <datafield tag="300" ind1=" " ind2=" ">
@@ -2555,7 +2547,6 @@ def test_marc21_to_physical_description_with_material_note_plus():
 
 def test_marc21_to_physical_description_300_without_b():
     """Test dojson extent, productionMethod."""
-
     marc21xml = """
     <record>
       <datafield tag="300" ind1=" " ind2=" ">
@@ -2634,7 +2625,6 @@ def test_marc21_to_physical_description_multiple_300():
 # series.number: [490$v repetitive]
 def test_marc21_to_series_statement():
     """Test dojson seriesStatement."""
-
     marc21xml = """
     <record>
        <datafield tag="490" ind1="1" ind2=" ">
@@ -2669,7 +2659,6 @@ def test_marc21_to_series_statement():
 
 def test_marc21_to_series_statement_mutiple_490():
     """Test dojson seriesStatement."""
-
     marc21xml = """
     <record>
        <datafield tag="490" ind1="1" ind2=" ">
@@ -2728,7 +2717,6 @@ def test_marc21_to_series_statement_mutiple_490():
 # series.number: [490$v repetitive]
 def test_marc21_to_series_statement_with_alt_graphic():
     """Test dojson seriesStatement."""
-
     marc21xml = """
     <record>
         <controlfield tag=
@@ -2765,7 +2753,6 @@ def test_marc21_to_series_statement_with_alt_graphic():
 # series.number: [490$v repetitive]
 def test_marc21_to_series_statement_with_missig_subfield_v():
     """Test dojson seriesStatement."""
-
     marc21xml = """
     <record>
         <datafield tag="490" ind1="1" ind2=" ">
@@ -2796,7 +2783,6 @@ def test_marc21_to_series_statement_with_missig_subfield_v():
 # series.number: [490$v repetitive]
 def test_marc21_to_series_statement_with_missig_subfield_a():
     """Test dojson seriesStatement."""
-
     marc21xml = """
     <record>
        <controlfield tag="001">REROILS:123456789</controlfield>
@@ -2816,7 +2802,6 @@ def test_marc21_to_series_statement_with_missig_subfield_a():
 # series.number: [490$v repetitive]
 def test_marc21_to_series_statement_with_succesive_subfield_v():
     """Test dojson seriesStatement."""
-
     marc21xml = """
     <record>
         <leader>00501nam a2200133 a 4500</leader>
@@ -2849,7 +2834,6 @@ def test_marc21_to_series_statement_with_succesive_subfield_v():
 # summary: [520$a repetitive]
 def test_marc21_to_summary():
     """Test dojson summary (L27)."""
-
     marc21xml = """
     <record>
       <datafield tag="520" ind1=" " ind2=" ">
@@ -2890,7 +2874,6 @@ def test_marc21_to_summary():
 
 def test_marc21_to_intended_audience():
     """Test dojson intendedAudience from field 521 (L27)."""
-
     marc21xml = """
     <record>
         <datafield tag="521" ind1=" " ind2=" ">
@@ -2928,7 +2911,6 @@ def test_marc21_to_intended_audience():
 
 def test_marc21_to_original_title_from_500():
     """Test dojson original title from field 500, (L36)."""
-
     marc21xml = """
     <record>
       <datafield tag="500" ind1=" " ind2=" ">
@@ -2943,7 +2925,6 @@ def test_marc21_to_original_title_from_500():
 
 def test_marc21_to_notes_from_500():
     """Test dojson notes from field 500 (L35)."""
-
     marc21xml = """
     <record>
       <datafield tag="500" ind1=" " ind2=" ">
@@ -2964,7 +2945,6 @@ def test_marc21_to_notes_from_500():
 
 def test_marc21_to_notes_from_510():
     """Test dojson notes from field 510 (L35)."""
-
     marc21xml = """
     <record>
       <datafield tag="510" ind1=" " ind2=" ">
@@ -2988,7 +2968,6 @@ def test_marc21_to_notes_from_510():
 
 def test_marc21_to_notes_from_530_545_555_580():
     """Test dojson notes from field 530, 545, 555 and 580 (L35)."""
-
     marc21xml = """
     <record>
       <datafield tag="530" ind1=" " ind2=" ">
@@ -3017,7 +2996,6 @@ def test_marc21_to_notes_from_530_545_555_580():
 
 def test_marc21_to_classification_from_050():
     """Test dojson classification from 050 (L38)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3047,7 +3025,6 @@ def test_marc21_to_classification_from_050():
 
 def test_marc21_to_classification_from_060():
     """Test dojson classification from 060 (L38)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3075,7 +3052,6 @@ def test_marc21_to_classification_from_060():
 
 def test_marc21_to_classification_from_080():
     """Test dojson classification from 080 (L38)."""
-
     marc21xml = """
     <record>
       <datafield tag="080" ind1="0" ind2=" ">
@@ -3129,7 +3105,6 @@ def test_marc21_to_classification_from_080():
 
 def test_marc21_to_classification_from_082():
     """Test dojson classification from 082 (L38)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3181,9 +3156,9 @@ def test_marc21_to_classification_from_082():
 
 def test_marc21_to_subjects_from_980_2_factum():
     """Test dojson subjects from 980 2$ factum (L50).
-    - no classification to produce for $2 factum (38)
-    """
 
+    - no classification to produce for $2 factum (38).
+    """
     marc21xml = """
     <record>
       <datafield tag="980" ind1=" " ind2=" ">
@@ -3219,7 +3194,6 @@ def test_marc21_to_subjects_from_980_2_factum():
 
 def test_marc21_to_classification_from_980_2_musg_musi():
     """Test dojson classification from 980 2$ musg and $2 musi (L38)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3254,7 +3228,6 @@ def test_marc21_to_classification_from_980_2_musg_musi():
 
 def test_marc21_to_classification_from_980_2_brp_and_dr_sys():
     """Test dojson classification from 980 2$ brp and $2 dr_sys (L38)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3286,7 +3259,6 @@ def test_marc21_to_classification_from_980_2_brp_and_dr_sys():
 
 def test_marc21_to_frequency():
     """Test dojson frequency from field 310, 321 (L32)."""
-
     # field 310, 321 ok
     marc21xml = """
     <record>
@@ -3348,7 +3320,6 @@ def test_marc21_to_frequency():
 
 def test_marc21_to_sequence_numbering_from_one_362():
     """Test dojson sequence_numbering from 362 (L39)."""
-
     marc21xml = """
     <record>
       <datafield tag="362" ind1="0" ind2=" ">
@@ -3363,7 +3334,6 @@ def test_marc21_to_sequence_numbering_from_one_362():
 
 def test_marc21_to_sequence_numbering_from_two_362():
     """Test dojson sequence_numbering from 362 (L39)."""
-
     marc21xml = """
     <record>
       <datafield tag="362" ind1="0" ind2=" ">
@@ -3381,7 +3351,6 @@ def test_marc21_to_sequence_numbering_from_two_362():
 
 def test_marc21_to_table_of_contents_from_505():
     """Test dojson tableOfContents from 505 (L44)."""
-
     marc21xml = """
     <record>
       <datafield tag="505" ind1="0" ind2=" ">
@@ -3404,7 +3373,6 @@ def test_marc21_to_table_of_contents_from_505():
 
 def test_marc21_to_usage_and_access_policy():
     """Test dojson usageAndAccessPolicy from field 506, 540 (L74)."""
-
     marc21xml = """
     <record>
       <datafield tag="506" ind1=" " ind2=" ">
@@ -3457,7 +3425,6 @@ def test_marc21_to_usage_and_access_policy():
 
 def test_marc21_to_credits_from_508():
     """Test dojson credits from 508 (L41)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3476,7 +3443,6 @@ def test_marc21_to_credits_from_508():
 
 def test_marc21_to_credits_from_511():
     """Test dojson credits from 511 (L41)."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -3523,7 +3489,6 @@ def test_marc21_to_dissertation():
 
 def test_marc21_to_supplementary_content_from_504():
     """Test dojson supplementaryContent from 504 (L42)."""
-
     marc21xml = """
     <record>
       <datafield tag="504" ind1=" " ind2=" ">
@@ -3539,7 +3504,6 @@ def test_marc21_to_supplementary_content_from_504():
 # part_of 773, 800, 830
 def test_marc21_to_part_of():
     """Test dojson partOf."""
-
     marc21xml = """
     <record>
       <datafield tag="773" ind1="1" ind2=" ">
@@ -3667,7 +3631,6 @@ def test_marc21_to_part_of():
 
 def test_marc21_to_specific_document_relation():
     """Test dojson for generation the specific document relations."""
-
     # one 770 with link and one 770 without link
     marc21xml = """
     <record>
@@ -3772,7 +3735,6 @@ def test_marc21_to_part_of_without_link():
     for a field 773 if a field 580 exists
     and for the fields 800 and 830 if a field 490 exists
     """
-
     marc21xml = """
     <record>
       <datafield tag="773" ind1="1" ind2=" ">
@@ -4027,7 +3989,6 @@ def test_marc21_to_part_of_with_multiple_800():
 
 def test_marc21_to_identified_by_from_020():
     """Test dojson identifiedBy from 020."""
-
     marc21xml = """
     <record>
       <datafield tag="020" ind1=" " ind2=" ">
@@ -4054,7 +4015,6 @@ def test_marc21_to_identified_by_from_020():
 
 def test_marc21_to_identified_by_from_022():
     """Test dojson identifiedBy from 022."""
-
     marc21xml = """
     <record>
       <datafield tag="022" ind1=" " ind2=" ">
@@ -4125,7 +4085,6 @@ def test_marc21_to_identified_by_from_024_snl_bnf():
 
 def test_marc21_to_identified_by_from_024_with_subfield_2():
     """Test dojson identifiedBy from 024 field with subfield 2."""
-
     marc21xml = """
     <record>
       <datafield tag="024" ind1="7" ind2=" ">
@@ -4170,7 +4129,6 @@ def test_marc21_to_identified_by_from_024_with_subfield_2():
 
 def test_marc21_to_identified_by_from_024_without_subfield_2():
     """Test dojson identifiedBy from 024 field without subfield 2."""
-
     marc21xml = """
     <record>
       <datafield tag="024" ind1=" " ind2=" ">
@@ -4256,7 +4214,6 @@ def test_marc21_to_identified_by_from_024_without_subfield_2():
 
 def test_marc21_to_identified_by_from_028():
     """Test dojson identifiedBy from 035."""
-
     marc21xml = """
     <record>
       <datafield tag="028" ind1="3" ind2=" ">
@@ -4302,7 +4259,6 @@ def test_marc21_to_identified_by_from_028():
 
 def test_marc21_to_acquisition_terms():
     """Test dojson acquisition terms from 020, 024 et 037."""
-
     marc21xml = """
     <record>
       <datafield tag="020" ind1=" " ind2=" ">
@@ -4833,7 +4789,6 @@ def test_marc21_to_genreForm_imported():
 
 def test_marc21_to_identified_by_from_035():
     """Test dojson identifiedBy from 035."""
-
     marc21xml = """
     <record>
       <datafield tag="035" ind1=" " ind2=" ">
@@ -4860,7 +4815,6 @@ def test_marc21_to_identified_by_from_035():
 @mock.patch("requests.Session.get")
 def test_marc21_to_electronicLocator_from_856(mock_cover_get, app):
     """Test dojson electronicLocator from 856."""
-
     marc21xml = """
     <record>
       <datafield tag="856" ind1="4" ind2="1">
@@ -4970,7 +4924,6 @@ def test_marc21_to_electronicLocator_from_856(mock_cover_get, app):
 
 def test_marc21_to_identified_by_from_930():
     """Test dojson identifiedBy from 930."""
-
     # identifier with source in parenthesis
     marc21xml = """
     <record>
@@ -4997,8 +4950,7 @@ def test_marc21_to_identified_by_from_930():
 
 @mock.patch("requests.Session.get")
 def test_get_mef_link(mock_get, capsys, app):
-    """Test get mef contribution link"""
-
+    """Test get mef contribution link."""
     mock_get.return_value = mock_response(json_data={"pid": "test", "idref": {"pid": "003945843"}})
     mef_url = get_mef_link(
         bibid="1",
@@ -5077,7 +5029,6 @@ def test_marc21_to_masked():
 
 def test_marc21_to_content_media_carrier():
     """Test dojson contentMediaCarrier (L30)."""
-
     marc21xml = """
     <record>
       <leader>00501nam a2200133 a 4500</leader>
@@ -5136,7 +5087,6 @@ def test_marc21_to_content_media_carrier():
 
 def test_marc21_to_content_media_carrier_with_linked_fields():
     """Test dojson contentMediaCarrier (L30)."""
-
     marc21xml = """
     <record>
       <leader>00501nam a2200133 a 4500</leader>
@@ -5229,7 +5179,6 @@ def test_marc21_to_content_media_carrier_with_linked_fields():
 
 def test_marc21_to_original_language():
     """Test dojson original_language (L31)."""
-
     marc21xml = """
     <record>
       <leader>00501nam a2200133 a 4500</leader>
@@ -5401,7 +5350,6 @@ def test_temporal_coverage(app, marc21_record):
 
 def test_marc21_to_fiction_statement():
     """Test dojson marc21 fiction."""
-
     marc21xml = """
     <record>
       <controlfield tag=

--- a/tests/unit/documents/test_documents_dojson_dc.py
+++ b/tests/unit/documents/test_documents_dojson_dc.py
@@ -53,9 +53,11 @@ def test_title_to_dc():
     result = dublincore.do(record)
     assert result == {
         "titles": [
-            "Statistique : exercices corrigés avec rappels de cours. T. 1, "
-            "Licence ès sciences économiques, 1ère année, étudiants de Grandes "
-            "écoles. Section 2, Grandes écoles / Edmond Berrebi"
+            (
+                "Statistique : exercices corrigés avec rappels de cours. T. 1, "
+                "Licence ès sciences économiques, 1ère année, étudiants de Grandes "
+                "écoles. Section 2, Grandes écoles / Edmond Berrebi"
+            )
         ]
     }
 

--- a/tests/unit/documents/test_documents_dojson_loc.py
+++ b/tests/unit/documents/test_documents_dojson_loc.py
@@ -13,7 +13,6 @@ from rero_ils.modules.documents.dojson.contrib.marc21tojson.loc import marc21
 @mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.loc.model.get_mef_link")
 def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
     """Test that GND subjects always go to subjects field, not subjects_imported."""
-
     # Test 1: GND subject WITHOUT MEF link should go to subjects
     marc21xml = """
     <record>

--- a/tests/unit/documents/test_documents_dojson_slsp.py
+++ b/tests/unit/documents/test_documents_dojson_slsp.py
@@ -146,7 +146,6 @@ def test_marc21_to_contribution():
 @mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.slsp.model.get_mef_link")
 def test_marc21_to_subjects(mock_get_mef_link):
     """Test dojson subjects imported from 6xx."""
-
     # 600 Person => to import (all subfields)
     marc21xml = """
     <record>
@@ -370,7 +369,6 @@ def test_marc21_to_subjects(mock_get_mef_link):
 @mock.patch("rero_ils.modules.documents.dojson.contrib.marc21tojson.slsp.model.get_mef_link")
 def test_marc21_to_subjects_gnd_routing(mock_get_mef_link):
     """Test that GND subjects always go to subjects field, not subjects_imported."""
-
     # Test 1: GND subject WITHOUT MEF link should go to subjects
     marc21xml = """
     <record>

--- a/tests/unit/documents/test_documents_dojson_unimarc.py
+++ b/tests/unit/documents/test_documents_dojson_unimarc.py
@@ -22,7 +22,6 @@ def test_unimarc_to_type():
     Sounds: LDR/6: i|j
     E-books (imported from Cantook)
     """
-
     unimarcxml = """
     <record>
         <leader>00501nam a2200133 a 4500</leader>
@@ -101,10 +100,7 @@ def test_unimarc_to_type():
 
 
 def test_marc21_to_mode_of_issuance():
-    """
-    Test dojson marc21_to_mode_issuance.
-    """
-
+    """Test dojson marc21_to_mode_issuance."""
     #  rdami:1001 (single unit)
     #    materialUnit > LDR07=m
     #    article > LDR07=a
@@ -237,7 +233,6 @@ def test_marc21_to_mode_of_issuance():
 
 def test_unimarc_to_title():
     """Test dojson unimarc to title."""
-
     # field 200 to bf:Title
     # field 200 with $a, $e, $f, $h, $i, $i
     unimarcxml = """
@@ -302,7 +297,6 @@ def test_unimarc_to_title():
 
 def test_unimarc_to_title_with_alt_graphic_with_bad_lang():
     """Test dojson unimarc to title with alternate graphic."""
-
     unimarcxml = """
     <record>
       <datafield tag="101" ind1=" " ind2=" ">
@@ -344,7 +338,6 @@ def test_unimarc_to_title_with_alt_graphic_with_bad_lang():
 
 def test_unimarc_to_title_with_alt_graphic():
     """Test dojson unimarc to title with alternate graphic."""
-
     unimarcxml = """
     <record>
       <datafield tag="101" ind1=" " ind2=" ">
@@ -386,7 +379,6 @@ def test_unimarc_to_title_with_alt_graphic():
 
 def test_unimarctotitle_with_parallel_title():
     """Test dojson unimarc to title and parallel title."""
-
     # field 200 to bf:Title
     # field 200 with $a, $e, $f, $g $h, $i
     # field 510 to bf:ParallelTitle
@@ -444,7 +436,6 @@ def test_unimarctotitle_with_parallel_title():
 
 def test_unimarctotitle_with_parallel_and_variant_title():
     """Test dojson unimarc to title, parallel and variant title."""
-
     # field 200 to bf:Title
     # field 200 with $a, $e, $f, $g $h, $i
     # field 510 to bf:ParallelTitle
@@ -543,7 +534,6 @@ def test_unimarctotitle_with_parallel_and_variant_title():
 # languages: 101 [$a]
 def test_unimarc_languages():
     """Test dojson unimarc_languages."""
-
     unimarcxml = """
     <record>
       <datafield tag="101" ind1=" " ind2=" ">
@@ -589,7 +579,6 @@ def test_unimarc_languages():
 
 def test_unimarc_contribution():
     """Test dojson unimarctocontribution."""
-
     unimarcxml = """
     <record>
       <datafield tag="700" ind1=" " ind2=" ">
@@ -671,7 +660,8 @@ def test_unimarc_contribution():
 
 def test_unimarc_edition():
     """Test dojson edition statement.
-    - 1 edition designation and 1 responsibility from field 205
+
+    - 1 edition designation and 1 responsibility from field 205.
     """
     unimarcxml = """
     <record>
@@ -693,7 +683,6 @@ def test_unimarc_edition():
 
 def test_unimarc_publishers_provision_activity():
     """Test dojson publishers publicationDate."""
-
     unimarcxml = """
     <record>
       <datafield tag="100" ind1=" " ind2=" ">
@@ -975,7 +964,6 @@ def test_unimarc_description():
 # seriesStatement: [225 repetitive]
 def test_unimarc_series_statement():
     """Test dojson seriesStatement."""
-
     unimarcxml = """
     <record>
       <datafield tag="225" ind1=" " ind2=" ">
@@ -1013,7 +1001,6 @@ def test_unimarc_series_statement():
 
 def test_unimarc_partOf_without_link(document):
     """Test dojson partOf when no linked record found."""
-
     unimarcxml = """
     <record>
       <datafield tag="410" ind1=" " ind2="0">
@@ -1043,7 +1030,6 @@ def test_unimarc_partOf_without_link(document):
 
 def test_unimarc_partOf_with_link(document_with_issn):
     """Test dojson partOf when linked record found."""
-
     unimarcxml = """
     <record>
       <datafield tag="410" ind1=" " ind2="0">
@@ -1145,7 +1131,6 @@ def test_unimarc_partOf_with_link(document_with_issn):
 # abstract: [330$a repetitive]
 def test_unimarc_summary():
     """Test dojson summary."""
-
     unimarcxml = """
     <record>
       <datafield tag="330" ind1=" " ind2=" ">
@@ -1161,7 +1146,6 @@ def test_unimarc_summary():
 # identifiers:isbn: 010$a
 def test_unimarc_identifiers():
     """Test dojson identifiers."""
-
     unimarcxml = """
     <record>
       <controlfield
@@ -1193,7 +1177,6 @@ def test_unimarc_identifiers():
 # notes: [300$a repetitive]
 def test_unimarc_notes():
     """Test dojson notes."""
-
     unimarcxml = """
     <record>
       <datafield tag="300" ind1=" " ind2=" ">
@@ -1228,7 +1211,6 @@ def test_unimarc_notes():
 # if possible deduplicate]
 def test_unimarc_subjects():
     """Test dojson subjects."""
-
     unimarcxml = """
     <record>
       <datafield tag="600" ind1=" " ind2=" ">
@@ -1266,7 +1248,6 @@ def test_unimarc_subjects():
 
 def test_unimarc_to_electronicLocator_from_856():
     """Test dojson electronicLocator from 856."""
-
     unimarcxml = """
     <record>
       <datafield tag="856" ind1="4" ind2=" ">
@@ -1287,7 +1268,6 @@ def test_unimarc_to_electronicLocator_from_856():
 
 def test_unimarc_to_isFiktion_from_105():
     """Test dojson isFiktion from 105."""
-
     unimarcxml = """
     <record>
       <datafield tag="105" ind1=" " ind2=" ">

--- a/tests/unit/documents/test_documents_jsonschema.py
+++ b/tests/unit/documents/test_documents_jsonschema.py
@@ -275,7 +275,7 @@ def test_series(document_schema, document_data_tmp):
         validate(document_data_tmp, document_schema)
 
     with pytest.raises(ValidationError):
-        document_data_tmp["seriesStatement"][0]["subseriesStatement"] is None
+        document_data_tmp["seriesStatement"][0]["subseriesStatement"] = None
         validate(document_data_tmp, document_schema)
 
 

--- a/tests/unit/test_acq_order_lines_jsonschema.py
+++ b/tests/unit/test_acq_order_lines_jsonschema.py
@@ -14,7 +14,6 @@ from rero_ils.modules.acquisition.acq_order_lines.models import AcqOrderLineNote
 
 def test_notes(app, acq_order_line_schema, acq_order_line_fiction_martigny_data_tmp):
     """Test notes acq order lines jsonschemas."""
-
     order_line_data = acq_order_line_fiction_martigny_data_tmp
     order_line_data["notes"] = [
         {"type": AcqOrderLineNoteType.STAFF, "content": "note content"},

--- a/tests/unit/test_acq_orders_jsonschema.py
+++ b/tests/unit/test_acq_orders_jsonschema.py
@@ -14,7 +14,6 @@ from rero_ils.modules.acquisition.acq_orders.models import AcqOrderNoteType
 
 def test_notes(app, acq_order_schema, acq_order_fiction_martigny_data_tmp):
     """Test notes acq orders jsonschemas."""
-
     order_data = acq_order_fiction_martigny_data_tmp
     order_data["notes"] = [
         {"type": AcqOrderNoteType.STAFF, "content": "note content"},

--- a/tests/unit/test_acq_receipt_lines_jsonschema.py
+++ b/tests/unit/test_acq_receipt_lines_jsonschema.py
@@ -11,7 +11,6 @@ from jsonschema.exceptions import ValidationError
 
 def test_vat_rate(acq_receipt_line_1_fiction_martigny, acq_receipt_line_schema):
     """Test VAT rate for acq receipt lines jsonschemas."""
-
     receipt_line_data = acq_receipt_line_1_fiction_martigny
     validate(receipt_line_data, acq_receipt_line_schema)
 

--- a/tests/unit/test_patron_transaction_events_jsonschema.py
+++ b/tests/unit/test_patron_transaction_events_jsonschema.py
@@ -110,7 +110,6 @@ def test_patron_transaction_events_amount(patron_transaction_event_schema, patro
 
 def test_patron_transaction_steps(patron_transaction_event_schema, patron_transaction_overdue_event_saxon_data):
     """Test amount for patron transaction event jsonschemas."""
-
     with pytest.raises(ValidationError):
         data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
         data["steps"] = []

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -178,7 +178,6 @@ def test_blocked_note(patron_schema, patron_martigny_data_tmp_with_id):
 
 def test_local_codes(patron_schema, patron_martigny_data_tmp_with_id):
     """Test local codes for patron jsonschemas."""
-
     with pytest.raises(ValidationError):
         patron_martigny_data_tmp_with_id["local_codes"] = "data"
         validate(patron_martigny_data_tmp_with_id, patron_schema)

--- a/tests/unit/test_stats_cfg_jsonschema.py
+++ b/tests/unit/test_stats_cfg_jsonschema.py
@@ -10,7 +10,6 @@ from jsonschema.exceptions import ValidationError
 
 def test_required(stats_cfg_schema):
     """Test required for template jsonschema."""
-
     with pytest.raises(ValidationError):
         validate({}, stats_cfg_schema)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -35,7 +35,7 @@ def test_unique_list():
 
 
 def test_read_json_record(request):
-    """Test IlsRecord PID after validation failed"""
+    """Test IlsRecord PID after validation failed."""
     file_name = os.path.join(request.fspath.dirname, "..", "data", "documents.json")
     with open(file_name) as json_file:
         count = 0
@@ -135,6 +135,6 @@ def test_password_generator():
     assert len(password_generator()) == 8
     assert len(password_generator(length=12)) == 12
     assert password_validator(password_generator())
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         password_generator(length=2)
         password_generator(length=3, special_char=True)

--- a/tests/unit/test_vendors_jsonschema.py
+++ b/tests/unit/test_vendors_jsonschema.py
@@ -14,7 +14,7 @@ from rero_ils.modules.vendors.api import Vendor
 
 
 def test_vendors_special_rero_validation(app, vendor_martigny_data, vendors_schema):
-    """Test RERO special validation data"""
+    """Test RERO special validation data."""
     record = copy.deepcopy(vendor_martigny_data)
     validate(record, vendors_schema)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,17 +141,17 @@ def loaded_resources_report():
         "holdings": Holding,
     }
     report = {}
-    for object in objects:
-        object_pids = objects[object].get_all_pids()
-        report[object] = len(list(object_pids))
+    for name, record_class in objects.items():
+        object_pids = record_class.get_all_pids()
+        report[name] = len(list(object_pids))
         item_details = []
-        if object == "items":
+        if name == "items":
             for item in object_pids:
                 item_details.append(
                     {
                         "item_pid": item,
-                        "item_status": objects[object].get_record_by_pid(item).status,
-                        "requests": objects[object].get_record_by_pid(item).number_of_requests(),
+                        "item_status": record_class.get_record_by_pid(item).status,
+                        "requests": record_class.get_record_by_pid(item).number_of_requests(),
                         "loans": get_loan_for_item(item_pid_to_object(item)),
                     }
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -39,11 +39,11 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
 ]
 
 [[package]]
@@ -88,27 +88,24 @@ wheels = [
 
 [[package]]
 name = "babel-edtf"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
     { name = "edtf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/25/b2ca3f471b91d37f59ec4304b5f98bdb6001e174a431dda34cf98b2a217c/babel-edtf-1.2.1.tar.gz", hash = "sha256:1ed0c454e123ed7579510d9531eae5af4399272b0dff897d3d42f68e9bed8d8e", size = 18138, upload-time = "2024-11-07T13:05:22.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/27/bda221fdb1fc784fce29df636efa2fd6eb94474af4131a2bc2c4f18aace6/babel_edtf-1.2.2.tar.gz", hash = "sha256:383d12703cafc1684727e317f25b9cbf1436090a2830232a26e6edf4e361227e", size = 4997, upload-time = "2026-07-16T12:05:21.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/f5/10fe146e609bcae84bfd32384c3e7ed837cf038c1306a7a72b11eeb165cf/babel_edtf-1.2.1-py2.py3-none-any.whl", hash = "sha256:706529185b335f05ca4567c468f4ec307ad36fa9ce13b63671f1e113a57f7d55", size = 6452, upload-time = "2024-11-07T13:05:21.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/71/e7ec06e2c6ccf1ee031e1c48d06e29b3d9228568486f8b84590173102867/babel_edtf-1.2.2-py2.py3-none-any.whl", hash = "sha256:e921c85a208858303a75d0aaccf8d74d882001a16931ce2f63422139db4cd1d9", size = 5679, upload-time = "2026-07-16T12:05:20.156Z" },
 ]
 
 [[package]]
 name = "base32-lib"
-version = "1.0.2"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ed/0752d75107d2ec3bb6a2f023f54fa81039f1062b913709b843205aee47ba/base32-lib-1.0.2.tar.gz", hash = "sha256:09663df621bbc454079a54c92fa25d3bc33ea4a191053a09dd1e05ea4c0fe47c", size = 12969, upload-time = "2020-05-07T14:46:12.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/81/4963fd2fa8626daf2860202bdc579b79c2e96f4f7636ae1c87e1e76f7cfe/base32_lib-1.1.1.tar.gz", hash = "sha256:ab0b93c046f8ebb9af3a5295eadc68f447080257a331cd9b871f0418d9b5166b", size = 6391, upload-time = "2026-07-16T15:48:51.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c9/5a769cb6649f2fdf366e1c10db4cafd0e6c7f8b3575d6cb5917bb9298086/base32_lib-1.0.2-py2.py3-none-any.whl", hash = "sha256:f3cbc1c4b3df7af844c9b7ffc1638a688423db2b1e51082b2c014b3959b756ae", size = 6701, upload-time = "2020-05-07T14:46:11.153Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/14bc1fdba1adccbecfdf2a99395f361e355107b03319583048441ef60d92/base32_lib-1.1.1-py3-none-any.whl", hash = "sha256:ef62b1fa9a20ddee2c0eac2eaf98540f2c6d0af5a806b43a716884ebeb07ac2a", size = 5408, upload-time = "2026-07-16T15:48:50.576Z" },
 ]
 
 [[package]]
@@ -183,16 +180,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -289,11 +286,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -488,41 +485,41 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.15.1"
+version = "7.15.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/83/6051c2a2feab48ae5bd27c84ef047191d2d4a3172f689e38eaa48ed17db1/coverage-7.15.1.tar.gz", hash = "sha256:165e9949eaf222ef1f018635d0d7f368a23bfe0212af558534c40d8c04686d67", size = 927640, upload-time = "2026-07-12T20:58:19.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/46/81961952e7aebfb38ad0ae4264e8954cc607a7af9e7ac111f9fa986595cc/coverage-7.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a886af95f59edf67d5770fd3564d53f4a8af93f25f8c1d60d27e00d7f5674ee8", size = 221560, upload-time = "2026-07-12T20:57:24.282Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d2/ee14d715889f216baf47301d9f469e08fff6995552aaf67e897b282865f6/coverage-7.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:985657ebd707941de90d488d1cbb5efac20bdf81f7b91eba771624ccda4d36f4", size = 221894, upload-time = "2026-07-12T20:57:25.87Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/38/f830bc6e6c2c5f23f43847125e6c650d378872f7eeba8d49f1d42193e8a9/coverage-7.15.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5bbe2a06e0a5e1404d9ffbdb49b819bbd6a3bb198ebea4c8dfe7ad9f1e1c2e81", size = 252938, upload-time = "2026-07-12T20:57:27.506Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/53/0d3dd963631259d794c898735d5436e68d6a8d40749c419a07ff7c171469/coverage-7.15.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bde0fe24083d0b7b3dbafa7a09f0796410af1afa2523f28f5f208d8340a4aaca", size = 255445, upload-time = "2026-07-12T20:57:29.234Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/fd/aabed228557565c958259251b89bab8c5669b31291fa63b3e2154ebb017a/coverage-7.15.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f89f7453d6d46db14cf233e2cd8edcd78de2b9c49d4f1dc109590b4e5dbfbb74", size = 256790, upload-time = "2026-07-12T20:57:30.826Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/aa/1cc888e5d3623e603c4e5399653cb25728bb2b40d7519188a3e293d24620/coverage-7.15.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc3656c9ecc27b36bd0907455b77f83c0069ca9ad4a66dec892b76c696eb6047", size = 259104, upload-time = "2026-07-12T20:57:32.63Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/61/fc16d5f5e53098dae41efa21e8ccc611a9b4fe922750dd03dc56db552182/coverage-7.15.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:24d8e85a2a45e44883b488c2659f51fa761dad5353fdb319b672a93facbd2ca9", size = 252956, upload-time = "2026-07-12T20:57:34.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f3/52384668c3de4519ca770bf1975a89e4d6eb5aa2faf0da0577a14008cba4/coverage-7.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68931b5fe746ed4fdaa8892989cab9e6c35781eeb3b0ab2ded893d561e1b3652", size = 254797, upload-time = "2026-07-12T20:57:35.947Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/68/54b807e7c1868178e902fd8360b5d4e559394462f97285c50edf1c4608db/coverage-7.15.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1ce6947e2a95534ecaa5a15e73c21e550514c980d80eda204d064d789a95f6a4", size = 252762, upload-time = "2026-07-12T20:57:37.856Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/48/dde8adf0338e3ace738757dccf1ce817e5fdcadfae77e1b48a77e5a3b265/coverage-7.15.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:841befdbc89b9c82435fc25b0f4f41858b6238693e45af758bec4cfc1968171c", size = 257037, upload-time = "2026-07-12T20:57:39.488Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f2/179dd88cf60a0aeeee16a970ffe250dccea8b80ed4beab4c5d3f6c41ad4b/coverage-7.15.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5d3de58b837375e7f4c0e1a088ccab5f655efb2fd7427b729df02c862a559633", size = 252577, upload-time = "2026-07-12T20:57:41.363Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/37/8a593d69ab521beb6a105a2017cac4ba94425ee0a8349e29c3c0b522d24f/coverage-7.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b1801963f9f44ae0c0f6d737bc7aeb2bbcde7d1fe7e3b43cddc1961af42d3b41", size = 254235, upload-time = "2026-07-12T20:57:43.025Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/34/bc9b3bced66f2cdad4bf5e57ae51c54ea226e8aaaebfc9370a9a11877bf3/coverage-7.15.1-cp314-cp314-win32.whl", hash = "sha256:8c7953c4128ef53b6ffb5f90d87c87d4ce26731df294760bb2314eb0e069e44b", size = 223771, upload-time = "2026-07-12T20:57:44.662Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f3/4d20337bed61915d14349e62b88d5e4144d5a9872b64adbe90e9906db6db/coverage-7.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:6f0bab60a582d415f0fb535ccff13ba334a47a1538f98913330a525d23bd535a", size = 224257, upload-time = "2026-07-12T20:57:46.412Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/df/bbfeae4948f3ded516f92b32f2d57952427fc5ecfc0924487bb6ee6a5f38/coverage-7.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:0f410ee8f0ac4ec7db71bc0b7632a8b9994e1cad2755bd1566c17e6a162caa74", size = 223683, upload-time = "2026-07-12T20:57:48.106Z" },
-    { url = "https://files.pythonhosted.org/packages/35/65/0b431856064e387d1f5cf474625e4a0465e907024d42f35de6af19ced0be/coverage-7.15.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc868bab88e049d41fcd41766810d790a8b960053be2a45e060f5ce0d31d258b", size = 222298, upload-time = "2026-07-12T20:57:49.882Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/96/50eac9bd49df8a3df5f3d38746d1bf332299dffb554486c94ebd55c9dc49/coverage-7.15.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:206d4ec6028f2773b40932d09f074539d6bcdd8f6b318d40cb04bdbd68ed0b49", size = 222561, upload-time = "2026-07-12T20:57:51.688Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/5b/6ba1c4a27e10b8816fd2622b98162c83d3bdf1185097360373611bf96364/coverage-7.15.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:620482ef1c9f4e61f962e159325fe77dea59d16e39d9c9470d069053b244d864", size = 263923, upload-time = "2026-07-12T20:57:53.392Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/59/fe03ade97a3ca2d890e98c572cf48a99fda9adba85757c34b823f41efe1e/coverage-7.15.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d385fc9b054e309ad3cecdc77b586d2af0c98aeec2fdb3773544586f366e817c", size = 266043, upload-time = "2026-07-12T20:57:55.095Z" },
-    { url = "https://files.pythonhosted.org/packages/16/e0/55c4b1217a572a43e13b39e1eb78d0da29fb23679003bd0cdf22c50b1978/coverage-7.15.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1198bca9c0dd7c188aae1f185b0c0b5fc4f0a2b6909000858c29550320bdb07", size = 268465, upload-time = "2026-07-12T20:57:57.017Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e2/ee47944f76afc03909119b036fe9e0da8cbd274a5141287de79791a0fb6d/coverage-7.15.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d0297e6a070eadb49df7cddd0ab6f420b8b689dd8904c7dd815a323168fa57e", size = 269584, upload-time = "2026-07-12T20:57:58.958Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/8a/6b4d9779c7b2e21c3d12c3425e3261aa7411399319e27aa402dfec4db5d0/coverage-7.15.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916fcf2214f56960e409561b37fc32a160a42b6e85483d0652d7b70fa55d707e", size = 263019, upload-time = "2026-07-12T20:58:00.979Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1e/db5c7fa0c8ba5ece390a1e1a3f30db71d440240a80589df28e66a7503c40/coverage-7.15.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f837bae572c7869ffaa502e604c87e182543012831cf87aae4586ad090ac6dcf", size = 265916, upload-time = "2026-07-12T20:58:03.005Z" },
-    { url = "https://files.pythonhosted.org/packages/83/53/fe5176682b00709b13fab36addd26883139d0dea430816fea412e69255e2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3ea65e3ee6c7c32349fd00559927a9e577bdd72386087eeed1c42b62dfce9b82", size = 263520, upload-time = "2026-07-12T20:58:04.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e7/16f15127be93fbc70c667df5ec5dce934fc76c9b0888d84969a5d5341e2c/coverage-7.15.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:345034976f46a1c54bd17f4e43eb30bb92cb7082fcddff03250cff136cc4eb82", size = 267254, upload-time = "2026-07-12T20:58:06.824Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/73/e5119111f6f065376395a525f7ce6e9174d83f3db6d217ea0211a61cca4d/coverage-7.15.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4f051a64eb8f8addb4661c2b41d6eea5b7ebc68ad4b2baea8d9bc54e1956e5f7", size = 262366, upload-time = "2026-07-12T20:58:08.555Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/9c/6d0a81182df18a73b081e7a8630f0e2a52b12dfd7898c6ab839551a454d2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a7625770f7720b49bb30d194ad2f8d50fab3c5177874af3d2399676f95f9c594", size = 264680, upload-time = "2026-07-12T20:58:10.359Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a2/bac0cbd4450638f1be2041a464b1766c8cc94abf705a2df6f1c8d4be870d/coverage-7.15.1-cp314-cp314t-win32.whl", hash = "sha256:81e503d130a472ad1bd38199ecd35116b40d92bcd31e27a2cacde035381f2070", size = 224077, upload-time = "2026-07-12T20:58:12.065Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/b2/d83c5403155172a43ba47c08641bad3f89822d8405102423a41339d2c857/coverage-7.15.1-cp314-cp314t-win_amd64.whl", hash = "sha256:724e878b213b302ad46e9f2fc872d386613f20ebfc492a211482d917ea76c14f", size = 224908, upload-time = "2026-07-12T20:58:13.956Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/41/442b74cad832cc77712080585455482e7cc4f4a9a13192f65731dcd18231/coverage-7.15.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ce2f05c14d077f406fefc4fa5e4f093ad0e0787549f6582535d6e28766f0361b", size = 224219, upload-time = "2026-07-12T20:58:16.315Z" },
-    { url = "https://files.pythonhosted.org/packages/34/98/07a67cf1a26e795d617ed5c540c042b0ac87b72f810c30c07f076cf334f3/coverage-7.15.1-py3-none-any.whl", hash = "sha256:717d01e6e00bed56ad13306f19e0dd2f4f645ee8159d2c72c72301d6cfc7090c", size = 213284, upload-time = "2026-07-12T20:58:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
 ]
 
 [[package]]
@@ -676,11 +673,11 @@ wheels = [
 
 [[package]]
 name = "dictdiffer"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/7b/35cbccb7effc5d7e40f4c55e2b79399e1853041997fcda15c9ff160abba0/dictdiffer-0.9.0.tar.gz", hash = "sha256:17bacf5fbfe613ccf1b6d512bd766e6b21fb798822a133aa86098b8ac9997578", size = 31513, upload-time = "2021-07-22T13:24:29.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/31/84b2b2113c2c972431582bffd74f0d04b5efd9126538127b766275580950/dictdiffer-0.10.0.tar.gz", hash = "sha256:0b912acf663949d73b820d3ed59362140a188ab742c94efe13c762dbd24cbbd3", size = 12451, upload-time = "2026-07-16T12:39:07.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ef/4cb333825d10317a36a1154341ba37e6e9c087bac99c1990ef07ffdb376f/dictdiffer-0.9.0-py2.py3-none-any.whl", hash = "sha256:442bfc693cfcadaf46674575d2eba1c53b42f5e404218ca2c2ff549f2df56595", size = 16754, upload-time = "2021-07-22T13:24:26.783Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/7ff60ad2cafd7c970bea75da5f4a9b84b784f7340abcb5fc634d4cf5cd37/dictdiffer-0.10.0-py3-none-any.whl", hash = "sha256:6ca50f38f7c5ee27d52789eee095ae473d9e02e1aa7612cb3aaf25fcf081dbf6", size = 16060, upload-time = "2026-07-16T12:39:06.842Z" },
 ]
 
 [[package]]
@@ -829,20 +826,20 @@ wheels = [
 
 [[package]]
 name = "fastjsonschema"
-version = "2.21.2"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/11/c802f752919c1fd83d44b3b955c6e7120c79f355d4a448c358198a11178c/fastjsonschema-2.22.0.tar.gz", hash = "sha256:6eb12e8f9900db6166c3d396d178ebdf6a4215fe22a06e19792edd612a20035a", size = 382291, upload-time = "2026-07-25T20:32:35.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9d/4a0f9355ca3e540b2d22d5f269212e2f227b8f277835b02d8908355245d1/fastjsonschema-2.22.0-py3-none-any.whl", hash = "sha256:60f4c92fda6f93efe3b3261638836478e1e11abc01c647e36e478199f7a86a37", size = 26248, upload-time = "2026-07-25T20:32:33.616Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.29.7"
+version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -919,27 +916,27 @@ wheels = [
 
 [[package]]
 name = "flask-celeryext"
-version = "0.5.0"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/58/1395b07b9f8ab38ee6e13db16f60ddd82927b4782624e554d3a686a45fd9/Flask-CeleryExt-0.5.0.tar.gz", hash = "sha256:a23a0293bbe8e134233119e003e83ce9fe4f2caaf3fc23d91e09d252c7beb6e5", size = 18526, upload-time = "2023-01-24T12:39:04.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f8/2dc1d579abd25cd0605361d461f7a68059e8a41c16aefc2614aa155575e4/flask_celeryext-0.5.1.tar.gz", hash = "sha256:874b3ee0691ab6041aebcdcfc71f65e8074d4d53851ab93e62557ac5f22ecdcd", size = 7456, upload-time = "2026-07-16T12:43:07.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/03/abf800759cd75ab335b3385dc1663c57797d4e7dfd54111ff3351c101246/Flask_CeleryExt-0.5.0-py2.py3-none-any.whl", hash = "sha256:9c4b5c3c157923c86f3c92980bf3a58d0949a2dbf5d3a14b87135bb20d19b71b", size = 10108, upload-time = "2023-01-24T12:39:02.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7a/f4ef5c2d43150e9ba3222c2c751996f1c9459ad9b9f9a3dd0c54814a5af7/flask_celeryext-0.5.1-py3-none-any.whl", hash = "sha256:d42a3857a17b35236b6ff2c2780f98b3360f6bb1b068112746692bfb20a3c778", size = 8768, upload-time = "2026-07-16T12:43:06.776Z" },
 ]
 
 [[package]]
 name = "flask-collect-invenio"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/ef/1b253332bd27ddb4152f7702e7c91b5d9048086edd1930c7a3ed97af56cf/Flask-Collect-Invenio-1.4.0.tar.gz", hash = "sha256:52c8343773f6366bb1594905e5c8e1f92101ec06c20e966420237ddad2a7918a", size = 10031, upload-time = "2021-10-11T20:31:04.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/9d/fda8a9b590a779931b36b02ebed731831dc87db7078a1b51b7cf2b04d01b/flask_collect_invenio-1.4.1.tar.gz", hash = "sha256:caf1ac862828997487b2508f9ad17970fcbc33ab3d1799cb59f392102e907dc7", size = 6123, upload-time = "2026-07-16T12:54:44.91Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/42/d92da307dddb7e4589e7cada9d6abeb144c20d990f34dd3edc2f96a26b34/Flask_Collect_Invenio-1.4.0-py2.py3-none-any.whl", hash = "sha256:cf969b7cddf27086ee19883e9660aeac2d455646cbad2a43799660b3cc0cbffb", size = 11990, upload-time = "2021-10-11T20:31:00.3Z" },
+    { url = "https://files.pythonhosted.org/packages/48/13/8b9d7e28ac69e5346b57a301137e722054c8a9f535411f598333e510ad16/flask_collect_invenio-1.4.1-py3-none-any.whl", hash = "sha256:c289b4a8990e9f8e1356a3eeee13496883e5aa1ca616e126a7275dd9efdf1c97", size = 9055, upload-time = "2026-07-16T12:54:44.023Z" },
 ]
 
 [[package]]
@@ -1022,14 +1019,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/05/2f/6a545452040c25565
 
 [[package]]
 name = "flask-menu"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/db/96bf20cb438a1dafa4c302b0091933dd09cad142fdbfe1c850dfc53e8a9c/flask_menu-2.0.0.tar.gz", hash = "sha256:162b409e444bea4ab10f12ab1270dd3d62dc0bd1f3d43b3e964a931019f5d580", size = 21775, upload-time = "2024-11-21T15:38:27.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/80/fc48ea89b8484d2f060fb3eb5b3620a5ad24b473ae8090e6ce0fe648fb89/flask_menu-2.0.1.tar.gz", hash = "sha256:9a222334d6c21dd7c76adc9b715e67143814c25bed750288e707285a48bb6344", size = 6400, upload-time = "2026-07-16T12:58:43.931Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/c1/81f36322304ccee08505329cb4ff185847fca107f2e51e3b0d4316bc1403/flask_menu-2.0.0-py3-none-any.whl", hash = "sha256:bd9a4c9c4241300aa05e3f27da7d8953f197d4591763a2e0495381b7d9713efa", size = 9440, upload-time = "2024-11-21T15:38:26.452Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cb/b4fe6daa726292564cd3dd4b1ad43f49094befb9c5e39f69c08b17e3949a/flask_menu-2.0.1-py3-none-any.whl", hash = "sha256:80d80b7ca665a9252e9d1a27e46a706cbf5cfd63eeb3291de941404c82a79466", size = 7633, upload-time = "2026-07-16T12:58:43.103Z" },
 ]
 
 [[package]]
@@ -1294,41 +1291,41 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.51"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/30/a8a0c15f9480dc91b5b7f11ebd26105e5f80898d7ff02da197fef35d8395/gitpython-3.1.51.tar.gz", hash = "sha256:22c9c94bb6b0b9f3c7157c684fece45a414cea204586b600beae6cd4570dcd6d", size = 223519, upload-time = "2026-07-12T13:40:07.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/1232bb1ba52a230f20ff08e1b3df7cd9d43a71b61cc0a1c37941064fe4c7/gitpython-3.1.51-py3-none-any.whl", hash = "sha256:d5b29685708f3c80a56db040b665bfd69492c8e150b5848532af8013b686c5a4", size = 215246, upload-time = "2026-07-12T13:40:06.43Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]
 name = "greenlet"
-version = "3.5.3"
+version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/74/b13368064b09053253555d3f2839cc2684d22d5aed0d2ccffbf7a6736558/greenlet-3.5.4.tar.gz", hash = "sha256:0232ae1de90a8e07867bb127d7a6ba2301e859145489f25cda8a6096dabe1d20", size = 206538, upload-time = "2026-07-22T12:47:14.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
-    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
-    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
-    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
-    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
+    { url = "https://files.pythonhosted.org/packages/05/75/625bcdd74d5e6b2dca1ecba3c3ac77bcf8a026c21a649a46cef23e421f97/greenlet-3.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:f260930bbbbcf9caee661211235a5111c86dfe5832fdf6ae4570da1e0995320f", size = 246892, upload-time = "2026-07-22T11:40:27.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
 ]
 
 [[package]]
@@ -1351,14 +1348,14 @@ wheels = [
 
 [[package]]
 name = "idutils"
-version = "1.6.1"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "isbnlib2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/1b/8d35c02739e1bcf53c23107324f56565e42ab87e53d3cb82322368a024ec/idutils-1.6.1.tar.gz", hash = "sha256:4604827ed52aa272843f1c53b25ed3be864868a9abcdf0ee7932df56f94458b8", size = 35853, upload-time = "2026-05-28T08:54:17.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/93/2a3357012f4abc1b3e9740af52e15cbb74ab139c8425311c4957491942b7/idutils-1.7.0.tar.gz", hash = "sha256:848702d9b953a34ba597ac9fd04823fa2ace9dafda3924e91bcf349223cd7442", size = 17933, upload-time = "2026-07-16T13:03:35.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/9c/aa092c1daaac95ba6b19d9d2f0542a27692c11ec4e3175f6f98e08d49681/idutils-1.6.1-py2.py3-none-any.whl", hash = "sha256:de24b0f5d9317052223819a99893f913d752820c3d7046d3a4e970b1221e0723", size = 23814, upload-time = "2026-05-28T08:54:16.43Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/c49c4729feead2d0f32d8261418293fa04138184a2af9b650fddbdfebaa3/idutils-1.7.0-py3-none-any.whl", hash = "sha256:2fb2dc5117c58a71261cbc724aa97c770b0f1540c01e671de7c5be66ad015422", size = 22196, upload-time = "2026-07-16T13:03:34.424Z" },
 ]
 
 [[package]]
@@ -1411,21 +1408,21 @@ wheels = [
 
 [[package]]
 name = "invenio-access"
-version = "7.0.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-accounts" },
     { name = "invenio-base" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/1b/184aac69687d098a0093563b530aa2a9d854faa6dc35016fd5086bcb8d4a/invenio_access-7.0.0.tar.gz", hash = "sha256:6b6f5375205a0b22b5c006bb6c60a829445c427d2429388aa70ab261eacc225a", size = 38458, upload-time = "2026-06-17T21:20:13.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/8a/3906bc6d577d831183d9c44bcf1c04b0c9e7e51d9c0c35bb708583d2d1e3/invenio_access-7.0.1.tar.gz", hash = "sha256:d82499cd5a334483c3adf62f92b973a22cb691518b390f9ca0ca8a2d0826ae2b", size = 24544, upload-time = "2026-07-16T13:06:01.286Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/a4/dd053210eab207e88fc0bb233a43a36af7d3590002b28dde11519021ecc6/invenio_access-7.0.0-py2.py3-none-any.whl", hash = "sha256:ec62ddaadfd6692b558c074ae7664df4a819e83b826ae5353685022c1b09b246", size = 80534, upload-time = "2026-06-17T21:20:11.958Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f0/ac5fb9c727b9fe2b6e4131df8ff5447bf4cf8f7db5abc60bdf1251d1924a/invenio_access-7.0.1-py3-none-any.whl", hash = "sha256:6155391320544969b81403feb9edd958ee86d6e1d925c0681a479cc18fa2ffdd", size = 56288, upload-time = "2026-07-16T13:06:00.12Z" },
 ]
 
 [[package]]
 name = "invenio-accounts"
-version = "9.0.0"
+version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -1442,14 +1439,14 @@ dependencies = [
     { name = "simplekv" },
     { name = "ua-parser" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/64/865f5435e3881f12a8eb2d599c2bcb75cf03bd858a0d01e769853edd5de6/invenio_accounts-9.0.0.tar.gz", hash = "sha256:495db3692bcfd73e732a438fb1f96b54f6055ed455da366c5acc5b5ac2ddcc99", size = 111544, upload-time = "2026-06-17T21:08:42.096Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7a/b073e8f7175445d3d3f535e6ff626dbcf81cbe05f61af06c88bffa3800b1/invenio_accounts-9.0.1.tar.gz", hash = "sha256:e35207a00bec640501b9afa0fbd6dd302d7f0d7764198d67fb790f617f90fc43", size = 74189, upload-time = "2026-07-16T14:57:21.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/a6/2143ca5f01d208e72f799827a7340c0e98630784a738dab0380ee0e32b02/invenio_accounts-9.0.0-py2.py3-none-any.whl", hash = "sha256:2c38a4c334f778907cffd0620130770bce7ecbfa6392cf98d0e8fa1dd53df160", size = 225680, upload-time = "2026-06-17T21:08:40.778Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/66/065a4f7831efb9b39feb6f7e68668cb32b9bb2903a71fb0de3acf76dcfd9/invenio_accounts-9.0.1-py3-none-any.whl", hash = "sha256:f3b739c170964c6bc1d10b0fecd9d576af8375e32087feba8bfec64a6097ed4f", size = 167325, upload-time = "2026-07-16T14:57:20.285Z" },
 ]
 
 [[package]]
 name = "invenio-admin"
-version = "1.6.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-admin" },
@@ -1462,14 +1459,14 @@ dependencies = [
     { name = "invenio-i18n" },
     { name = "wtforms" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/a7/57eccea9337dae0ed5b6098b33c4d6314d2ceabab67a6ef2f1252ae2aa8a/invenio_admin-1.6.0.tar.gz", hash = "sha256:6473fd1da15d559c528a9adb6ff4ab08ad0c4070fcef86aed32a8ee3fd49db5b", size = 18076, upload-time = "2026-01-27T19:56:45.643Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/aa/2c077396eaa3c886246951f406ba4885c6d47019d7f861f4f953189397fb/invenio_admin-1.6.1.tar.gz", hash = "sha256:045262309adf531f65d92b1bd67b1a945b4b07276a9a8600a183a848902518de", size = 11167, upload-time = "2026-07-16T14:55:00.943Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/c2/416f7365d9c5ea7b3b656b3416878dc0d0ae7005e87eff5c82849d8650fb/invenio_admin-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a0329c64cbc1bf45bf486fe53d170abe2aeeeacbd28a7041b3230ff80e1b6ea", size = 23376, upload-time = "2026-01-27T19:56:44.709Z" },
+    { url = "https://files.pythonhosted.org/packages/49/11/22b4bd87ab1dd87efa2e95e2e737f24ed6684cc315fbf2eab6db8dd08577/invenio_admin-1.6.1-py3-none-any.whl", hash = "sha256:e91fe4f364e21ca2cba07581f4b2a635aa93e1da91426f51fef1e3ef0f0cf689", size = 17688, upload-time = "2026-07-16T14:54:59.855Z" },
 ]
 
 [[package]]
 name = "invenio-app"
-version = "3.1.1"
+version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
@@ -1482,28 +1479,28 @@ dependencies = [
     { name = "invenio-config" },
     { name = "uritools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/64/7077a69090c0654de5502e61283f0280a9241fc728464aec27af081a5b7a/invenio_app-3.1.1.tar.gz", hash = "sha256:0a7c94cd2619b9629fd190fe908a96d55cee854185c9e7769d5eaef71550a210", size = 19897, upload-time = "2026-04-30T13:21:42.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/67/f97eff5e5326a5451c9834f40e338b74b1acb5338f8fc74e89204b8a7d41/invenio_app-3.1.2.tar.gz", hash = "sha256:f2f9b228a2fcf72ea0e91cbdc05c256fcf896bf171477263b485f5ae4de8544c", size = 12439, upload-time = "2026-07-16T14:48:47.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/76/4e3d1a62e87e490f0e487de9397b03236d51d1c7388c982621d38cdab8c1/invenio_app-3.1.1-py2.py3-none-any.whl", hash = "sha256:d3aa26d3045e0ad568babde487ff45b5ae2f9894aa87d6c0a6f3e93ea25a4113", size = 20136, upload-time = "2026-04-30T13:21:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/aa/aff9350938564ed9a4a616337ea55bb1e128340f40d8b483b378cfdb0326/invenio_app-3.1.2-py3-none-any.whl", hash = "sha256:65c68a211d627bd723a114e8ef28856f6e84012587d8d9ee7febb65d987e60c6", size = 16832, upload-time = "2026-07-16T14:48:46.06Z" },
 ]
 
 [[package]]
 name = "invenio-assets"
-version = "4.2.3"
+version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-collect-invenio" },
     { name = "flask-webpackext" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/39/d0282ab71f7f8b669c858fd61f7a0041439e1dfcc9d1928511b7afd2b18c/invenio_assets-4.2.3.tar.gz", hash = "sha256:e00dd1fe99e2d643d70e7293f922f2ed486f19e5197c2c31657debe0c27f33ac", size = 11755, upload-time = "2026-07-01T12:15:52.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/28/c06078979b18af770237f2699f086bbf8bfc143336783bcb22a361dd36db/invenio_assets-4.2.4.tar.gz", hash = "sha256:c55ecf5f2e1d22fbbe49f8575fb7a3a911f892b5994afc85649caa20ebd92bf8", size = 11861, upload-time = "2026-07-24T17:37:07.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/f7/2b93707497527375906ad2147b8e24534887c7ba81e0c75268cfc5a46a57/invenio_assets-4.2.3-py3-none-any.whl", hash = "sha256:5c7c65938257c2977528ea0427c3c74febecca4d362cc3759a39a02d65cb7460", size = 18376, upload-time = "2026-07-01T12:15:51.928Z" },
+    { url = "https://files.pythonhosted.org/packages/16/46/f1ef4713acccdc589689b08334139c8e87885f89ae7f3853ad2150b49d87/invenio_assets-4.2.4-py3-none-any.whl", hash = "sha256:1e71d66571312613f652b6c24375ab3e982fd1ea0b3485ed68cc8e83b1a9f41c", size = 18487, upload-time = "2026-07-24T17:37:06.578Z" },
 ]
 
 [[package]]
 name = "invenio-base"
-version = "2.4.0"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -1515,27 +1512,27 @@ dependencies = [
     { name = "watchdog" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/1e/49fc2c14dfbd8f4accec858dfe05d5d2739cbc5192f74bd380b3333efb46/invenio_base-2.4.0.tar.gz", hash = "sha256:283552103785b17c60a7c034382baa69fab9c60b81fa1f961bb1f44ea11134ec", size = 24530, upload-time = "2025-12-02T21:03:24.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/a7/9fb93f28dcedab421c4e560b419fde317e6a9d61c74b745cd424ca94c28f/invenio_base-2.4.1.tar.gz", hash = "sha256:a2cd51e1b7db786ad73164c4051e3c5bb3ec08174118a964e4393e64dd22b1a9", size = 16486, upload-time = "2026-07-16T14:42:12.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/ee/5e77531034354e402e84ffd530d032b16a7d0fbf786883c61ebdafced3da/invenio_base-2.4.0-py2.py3-none-any.whl", hash = "sha256:407fffa5e85208b5ca9576b4e59cd9d542e5651aaac1baecf7ac160af820ab22", size = 25307, upload-time = "2025-12-02T21:03:23.793Z" },
+    { url = "https://files.pythonhosted.org/packages/93/43/9bccdd5c9a593f89cf45d053c4588d9c83564d2fbef8cfe752b7a62f4782/invenio_base-2.4.1-py3-none-any.whl", hash = "sha256:1655356af811f20eaa291906e0b831caca99e60ffabeddea5728ce86c0ed1b11", size = 21580, upload-time = "2026-07-16T14:42:11.459Z" },
 ]
 
 [[package]]
 name = "invenio-cache"
-version = "3.0.0"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-caching" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/0a/942747c7f789b47dacdfdb8ca879e12b286108b71e762b2ed8ef3fbccd7f/invenio_cache-3.0.0.tar.gz", hash = "sha256:0399ec800d102a70e8bd7f35ac7f185f6543bc4752a0c747508fdef5cb86d4ba", size = 11995, upload-time = "2026-01-27T13:02:46.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/ee/36fb71ec0f552e8dda7928607a28c5a7ac77e5c0cca3b84a2e8277d641bc/invenio_cache-3.0.1.tar.gz", hash = "sha256:c0f0d288bfac367f86abd0b5c66c4ab80883731d901cfccf3ae1116557e36fd6", size = 7393, upload-time = "2026-07-16T14:36:07.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a4/513432cac2b6b6756b62e322e6fc1fa8d2c0daf942feb5d5bc0fe2164ecb/invenio_cache-3.0.0-py2.py3-none-any.whl", hash = "sha256:663fb5248e446e307d82291da02d1fa83118476850b207231820f3fe708f6191", size = 12226, upload-time = "2026-01-27T13:02:44.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d9/a3491db20ba2509f6d38656c4dc125f80b12ef2375987551d3926f1a413a/invenio_cache-3.0.1-py3-none-any.whl", hash = "sha256:c71b50e0a7cdd250f6488037de357c974f45deb2b8f56fe973b396e051425aec", size = 10678, upload-time = "2026-07-16T14:36:06.133Z" },
 ]
 
 [[package]]
 name = "invenio-celery"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
@@ -1544,9 +1541,9 @@ dependencies = [
     { name = "msgpack" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/0b/33f7e233501a833706c25892ccb3132133285a23762fdbe4e25ad5a688f7/invenio_celery-2.2.0.tar.gz", hash = "sha256:348f9fadd2af2b33ec8cef61e0c926a9d12995c1687bf74d1de579440ad7f046", size = 21141, upload-time = "2025-07-03T21:30:49.923Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/dc/163a3ad4a1b2059f7bcfb8a1abc26d3b24f7c296603e8957db3d01e7e5c2/invenio_celery-2.2.1.tar.gz", hash = "sha256:8d0dd7cb299080446bab56dd1c95209725d392ad61da7a0b1e221aaf2fa8367a", size = 5235, upload-time = "2026-07-16T14:35:20.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/e8/4667c7a6112d62e541e35b1afa40744ad64d71811989488529a74e210f84/invenio_celery-2.2.0-py2.py3-none-any.whl", hash = "sha256:1b34b97d8754f4ecfc121676edbb0a70ff72d3277bfdb2e59e88550bf862fb0e", size = 8320, upload-time = "2025-07-03T21:30:48.969Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/50/2536232567a9f6c23537d917e6cce1c440399530e9b2a8d63b4ffc37a638/invenio_celery-2.2.1-py3-none-any.whl", hash = "sha256:70145edd98b0575633ff6859fe0cf7655fa96526792905f7d48d3d2acbef6962", size = 6629, upload-time = "2026-07-16T14:35:20.194Z" },
 ]
 
 [[package]]
@@ -1572,20 +1569,20 @@ wheels = [
 
 [[package]]
 name = "invenio-config"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/86/1f2d8ea2b2f4b67e5c5c15325d7acc6d2a04b4d238c06abe4b53d57458dd/invenio_config-1.1.0.tar.gz", hash = "sha256:bb6e05b6c24c19fa53349a011e0997c9b88991ccd5144bd7e2cfeecb16477ffe", size = 21289, upload-time = "2025-07-01T20:08:33.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/77/d6d058ec1f3160e49eed014222c46abf952e619c47e51a8d923a7b391e57/invenio_config-1.1.1.tar.gz", hash = "sha256:bcbdd05557a946f8ee2d8349b16fef44b2c013f3dfc7aaf22b927c9baeecf7e6", size = 6712, upload-time = "2026-07-16T14:20:05.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/d4/b39da24c4b1d0b4f9246de3c001ffd36d2b28d288d402f7d855097fedc0f/invenio_config-1.1.0-py2.py3-none-any.whl", hash = "sha256:34f34902236fa13257c062f1cc4e9e218b7bb8bbe77292b2542e106479b4d37f", size = 11177, upload-time = "2025-07-01T20:08:32.763Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/88/9432ebf48e8b5bd59fe16aeb047adcc41e863b8d75bc7880e8de77cace33/invenio_config-1.1.1-py3-none-any.whl", hash = "sha256:d8592cd616e934abfd404420ac9492e0d4b74f8359c71e70caa2103619568055", size = 9792, upload-time = "2026-07-16T14:20:04.901Z" },
 ]
 
 [[package]]
 name = "invenio-db"
-version = "2.5.1"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -1596,9 +1593,9 @@ dependencies = [
     { name = "sqlalchemy-continuum" },
     { name = "sqlalchemy-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/48/9e2406e698716243fe22bf8f35823ca456d4405ac86a66a4bd4827043db1/invenio_db-2.5.1.tar.gz", hash = "sha256:1308749b96cd0a29c537c3b60224745bf59b1b631038de8f01b4e0676111b76f", size = 22469, upload-time = "2026-06-05T12:54:14.178Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/65/524ff8dc36965ad10b8cad716660af4a11fab9aab94267acda541ae34779/invenio_db-2.5.2.tar.gz", hash = "sha256:0fdea16d8102377d352894a10628ada224c0744dffbd535a481678ccf37c8280", size = 13823, upload-time = "2026-07-16T14:17:24.024Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/e3/044a8c02bd4ea69ceea0a2c6fa04d5527271e4b85e9e08cd11c497baee72/invenio_db-2.5.1-py2.py3-none-any.whl", hash = "sha256:0cac942699aeaed0ad38f088e3b743d5871c66f909f4f449b02623bac57bf633", size = 22084, upload-time = "2026-06-05T12:54:13.198Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ae/fbe2757e3e057e5cd29ed6499fcdcf16d4fc1656d701599e7c67494a0b99/invenio_db-2.5.2-py3-none-any.whl", hash = "sha256:9d41fcf9d594df4e3c08beba6a3cb9c3dc92fda6f617a14fa0fc4f2894b2e63e", size = 18549, upload-time = "2026-07-16T14:17:22.879Z" },
 ]
 
 [package.optional-dependencies]
@@ -1657,7 +1654,7 @@ wheels = [
 
 [[package]]
 name = "invenio-indexer"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-db" },
@@ -1665,35 +1662,35 @@ dependencies = [
     { name = "invenio-records" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/9e/debe789ebfb09896ccebb62037752ac16d6011d0e56074c9bdbb74775ff1/invenio_indexer-6.0.0.tar.gz", hash = "sha256:39683dbf2c181158954086d67a7ba969f6d708847e59d36c0b951675f1d477da", size = 20800, upload-time = "2026-06-17T21:37:30.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/50/2de64257789c7dac573396ad8e612f1482d92d8efdc120de07a398f8fd7d/invenio_indexer-6.0.1.tar.gz", hash = "sha256:504a778ce7e6aa6682c59ba7f3e387af3981586cbb4fe7cde8b18d0c5c01a376", size = 13988, upload-time = "2026-07-16T14:12:14.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/31/766c3ed08e4f8577956187661e4ad0ce6b6bd4dcd4738271ee8b788b74ba/invenio_indexer-6.0.0-py2.py3-none-any.whl", hash = "sha256:58e2ae7e9dc10aaf53e758536b065983f571e512d7f3bd686c05e7f673881eeb", size = 19854, upload-time = "2026-06-17T21:37:29.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ab/d9125b587e950076d3314b076088fe587d7aa412c0bc26fedf2988637ccd/invenio_indexer-6.0.1-py3-none-any.whl", hash = "sha256:ef6a72279562acddc48ed5fd2e65fd67887897229460572948e0fe64cd4f698e", size = 18037, upload-time = "2026-07-16T14:12:13.394Z" },
 ]
 
 [[package]]
 name = "invenio-jsonschemas"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
     { name = "jsonref" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/88/6d11d8ea9e67bd66dff593ead49b7c87b39c6c91ce693c68fe72e89a6ee2/invenio_jsonschemas-2.1.0.tar.gz", hash = "sha256:98712916a35bd6f998a3b1585a7b39e42f61d11a749149d55672918774fa1bd2", size = 28830, upload-time = "2025-07-14T19:38:50.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/79/9a740a7cfe682a7abff25e56f7c9f4afd959b6db96f35c28c27325f26e1a/invenio_jsonschemas-2.1.1.tar.gz", hash = "sha256:838539177fe6b0a1e7154350886178692bc3ffd5db47deb38532c1eb1c9469c8", size = 11020, upload-time = "2026-07-16T14:08:23.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/cf/d93bec8f33253004d18d1f0034adec756866eb40900685706b23f2ef8730/invenio_jsonschemas-2.1.0-py2.py3-none-any.whl", hash = "sha256:eca99353d7a414bc665b9a99ca594016cc294a6304caea98092f7912a4a8b0c7", size = 16636, upload-time = "2025-07-14T19:38:49.854Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/62/6af3976e3bf102308ff3537a074a52e3ca1d7a5720132e88b8135e451922/invenio_jsonschemas-2.1.1-py3-none-any.whl", hash = "sha256:938d8bcba4d62e13083f69a32f8b3c6caf70da8bd225d944527207c3e0effe6c", size = 14837, upload-time = "2026-07-16T14:08:22.627Z" },
 ]
 
 [[package]]
 name = "invenio-logging"
-version = "4.2.0"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-celery" },
     { name = "invenio-db" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7b/0da29431207f7667b07c5c8638e8f6535b51580ecf221bd1331471725a72/invenio_logging-4.2.0.tar.gz", hash = "sha256:cae00b33022daf5cc2f6d837ce179a76e53206c247a87e1bf1c252d10e4a4540", size = 12631, upload-time = "2026-06-12T08:11:26.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/5f/71cb046f99682615fe2c1a27f93a7c8ec7c7164a8630f9c166c7298a082d/invenio_logging-4.3.0.tar.gz", hash = "sha256:f347dd4a6a3c81fbcf1caeb8eb4b51be44152b756c5fe096348cad08bba324ce", size = 7084, upload-time = "2026-07-16T14:08:21.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2b/1ef377db4d2cefa57b9bbc7ffda9ba9d15c6689af0ddeb2ce192489b3270/invenio_logging-4.2.0-py2.py3-none-any.whl", hash = "sha256:35f7ca2d1162ad8332cd0ea4328cd6d78f8a1bbaaace1b28bb4d6840ec954996", size = 11315, upload-time = "2026-06-12T08:11:25.223Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3e/3962353bc29496cf2d7dd62da4ed2878a5f51dc4ef45aef82a7ebdab3bd8/invenio_logging-4.3.0-py3-none-any.whl", hash = "sha256:1f84f183aaaa093db5d9755228cbfdb092bfc42d8471c22e1237df1be17ac5b7", size = 10380, upload-time = "2026-07-16T14:08:20.089Z" },
 ]
 
 [package.optional-dependencies]
@@ -1703,15 +1700,15 @@ sentry = [
 
 [[package]]
 name = "invenio-mail"
-version = "2.3.0"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "flask-mail" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/72/f27e212fc8580a216ab0589ae087e2eeff206413e6f05863c19dd8ad7a46/invenio_mail-2.3.0.tar.gz", hash = "sha256:a8ecc485ea0e38307a33f87c7374c329e5e491a3cb3d3dc34aeb84485e78c34b", size = 26940, upload-time = "2025-03-27T17:53:13.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/d7/7ab5c068b2670a1c5e39926080fdc55d146fbe8fd4f9b22fba2d3d6891d9/invenio_mail-2.3.1.tar.gz", hash = "sha256:49019aeca5e7277fd4f385d022b82212958d33f12119b80ad06e9147ed349453", size = 6571, upload-time = "2026-07-16T14:05:34.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/65/7a30bab57a268a9d52ff7c4b2210448477cd82d2509bcf87bb4f8922e159/invenio_mail-2.3.0-py2.py3-none-any.whl", hash = "sha256:2f560d1e597ce4f033bfe46263d78bf61605980e6b7941ce0ea7adb203df9c3f", size = 10181, upload-time = "2025-03-27T17:53:11.473Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/75662ff3ed9d7e124ee548eaf9305d8f1a53a85c6ca4dbc682bec3d1d8aa/invenio_mail-2.3.1-py3-none-any.whl", hash = "sha256:4734a7c3b5843082882749eed4cc9e779c98114f04dd2c676c89ea73374557ae", size = 8814, upload-time = "2026-07-16T14:05:33.203Z" },
 ]
 
 [[package]]
@@ -1731,7 +1728,7 @@ wheels = [
 
 [[package]]
 name = "invenio-oaiserver"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -1743,14 +1740,14 @@ dependencies = [
     { name = "invenio-rest" },
     { name = "lxml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/17/c6b7111dbdeb9d6ca76411b3f63777aa06d83ae625e87a48bcb134ce2fe5/invenio_oaiserver-6.0.0.tar.gz", hash = "sha256:f821213526e09d54eed97193b8d821715025b84f0bc6e6c6b6729f6203f6252b", size = 51316, upload-time = "2026-06-17T21:46:34.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/ba/a653749dd235e5409c1a369f95436e02ba616ce171ad1b5a2bb4993f173f/invenio_oaiserver-6.0.1.tar.gz", hash = "sha256:5dce4be1d05ec25628d9b973215fe589145415b789d96910f6a1ed89dd380c20", size = 33986, upload-time = "2026-07-16T13:58:34.871Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/a1/060488290240566a9ec1864d6eb31e87235a641847fb8bd1039822cdabb2/invenio_oaiserver-6.0.0-py2.py3-none-any.whl", hash = "sha256:ccfc9caa8b3c909ff1e97d1c8342b76cd6421766ec8f88436f1795b5e2a35606", size = 106918, upload-time = "2026-06-17T21:46:33.891Z" },
+    { url = "https://files.pythonhosted.org/packages/66/74/0c581724b1e4bded446dcdab4dae2597cbf65329e10a1eaf14a57ee67e8a/invenio_oaiserver-6.0.1-py3-none-any.whl", hash = "sha256:5cf80dfb2999102baf5919446c4b23c692f0d51c39ccae6848b9002cdf48af91", size = 78269, upload-time = "2026-07-16T13:58:33.917Z" },
 ]
 
 [[package]]
 name = "invenio-oauth2server"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib" },
@@ -1767,14 +1764,14 @@ dependencies = [
     { name = "wtforms" },
     { name = "wtforms-alchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/5c/1677d771906cc0a3bab8518d03b05245143d5c62d2207f510965eb58134a/invenio_oauth2server-6.0.0.tar.gz", hash = "sha256:e86f7a342df10b092287871abca11b508a344b69be12df43c8f9a3ac9cb08642", size = 120448, upload-time = "2026-06-17T21:45:27.61Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/c53eb2ea5f311a7bc99a6ac0159ba3be27d2064fc1c24e5929b4dd313953/invenio_oauth2server-6.0.1.tar.gz", hash = "sha256:a4d8912df62ad90bc97e76db33d4cfc0b411b97dc49d180d388dc5325dbdc273", size = 67707, upload-time = "2026-07-16T13:54:45.377Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/f2/7b8dc438b77911eed6f6602411b0b770dddf693471edcd57941c084d67df/invenio_oauth2server-6.0.0-py2.py3-none-any.whl", hash = "sha256:7c07529edbfc9d9ef603f65d218acd7c923b1a2523f0010aa25a719a7fc85a46", size = 237762, upload-time = "2026-06-17T21:45:26.45Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/517d41e816aad60fefc2466c8e200b937af4ca147aebd228298a1e65a743/invenio_oauth2server-6.0.1-py3-none-any.whl", hash = "sha256:295207e9b25629c8bc021670d29c8eafee8fcbaec9306a9a94c00b3210d75f07", size = 170610, upload-time = "2026-07-16T13:54:44.253Z" },
 ]
 
 [[package]]
 name = "invenio-oauthclient"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -1791,14 +1788,14 @@ dependencies = [
     { name = "uritemplate" },
     { name = "uritools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/76/5db32271878dcadb050f80aa690e2116e9ed8946cdcebe8165730993b88a/invenio_oauthclient-9.1.0.tar.gz", hash = "sha256:84c4a8634204ce88c2bbf188dc9d43054c16f808920d86856bbbf8b3f595dccb", size = 106004, upload-time = "2026-06-30T10:27:18.454Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/c1c7808fa646704f26c0c6dae46c7cef0557aeb7bc730c24f135a719ff0d/invenio_oauthclient-9.1.1.tar.gz", hash = "sha256:13f51add27414b4928d4366cb7b44281bd94512562ec14bd725ab61df2a29214", size = 74612, upload-time = "2026-07-16T13:54:51.569Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/9b/a11c20d317ffab84a0cc70fe86a5934b0dc7725335706becfb44e52b3902/invenio_oauthclient-9.1.0-py2.py3-none-any.whl", hash = "sha256:6613a317fb2dea8e51f1555a661c07910dffe2366e68018e208a456e7422bf82", size = 220493, upload-time = "2026-06-30T10:27:17.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ba/dcf35640339b66ba2e28741f6aded43273152cd684efc0674d536c43bbb4/invenio_oauthclient-9.1.1-py3-none-any.whl", hash = "sha256:07f8df741d93accf67b321640d0095c0cc84002d945ff37635f4cd11409d979e", size = 173822, upload-time = "2026-07-16T13:54:50.356Z" },
 ]
 
 [[package]]
 name = "invenio-pidstore"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "base32-lib" },
@@ -1807,9 +1804,9 @@ dependencies = [
     { name = "invenio-base" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/22/a05addce12bd099c148f44963be722ce78df896c56268cd508cc8def9507/invenio_pidstore-4.0.0.tar.gz", hash = "sha256:0bffa43fb1a4b6811da415bad7bec1d2cea15e24483ebe039f4d10f7a9611a25", size = 39857, upload-time = "2026-06-17T21:28:42.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/5b/c4f8050bba769494c56485e09f7bffe08e548272b7eaa2de7321d0b83e9c/invenio_pidstore-4.0.1.tar.gz", hash = "sha256:1dc8050fe13ec46ce9fa9d61ec19c76645522f0d6e9f8a3c75eede913de698e7", size = 24813, upload-time = "2026-07-16T13:52:01.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/02/6a0e95937d28fac39a0615597600e7068881c1a1bd7becdbe524560d43b9/invenio_pidstore-4.0.0-py2.py3-none-any.whl", hash = "sha256:221f14353f9d67c4dbd78763af4f88d55b123638f2bb4d3677f8b0400ed3bcfc", size = 83153, upload-time = "2026-06-17T21:28:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/47/81/840a902bea5e86ad782cdc912eb3b66f02f239f892dd410e975b146a70f4/invenio_pidstore-4.0.1-py3-none-any.whl", hash = "sha256:3ef405f029b0febae75ca76a8d53e6a23ea1b5596550057705498668b82b30a8", size = 58333, upload-time = "2026-07-16T13:52:00.334Z" },
 ]
 
 [[package]]
@@ -1836,21 +1833,21 @@ wheels = [
 
 [[package]]
 name = "invenio-queues"
-version = "1.0.3"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
     { name = "invenio-celery" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/7b/ef16e5d2ef1a6049d2142bd2a295d6e333305b8bd48c2980a9920fe63f5e/invenio_queues-1.0.3.tar.gz", hash = "sha256:7078086422b8c34e98c7a3eed5f79a60a9490ad47c675a3bca1cc991e283715e", size = 11026, upload-time = "2026-04-30T15:13:08.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/a3/f78300fbb26a80ddcceccb347e14046745326d135b62a7e8dc2322d10b05/invenio_queues-1.0.4.tar.gz", hash = "sha256:74422cb115c38e59ff782147ca15e44a6f7f074ee727629f4a4bb2a17a8f3adc", size = 6349, upload-time = "2026-07-16T13:50:22.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b6/c711e260629c5d89f76a9453d48c66c8e27bab054b63745a8980a42ac484/invenio_queues-1.0.3-py2.py3-none-any.whl", hash = "sha256:b2a317d8ff27110356723f25dd0cc5db8c0ddcb53f8775d4e52a8c3da0afa836", size = 10717, upload-time = "2026-04-30T15:13:07.657Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c8/87fbf750c51aa1de8f4d6296be5cc5293aeaba383fb018c7d80334be8ac6/invenio_queues-1.0.4-py3-none-any.whl", hash = "sha256:f75b2ed2c3f05fc40c09717a2b08e83adfdf03b6338fa8defd9d1cb0636fa504", size = 9209, upload-time = "2026-07-16T13:50:21.219Z" },
 ]
 
 [[package]]
 name = "invenio-records"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -1861,26 +1858,26 @@ dependencies = [
     { name = "jsonresolver" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/13/c516432ea5bf99bee34efdfffa250f1954281f7dddc7d74759aafe3613b7/invenio_records-6.0.0.tar.gz", hash = "sha256:8714c7798078e86c67136d8e68a796fc6bc015ef1f6783142e6e30b38d0cb611", size = 116516, upload-time = "2026-06-17T21:13:34.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/d1/57db79d6b42475df5f1b82fc2877bc058bc0376a38b2d7ef02c659f84590/invenio_records-6.0.1.tar.gz", hash = "sha256:645dd6f2349d2e5165cf529c197c510ba546985af622354bcce3997b957e029f", size = 98320, upload-time = "2026-07-16T13:49:11.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/04/f3f5098fb0af1619f52e4b02b519f09eee162cb0a055c8762ccd6954a9dd/invenio_records-6.0.0-py2.py3-none-any.whl", hash = "sha256:a016e8923f8a0d177e001884844c8c520f53d979aa0bc509365c231de7aa4c5c", size = 162452, upload-time = "2026-06-17T21:13:32.927Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bc/b78f114ab88e16780198e24fc3cff2fdce63d0b1a90fcb17aa6525326274/invenio_records-6.0.1-py3-none-any.whl", hash = "sha256:cd9005274e343f380c656ba698e151d4dae8b734971874890b4f253a08a341ed", size = 137482, upload-time = "2026-07-16T13:49:09.811Z" },
 ]
 
 [[package]]
 name = "invenio-records-permissions"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-access" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/1e/7466671f11c75d137a81adbd9cc353747d6e5e0cf4992d13c73d1bcf0a35/invenio_records_permissions-4.0.0.tar.gz", hash = "sha256:765414adb4e485b62d90784c07dec033e5ed8ec3684d3d166ded91875575b5db", size = 16379, upload-time = "2026-06-17T21:44:00.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f0/9df224f22bafc6bc624346b92ff4b446627a76a92e3797253dc5521cbf39/invenio_records_permissions-4.0.1.tar.gz", hash = "sha256:76ed98fff58698fc9334e12497253f4a47fb44a6cbf2a983c07dba0fdb2b88a2", size = 11327, upload-time = "2026-07-16T13:46:11.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/57/ad22510040651d8ad33e7a50dfcf492ce36af07f4adb6208e280603a300e/invenio_records_permissions-4.0.0-py2.py3-none-any.whl", hash = "sha256:2dd3cdbba7002706dfe6811810729ad0d754898c59cd1c48ee89d97d5e28666d", size = 16237, upload-time = "2026-06-17T21:43:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/53/47b8e1ef34661db1411537a4511727d9e2dd8cb2d7eca895b5d74d535e4d/invenio_records_permissions-4.0.1-py3-none-any.whl", hash = "sha256:06db1aed91ad6e66ade0bfa64cbe6201784bd4e02b2585893ac9aa687f918d4b", size = 15381, upload-time = "2026-07-16T13:46:10.018Z" },
 ]
 
 [[package]]
 name = "invenio-records-resources"
-version = "11.0.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel-edtf" },
@@ -1903,9 +1900,9 @@ dependencies = [
     { name = "xmltodict" },
     { name = "zipstream-ng" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/5e/adb93f432939a8df6ac15b35481401dec7e03c56cb0354bffa219881bd93/invenio_records_resources-11.0.0.tar.gz", hash = "sha256:8e2dcebc45c3741c7a1960bdb7d8ea56674cd5e8a5f387af7f1b32eaed1e7d63", size = 145602, upload-time = "2026-06-17T22:15:55.197Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bd/0aeb58f53334823f2e87fae11911c53839fe9d4958929121d74b2b9ee8b2/invenio_records_resources-11.0.1.tar.gz", hash = "sha256:2991bb9aa208bae8efd469f0aff4d57c4076b5b4bbd60b97d70e6923300424ae", size = 115923, upload-time = "2026-07-16T13:47:05.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/80/a53c1cba1a040652a2b2b789d133248ca58bd4f57a2862cb6b9f1bebcb97/invenio_records_resources-11.0.0-py2.py3-none-any.whl", hash = "sha256:d048f7d9876920bd2319aeffaa2926d02de3dad32e65d95da81cff21d927d643", size = 266097, upload-time = "2026-06-17T22:15:53.706Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d4/7cd6c1a90293ab1b2bd0933e2d0f510f6ebac87c0ebfbe361174cd50187e/invenio_records_resources-11.0.1-py3-none-any.whl", hash = "sha256:cf9cdf746b2f392d246c1bb0ed62b802e179502b4a031220ad0b8505eba04b3a", size = 225173, upload-time = "2026-07-16T13:47:04.176Z" },
 ]
 
 [[package]]
@@ -1930,7 +1927,7 @@ wheels = [
 
 [[package]]
 name = "invenio-records-ui"
-version = "5.0.0"
+version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
@@ -1938,14 +1935,14 @@ dependencies = [
     { name = "invenio-pidstore" },
     { name = "invenio-records" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/80/e05c11b35047855578b9e94a5dea9b75fb61d7a5b335e0d9bdb64f9ca27f/invenio_records_ui-5.0.0.tar.gz", hash = "sha256:82548ab0bc805d636fc3094d5e9502eaf2997f2e8f86f4d86463edce13042801", size = 25755, upload-time = "2026-06-17T21:38:33.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ab/06476ac4e5401e26fdf60c1360b7681e1674c88455db8b2b5875d97f20c0/invenio_records_ui-5.0.1.tar.gz", hash = "sha256:ba761438bb9a9eeb2be96d7ebb9da001d383a8d0583cde1e972eaaa2eda6cb66", size = 14890, upload-time = "2026-07-16T13:42:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/e0/0ed54b4a1814e642294ff2ca06a978314a10ceef484b39c2514bb1abd088/invenio_records_ui-5.0.0-py2.py3-none-any.whl", hash = "sha256:0538b8eb35db7a7f700ffa83dae57f54816fa3a50fd585204990b0bce8a8cc81", size = 64910, upload-time = "2026-06-17T21:38:32.339Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/31/93a94f240d8e195fb8f6d2fdd8c6483ceb2eb26cf8badcbdf8d035a8e8af/invenio_records_ui-5.0.1-py3-none-any.whl", hash = "sha256:fab69c202c76a3dea040b67662598a69409f18d75b71f21a6c2768e7aa39f0ac", size = 44431, upload-time = "2026-07-16T13:42:31.544Z" },
 ]
 
 [[package]]
 name = "invenio-rest"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-cors" },
@@ -1956,22 +1953,22 @@ dependencies = [
     { name = "marshmallow-utils" },
     { name = "webargs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/9739dcb963381cc39e3969e8b8c79c349701c83649d177d1e1c3ac1bdae1/invenio_rest-4.0.0.tar.gz", hash = "sha256:1e4814d18b71ed27a788492e8293d0b1de3a16c5e55b5eb45f7ec7e647bfe3b5", size = 22135, upload-time = "2026-06-17T20:56:56.39Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/fb/27a0716a2b8ea96c9202ed57356277da603687670557a20b33f3318f920a/invenio_rest-4.0.1.tar.gz", hash = "sha256:b70facad145e674e60c3aecd74b49663721bdf81951d942cbe668f102a3347ea", size = 15944, upload-time = "2026-07-16T13:38:01.163Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/e6/824024ca26e93dcca70e82310a46d8bbd889b2cdf4543e0ca0ac607ac6d2/invenio_rest-4.0.0-py2.py3-none-any.whl", hash = "sha256:bde127f4ec65e72d2122f02656c463dd6c0d212e29899eeaee9fca7fae7b0152", size = 21505, upload-time = "2026-06-17T20:56:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/aea2122ae8e67d0c408d5dbaf7a39eecfc2d5cf7eb87347497e4998c8f46/invenio_rest-4.0.1-py3-none-any.whl", hash = "sha256:16cd91cac9dd6d76e5a03443ba0724248804b5efcec79c123b0f3665d6600ab7", size = 19953, upload-time = "2026-07-16T13:38:00.196Z" },
 ]
 
 [[package]]
 name = "invenio-search"
-version = "3.1.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dictdiffer" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/51/fc1108453d09cdc5a2c257624e5d7055090b77d49e63a4f921d6d511120c/invenio_search-3.1.2.tar.gz", hash = "sha256:8edfc9eca1506ed841a861231b29ce374770db0862490346cc3d327b8e6dd440", size = 27992, upload-time = "2025-11-20T13:32:40.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/55/d71c905eaa1c3eb67fe442116d6947d89f28d3c8407cfa13ff8d197dbbb0/invenio_search-3.1.3.tar.gz", hash = "sha256:ceb6957d3590d5081a9028901d1335bbbd4eaadc0bbfb66b45715b8a84398f86", size = 19526, upload-time = "2026-07-16T13:31:47.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/04/eca8047b8aae592f7e0726debc02bc26ca25b4909c6940b66d2d867957be/invenio_search-3.1.2-py2.py3-none-any.whl", hash = "sha256:5c714fe51d2a103b95725088dad433af6ef531d4a01230d850bfeb50f641ef6c", size = 26272, upload-time = "2025-11-20T13:32:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/69/51af2cc8fd85204bbf314b925481abde804354adb77ce6ef4b04541ee032/invenio_search-3.1.3-py3-none-any.whl", hash = "sha256:590b2e5be4b664008bde38072e9875eb1ab130539752963f302adfd4deaf782e", size = 23657, upload-time = "2026-07-16T13:31:46.079Z" },
 ]
 
 [package.optional-dependencies]
@@ -1982,7 +1979,7 @@ elasticsearch7 = [
 
 [[package]]
 name = "invenio-search-ui"
-version = "5.0.1"
+version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1990,9 +1987,9 @@ dependencies = [
     { name = "invenio-base" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/56/b72c62ee3f2b811083d3ac473800cbccaa5fd0a9a755ccf6130d652602b5/invenio_search_ui-5.0.1.tar.gz", hash = "sha256:20d259df9d9b891285ad94cd329b2d33b0de285575a44c6cc518c5c482f7d733", size = 57519, upload-time = "2026-06-22T15:51:44.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/38/138e64ab2b9a4a602a2664f9234bc3d8709aa8bafc7ae09e265680ac974f/invenio_search_ui-5.0.2.tar.gz", hash = "sha256:810964d531792ca3b7825528d4028fbee797bf1b1135fd6efb8e34e7ce76c074", size = 39292, upload-time = "2026-07-16T13:31:35.449Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c9/8cce950ea6c17f581fde2206ee2282e69153c42aff587b10b7b93517ac68/invenio_search_ui-5.0.1-py2.py3-none-any.whl", hash = "sha256:a430fe6ff8b554cb1ab6e1bf0a0a04808eada16e0dd3d15a64b86bc992e449d1", size = 139796, upload-time = "2026-06-22T15:51:43.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/fd/e9aa5bb2d76db79bdeab119708fe7d304967b9e2320864f9c8d9850ad0a9/invenio_search_ui-5.0.2-py3-none-any.whl", hash = "sha256:4e14c3bf36b18d91dc85d14330c8c36ad236e9eea232e57eaaf3ed36c90beeab", size = 116911, upload-time = "2026-07-16T13:31:34.317Z" },
 ]
 
 [[package]]
@@ -2017,7 +2014,7 @@ wheels = [
 
 [[package]]
 name = "invenio-stats"
-version = "7.0.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "counter-robots" },
@@ -2030,9 +2027,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-geoip" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/33/239c050c61c8da6eb66d861756a0e69bafaaba24457d166afc4d8bf826c6/invenio_stats-7.0.0.tar.gz", hash = "sha256:649d2d9804d5fe0c8287964e0e7f928c23926ce1c0fb39ab27b6b74e4f228d5e", size = 39596, upload-time = "2026-06-17T21:47:50.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/19/591864abc6b8da4f5930600a404041bd95bac5418b7379675fdc2baa5894/invenio_stats-7.0.1.tar.gz", hash = "sha256:43b9fdc1d08f56becd07776400ffc9e99d4b597e3cae40752299f4151f8fdfd1", size = 27931, upload-time = "2026-07-16T13:26:17.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/0e/775c35d5b23db3f952b4fa932948dd0ecca99a519c15031b6539041b7b56/invenio_stats-7.0.0-py2.py3-none-any.whl", hash = "sha256:3066520ed5d882618312ada2675d3c21f941e4af1369d830b4e7c472d228f0e1", size = 51065, upload-time = "2026-06-17T21:47:48.922Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3e/5e1c602b0884eee59cbb8b81615153035bfd6046c2533d3aec5f0dbe0b95/invenio_stats-7.0.1-py3-none-any.whl", hash = "sha256:b4ab8d42992bdcfcbb45b3138676f0497161509e656d5cd9f3d4cc8d987514c5", size = 48774, upload-time = "2026-07-16T13:26:16.3Z" },
 ]
 
 [[package]]
@@ -2096,11 +2093,11 @@ wheels = [
 
 [[package]]
 name = "isbnlib2"
-version = "3.11.19"
+version = "3.11.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/9d/18f104b965db7ee0ac5543d2c6c39cd44b6f4f016484cd57a0b56c1f15c5/isbnlib2-3.11.19.tar.gz", hash = "sha256:37c2833b6feb6b05abfc028134149dffc813def244cd1bdc251ab3a3fabe08dd", size = 56888, upload-time = "2026-06-14T11:13:59.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/8c/2b64e22100cd18642450f909c6a9ee43abba5141be958f2e6e0c6dc0810f/isbnlib2-3.11.20.tar.gz", hash = "sha256:cafe3f1116cd78374d463d5323d06b58b98ab624b26c19b2dab202a23116b35c", size = 56938, upload-time = "2026-07-20T11:01:48.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/af/bce0a35779136f2301e8442e62094890da8d36504d0ab71b370bfc3631ac/isbnlib2-3.11.19-py3-none-any.whl", hash = "sha256:fec59123b56c4b71ff70ccdfa898a3df2c38618642b2d73650318a7a0b565ec1", size = 67860, upload-time = "2026-06-14T11:13:58.185Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f3/72889557fb99d3b091aa53a515750262eaf230a26de342539433745214b0/isbnlib2-3.11.20-py3-none-any.whl", hash = "sha256:54a8dac35c6c1f520d57b3d8413a5b3a711e36fe021001f0926d7eb7b2e14e4b", size = 67889, upload-time = "2026-07-20T11:01:47.462Z" },
 ]
 
 [[package]]
@@ -2210,16 +2207,16 @@ wheels = [
 
 [[package]]
 name = "jsonresolver"
-version = "0.5.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema-specifications" },
     { name = "pluggy" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/c2/5d7ee99eaf8cb1f2b97ef295332921a8dd3903f0eafb15559e04312bc200/jsonresolver-0.5.1.tar.gz", hash = "sha256:dc48f19f3e329af6d30a696c53fb087edf95d97c4615bccd27f517e683503864", size = 13788, upload-time = "2026-03-20T07:27:53.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/51/e352275d8f44074ca1d395cb5ebebbf0a85f2ac62bf1de9fd27ccfddbe7e/jsonresolver-0.5.2.tar.gz", hash = "sha256:f98791c636702f6f8ffb644b242103cc2b943b25d56c319a83cf6368ec8dfaa8", size = 8090, upload-time = "2026-07-16T13:08:22.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/57/45bde3c362518fd3a8078a32d704edeb94a61ad814302a246b351016f492/jsonresolver-0.5.1-py2.py3-none-any.whl", hash = "sha256:5736bca6678cde4ef501c09a9b7754467d11863bab89af6d2cee45adc49f689d", size = 13634, upload-time = "2026-03-20T07:27:52.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/bb67a0598cac4703b27c55379f106266d65f343c406070477d50816971ba/jsonresolver-0.5.2-py3-none-any.whl", hash = "sha256:41d69f88a3d32d3082e22edf2cb225edae79fbb26e04dd4be7ae76ded1673083", size = 11364, upload-time = "2026-07-16T13:08:21.311Z" },
 ]
 
 [[package]]
@@ -2629,11 +2626,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.3.3"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/328a294a6de83bacb95bed01f04e0eaff4e3616ee359fc821a5dfc539b02/mistune-3.3.4.tar.gz", hash = "sha256:58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe", size = 121426, upload-time = "2026-07-22T05:22:30.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953bc01de09f686f40d8ee84578135aa7767d5d4e60b5278/mistune-3.3.4-py3-none-any.whl", hash = "sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a", size = 66862, upload-time = "2026-07-22T05:22:29.419Z" },
 ]
 
 [[package]]
@@ -2915,11 +2912,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -2964,14 +2961,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.52"
+version = "3.0.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
 ]
 
 [[package]]
@@ -3537,42 +3534,42 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.7.10"
+version = "2026.7.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/37/451aaddbf50922f34d744ad5ca919ae1fcfac112123885d9728f52a484b3/regex-2026.7.10.tar.gz", hash = "sha256:1050fedf0a8a92e843971120c2f57c3a99bea86c0dfa1d63a9fac053fe54b135", size = 416282, upload-time = "2026-07-10T19:49:46.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/4a/a7fa3ada9bd2d2ce20d56dfceec6b2a51afeed9bf3d8286355ceec5f0628/regex-2026.7.10-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:39f81d1fdf594446495f2f4edd8e62d8eda0f7a802c77ac596dc8448ad4cc5ca", size = 497087, upload-time = "2026-07-10T19:48:40.543Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/7e/ca0b1a87192e5828dbc16f16ae6caca9b67f25bf729a3348468a5ff52755/regex-2026.7.10-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:441edc66a54063f8269d1494fc8474d06605e71e8a918f4bcfd079ebda4ce042", size = 297307, upload-time = "2026-07-10T19:48:42.213Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6c/fb40bb34275d3cd4d7a376d5fb2ea1f0f4a96fd884fa83c0c4ae869001bf/regex-2026.7.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cfeb11990f59e59a0df26c648f0adfcbf27be77241250636f5769eb08db662be", size = 292163, upload-time = "2026-07-10T19:48:43.929Z" },
-    { url = "https://files.pythonhosted.org/packages/18/0b/34cbea16c8fea9a18475a7e8f5837c70af451e738bfeb4eb5b029b7dc07a/regex-2026.7.10-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:460176b2db044a292baaee6891106566739657877af89a251cded228689015a6", size = 797064, upload-time = "2026-07-10T19:48:45.623Z" },
-    { url = "https://files.pythonhosted.org/packages/87/77/f6805d97f15f5a710bdfd56a768f3468c978239daf9e1b15efd8935e1967/regex-2026.7.10-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9dc55698737aca028848bde418d6c51d74f2a5fd44872d3c8b56b626729adb89", size = 866155, upload-time = "2026-07-10T19:48:47.589Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/e3/a2a905807bba3bcd90d6ebbb67d27af2adf7d41708175cbc6b956a0c75f1/regex-2026.7.10-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d3e10779f60c000213a5b53f518824bd07b3dc119333b26d70c6be1c27b5c794", size = 911596, upload-time = "2026-07-10T19:48:49.473Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ca/a3126888b2c6f33c7e29144fedf85f6d5a52a400024fa045ad8fc0550ef1/regex-2026.7.10-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38a5926601aaccf379512746b86eb0ac1d29121f6c776dac6ac5b31077432f2c", size = 800713, upload-time = "2026-07-10T19:48:51.452Z" },
-    { url = "https://files.pythonhosted.org/packages/66/19/9d252fd969f726c8b56b4bacf910811cc70495a110907b3a7ccb96cd9cad/regex-2026.7.10-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a72ecf5bfd3fc8d57927f7e3ded2487e144472f39010c3acaec3f6f3ff53f361", size = 777286, upload-time = "2026-07-10T19:48:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/40/7a/5f1bf433fa446ecb3aab87bb402603dc9e171ef8052c1bb8690bb4e255a3/regex-2026.7.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d50714405845c1010c871098558cfe5718fe39d2a2fab5f95c8863caeb7a82b3", size = 785826, upload-time = "2026-07-10T19:48:55.381Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ca/69f3a7281d86f1b592338007f3e535cc219d771448e2b61c0b56e4f9d05b/regex-2026.7.10-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ec1c44cf9bd22079aac37a07cb49a29ced9050ab5bddf24e50aba298f1e34d90", size = 860957, upload-time = "2026-07-10T19:48:57.962Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/11/487ff55c8d515ec9dd60d7ba3c129eeaa9e527358ed9e8a054a9e9430f81/regex-2026.7.10-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9e9aaef25a40d1f1e1bbb1d0eb0190c4a64a7a1750f7eb67b8399bed6f4fd2a6", size = 765959, upload-time = "2026-07-10T19:49:00.27Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e1/fa034e6fa8896a09bd0d5e19c81fdc024411ab37980950a0401dccee8f6d/regex-2026.7.10-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e54e088dc64dd2766014e7cfe5f8bc45399400fd486816e494f93e3f0f55da06", size = 851447, upload-time = "2026-07-10T19:49:02.128Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a5/b9427ed53b0e14c540dc436d56aaf57a19fb9183c6e7abd66f4b4368fbad/regex-2026.7.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:834271b1ff2cfa1f67fcd65a48bf11d11e9ab837e21bf79ce554efb648599ae8", size = 789418, upload-time = "2026-07-10T19:49:03.949Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/52/aab92420c8aa845c7bcbe68dc65023d4a9e9ea785abf0beb2198f0de5ba1/regex-2026.7.10-cp314-cp314-win32.whl", hash = "sha256:f988a1cec68058f71a38471813fba9e87dffe855582682e8a10e40ece12567a2", size = 272538, upload-time = "2026-07-10T19:49:05.833Z" },
-    { url = "https://files.pythonhosted.org/packages/99/16/5c7050e0ef7dd8889441924ff0a2c33b7f0587c0ccb0953fe7ca997d673b/regex-2026.7.10-cp314-cp314-win_amd64.whl", hash = "sha256:2129e4a5e86f26926982d883dff815056f2e98220fdf630e59f961b578a26c43", size = 280796, upload-time = "2026-07-10T19:49:07.593Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/1a/4f6099d2ba271502fdb97e697bae2ed0213c0d87f2273fe7d21e2e401d12/regex-2026.7.10-cp314-cp314-win_arm64.whl", hash = "sha256:9cd5b6805396157b4cf993a6940cbb8663161f29b4df2458c1c9991f099299c5", size = 281017, upload-time = "2026-07-10T19:49:09.767Z" },
-    { url = "https://files.pythonhosted.org/packages/19/02/4061fc71f64703e0df61e782c2894c3fbc089d277767eff6e16099581c73/regex-2026.7.10-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:103e8f3acc3dcede88c0331c8612766bdcfc47c9250c5477f0e10e0550b9da49", size = 501467, upload-time = "2026-07-10T19:49:11.952Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a5/8d42b2f3fd672908a05582effd0f88438bf9bb4e8e02d69a62c723e23601/regex-2026.7.10-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:538ddb143f5ca085e372def17ef3ed9d74b50ad7fc431bd85dc50a9af1a7076f", size = 299700, upload-time = "2026-07-10T19:49:14.067Z" },
-    { url = "https://files.pythonhosted.org/packages/65/70/36fa4b46f73d268c0dbe77c40e62da2cd4833ee206d3b2e438c2034e1f36/regex-2026.7.10-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6e3448e86b05ce87d4eb50f9c680860830f3b32493660b39f43957d6263e2eba", size = 294590, upload-time = "2026-07-10T19:49:15.883Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/a7/b6db1823f3a233c2a46f854fdc986f4fd424a84ed557b7751f2998efb266/regex-2026.7.10-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5eab9d3f981c423afd1a61db055cfe83553c3f6455949e334db04722469dd0a2", size = 811925, upload-time = "2026-07-10T19:49:17.97Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/7d/f8bee4c210c42c7e8b952bb9fb7099dd7fb2f4bd0f33d0d65a8ab08aafc0/regex-2026.7.10-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:177f930af3ad72e1045f8877540e0c43a38f7d328cf05f31963d0bd5f7ecf067", size = 871257, upload-time = "2026-07-10T19:49:19.943Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/78/22adf72e614ba0216b996e9aaef5712c23699e360ea127bb3d5ee1a7666f/regex-2026.7.10-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dd3b6d97beb39afb412f2c79522b9e099463c31f4c49ab8347c5a2ca3531c478", size = 917551, upload-time = "2026-07-10T19:49:22.069Z" },
-    { url = "https://files.pythonhosted.org/packages/03/f7/ebc15a39e81e6b58da5f913b91fc293a25c6700d353c14d5cd25fc85712a/regex-2026.7.10-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8679f0652a183d93da646fcec8da8228db0be40d1595da37e6d74c2dc8c4713c", size = 816436, upload-time = "2026-07-10T19:49:24.131Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/33/20bc2bdd57f7e0fcc51be37e4c4d1bca7f0b4af8dc0a148c23220e689da8/regex-2026.7.10-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:494b19a5805438aeb582de99f9d97603d8fd48e6f4cc74d0088bb292b4da3b70", size = 785935, upload-time = "2026-07-10T19:49:26.265Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/51/87ff99c849b56309c40214a72b54b0eef320d0516a8a516970cc8be1b725/regex-2026.7.10-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0911e34151a5429d0325dae538ba9851ec0b62426bdfd613060cda8f1c36ec7f", size = 801494, upload-time = "2026-07-10T19:49:28.493Z" },
-    { url = "https://files.pythonhosted.org/packages/16/11/fde67d49083fef489b7e0f841e2e5736516795b166c9867f05956c1e494b/regex-2026.7.10-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b862572b7a5f5ed47d2ba5921e63bf8d9e3b682f859d8f11e0e5ca46f7e82173", size = 866549, upload-time = "2026-07-10T19:49:30.592Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b5/31a156c36acf10181d88f55a66c688d5454a344e53ccc03d49f4a48a2297/regex-2026.7.10-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:3f361215e000d68a4aff375106637b83c80be36091d83ee5107ad3b32bd73f48", size = 773089, upload-time = "2026-07-10T19:49:32.661Z" },
-    { url = "https://files.pythonhosted.org/packages/27/bb/734e978c904726664df47ae36ce5eca5065de5141185ae46efec063476a2/regex-2026.7.10-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4533af6099543db32ef26abc2b2f824781d4eebb309ab9296150fd1a0c7eb07d", size = 856710, upload-time = "2026-07-10T19:49:35.289Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e5/dc35cea074dbdcb9776c4b0542a3bc326ff08454af0768ef35f3fc66e7fa/regex-2026.7.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:668ab85105361d0200e3545bec198a1acfc6b0aeb5fff8897647a826e5a171be", size = 803621, upload-time = "2026-07-10T19:49:37.704Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/b2/124564af46bc0b592785610b3985315610af0a07f4cf21fa36e06c2398dd/regex-2026.7.10-cp314-cp314t-win32.whl", hash = "sha256:dd7715817a187edd7e2a2390908757f7ba42148e59cad755fb8ee1160c628eca", size = 274558, upload-time = "2026-07-10T19:49:39.926Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/9c/cd813ce9f3404c0443915175c1e339c5afd8fcda04310102eaf233015eef/regex-2026.7.10-cp314-cp314t-win_amd64.whl", hash = "sha256:78712d4954234df5ca24fdadb65a2ab034213f0cdfde376c272f9fc5e09866bb", size = 283687, upload-time = "2026-07-10T19:49:41.872Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/d3/3dae6a6ce46144940e64425e32b8573a393a009aeaf75fa6752a35399056/regex-2026.7.10-cp314-cp314t-win_arm64.whl", hash = "sha256:749b92640e1970e881fdf22a411d74bf9d049b154f4ef7232eeb9a90dd8be7f3", size = 283377, upload-time = "2026-07-10T19:49:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/0c4c452f8ef3efe456745b2f33195f5904b573fb4c2ff3f0cb9ec188461e/regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd", size = 496750, upload-time = "2026-07-19T00:18:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9e/b70ca6c1704f6c7cd32a9e143c86cc5968d10981eca284bad670c245ea7d/regex-2026.7.19-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4aa5435cdb3eb6f55fe98a171b05e3fbcd95fadaa4aa32acf62afd9b0cfdbcac", size = 297093, upload-time = "2026-07-19T00:18:41.583Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0b692da2520d51fbff19c88b83d97e4c702909dd02386c585998b7e2dbed/regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5", size = 292043, upload-time = "2026-07-19T00:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a7/1d478e614016045a33feae57446215f9fd65b665a5ceb2f891fb3183bc52/regex-2026.7.19-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d19662dbedbe783d323196312d38f5ba53cf56296378252171985da6899887d3", size = 797214, upload-time = "2026-07-19T00:18:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ae/11b9c9411d92c30e3d2db32df5a31133e4a99a8fc397a604fd08f6c4bffb/regex-2026.7.19-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d15df07081d91b76ff20d43f94592ee110330152d617b730fdbe5ef9fb680053", size = 866433, upload-time = "2026-07-19T00:18:47.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/62/2b2efc4992f91d6d204b24c647c9f9412e85379d92b7c0ab9fdae622327e/regex-2026.7.19-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:56ad4d9f77df871a99e25c37091052a02528ec0eb059de928ee33956b854b45b", size = 911360, upload-time = "2026-07-19T00:18:49.588Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/986ceea9aa3da548bf1357cad89b63915ec6d21ec957c8113b29ece567df/regex-2026.7.19-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7322ec6cc9fba9d49ab888bb82d67ac5625627aa168f0165139b17018df3fb8a", size = 801275, upload-time = "2026-07-19T00:18:51.767Z" },
+    { url = "https://files.pythonhosted.org/packages/15/be/ce9d9534b2cda96eab32c548261224b9b4e220a4126f098f60f42ae7b4cd/regex-2026.7.19-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c7472192ebfad53a6be7c4a8bfb2d64b81c0e93a1fc8c57e1dd0b638297b5d1", size = 777131, upload-time = "2026-07-19T00:18:54.053Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2b/58b5c710f2c3929515a25f3a1ca0dad0dcd4518d4fff3cf23bc7adb8dcd2/regex-2026.7.19-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c10b82c2634df08dfb13b1f04e38fe310d086ee092f4f69c0c8da234251e556e", size = 785020, upload-time = "2026-07-19T00:18:56.579Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/5fe091935b74f15fe0f97998c215cae418d1c0413f6258c7d4d2e83aa37f/regex-2026.7.19-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:17ed5692f6acc4183e98331101a5f9e4f64d72fe58b753da4d444a2c77d05b12", size = 861263, upload-time = "2026-07-19T00:18:58.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/d60bf82e10841eef62a9e32aac401468f05fddfbcb2942e342b1ba3d2433/regex-2026.7.19-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:22a992de9a0d91bda927bf02b94351d737a0302905432c88a53de7c4b9ce62e2", size = 766199, upload-time = "2026-07-19T00:19:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5d/11e64d151b0662b81d6bf644c74dc118d461df85bdf2577fadbbf751788a/regex-2026.7.19-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:618a0aed532be87294c4477b0481f3aa0f1520f4014a4374dd4cf789b4cd2c97", size = 851317, upload-time = "2026-07-19T00:19:03.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/34/532efb87488d90807bae6a443d357ee5e2728a478c597619c8aaa17cc0bd/regex-2026.7.19-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce9e679f776649746729b6c86382da519ef649c8e34cc41df0d2e5e0f6c36d4", size = 789557, upload-time = "2026-07-19T00:19:05.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/3a8d5ca977171ec3ae21a71207d2228b2663bde14d7f7ef0e6363ecf9290/regex-2026.7.19-cp314-cp314-win32.whl", hash = "sha256:73f272fba87b8ccfe70a137d02a54af386f6d27aa509fbffdd978f5947aae1aa", size = 272531, upload-time = "2026-07-19T00:19:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/8862885e70409de70e8c005f57fb2e7be8d9ef0317250d60f4c9660a300d/regex-2026.7.19-cp314-cp314-win_amd64.whl", hash = "sha256:d721e53758b2cca74990185eb0671dd466d7a388a1a45d0c6f4c13cef41a68ac", size = 280831, upload-time = "2026-07-19T00:19:09.46Z" },
+    { url = "https://files.pythonhosted.org/packages/08/82/2693e53e29f9104d9de95d37ce4dd826bd32d5f9c0085d3aa6ac042675c4/regex-2026.7.19-cp314-cp314-win_arm64.whl", hash = "sha256:65fa6cb38ed5e9c3637e68e544f598b39c3b86b808ed0627a67b68320384b459", size = 281099, upload-time = "2026-07-19T00:19:11.398Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b7/9a01aa16461a18cde9d7b9c3ab21e501db2ce33725f53014342b91df2b0a/regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3", size = 501121, upload-time = "2026-07-19T00:19:13.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/bbaeca815dc9191c424c94a4fdc5c87c75748a64a6271821212ebdd4e1a3/regex-2026.7.19-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:199535629f25caf89698039af3d1ad5fcae7f933e2112c73f1cdf49165c99518", size = 299415, upload-time = "2026-07-19T00:19:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/0dd1a321afaab95eb7ff44aa0f637301786f1dc71c6b797b9ed236ed8890/regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9", size = 294483, upload-time = "2026-07-19T00:19:17.879Z" },
+    { url = "https://files.pythonhosted.org/packages/92/5f/40bacf91d0904f812e13bbbab3864604c463eced8afdc54aeaa50492ea95/regex-2026.7.19-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbece16025afda5e3031af0c4059207e61dcf73ef13af844964f57f387d1c435", size = 811833, upload-time = "2026-07-19T00:19:20.102Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/4902744261f775aeede8b5627314b38482da29cf49a57b66a6fb753246c5/regex-2026.7.19-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d24ecb4f5e009ea0bd275ee37ad9953b32005e2e5e60f8bbae16da0dbbf0d3a0", size = 871270, upload-time = "2026-07-19T00:19:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/16/70/6980c9be6bf21c0a60ed3e0aea39cf419ecf3b08d1d9947bc56e196ef186/regex-2026.7.19-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8cae6fd77a5b72dae505084b1a2ee0360139faf72fedbab667cd7cc65aae7a6a", size = 917534, upload-time = "2026-07-19T00:19:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/52/92/8b2bd872782ce8c42691e39acb38eb8efe014e5ddb78ad7d943d6f197ce9/regex-2026.7.19-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9724e6cb5e478cd7d8cabf027826178739cb18cf0e117d0e32814d479fa02276", size = 816135, upload-time = "2026-07-19T00:19:26.919Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/33a602f657bdc4041f17d79f92ab18261d255d91a06117a6e29df023e5e2/regex-2026.7.19-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:572fc57b0009c735ee56c175ea021b637a15551a312f56734277f923d6fd0f6c", size = 785492, upload-time = "2026-07-19T00:19:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/36/0987cf4cb271680064a70d24a475873775a151d0b7058698a006cb0cae4a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:20568e182eb82d39a6bf7cff3fd58566f14c75c6f74b2c8c96537eecf9010e3a", size = 800658, upload-time = "2026-07-19T00:19:31.392Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/24/c14f31c135e1ba55fa4f9a58ca98d0842512bf6188230763c31c8f449e3b/regex-2026.7.19-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1d58561843f0ff7dc78b4c28b5e2dc388f3eff94ebc8a232a3adba961fc00009", size = 865073, upload-time = "2026-07-19T00:19:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/14/85/181a12211f22469f24d2de1ebddfe397d2396e2c29013b9a58134a91069a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:61bb1bd45520aacd56dd80943bd34991fb5350afdd1f36f2282230fd5154a218", size = 773684, upload-time = "2026-07-19T00:19:35.599Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/bd1a0c1a62251366f8d21f41b1ea3c76994962071b8b6ea42f72d505c0f0/regex-2026.7.19-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:cd3584591ea4429026cdb931b054342c2bcf189b44ff367f8d5c15bc092a2966", size = 857769, upload-time = "2026-07-19T00:19:37.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4f/f7e2dad6756b2fe1fe75dd90a628c3b45f249d39f948dd90cd2476325417/regex-2026.7.19-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cc26a66e212fa5d6c6170c3a40d99d888db3020c6fdab1523250d4341382e44", size = 804546, upload-time = "2026-07-19T00:19:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d7/01d31d5bdb09bc026fab77f59a371fdf8f9b292e4810546c56182ca70498/regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78", size = 274526, upload-time = "2026-07-19T00:19:42.398Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0e/cea4ce73bc0a8247a0748228ae6669984c7e1f8134b6fa66e59c0572e0ea/regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2", size = 283763, upload-time = "2026-07-19T00:19:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/26e41975febae63b7a6e3e02f32cff6cff2e4f10d19c929082f56aebf7c6/regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547", size = 283451, upload-time = "2026-07-19T00:19:46.639Z" },
 ]
 
 [[package]]
@@ -3904,27 +3901,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -3946,15 +3943,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.65.0"
+version = "2.66.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/1f/ed17a390348156ca99fe622b97cd7d2f1969b5f49df89084b0f28e7953e9/sentry_sdk-2.65.0.tar.gz", hash = "sha256:c94dc945d54bad49d4f20448b1e6b217ca2f92f46d05c3e83d41764af685c3d1", size = 932133, upload-time = "2026-07-13T11:33:19.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/3b/326ad4c03b5da89b5124c8890af66e8119c4d2e10abc0619e0d67d9f7c7f/sentry_sdk-2.65.0-py3-none-any.whl", hash = "sha256:3595169677a808e4d0e1ea6ffb89443459549c7a98392ed71c77c847182ab6bf", size = 503869, upload-time = "2026-07-13T11:33:17.71Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
 ]
 
 [package.optional-dependencies]
@@ -4082,11 +4079,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]
@@ -4305,7 +4302,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.8"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -4313,9 +4310,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
 ]
 
 [[package]]
@@ -4400,11 +4397,11 @@ wheels = [
 
 [[package]]
 name = "uritools"
-version = "6.1.2"
+version = "6.1.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/75/b1f0e26e0c080c2febdd3a98a752c9fbcf078778f60fe90ea489dc8226ed/uritools-6.1.2.tar.gz", hash = "sha256:fa60028843a8be651699a1ee2b399066eeaef349224b32a177efa4aeba463f00", size = 24189, upload-time = "2026-05-21T23:11:11.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/0d/20d02264b6682f07e92cbf7ee43e5e803670d101a03ef204ba18368c321f/uritools-6.1.3.tar.gz", hash = "sha256:3a498e7e85ef3249343d5710618d641a414da0fbae6d23053ada7976ee83ea5f", size = 23909, upload-time = "2026-07-23T23:17:44.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/3f/44a8c5de526ad21bd540015fd44987da69469ea9f51b7c9ac6a8b475a4a8/uritools-6.1.2-py3-none-any.whl", hash = "sha256:5682f8c58e96e379224fd72aec227a45432740c1fa860a06b3024d47c2968601", size = 11991, upload-time = "2026-05-21T23:11:10.002Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/76/e9bb35862bcc5b82218d2c017b1eacdcfeb3ba46ce0c0ca8ffc4db80ddbe/uritools-6.1.3-py3-none-any.whl", hash = "sha256:136f113e76e53f85bf2d9cce0c3d40ceec775d0409e7d6de9b28f046a7d42838", size = 11981, upload-time = "2026-07-23T23:17:43.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ruff 0.16 ships a much broader default rule set, which surfaced 332 new errors. Adapt the code and the linter configuration.

* Fixes the defects found on the way: `raise StopIteration` in a generator, `__all__` as a string, a `@property` on a method taking an argument, and dead test assertions.
* Retires 14 rules from the ignore lists by fixing their violations.
* Ignores `BLE001` and `DTZ`, deliberate patterns in the code base.

Updated dependencies (53 packages).