### PR TITLE
fix(header): keep mobile menu visible in header

### DIFF
--- a/rero_ils/theme/assets/scss/rero_ils/header.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/header.scss
@@ -6,6 +6,16 @@
   margin: 7px 0;
 }
 
+.rero-ils-header-search {
+  min-width: 0;
+}
+
+@include media-breakpoint-down(md) {
+  .rero-ils-header-actions:has(.rero-ils-header-search) {
+    min-width: 10rem;
+  }
+}
+
 header {
   position: relative;
 }

--- a/rero_ils/theme/templates/rero_ils/header.html
+++ b/rero_ils/theme/templates/rero_ils/header.html
@@ -6,7 +6,7 @@
   {%- block navbar %}
     <!-- SEARCH NAVBAR :: Brand / search / expand ========================= -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark rero-ils-header">
-      <div class="container d-flex align-self-center justify-content-between">
+      <div class="container d-flex flex-wrap align-self-center justify-content-between">
         {%- block navbar_brand %}
           {%- if config.THEME_LOGO %}
             <a href="/{% if viewcode != config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE %}{{ viewcode }}{% endif %}" class="navbar-brand pr-2" id="homepage-logo" aria-label="{{ _(config.THEME_SITENAME) }} — {{ _('Home') }}">
@@ -17,23 +17,25 @@
             <a href="/{% if viewcode != config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE %}{{ viewcode }}{% endif %}" class="navbar-brand">{{_(config.THEME_SITENAME)}}</a>
           {%- endif %}
         {%- endblock navbar_brand %}
-        {%- block navbar_search %}
-          <main-search-bar
-            class="flex-grow-1 rero-ils-ui"
-            inputstyleclass="ui:text-sm ui:py-1 ui:w-full"
-            styleclass="ui:w-full"
-            placeholder="{{ _('Search') }}"
-            viewcode="{{ viewcode or config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE }}"
-            language="{{ current_i18n.locale.language[:2] }}"
-          />
-        {%- endblock navbar_search %}
-        {%- block navbar_menus %}
-          <button class="navbar-toggler ml-2" type="button"
-                  data-toggle="collapse" data-target="#mobileHide"
-                  aria-controls="mobileHide" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="fa-solid fa-bars"></span>
-          </button>
-        {%- endblock navbar_menus %}
+        <div class="rero-ils-header-actions d-flex flex-grow-1 flex-nowrap align-items-center justify-content-end">
+          {%- block navbar_search %}
+            <main-search-bar
+              class="flex-grow-1 rero-ils-header-search rero-ils-ui"
+              inputstyleclass="ui:text-sm ui:py-1 ui:w-full"
+              styleclass="ui:w-full"
+              placeholder="{{ _('Search') }}"
+              viewcode="{{ viewcode or config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE }}"
+              language="{{ current_i18n.locale.language[:2] }}"
+            ></main-search-bar>
+          {%- endblock navbar_search %}
+          {%- block navbar_menus %}
+            <button class="navbar-toggler flex-shrink-0 ml-2" type="button"
+                    data-toggle="collapse" data-target="#mobileHide"
+                    aria-controls="mobileHide" aria-expanded="false" aria-label="{{ _('Toggle navigation') }}">
+              <span class="fa-solid fa-bars"></span>
+            </button>
+          {%- endblock navbar_menus %}
+        </div>
       </div>
     </nav>
     <!-- MAIN NAVBAR :: Main menus (visible only on large screens) ======== -->
@@ -124,4 +126,3 @@
   {%- from "rero_ils/macros/messages.html" import flashed_messages with context -%}
   {{ flashed_messages() }}
 {%- endblock flashmessages %}
-


### PR DESCRIPTION
* Corrects the search custom element markup so the hamburger remains outside the search component.
* Groups the search and menu items so they wrap together below wide logos instead of overlapping the logo.
* Closes #4193.