### PR TITLE
fix(documents): invalidate permissions cache

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -12,6 +12,7 @@ from dateutil.relativedelta import relativedelta
 from elasticsearch_dsl import Q
 from flask import current_app
 from flask_babel import gettext as _
+from invenio_db import db
 from invenio_records_rest.utils import obj_or_import_string
 from jinja2 import Environment
 
@@ -36,6 +37,7 @@ from rero_ils.modules.locations.api import Location
 from rero_ils.modules.minters import id_minter
 from rero_ils.modules.operation_logs.extensions import OperationLogObserverExtension
 from rero_ils.modules.organisations.api import Organisation
+from rero_ils.modules.permissions_cache import register_record_permissions_cache_deletion
 from rero_ils.modules.providers import Provider
 from rero_ils.modules.record_extensions import OrgLibRecordExtension
 from rero_ils.modules.utils import (
@@ -181,7 +183,12 @@ class Holding(IlsRecord):
                 # Delete all attached items
                 for item in self.get_all_items():
                     item.delete(force=force, dbcommit=dbcommit, delindex=False)
-            return super().delete(force=force, dbcommit=dbcommit, delindex=delindex)
+            # Defer the commit until cache invalidation is registered.
+            record = super().delete(force=force, dbcommit=False, delindex=delindex)
+            register_record_permissions_cache_deletion("documents", self.document_pid)
+            if dbcommit:
+                db.session.commit()
+            return record
         raise IlsRecordError.NotDeleted()
 
     @property

--- a/rero_ils/modules/permissions_cache.py
+++ b/rero_ils/modules/permissions_cache.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Helpers for record permissions cache."""
+
+from flask import request
+from invenio_cache import current_cache
+from invenio_db import db
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+_AFTER_COMMIT_DELETIONS = "record_permissions_cache_after_commit_deletions"
+
+
+def record_permissions_cache_key(route_name=None, record_pid=None):
+    """Build the cache key for record permissions."""
+    if route_name is None:
+        route_name = request.view_args["route_name"]
+        record_pid = request.view_args.get("record_pid")
+    cache_key = f"/permissions/{route_name}"
+    return f"{cache_key}/{record_pid}" if record_pid else cache_key
+
+
+def delete_record_permissions_cache(route_name, record_pid=None):
+    """Delete a record permissions cache entry."""
+    return current_cache.delete(record_permissions_cache_key(route_name, record_pid))
+
+
+def register_record_permissions_cache_deletion(route_name, record_pid=None):
+    """Register a record permissions cache deletion after commit."""
+    deletions = db.session.info.setdefault(_AFTER_COMMIT_DELETIONS, set())
+    deletions.add((route_name, record_pid))
+
+
+@event.listens_for(Session, "after_commit")
+def _delete_record_permissions_cache_after_commit(session):
+    """Delete registered cache entries after the outer transaction commits."""
+    if session.in_nested_transaction():
+        return
+    deletions = session.info.pop(_AFTER_COMMIT_DELETIONS, set())
+    for route_name, record_pid in deletions:
+        delete_record_permissions_cache(route_name, record_pid)
+
+
+@event.listens_for(Session, "after_rollback")
+def _discard_record_permissions_cache_deletions_after_rollback(session):
+    """Discard registered cache deletions after the outer transaction rolls back."""
+    if not session.in_nested_transaction():
+        session.info.pop(_AFTER_COMMIT_DELETIONS, None)

--- a/rero_ils/modules/views.py
+++ b/rero_ils/modules/views.py
@@ -26,6 +26,7 @@ from .permissions import (
     record_permissions,
 )
 from .permissions import permission_management as permission_management_action
+from .permissions_cache import record_permissions_cache_key
 
 api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="")
 
@@ -35,7 +36,7 @@ api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="")
 
 @api_blueprint.route("/permissions/<route_name>", methods=["GET"])
 @api_blueprint.route("/permissions/<route_name>/<record_pid>", methods=["GET"])
-@cached(timeout=10, query_string=True)  # 10 seconds timeout
+@cached(timeout=10, key_prefix=record_permissions_cache_key)  # 10 seconds timeout
 @check_authentication
 def permissions(route_name, record_pid=None):
     """HTTP GET request for record permissions.

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -5,7 +5,11 @@
 
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
+from invenio_cache import current_cache
+from invenio_db import db
 
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
+from rero_ils.modules.permissions_cache import record_permissions_cache_key
 from tests.utils import get_json, login_user
 
 
@@ -51,6 +55,37 @@ def test_document_permissions(
     assert data.get("delete", {}).get("can") is False
     reasons = data.get("delete", {}).get("reasons", {})
     assert "others" in reasons and "permission" in reasons["others"]
+
+
+def test_document_permissions_cache_is_invalidated_by_holding_deletion(
+    client,
+    document,
+    holding_lib_martigny_data_tmp,
+    librarian_martigny,
+    loc_public_martigny,
+    item_type_standard_martigny,
+):
+    """Test document permissions cache invalidation on holding deletion."""
+    holding_data = holding_lib_martigny_data_tmp
+    holding_data["pid"] = "holding-permissions-cache"
+    holding = Holding.create(data=holding_data, delete_pid=False, dbcommit=True, reindex=True)
+    HoldingsSearch.flush_and_refresh()
+
+    login_user_via_session(client, librarian_martigny.user)
+    permissions = call_api_permissions(client, "documents", document.pid)
+    assert not permissions["delete"]["can"]
+    assert permissions["delete"]["reasons"]["links"]["holdings"] == 1
+    cache_key = record_permissions_cache_key("documents", document.pid)
+    current_cache.set(cache_key, permissions, timeout=10)
+
+    holding.delete(dbcommit=False, delindex=True)
+    assert current_cache.get(cache_key) == permissions
+
+    db.session.commit()
+    assert current_cache.get(cache_key) is None
+    HoldingsSearch.flush_and_refresh()
+
+    assert call_api_permissions(client, "documents", document.pid)["delete"]["can"]
 
 
 def test_patrons_permissions(

--- a/tests/unit/test_permissions_cache.py
+++ b/tests/unit/test_permissions_cache.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Record permissions cache tests."""
+
+from unittest.mock import patch
+
+from invenio_db import db
+from sqlalchemy import text
+
+from rero_ils.modules.permissions_cache import (
+    delete_record_permissions_cache,
+    record_permissions_cache_key,
+    register_record_permissions_cache_deletion,
+)
+
+
+def test_record_permissions_cache_key():
+    """Test record permissions cache key creation."""
+    assert record_permissions_cache_key("documents", "doc1") == "/permissions/documents/doc1"
+    assert record_permissions_cache_key("documents") == "/permissions/documents"
+
+
+@patch("rero_ils.modules.permissions_cache.current_cache.delete")
+def test_delete_record_permissions_cache(cache_delete, appctx):
+    """Test deleting a record permissions cache entry."""
+    delete_record_permissions_cache("documents", "doc1")
+
+    cache_delete.assert_called_once_with("/permissions/documents/doc1")
+
+
+@patch("rero_ils.modules.permissions_cache.delete_record_permissions_cache")
+def test_delete_record_permissions_cache_after_commit(cache_delete, appctx):
+    """Test deleting a record permissions cache entry after commit."""
+    db.session.execute(text("SELECT 1"))
+    register_record_permissions_cache_deletion("documents", "doc1")
+
+    with db.session.begin_nested():
+        pass
+    cache_delete.assert_not_called()
+
+    db.session.commit()
+    cache_delete.assert_called_once_with("documents", "doc1")
+
+
+@patch("rero_ils.modules.permissions_cache.delete_record_permissions_cache")
+def test_cancel_record_permissions_cache_deletion_after_rollback(cache_delete, appctx):
+    """Test cancelling a record permissions cache deletion after rollback."""
+    db.session.execute(text("SELECT 1"))
+    register_record_permissions_cache_deletion("documents", "doc1")
+
+    db.session.rollback()
+    db.session.commit()
+
+    cache_delete.assert_not_called()


### PR DESCRIPTION
* Invalidates cached document permissions after a holding is deleted.
* Ensures the document delete status reflects the current holdings without waiting for the 10sec cache to expire.
* Relates to: https://github.com/rero/rero-ils-ui/pull/1503
* Closes #2979