### PR TITLE
feat(stats): add publication year distribution

### DIFF
--- a/rero_ils/modules/stats/api/indicators/others.py
+++ b/rero_ils/modules/stats/api/indicators/others.py
@@ -55,6 +55,12 @@ class NumberOfDocumentsCfg(IndicatorCfg):
                 calendar_interval="year",
                 format="yyyy",
             ),
+            "publication_year": A(
+                "terms",
+                field="sort_date_old",
+                order={"_key": "asc"},
+                size=self.cfg.aggs_size,
+            ),
             "imported": A(
                 "filters",
                 other_bucket_key="not imported",
@@ -75,6 +81,7 @@ class NumberOfDocumentsCfg(IndicatorCfg):
             "owning_library": lambda: f"{self.cfg.libraries.get(bucket.key, self.label_na_msg)} ({bucket.key})",
             "created_month": lambda: bucket.key_as_string,
             "created_year": lambda: bucket.key_as_string,
+            "publication_year": lambda: str(bucket.key),
             "imported": lambda: bucket,
         }
         return cfg[distribution]()

--- a/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
+++ b/rero_ils/modules/stats_cfg/jsonschemas/stats_cfg/stat_cfg-v0.0.1.json
@@ -210,6 +210,7 @@
                             "enum": [
                               "created_month",
                               "created_year",
+                              "publication_year",
                               "owning_library",
                               "imported"
                             ]
@@ -227,6 +228,10 @@
                                   {
                                     "value": "created_year",
                                     "label": "created_year"
+                                  },
+                                  {
+                                    "value": "publication_year",
+                                    "label": "publication_year"
                                   },
                                   {
                                     "value": "owning_library",

--- a/tests/ui/stats/test_stats_report_n_docs.py
+++ b/tests/ui/stats/test_stats_report_n_docs.py
@@ -16,6 +16,7 @@ def test_stats_report_number_of_documents(org_martigny, org_sion, lib_martigny, 
         id="1",
         body={
             "_created": "2023-02-01",
+            "sort_date_old": 2023,
             "adminMetadata": {"source": "foo"},
             "holdings": [
                 {
@@ -32,6 +33,7 @@ def test_stats_report_number_of_documents(org_martigny, org_sion, lib_martigny, 
         id="2",
         body={
             "_created": "2024-01-01",
+            "sort_date_old": 2024,
             "holdings": [
                 {
                     "organisation": {
@@ -53,6 +55,7 @@ def test_stats_report_number_of_documents(org_martigny, org_sion, lib_martigny, 
         id="3",
         body={
             "_created": "2024-01-01",
+            "sort_date_old": 2024,
             "holdings": [
                 {
                     "organisation": {
@@ -158,6 +161,59 @@ def test_stats_report_number_of_documents(org_martigny, org_sion, lib_martigny, 
         ["2024", 1, 0],
     ]
 
+    # publication year
+    es.index(
+        index="documents",
+        id="publication-year",
+        body={
+            "_created": "2024-01-01",
+            "sort_date_old": 2024,
+            "holdings": [
+                {
+                    "organisation": {
+                        "organisation_pid": org_martigny.pid,
+                        "library_pid": lib_martigny_bourg.pid,
+                    }
+                }
+            ],
+        },
+    )
+    es.indices.refresh(index="documents")
+    cfg = {
+        "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
+        "is_active": True,
+        "category": {
+            "indicator": {
+                "type": "number_of_documents",
+                "distributions": ["publication_year"],
+            }
+        },
+    }
+    assert StatsReport(cfg).collect() == [["2023", 1], ["2024", 2]]
+
+    # publication year and owning library
+    cfg = {
+        "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
+        "is_active": True,
+        "category": {
+            "indicator": {
+                "type": "number_of_documents",
+                "distributions": ["publication_year", "owning_library"],
+            }
+        },
+    }
+    assert StatsReport(cfg).collect() == [
+        [
+            "",
+            f"{lib_martigny_bourg.get('name')} ({lib_martigny_bourg.pid})",
+            f"{lib_martigny.get('name')} ({lib_martigny.pid})",
+        ],
+        ["2023", 0, 1],
+        ["2024", 2, 0],
+    ]
+    es.delete(index="documents", id="publication-year")
+    es.indices.refresh(index="documents")
+
     # imported
     cfg = {
         "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
@@ -195,3 +251,32 @@ def test_stats_report_number_of_documents(org_martigny, org_sion, lib_martigny, 
         ["imported", 0, 1],
         ["not imported", 1, 0],
     ]
+
+    # documents without a publication year are ignored
+    es.index(
+        index="documents",
+        id="4",
+        body={
+            "_created": "2024-01-01",
+            "holdings": [
+                {
+                    "organisation": {
+                        "organisation_pid": org_martigny.pid,
+                        "library_pid": lib_martigny.pid,
+                    }
+                }
+            ],
+        },
+    )
+    es.indices.refresh(index="documents")
+    cfg = {
+        "library": {"$ref": "https://bib.rero.ch/api/libraries/lib1"},
+        "is_active": True,
+        "category": {
+            "indicator": {
+                "type": "number_of_documents",
+                "distributions": ["publication_year"],
+            }
+        },
+    }
+    assert StatsReport(cfg).collect() == [["2023", 1], ["2024", 1]]

--- a/tests/unit/test_stats_cfg_jsonschema.py
+++ b/tests/unit/test_stats_cfg_jsonschema.py
@@ -31,7 +31,7 @@ def test_valid_circulation_n_docs(stats_cfg_schema):
         "category": {"type": "catalog", "indicator": {"type": "number_of_documents"}},
         "is_active": True,
     }
-    for dist in ["created_month", "created_year", "imported", "owning_library"]:
+    for dist in ["created_month", "created_year", "imported", "owning_library", "publication_year"]:
         data["category"]["indicator"]["distributions"] = [dist]
         validate(data, stats_cfg_schema)
 


### PR DESCRIPTION
* Adds publication year as a distribution for document stats.
* Uses the existing `sort_date_old` field for the aggregation.
* Closes #4107