### PR TITLE
feat(exports): add Excel exports

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -917,8 +917,13 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             "application/json": "rero_ils.modules.serializers:json_v1_response",
             "text/csv": "rero_ils.modules.stats.serializers:csv_v1_response",
+            "application/vnd.ms-excel": "rero_ils.modules.stats.serializers:excel_xml_v1_response",
         },
-        record_serializers_aliases={"json": "application/json", "csv": "text/csv"},
+        record_serializers_aliases={
+            "json": "application/json",
+            "csv": "text/csv",
+            "xml": "application/vnd.ms-excel",
+        },
         search_serializers={
             "application/json": "rero_ils.modules.serializers:json_v1_search"
         },
@@ -3991,32 +3996,36 @@ RERO_INVENIO_BASE_EXPORT_REST_ENDPOINTS = dict(
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.acquisition.acq_accounts.serializers:csv_acq_account_search",
+            "application/vnd.ms-excel": "rero_ils.modules.acquisition.acq_accounts.serializers:excel_xml_acq_account_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={"csv": "text/csv", "xml": "application/vnd.ms-excel"},
     ),
     acq_order=dict(
         resource=RECORDS_REST_ENDPOINTS.get("acor"),
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.acquisition.acq_orders.serializers:csv_acor_search",
+            "application/vnd.ms-excel": "rero_ils.modules.acquisition.acq_orders.serializers:excel_xml_acor_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={"csv": "text/csv", "xml": "application/vnd.ms-excel"},
     ),
     loan=dict(
         resource=CIRCULATION_REST_ENDPOINTS.get("loanid"),
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.loans.serializers:csv_stream_search",
+            "application/vnd.ms-excel": "rero_ils.modules.loans.serializers:excel_xml_loan_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={"csv": "text/csv", "xml": "application/vnd.ms-excel"},
     ),
     patron_transaction_events=dict(
         resource=RECORDS_REST_ENDPOINTS.get("ptre"),
         default_media_type="text/csv",
         search_serializers={
             "text/csv": "rero_ils.modules.patron_transaction_events.serializers:csv_ptre_search",
+            "application/vnd.ms-excel": "rero_ils.modules.patron_transaction_events.serializers:excel_xml_ptre_search",
         },
-        search_serializers_aliases={"csv": "text/csv"},
+        search_serializers_aliases={"csv": "text/csv", "xml": "application/vnd.ms-excel"},
     ),
 )
 

--- a/rero_ils/modules/acquisition/acq_accounts/serializers/__init__.py
+++ b/rero_ils/modules/acquisition/acq_accounts/serializers/__init__.py
@@ -11,12 +11,14 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import excel_xml_converter
 
 from .csv import AcqAccountCSVSerializer
 from .json import AcqAccountJSONSerializer
 
 __all__ = [
     "csv_acq_account_search",
+    "excel_xml_acq_account_search",
     "json_acq_account_response",
     "json_acq_account_search",
 ]
@@ -41,3 +43,13 @@ _csv = AcqAccountCSVSerializer(
 )
 
 csv_acq_account_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_prefix="export-accounts")
+excel_xml_acq_account_search = search_responsify_file(
+    _csv,
+    "application/vnd.ms-excel",
+    file_extension="xls",
+    file_prefix="export-accounts",
+    content_converter=excel_xml_converter(
+        "rero_ils/exports/acquisition_accounts.xml",
+        worksheet_name="Acquisition accounts",
+    ),
+)

--- a/rero_ils/modules/acquisition/acq_orders/serializers/__init__.py
+++ b/rero_ils/modules/acquisition/acq_orders/serializers/__init__.py
@@ -11,11 +11,17 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import excel_xml_converter
 
 from .csv import AcqOrderCSVSerializer
 from .json import AcqOrderJSONSerializer
 
-__all__ = ["csv_acor_search", "json_acor_record", "json_acor_search"]
+__all__ = [
+    "csv_acor_search",
+    "excel_xml_acor_search",
+    "json_acor_record",
+    "json_acor_search",
+]
 
 """JSON serializer."""
 _json = AcqOrderJSONSerializer(RecordSchemaJSONV1)
@@ -56,3 +62,13 @@ _csv = AcqOrderCSVSerializer(
 )
 
 csv_acor_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_prefix="export-orders")
+excel_xml_acor_search = search_responsify_file(
+    _csv,
+    "application/vnd.ms-excel",
+    file_extension="xls",
+    file_prefix="export-orders",
+    content_converter=excel_xml_converter(
+        "rero_ils/exports/acquisition_orders.xml",
+        worksheet_name="Acquisition orders",
+    ),
+)

--- a/rero_ils/modules/items/serializers/__init__.py
+++ b/rero_ils/modules/items/serializers/__init__.py
@@ -11,6 +11,7 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import excel_xml_converter
 
 from .csv import ItemCSVSerializer
 from .json import ItemsJSONSerializer
@@ -94,6 +95,16 @@ _csv = ItemCSVSerializer(
 """CSV serializer."""
 csv_item_response = record_responsify(_csv, "text/csv")
 csv_item_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_suffix="inventory")
+excel_xml_item_search = search_responsify_file(
+    _csv,
+    "application/vnd.ms-excel",
+    file_extension="xls",
+    file_suffix="inventory",
+    content_converter=excel_xml_converter(
+        "rero_ils/exports/inventory.xml",
+        worksheet_name="Inventory",
+    ),
+)
 
 """JSON serializer."""
 _json = ItemsJSONSerializer(RecordSchemaJSONV1)

--- a/rero_ils/modules/items/views/rest.py
+++ b/rero_ils/modules/items/views/rest.py
@@ -10,7 +10,7 @@ from invenio_rest import ContentNegotiatedMethodView
 
 from rero_ils.modules.decorators import check_logged_as_librarian
 from rero_ils.modules.items.api import ItemsSearch
-from rero_ils.modules.items.serializers import csv_item_search
+from rero_ils.modules.items.serializers import csv_item_search, excel_xml_item_search
 from rero_ils.query import items_search_factory
 
 
@@ -24,11 +24,13 @@ class InventoryListResource(ContentNegotiatedMethodView):
         super().__init__(
             method_serializers={
                 "GET": {
+                    "application/vnd.ms-excel": excel_xml_item_search,
                     "text/csv": csv_item_search,
                 }
             },
             serializers_query_aliases={
                 "csv": "text/csv",
+                "xml": "application/vnd.ms-excel",
             },
             default_method_media_type={"GET": "text/csv"},
             default_media_type="text/csv",

--- a/rero_ils/modules/loans/serializers/__init__.py
+++ b/rero_ils/modules/loans/serializers/__init__.py
@@ -9,11 +9,12 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import excel_xml_converter
 
 from .csv import LoanStreamedCSVSerializer
 from .json import LoanJSONSerializer
 
-__all__ = ["csv_stream_search", "json_loan_search"]
+__all__ = ["csv_stream_search", "excel_xml_loan_search", "json_loan_search"]
 
 
 _json = LoanJSONSerializer(RecordSchemaJSONV1)
@@ -39,3 +40,13 @@ _streamed_csv = LoanStreamedCSVSerializer(
 
 json_loan_search = search_responsify(_json, "application/rero+json")
 csv_stream_search = search_responsify_file(_streamed_csv, "text/csv", file_extension="csv", file_prefix="export-loans")
+excel_xml_loan_search = search_responsify_file(
+    _streamed_csv,
+    "application/vnd.ms-excel",
+    file_extension="xls",
+    file_prefix="export-loans",
+    content_converter=excel_xml_converter(
+        "rero_ils/exports/loans.xml",
+        worksheet_name="Loans",
+    ),
+)

--- a/rero_ils/modules/patron_transaction_events/serializers/__init__.py
+++ b/rero_ils/modules/patron_transaction_events/serializers/__init__.py
@@ -8,11 +8,12 @@ from rero_ils.modules.serializers import (
     search_responsify,
     search_responsify_file,
 )
+from rero_ils.modules.serializers.utils import excel_xml_converter
 
 from .csv import PatronTransactionEventCSVSerializer
 from .json import PatronTransactionEventsJSONSerializer
 
-__all__ = ["csv_ptre_search", "json_ptre_search"]
+__all__ = ["csv_ptre_search", "excel_xml_ptre_search", "json_ptre_search"]
 
 
 """JSON serializer."""
@@ -41,3 +42,13 @@ _csv = PatronTransactionEventCSVSerializer(
 )
 
 csv_ptre_search = search_responsify_file(_csv, "text/csv", file_extension="csv", file_prefix="export-fees")
+excel_xml_ptre_search = search_responsify_file(
+    _csv,
+    "application/vnd.ms-excel",
+    file_extension="xls",
+    file_prefix="export-fees",
+    content_converter=excel_xml_converter(
+        "rero_ils/exports/fees.xml",
+        worksheet_name="Fees",
+    ),
+)

--- a/rero_ils/modules/serializers/response.py
+++ b/rero_ils/modules/serializers/response.py
@@ -65,12 +65,21 @@ def search_responsify(serializer, mimetype):
     return view
 
 
-def search_responsify_file(serializer, mimetype, file_extension, file_prefix=None, file_suffix=None):
+def search_responsify_file(
+    serializer,
+    mimetype,
+    file_extension,
+    file_prefix=None,
+    file_suffix=None,
+    content_converter=None,
+):
     """Create a Records-REST search result response serializer.
 
     :param serializer: Serializer instance.
     :param mimetype: MIME type of response.
     :param file_extension: File extension.
+    :param content_converter: Optional function used to convert the serialized
+        content before creating the response.
     :returns: Function that generates a record HTTP response.
     """
 
@@ -82,15 +91,16 @@ def search_responsify_file(serializer, mimetype, file_extension, file_prefix=Non
         links=None,
         item_links_factory=None,
     ):
-        response = current_app.response_class(
-            serializer.serialize_search(
-                pid_fetcher,
-                search_result,
-                links=links,
-                item_links_factory=item_links_factory,
-            ),
-            mimetype=mimetype,
+        content = serializer.serialize_search(
+            pid_fetcher,
+            search_result,
+            links=links,
+            item_links_factory=item_links_factory,
         )
+        if content_converter:
+            content = content_converter(content)
+
+        response = current_app.response_class(content, mimetype=mimetype)
         response.status_code = code
         if headers is not None:
             response.headers.extend(headers)

--- a/rero_ils/modules/serializers/utils.py
+++ b/rero_ils/modules/serializers/utils.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Serializer utilities."""
+
+import csv
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from functools import partial
+
+from babel.numbers import get_decimal_symbol, get_group_symbol
+from flask import current_app, stream_with_context
+from invenio_i18n.ext import current_i18n
+
+
+def _excel_number(value, decimal_separator, thousands_separator):
+    """Return a SpreadsheetML-compatible number or ``None``."""
+    number = str(value).strip()
+    number = number.replace("\u202f", "").replace("\xa0", "").replace(" ", "")
+    number = number.replace("\u2019", "").replace("'", "")
+    if "," in number:
+        if "." in number:
+            if number.rfind(",") > number.rfind("."):
+                number = number.replace(".", "").replace(",", ".")
+            else:
+                number = number.replace(",", "")
+        elif decimal_separator == ",":
+            number = number.replace(",", ".")
+        elif thousands_separator == ",":
+            number = number.replace(",", "")
+    try:
+        Decimal(number)
+    except InvalidOperation:
+        return None
+    return number
+
+
+def _excel_datetime(value):
+    """Return a SpreadsheetML-compatible date or ``None``."""
+    value = str(value).strip()
+    try:
+        parsed = date.fromisoformat(value) if "T" not in value else datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if isinstance(parsed, datetime):
+        return parsed.replace(tzinfo=None).isoformat(timespec="milliseconds")
+    return f"{parsed.isoformat()}T00:00:00.000"
+
+
+def csv_to_excel_xml(
+    csv_rows,
+    template_name,
+    worksheet_name="Export",
+):
+    """Stream serialized CSV rows through an Excel XML template."""
+    rows = iter(csv.reader(csv_rows))
+    header = next(rows, [])
+    template = current_app.jinja_env.get_template(template_name)
+    locale = current_i18n.locale
+    return stream_with_context(
+        template.generate(
+            header=header,
+            data_generator=rows,
+            worksheet_name=worksheet_name,
+            excel_datetime=_excel_datetime,
+            excel_number=partial(
+                _excel_number,
+                decimal_separator=get_decimal_symbol(locale),
+                thousands_separator=get_group_symbol(locale),
+            ),
+        )
+    )
+
+
+def excel_xml_converter(template_name, worksheet_name="Export"):
+    """Create a CSV-to-Excel-XML converter for a template."""
+    return partial(
+        csv_to_excel_xml,
+        template_name=template_name,
+        worksheet_name=worksheet_name,
+    )

--- a/rero_ils/modules/stats/serializers.py
+++ b/rero_ils/modules/stats/serializers.py
@@ -9,6 +9,8 @@ from flask import current_app
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 from invenio_records_rest.serializers.response import add_link_header
 
+from rero_ils.modules.serializers.utils import excel_xml_converter
+
 from .models import StatType
 
 
@@ -118,21 +120,30 @@ csv_v1 = StatCSVSerializer()
 """CSV serializer."""
 
 
-def record_responsify(serializer, mimetype):
+def record_responsify(
+    serializer,
+    mimetype,
+    file_extension,
+    content_converter=None,
+):
     """Create a Records-REST response serializer.
 
     This function is the same as the `invenio-records-rest`, but it adds an
     header to change the download file name.
     :param serializer: Serializer instance.
     :param mimetype: MIME type of response.
+    :param file_extension: File extension.
+    :param content_converter: Optional function used to convert the serialized
+        content before creating the response.
     :returns: Function that generates a record HTTP response.
     """
 
     def view(pid, record, code=200, headers=None, links_factory=None):
-        response = current_app.response_class(
-            serializer.serialize(pid, record, links_factory=links_factory),
-            mimetype=mimetype,
-        )
+        content = serializer.serialize(pid, record, links_factory=links_factory)
+        if content_converter:
+            content = content_converter(content)
+
+        response = current_app.response_class(content, mimetype=mimetype)
         response.status_code = code
         response.cache_control.no_cache = True
         response.set_etag(str(record.revision_id))
@@ -142,7 +153,7 @@ def record_responsify(serializer, mimetype):
 
         # set the output filename
         date = record.created.isoformat()
-        filename = f"stats-{date}.csv"
+        filename = f"stats-{date}.{file_extension}"
         if not response.headers.get("Content-Disposition"):
             response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
 
@@ -154,4 +165,13 @@ def record_responsify(serializer, mimetype):
     return view
 
 
-csv_v1_response = record_responsify(csv_v1, "text/csv")
+csv_v1_response = record_responsify(csv_v1, "text/csv", file_extension="csv")
+excel_xml_v1_response = record_responsify(
+    csv_v1,
+    "application/vnd.ms-excel",
+    file_extension="xls",
+    content_converter=excel_xml_converter(
+        "rero_ils/exports/statistics.xml",
+        worksheet_name="Statistics",
+    ),
+)

--- a/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
+++ b/rero_ils/modules/stats/templates/rero_ils/detailed_view_stats.html
@@ -9,7 +9,8 @@
     {% set values = record['values']|sort_dict_by_library %}
     <div class="ml-5 mr-5 mt-2 mb-4">
       {%- if record.pid %}
-        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=xml" role="button" aria-label="{{_('Export to Excel')}}"><i class="fa-regular fa-file-excel"></i></a>
+        <a class="btn btn-primary float-right mr-1" href="/api/stats/{{record.pid}}?format=csv" role="button" aria-label="{{_('Export to CSV')}}"><i class="fa-solid fa-file-csv"></i></a>
       {%- endif %}
       {%- if 'date_range' in record and 'from' in record.date_range %}
         {% set stat_name = record.date_range.to|yearmonthfilter+
@@ -56,7 +57,8 @@
   {%- else %}
     <div class="ml-5 mr-5 mt-2 mb-4">
       {%- if record.pid %}
-        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+        <a class="btn btn-primary float-right" href="/api/stats/{{record.pid}}?format=xml" role="button" aria-label="{{_('Export to Excel')}}"><i class="fa-regular fa-file-excel"></i></a>
+        <a class="btn btn-primary float-right mr-1" href="/api/stats/{{record.pid}}?format=csv" role="button" aria-label="{{_('Export to CSV')}}"><i class="fa-solid fa-file-csv"></i></a>
       {%- endif %}
       {%- if 'date_range' in record and 'from' in record.date_range %}
         {% set stat_name = record.date_range.to|yearmonthfilter+

--- a/rero_ils/modules/stats/templates/rero_ils/stats_list.html
+++ b/rero_ils/modules/stats/templates/rero_ils/stats_list.html
@@ -30,7 +30,10 @@
           {{rec._source._created | format_date}}
         {% endif %}
       </a>
-      <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+      <div class="btn-group">
+        <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=csv" role="button" aria-label="{{_('Export to CSV')}}"><i class="fa-solid fa-file-csv"></i></a>
+        <a class="btn btn-outline-secondary" href="/api/stats/{{rec._source.pid}}?format=xml" role="button" aria-label="{{_('Export to Excel')}}"><i class="fa-regular fa-file-excel"></i></a>
+      </div>
     </span>
     {%- endfor %}
   </div>
@@ -57,14 +60,18 @@
     <tr>
       <td class="col-xs-12">
         <a href="{{url_for('invenio_records_ui.stats', pid_value=rec._source.pid)}}">{{_('View statistics')}}</a>
-        <a class="btn btn-outline-secondary float-right" href="/api/stats/{{rec._source.pid}}?format=csv" role="button"><i class="fa-solid fa-download"></i></a>
+        <a class="btn btn-outline-secondary float-right" href="/api/stats/{{rec._source.pid}}?format=xml" role="button" aria-label="{{_('Export to Excel')}}"><i class="fa-regular fa-file-excel"></i></a>
+        <a class="btn btn-outline-secondary float-right mr-1" href="/api/stats/{{rec._source.pid}}?format=csv" role="button" aria-label="{{_('Export to CSV')}}"><i class="fa-solid fa-file-csv"></i></a>
       </td>
     </tr>
     <tr>
       <td>{{_('Loans of the transaction library by item location')}}
         <a class="btn btn-outline-secondary float-right"
         href="{{url_for('stats.stats_librarian_queries', record_pid=rec._source.pid, query_id='loans_of_transaction_library_by_item_location')}}"
-        role="button"><i class="fa-solid fa-download"></i></a>
+        role="button" aria-label="{{_('Export to CSV')}}"><i class="fa-solid fa-file-csv"></i></a>
+        <a class="btn btn-outline-secondary float-right mr-1"
+        href="{{url_for('stats.stats_librarian_queries_xml', record_pid=rec._source.pid, query_id='loans_of_transaction_library_by_item_location')}}"
+        role="button" aria-label="{{_('Export to Excel')}}"><i class="fa-regular fa-file-excel"></i></a>
       </td>
     </tr>
     {%- endfor %}

--- a/rero_ils/modules/stats/views.py
+++ b/rero_ils/modules/stats/views.py
@@ -11,7 +11,9 @@ from io import StringIO
 import arrow
 import jinja2
 from elasticsearch_dsl import Q
-from flask import Blueprint, abort, make_response, render_template, request
+from flask import Blueprint, abort, current_app, make_response, render_template, request
+
+from rero_ils.modules.serializers.utils import excel_xml_converter
 
 from .api.api import Stat, StatsSearch
 from .api.pricing import StatsForPricing
@@ -80,13 +82,12 @@ def stats_librarian():
     return render_template("rero_ils/stats_list.html", records=hits["hits"]["hits"], type="librarian")
 
 
-@blueprint.route("/librarian/<record_pid>/csv")
-@check_logged_as_librarian
-def stats_librarian_queries(record_pid):
-    """Download specific statistic query into csv file.
+def _stats_librarian_queries(record_pid, file_format):
+    """Download a specific librarian statistics query.
 
     :param record_pid: statistics pid
-    :return: response object, the csv file
+    :param file_format: Export file format
+    :return: response object
     """
     queries = ["loans_of_transaction_library_by_item_location"]
     query_id = request.args.get("query_id", None)
@@ -102,7 +103,8 @@ def stats_librarian_queries(record_pid):
 
     _from = record["date_range"]["from"].split("T")[0]
     _to = record["date_range"]["to"].split("T")[0]
-    filename = f"{query_id}_{_from}_{_to}.csv"
+    file_extension = "xls" if file_format == "xml" else file_format
+    filename = f"{query_id}_{_from}_{_to}.{file_extension}"
 
     data = StringIO()
     w = csv.writer(data)
@@ -136,10 +138,36 @@ def stats_librarian_queries(record_pid):
                         )
                     )
 
-    output = make_response(data.getvalue())
+    if file_format == "xml":
+        data.seek(0)
+        content = excel_xml_converter(
+            "rero_ils/exports/librarian_query.xml",
+            worksheet_name="Librarian query",
+        )(data)
+        output = current_app.response_class(
+            content,
+            mimetype="application/vnd.ms-excel",
+        )
+    else:
+        output = make_response(data.getvalue())
+        output.headers["Content-type"] = "text/csv"
+
     output.headers["Content-Disposition"] = f"attachment; filename={filename}"
-    output.headers["Content-type"] = "text/csv"
     return output
+
+
+@blueprint.route("/librarian/<record_pid>/csv")
+@check_logged_as_librarian
+def stats_librarian_queries(record_pid):
+    """Download a specific librarian statistics query as CSV."""
+    return _stats_librarian_queries(record_pid, "csv")
+
+
+@blueprint.route("/librarian/<record_pid>/xml")
+@check_logged_as_librarian
+def stats_librarian_queries_xml(record_pid):
+    """Download a specific librarian statistics query as Excel XML."""
+    return _stats_librarian_queries(record_pid, "xml")
 
 
 # JINJA FILTERS ===============================================================

--- a/rero_ils/theme/templates/rero_ils/exports/_spreadsheet.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/_spreadsheet.xml
@@ -1,0 +1,75 @@
+{% set number_columns = number_columns|default([]) %}
+{% set pid_columns = pid_columns|default([]) %}
+{% set date_columns = date_columns|default([]) %}
+{% set boolean_columns = boolean_columns|default([]) %}
+{% set string_columns = string_columns|default([]) %}
+{% set infer_numbers = infer_numbers|default(false) %}
+{% set state = namespace(row_count=1) %}
+<Workbook
+  xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+  xmlns:o="urn:schemas-microsoft-com:office:office"
+  xmlns:x="urn:schemas-microsoft-com:office:excel"
+  xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+>
+  <Styles>
+    <Style ss:ID="Header">
+      <Font ss:Bold="1"/>
+    </Style>
+    <Style ss:ID="Date">
+      <NumberFormat ss:Format="yyyy-mm-dd"/>
+    </Style>
+  </Styles>
+  <Worksheet ss:Name="{{ worksheet_name }}">
+    <Table>
+      {% for column in header %}
+      <Column ss:AutoFitWidth="0" ss:Width="{{ column|length * 6 + 12 }}"/>
+      {% endfor %}
+      {% if header %}
+      <Row ss:StyleID="Header">
+        {% for column in header %}
+        <Cell><Data ss:Type="String">{{ column }}</Data></Cell>
+        {% endfor %}
+      </Row>
+      {% endif %}
+      {% for row in data_generator %}
+      {% set state.row_count = state.row_count + 1 %}
+      <Row>
+        {% for column in header %}
+        {% set value = row[loop.index0] %}
+        {% set column_name = column|lower %}
+        {% set number = excel_number(value) %}
+        {% set datetime = excel_datetime(value) if column_name in date_columns else none %}
+        {% set inferred_number = infer_numbers and loop.index0 > 0 and column_name not in string_columns %}
+        {% if not value %}
+        <Cell/>
+        {% elif number and (
+          column_name in number_columns
+          or column_name in pid_columns
+          or inferred_number
+        ) %}
+        <Cell><Data ss:Type="Number">{{ number }}</Data></Cell>
+        {% elif datetime %}
+        <Cell ss:StyleID="Date"><Data ss:Type="DateTime">{{ datetime }}</Data></Cell>
+        {% elif column_name in boolean_columns %}
+        <Cell><Data ss:Type="Boolean">{{ "1" if value|lower in ["true", "1"] else "0" }}</Data></Cell>
+        {% else %}
+        <Cell><Data ss:Type="String">{{ value }}</Data></Cell>
+        {% endif %}
+        {% endfor %}
+      </Row>
+      {% endfor %}
+    </Table>
+    <WorksheetOptions xmlns="urn:schemas-microsoft-com:office:excel">
+      <FreezePanes/>
+      <FrozenNoSplit/>
+      <SplitHorizontal>1</SplitHorizontal>
+      <TopRowBottomPane>1</TopRowBottomPane>
+    </WorksheetOptions>
+    {% if header %}
+    <AutoFilter
+      x:Range="R1C1:R{{ state.row_count }}C{{ header|length }}"
+      xmlns="urn:schemas-microsoft-com:office:excel"
+    />
+    {% endif %}
+  </Worksheet>
+</Workbook>

--- a/rero_ils/theme/templates/rero_ils/exports/acquisition_accounts.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/acquisition_accounts.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set number_columns = [
+  "account_allocated_amount",
+  "account_available_amount",
+  "account_current_encumbrance",
+  "account_current_expenditure",
+  "account_available_balance",
+] %}
+{% set pid_columns = ["account_pid"] %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/rero_ils/theme/templates/rero_ils/exports/acquisition_orders.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/acquisition_orders.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set number_columns = [
+  "ordered_quantity",
+  "ordered_unit_price",
+  "ordered_amount",
+  "received_quantity",
+  "received_amount",
+] %}
+{% set pid_columns = [
+  "order_pid",
+  "document_pid",
+] %}
+{% set date_columns = [
+  "order_date",
+  "receipt_date",
+] %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/rero_ils/theme/templates/rero_ils/exports/fees.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/fees.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set number_columns = ["amount"] %}
+{% set pid_columns = ["document_pid"] %}
+{% set date_columns = ["transaction_date"] %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/rero_ils/theme/templates/rero_ils/exports/inventory.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/inventory.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set number_columns = [
+  "item_legacy_checkout_count",
+  "item_price",
+  "issue_claims_count",
+  "item_checkouts_count",
+  "item_renewals_count",
+  "current_pending_requests",
+] %}
+{% set pid_columns = [
+  "document_pid",
+  "item_pid",
+  "item_holding_pid",
+] %}
+{% set date_columns = [
+  "item_acquisition_date",
+  "item_create_date",
+  "temporary_item_type_expiry_date",
+  "issue_status_date",
+  "issue_expected_date",
+  "last_transaction_date",
+  "last_checkout_date",
+] %}
+{% set boolean_columns = ["issue_regular"] %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/rero_ils/theme/templates/rero_ils/exports/librarian_query.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/librarian_query.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set number_columns = ["checkins", "checkouts"] %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/rero_ils/theme/templates/rero_ils/exports/loans.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/loans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set pid_columns = ["pid"] %}
+{% set date_columns = [
+  "checkout_date",
+  "end_date",
+  "request_expire_date",
+] %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/rero_ils/theme/templates/rero_ils/exports/statistics.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/statistics.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+{% set number_columns = [
+  "files_volume",
+  "checkouts_for_transaction_library",
+  "checkouts_for_owning_library",
+  "renewals",
+  "validated_requests",
+  "new_items",
+  "new_documents",
+  "number_of_active_patrons",
+  "number_of_checkins",
+  "number_of_checkouts",
+  "number_of_deleted_items",
+  "number_of_docs_with_files",
+  "number_of_documents",
+  "number_of_files",
+  "number_of_ill_requests",
+  "number_of_items",
+  "number_of_librarians",
+  "number_of_libraries",
+  "number_of_new_items",
+  "number_of_new_patrons",
+  "number_of_order_lines",
+  "number_of_patrons",
+  "number_of_renewals",
+  "number_of_requests",
+] %}
+{% set string_columns = ["library id", "library name"] %}
+{% set infer_numbers = true %}
+{% include "rero_ils/exports/_spreadsheet.xml" %}

--- a/tests/api/acq_accounts/test_acq_accounts_serializers.py
+++ b/tests/api/acq_accounts/test_acq_accounts_serializers.py
@@ -7,7 +7,7 @@
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
-from tests.utils import get_csv
+from tests.utils import get_csv, parse_csv, parse_excel_xml
 
 
 def test_csv_serializer(
@@ -36,3 +36,14 @@ def test_csv_serializer(
         '"account_current_encumbrance","account_current_expenditure",'
         '"account_available_balance"' in data
     )
+
+    xml_url = url_for(
+        "api_exports.acq_account_export",
+        q=f"pid:{acq_account_fiction_martigny.pid}",
+        format="xml",
+    )
+    xml_response = client.get(xml_url)
+    assert xml_response.status_code == 200
+    assert xml_response.mimetype == "application/vnd.ms-excel"
+    assert xml_response.headers["Content-Disposition"].endswith('.xls"')
+    assert parse_excel_xml(xml_response.get_data()) == list(parse_csv(data))

--- a/tests/api/acq_orders/test_acq_orders_serializers.py
+++ b/tests/api/acq_orders/test_acq_orders_serializers.py
@@ -11,7 +11,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 from rero_ils.modules.documents.api import DocumentsSearch
-from tests.utils import get_csv
+from tests.utils import get_csv, parse_csv, parse_excel_xml
 
 
 def test_csv_serializer(
@@ -46,6 +46,17 @@ def test_csv_serializer(
         '"receipt_reference","received_quantity","received_amount",'
         '"receipt_date"' in data
     )
+
+    xml_url = url_for(
+        "api_exports.acq_order_export",
+        q=f"pid:{acq_order_fiction_martigny.pid}",
+        format="xml",
+    )
+    xml_response = client.get(xml_url)
+    assert xml_response.status_code == 200
+    assert xml_response.mimetype == "application/vnd.ms-excel"
+    assert xml_response.headers["Content-Disposition"].endswith('.xls"')
+    assert parse_excel_xml(xml_response.get_data(), csv_compatible=True) == list(parse_csv(data))
 
 
 def test_csv_serializer_missing_document(

--- a/tests/api/items/test_items_serializer.py
+++ b/tests/api/items/test_items_serializer.py
@@ -6,7 +6,7 @@
 from flask import url_for
 
 from rero_ils.modules.utils import get_ref_for_pid
-from tests.utils import get_csv, login_user
+from tests.utils import get_csv, login_user, parse_csv, parse_excel_xml
 
 
 def test_serializers(
@@ -134,6 +134,16 @@ def test_serializers(
     ]
     for field in fields:
         assert field in data
+
+    csv_rows = list(parse_csv(data))
+    list_url = url_for("api_item.inventory_search", format="xml")
+    response = client.get(list_url, buffered=False)
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/vnd.ms-excel"
+    assert response.is_streamed
+    assert response.headers["Content-Disposition"].endswith('-inventory.xls"')
+    assert parse_excel_xml(response.get_data(), csv_compatible=True) == csv_rows
 
     # test provisionActivity without type bf:Publication
     document["provisionActivity"][0]["type"] = "bf:Manufacture"

--- a/tests/api/stats/test_stats_rest.py
+++ b/tests/api/stats/test_stats_rest.py
@@ -8,7 +8,14 @@ from unittest import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
-from tests.utils import VerifyRecordPermissionPatch, get_csv, get_json, to_relative_url
+from tests.utils import (
+    VerifyRecordPermissionPatch,
+    get_csv,
+    get_json,
+    parse_csv,
+    parse_excel_xml,
+    to_relative_url,
+)
 
 
 @mock.patch(
@@ -48,6 +55,14 @@ def test_stats_get(client, stats, csv_header):
         "0,0,0,0,0,1,0,1,1,0,2,1,1,0,1,0,0\r\n"
         "0.000,lib4,Library of Sion,0,0,0,0,0,1,0,0,1,0,1,1,0,0,0,0,0\r\n"
     )
+
+    params = {"pid_value": stats.pid, "format": "xml"}
+    item_url = url_for("invenio_records_rest.stat_item", **params)
+    res = client.get(item_url)
+    assert res.status_code == 200
+    assert res.mimetype == "application/vnd.ms-excel"
+    assert res.headers["Content-Disposition"].endswith('.xls"')
+    assert parse_excel_xml(res.get_data()) == list(parse_csv(data))
 
     list_url = url_for("invenio_records_rest.stat_list")
     res = client.get(list_url)
@@ -116,8 +131,17 @@ def test_stats_report_get(client, stats_report_martigny, csv_header):
     item_url = url_for("invenio_records_rest.stat_item", **params)
     res = client.get(item_url, headers=csv_header)
     assert res.status_code == 200
-    data = get_csv(res)
-    assert data
+    csv_data = get_csv(res)
+    assert csv_data
+
+    params = {"pid_value": stats_report_martigny.pid, "format": "xml"}
+    item_url = url_for("invenio_records_rest.stat_item", **params)
+    res = client.get(item_url)
+    assert res.status_code == 200
+    assert res.mimetype == "application/vnd.ms-excel"
+    assert res.headers["Content-Disposition"].endswith('.xls"')
+    assert parse_excel_xml(res.get_data()) == list(parse_csv(csv_data))
+
     list_url = url_for("invenio_records_rest.stat_list")
     res = client.get(list_url)
     assert res.status_code == 200

--- a/tests/api/test_exports.py
+++ b/tests/api/test_exports.py
@@ -9,7 +9,7 @@ from invenio_accounts.testutils import login_user_via_session
 from invenio_db import db
 
 from rero_ils.modules.utils import get_ref_for_pid
-from tests.utils import get_csv, parse_csv
+from tests.utils import get_csv, parse_csv, parse_excel_xml
 
 
 def test_loans_exports(app, client, librarian_martigny, loan_pending_martigny, loan2_validated_martigny):
@@ -25,7 +25,8 @@ def test_loans_exports(app, client, librarian_martigny, loan_pending_martigny, l
     login_user_via_session(client, librarian_martigny.user)
     res = client.get(url)
     assert res.status_code == 200
-    data = list(parse_csv(get_csv(res)))
+    csv_rows = list(parse_csv(get_csv(res)))
+    data = list(csv_rows)
 
     header = data.pop(0)
     header_columns = [
@@ -46,6 +47,12 @@ def test_loans_exports(app, client, librarian_martigny, loan_pending_martigny, l
     ]
     assert all(field in header for field in header_columns)
     assert len(data) == 2
+
+    res = client.get(url_for("api_exports.loan_export", format="xml"))
+    assert res.status_code == 200
+    assert res.mimetype == "application/vnd.ms-excel"
+    assert res.headers["Content-Disposition"].endswith('.xls"')
+    assert parse_excel_xml(res.get_data(), csv_compatible=True) == csv_rows
 
 
 def test_patron_transaction_events_exports(
@@ -91,7 +98,8 @@ def test_patron_transaction_events_exports(
 
     res = client.get(url)
     assert res.status_code == 200
-    data = list(parse_csv(get_csv(res)))
+    csv_rows = list(parse_csv(get_csv(res)))
+    data = list(csv_rows)
 
     header = data.pop(0)
     header_columns = [
@@ -113,3 +121,15 @@ def test_patron_transaction_events_exports(
     ]
     assert all(field in header for field in header_columns)
     assert len(data) == 1
+
+    res = client.get(url_for("api_exports.patron_transaction_events_export", format="xml"))
+    assert res.status_code == 200
+    assert res.mimetype == "application/vnd.ms-excel"
+    assert res.headers["Content-Disposition"].endswith('.xls"')
+    xml_rows = parse_excel_xml(res.get_data())
+    assert xml_rows[0] == csv_rows[0]
+    assert len(xml_rows) == len(csv_rows)
+    transaction_date_index = header.index("transaction_date")
+    assert [value for index, value in enumerate(xml_rows[1]) if index != transaction_date_index] == [
+        value for index, value in enumerate(csv_rows[1]) if index != transaction_date_index
+    ]

--- a/tests/ui/stats/test_stats_views.py
+++ b/tests/ui/stats/test_stats_views.py
@@ -9,6 +9,8 @@ from unittest import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
+from tests.utils import parse_csv, parse_excel_xml
+
 
 def test_view_status(client, patron_martigny, librarian_martigny, system_librarian_martigny):
     """Test view status."""
@@ -55,3 +57,52 @@ def test_view_status(client, patron_martigny, librarian_martigny, system_librari
     with mock.patch("rero_ils.modules.stats.permissions.admin_permission", mock.MagicMock()):
         result = client.get(url_for("stats.stats_billing"))
         assert result.status_code == 200
+
+
+def test_stats_librarian_query_exports(client, system_librarian_martigny):
+    """Test CSV and Excel XML exports for a librarian query."""
+    login_user_via_session(client, system_librarian_martigny.user)
+    query = "loans_of_transaction_library_by_item_location"
+    record = mock.MagicMock()
+    record.dumps.return_value = {
+        "date_range": {
+            "from": "2026-01-01T00:00:00",
+            "to": "2026-01-31T23:59:59",
+        },
+        "values": [
+            {
+                "library": {"pid": "lib1", "name": "Library"},
+                query: {
+                    "lib1 - Main location": {
+                        "location_name": "Main location",
+                        "checkin": 2,
+                        "checkout": 3,
+                    }
+                },
+            }
+        ],
+    }
+
+    with mock.patch(
+        "rero_ils.modules.stats.views.Stat.get_record_by_pid",
+        return_value=record,
+    ):
+        csv_url = url_for(
+            "stats.stats_librarian_queries",
+            record_pid="1",
+            query_id=query,
+        )
+        csv_response = client.get(csv_url)
+        assert csv_response.status_code == 200
+        assert "/csv?" in csv_url
+
+        xml_url = url_for(
+            "stats.stats_librarian_queries_xml",
+            record_pid="1",
+            query_id=query,
+        )
+        xml_response = client.get(xml_url)
+        assert xml_response.status_code == 200
+        assert xml_response.mimetype == "application/vnd.ms-excel"
+        assert xml_response.headers["Content-Disposition"].endswith(".xls")
+        assert parse_excel_xml(xml_response.get_data()) == list(parse_csv(csv_response.get_data(as_text=True)))

--- a/tests/unit/test_serializer_utils.py
+++ b/tests/unit/test_serializer_utils.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests serializer utilities."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from xml.etree import ElementTree
+
+import pytest
+from babel import Locale
+from flask import Flask
+from jinja2 import FileSystemLoader
+
+import rero_ils
+from rero_ils.modules.serializers.utils import excel_xml_converter
+from tests.utils import parse_excel_xml
+
+
+def _create_app(locale="en"):
+    """Create a minimal application with an active export locale."""
+    app = Flask(__name__)
+    template_path = Path(rero_ils.__file__).parent / "theme" / "templates"
+    app.jinja_loader = FileSystemLoader(template_path)
+    app.extensions["invenio-i18n"] = SimpleNamespace(locale=Locale.parse(locale))
+    return app
+
+
+@pytest.mark.parametrize(
+    ("template_name", "csv_data", "expected_types", "locale"),
+    [
+        (
+            "loans.xml",
+            '"pid","checkout_date","item_barcode"\r\n"12","2026-07-29","000123"\r\n',
+            ["Number", "DateTime", "String"],
+            "en",
+        ),
+        (
+            "fees.xml",
+            (
+                '"amount","transaction_date","document_pid"\r\n'
+                '"1\u202f234,50","2026-07-29T14:30:45.123456+02:00","42"\r\n'
+            ),
+            ["Number", "DateTime", "Number"],
+            "fr_CH",
+        ),
+        (
+            "acquisition_accounts.xml",
+            ('"account_pid","account_allocated_amount","account_number"\r\n"12","1500.50","000123"\r\n'),
+            ["Number", "Number", "String"],
+            "en",
+        ),
+        (
+            "acquisition_orders.xml",
+            ('"order_pid","order_date","ordered_quantity","account_number"\r\n"12","2026-07-29","3","000123"\r\n'),
+            ["Number", "DateTime", "Number", "String"],
+            "en",
+        ),
+        (
+            "statistics.xml",
+            '"label","dynamic total","library id"\r\n"Total","12","lib1"\r\n',
+            ["String", "Number", "String"],
+            "en",
+        ),
+        (
+            "librarian_query.xml",
+            '"Transaction library","Checkins","Checkouts"\r\n"Library","2","3"\r\n',
+            ["String", "Number", "Number"],
+            "en",
+        ),
+    ],
+)
+def test_excel_xml_template_column_types(template_name, csv_data, expected_types, locale):
+    """Test the column types configured by each export template."""
+    app = _create_app(locale)
+    converter = excel_xml_converter(
+        f"rero_ils/exports/{template_name}",
+        worksheet_name="Test",
+    )
+
+    with app.test_request_context():
+        xml = "".join(converter(iter(csv_data.splitlines(keepends=True))))
+
+    namespace = "{urn:schemas-microsoft-com:office:spreadsheet}"
+    workbook = ElementTree.fromstring(xml)
+    data_cells = workbook.findall(f".//{namespace}Row")[1].findall(f"{namespace}Cell")
+    assert [cell.find(f"{namespace}Data").get(f"{namespace}Type") for cell in data_cells] == expected_types
+
+
+def test_excel_xml_converter_streams_csv_rows():
+    """Test that Excel XML conversion does not consume all CSV rows upfront."""
+    app = _create_app()
+    consumed = []
+
+    def csv_rows():
+        consumed.append("header")
+        yield (
+            '"document_pid","item_pid","item_holding_pid","item_price","item_acquisition_date",'
+            '"issue_regular","item_barcode","document_publication_year",'
+            '"document_title"\r\n'
+        )
+        consumed.append("data")
+        yield '"123","456","789","23.2","2026-07-29","True","000123","2020 - 2022","R&D <test>"\r\n'
+        consumed.append("non-numeric-pids")
+        yield '"doc1","item1","holding1","","","","","",""\r\n'
+
+    converter = excel_xml_converter(
+        "rero_ils/exports/inventory.xml",
+        worksheet_name="Test",
+    )
+
+    with app.test_request_context():
+        content = converter(csv_rows())
+        assert consumed == ["header"]
+        xml = "".join(content)
+
+    assert consumed == ["header", "data", "non-numeric-pids"]
+    namespace = "{urn:schemas-microsoft-com:office:spreadsheet}"
+    excel_namespace = "{urn:schemas-microsoft-com:office:excel}"
+    workbook = ElementTree.fromstring(xml)
+    parsed_rows = parse_excel_xml(xml)
+    columns = workbook.findall(f".//{namespace}Worksheet/{namespace}Table/{namespace}Column")
+    assert len(columns) == 9
+    assert all(column.get(f"{namespace}AutoFitWidth") == "0" for column in columns)
+    assert [int(column.get(f"{namespace}Width")) for column in columns] == [
+        len(header) * 6 + 12 for header in parsed_rows[0]
+    ]
+    data_cells = workbook.findall(f".//{namespace}Row")[1].findall(f"{namespace}Cell")
+    assert [cell.find(f"{namespace}Data").get(f"{namespace}Type") for cell in data_cells] == [
+        "Number",
+        "Number",
+        "Number",
+        "Number",
+        "DateTime",
+        "Boolean",
+        "String",
+        "String",
+        "String",
+    ]
+    fallback_cells = workbook.findall(f".//{namespace}Row")[2].findall(f"{namespace}Cell")
+    assert [cell.find(f"{namespace}Data").get(f"{namespace}Type") for cell in fallback_cells[:3]] == [
+        "String",
+        "String",
+        "String",
+    ]
+    worksheet_options = workbook.find(f".//{excel_namespace}WorksheetOptions")
+    assert worksheet_options.find(f"{excel_namespace}FreezePanes") is not None
+    assert worksheet_options.findtext(f"{excel_namespace}SplitHorizontal") == "1"
+    assert worksheet_options.findtext(f"{excel_namespace}TopRowBottomPane") == "1"
+    auto_filter = workbook.find(f".//{excel_namespace}AutoFilter")
+    assert auto_filter.get(f"{excel_namespace}Range") == "R1C1:R3C9"
+    assert parsed_rows == [
+        [
+            "document_pid",
+            "item_pid",
+            "item_holding_pid",
+            "item_price",
+            "item_acquisition_date",
+            "issue_regular",
+            "item_barcode",
+            "document_publication_year",
+            "document_title",
+        ],
+        [
+            "123",
+            "456",
+            "789",
+            "23.2",
+            "2026-07-29T00:00:00.000",
+            "1",
+            "000123",
+            "2020 - 2022",
+            "R&D <test>",
+        ],
+        ["doc1", "item1", "holding1", "", "", "", "", "", ""],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("locale", "value", "expected_type", "expected_value"),
+    [
+        ("en", "1,234", "Number", "1234"),
+        ("fr_CH", "1\u202f234,50", "Number", "1234.50"),
+        ("de", "1.234,50", "Number", "1234.50"),
+        ("de_CH", "1\u2019234.50", "Number", "1234.50"),
+        ("en", "invalid", "String", "invalid"),
+    ],
+)
+def test_excel_xml_number_uses_export_locale(locale, value, expected_type, expected_value):
+    """Test that localized numbers use the active export locale."""
+    app = _create_app(locale)
+    converter = excel_xml_converter(
+        "rero_ils/exports/fees.xml",
+        worksheet_name="Test",
+    )
+
+    with app.test_request_context():
+        csv_data = f'"amount"\r\n"{value}"\r\n'
+        xml = "".join(converter(iter(csv_data.splitlines(keepends=True))))
+
+    namespace = "{urn:schemas-microsoft-com:office:spreadsheet}"
+    workbook = ElementTree.fromstring(xml)
+    data = workbook.findall(f".//{namespace}Row")[1].find(f"{namespace}Cell/{namespace}Data")
+    assert data.get(f"{namespace}Type") == expected_type
+    assert data.text == expected_value

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ import json
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, Mock
+from xml.etree import ElementTree
 
 import jsonref
 import xmltodict
@@ -90,6 +91,32 @@ def parse_csv(raw_data):
     """Parse CSV raw data into a iterable raw file."""
     content = StringIO(raw_data)
     return csv.reader(content)
+
+
+def parse_excel_xml(raw_data, csv_compatible=False):
+    """Parse rows from an Excel XML workbook.
+
+    :param csv_compatible: Convert typed dates and booleans back to the text
+        produced by the CSV serializer.
+    """
+    namespace_uri = "urn:schemas-microsoft-com:office:spreadsheet"
+    namespace = {"ss": namespace_uri}
+    workbook = ElementTree.fromstring(raw_data)
+    rows = []
+    for row in workbook.findall(".//ss:Worksheet/ss:Table/ss:Row", namespace):
+        values = []
+        for cell in row.findall("ss:Cell", namespace):
+            data = cell.find("ss:Data", namespace)
+            value = (data.text or "") if data is not None else ""
+            if csv_compatible and data is not None:
+                data_type = data.get(f"{{{namespace_uri}}}Type")
+                if data_type == "DateTime":
+                    value = value.partition("T")[0]
+                elif data_type == "Boolean":
+                    value = "True" if value == "1" else "False"
+            values.append(value)
+        rows.append(values)
+    return rows
 
 
 def postdata(client, endpoint, data=None, headers=None, url_data=None, force_data_as_json=True):


### PR DESCRIPTION
* Adds streamed SpreadsheetML XML exports wherever CSV is available.
* Uses the `.xls` extension so downloaded files open with Excel.
* Reuses existing CSV serializers to preserve identical content.
* Adds shared and export-specific SpreadsheetML templates.
* Adds new Excel export routes.
* Adds typed cells, filters, frozen headers, and column widths.
* Adds Excel download buttons to the statistics pages.
* Adds CSV and Excel XML equivalence tests.
* Closes https://github.com/rero/rero-ils/issues/4168.