### PR TITLE
ci: add a license header check

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Developer resources
 
 This directory contains resources about RERO ILS: loan state chart, item state chart,

--- a/doc/circulation/README.md
+++ b/doc/circulation/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Circulation
 
 ## Circulation state diagram

--- a/doc/circulation/actions.md
+++ b/doc/circulation/actions.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Circulation Actions
 
 ## Add a request

--- a/doc/circulation/scenarios.md
+++ b/doc/circulation/scenarios.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Circulation Scenarios
 
 ## Template

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 RUN bin/elasticsearch-plugin install analysis-icu

--- a/rero_ils/modules/cli/utils.py
+++ b/rero_ils/modules/cli/utils.py
@@ -8,6 +8,7 @@ import contextlib
 import itertools
 import json
 import os
+import subprocess
 import sys
 import traceback
 from collections import OrderedDict
@@ -186,6 +187,84 @@ def check_json(paths, replace, indent, sort_keys, verbose):
         tot_error_cnt += error_cnt
 
     sys.exit(tot_error_cnt)
+
+
+SPDX_TAGS = ("SPDX-FileCopyrightText:", "SPDX-License-Identifier: AGPL-3.0-or-later")
+SPDX_EXTENSIONS = (
+    ".cfg",
+    ".conf",
+    ".css",
+    ".html",
+    ".ini",
+    ".js",
+    ".md",
+    ".py",
+    ".scss",
+    ".sh",
+    ".toml",
+    ".yml",
+)
+# `.github` templates and generated or fixture content have no license header
+SPDX_EXCLUDED_PATHS = (".github/", "CHANGELOG.md", "data/wiki/", "tests/data/help/")
+
+
+def needs_spdx_header(file_name):
+    """Check if a file is expected to have a SPDX license header.
+
+    Files are selected by extension. Files without extension are selected when
+    they are Dockerfiles or scripts starting with a shebang.
+
+    :param file_name: the path of the file to check.
+    :returns: True if the file requires a SPDX license header.
+    """
+    if any(excluded in file_name for excluded in SPDX_EXCLUDED_PATHS):
+        return False
+    base_name = os.path.basename(file_name)
+    if base_name.startswith("Dockerfile"):
+        return True
+    if extension := os.path.splitext(base_name)[1]:
+        return extension in SPDX_EXTENSIONS
+    with open(file_name, "rb") as opened_file:
+        return opened_file.read(2) == b"#!"
+
+
+def has_spdx_header(file_name):
+    """Check if a file starts with the SPDX license header.
+
+    The comment syntax is not checked, only the presence of both SPDX tags in
+    the first lines of the file.
+
+    :param file_name: the path of the file to check.
+    :returns: True if the copyright and the license tags are both present.
+    """
+    with open(file_name) as opened_file:
+        header = "".join(itertools.islice(opened_file, 5))
+    return all(tag in header for tag in SPDX_TAGS)
+
+
+@utils.command("check_license")
+@click.option("-v", "--verbose", "verbose", is_flag=True, default=False)
+def check_license(verbose):
+    """Check SPDX license headers of the files tracked by git."""
+    click.secho("Testing SPDX license headers.", fg="green")
+    try:
+        tracked_files = subprocess.check_output(["git", "ls-files", "-z"], text=True).split("\0")
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise click.ClickException("git is required and must run in a git repository.") from error
+    error_cnt = 0
+    for file_name in tracked_files:
+        if not os.path.isfile(file_name) or not needs_spdx_header(file_name):
+            continue
+        if has_spdx_header(file_name):
+            if verbose:
+                click.echo(f"{file_name}: ", nl=False)
+                click.secho("License header found", fg="green")
+        else:
+            click.echo(f"{file_name}: ", nl=False)
+            click.secho("Missing license header", fg="red")
+            error_cnt += 1
+
+    sys.exit(1 if error_cnt else 0)
 
 
 @utils.command("schedules")

--- a/scripts/all_year_days
+++ b/scripts/all_year_days
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 #
 # Launch a command every day of current year
 #

--- a/scripts/setup_e2e
+++ b/scripts/setup_e2e
@@ -1,20 +1,6 @@
 #!/usr/bin/env bash
-# -*- coding: utf-8 -*-
-#
-# RERO ILS
-# Copyright (C) 2026 RERO
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, version 3 of the License.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Minimal fixture setup for E2E tests.
 #

--- a/scripts/test
+++ b/scripts/test
@@ -77,7 +77,9 @@ function pretests () {
 
   info_msg "Check json:"
   invenio reroils utils check_json tests/data rero_ils/modules data
-info_msg "Test formatting:"
+  info_msg "Check license headers:"
+  invenio reroils utils check_license
+  info_msg "Test formatting:"
   ruff format --check rero_ils tests
   info_msg "Test linting:"
   ruff check rero_ils tests

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # E2E Tests
 
 Playwright-based end-to-end tests for RERO ILS. Tests run against a live server

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -14,6 +14,8 @@ from rero_ils.modules.cli.documents import (
 from rero_ils.modules.cli.utils import (
     check_validate,
     extract_from_xml,
+    has_spdx_header,
+    needs_spdx_header,
     token_create,
 )
 
@@ -107,3 +109,35 @@ def test_cli_create_documents_items_lofi(app, loc_public_martigny, item_type_sta
         "    ok    : 2",
         "    errors: 2",
     ]
+
+
+def test_cli_needs_spdx_header(tmp_path):
+    """Test the selection of the files requiring a license header."""
+    (script := tmp_path / "server").write_text("#!/usr/bin/env bash\necho\n")
+    (plain := tmp_path / "LICENSE").write_text("GNU AFFERO GENERAL PUBLIC LICENSE\n")
+
+    assert needs_spdx_header("rero_ils/modules/cli/utils.py")
+    assert needs_spdx_header("docker/nginx/Dockerfile")
+    assert needs_spdx_header(str(script))
+    assert not needs_spdx_header(str(plain))
+    assert not needs_spdx_header("tests/data/documents.json")
+    assert not needs_spdx_header("rero_ils/modules/notifications/templates/email/at_desk/eng.txt")
+    assert not needs_spdx_header(".github/workflows/release.yml")
+
+
+def test_cli_has_spdx_header(tmp_path):
+    """Test the detection of the license header."""
+    copyright_tag = "SPDX-FileCopyrightText: Fondation RERO+"
+    license_tag = "SPDX-License-Identifier: AGPL-3.0-or-later"
+
+    def write(name, content):
+        (file_path := tmp_path / name).write_text(content)
+        return str(file_path)
+
+    assert has_spdx_header(write("api.py", f"# {copyright_tag}\n# {license_tag}\n"))
+    assert has_spdx_header(write("page.html", f"{{# {copyright_tag} #}}\n{{# {license_tag} #}}\n"))
+    assert has_spdx_header(write("README.md", f"<!--\n{copyright_tag}\n{license_tag}\n-->\n"))
+    # missing tag, wrong license and header pushed out of the first lines
+    assert not has_spdx_header(write("no_license.py", f"# {copyright_tag}\n"))
+    assert not has_spdx_header(write("wrong_license.py", f"# {copyright_tag}\n# SPDX-License-Identifier: MIT\n"))
+    assert not has_spdx_header(write("too_late.py", f"{'\n' * 5}# {copyright_tag}\n# {license_tag}\n"))


### PR DESCRIPTION
2 commits:

- d90e1e9f5d3093c69f57c7eb00527fbccaf28eb2: Add missing license headers
- 4b1215e208036b8060a95f1c30e985f9f0e1c57e: Add license check