### PR TITLE
docs: keep only non-derivable rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 rero-ils is the Python/Flask backend of the RERO ILS Integrated Library System (ILS). Some frontend elements are defined in this project as HTML/Jinja templates, the rest is a separate Angular project (rero-ils-ui) based on (ng-core).
 
-**Stack**: Python 3.14, Flask (Invenio), PostgreSQL, Elasticsearch 7, Celery, RabbitMQ, Redis
-**Package manager**: `uv` with `poethepoet` for task running
-
 ## Commands
 
 During development, all commands are run through uv's virtual env with `uv run`.
@@ -31,47 +28,16 @@ Human developers will run the required containers, the app setup and the servers
 
 ## Architecture
 
-### Module Structure
-
-All business logic lives in `rero_ils/modules/`. Each module follows a consistent pattern:
-
-```text
-rero_ils/modules/<module_name>/
-├── api.py            # Record class + Search class (core business logic)
-├── models.py         # SQLAlchemy model + Identifier + Metadata
-├── views.py          # Flask blueprint (UI routes)
-├── api_views.py      # Flask blueprint (REST API routes)
-├── tasks.py          # Celery async tasks
-├── listener.py       # Signal handlers (enrich data before indexing)
-├── permissions.py    # Access control rules
-├── jsonschemas/      # JSON Schema for validation
-├── mappings/v7/      # Elasticsearch index mappings
-├── serializers/      # REST response serializers
-├── dumpers.py        # Data dumpers for ES indexing
-└── jsonresolver.py   # JSON $ref resolver
-```
-
-### Base Classes
-
-- **`IlsRecord`** (`rero_ils/modules/api.py`): extends `invenio_records.api.Record`. All domain records (Document, Item, Patron, Loan, etc.) inherit from this. Provides PID management, extended validation, and bulk indexing.
-- **`IlsRecordsSearch`** (`rero_ils/modules/api.py`): extends `invenio_search.api.RecordsSearch`. Each module defines its own search class with a specific ES index.
-
 ### Signal/Event Flow
 
 The `ext.py` file wires up all signal listeners. Before a record is indexed in Elasticsearch, `listener.py` in each module can enrich the data (e.g., adding computed fields, resolving references). This is the primary mechanism for denormalizing data into ES.
-
-### API Entry Points
-
-REST endpoints are registered in `pyproject.toml` under `[project.entry-points."invenio_base.api_blueprints"]`. Each module's `api_views.py` exports an `api_blueprint`.
-
-### Permissions
-
-Each module has a `permissions.py` using `invenio-records-permissions`. Access is typically scoped by organisation membership (multi-tenancy).
 
 ## Code Style
 
 - Be clear and concise in the docstrings and do not over-comment the code.
 - Do not use Python type annotations (no `-> str`, `: str`, etc. in signatures).
+- Ruff is configured in `pyproject.toml`: `line-length = 120` under `[tool.ruff]`, the enabled rule sets under `[tool.ruff.lint]`, and the pep257 docstring convention under `[tool.ruff.lint.pydocstyle]`.
+- Since Python 3.14 (PEP 758), parentheses around multiple exception types are optional when the `except`/`except*` clause has no `as` target: `except AttributeError, UnboundLocalError:` is valid and equivalent to `except (AttributeError, UnboundLocalError):` — not the old Python 2 comma syntax. `ruff format` removes the parentheses in that case; this is expected, not a bug. Parentheses are still required when binding the exception: `except (AttributeError, UnboundLocalError) as error:`.
 
 ### Commit Messages
 
@@ -80,6 +46,7 @@ Commit messages follow [Conventional Commits](https://www.conventionalcommits.or
 Format: `<type>(<scope>): <subject>`
 
 Rules:
+
 - The subject line must not exceed 50 characters.
 - Body lines must not exceed 72 characters.
 - Use `*` for bullet points in the body, not `-`.
@@ -99,12 +66,7 @@ Translations are only added manually before a release. During standard developme
 ## Testing Notes
 
 - Tests use function-based style (no class-based tests).
-- Tests are split into `tests/api/`, `tests/unit/`, `tests/ui/`, `tests/e2e/`, `tests/scheduler/`
 - The project follows a test-driven development methodology. Each commit must be accompanied by tests that ensure that the functionality works as intended. Tests must follow DRY principles and should only test specific app behaviour and not the behaviour of external modules (e.g. invenio dependencies).
-- Test fixtures (shared data) are in `tests/fixtures/` and `tests/conftest.py`
-- Sample data is in `tests/data/` and `data/`
-- End-to-end tests (Cypress) are skipped by default because unmaintained
-- Tests marked `@pytest.mark.external` hit external services and are excluded by default
 
 ### Running the tests (done by humans)
 


### PR DESCRIPTION
CLAUDE.md loads into context at the start of every session, so anything a session can reconstruct by reading the code costs tokens without adding signal (see https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models)

* Drop the module tree, base classes, entry points, stack and test layout: `ls` and `pyproject.toml` show them all
* Drop two stale claims: e2e is Playwright, not Cypress, and acquisition blueprints live in `views.py`
* Add the ruff config pointer and the PEP 758 exception syntax, which looks like a bug but is expected