### PR TITLE
fix(permissions): repair wiki edition permission

### DIFF
--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -8,7 +8,6 @@ from functools import wraps
 from flask import abort, current_app, redirect, request, url_for
 from flask_login import current_user
 from flask_principal import RoleNeed
-from flask_security import login_required, roles_required
 from invenio_access.permissions import Permission
 
 from rero_ils.modules.users.models import UserRole
@@ -122,22 +121,19 @@ def check_user_is_authenticated(redirect_to=None, code=302):
 def wiki_edit_view_permission():
     """Wiki edition permission.
 
-    :return: true if the logged user has the editor role
+    :return: True if the logged user has the editor or the admin role, False if
+        it has neither, the unauthorized response if it isn't authenticated.
     """
-
-    @login_required
-    @roles_required("editor")
-    def foo():
-        return True
-
-    return foo()
+    if not current_user.is_authenticated:
+        return current_app.login_manager.unauthorized()
+    return editor_permission.can()
 
 
 def wiki_edit_ui_permission():
     """Wiki edition permision for the user interface.
 
     Mainly used to display buttons in the user interface.
-    :return: true if the logged user has the editor role
+    :return: True if the logged user has the editor or admin role
     """
     return editor_permission.can()
 

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -7,7 +7,7 @@ import pytest
 from flask import session, url_for
 from flask_login import login_user, logout_user
 from flask_security import url_for_security
-from invenio_accounts.testutils import login_user_via_view
+from invenio_accounts.testutils import login_user_via_session, login_user_via_view
 
 from rero_ils.modules.users.api import user_formatted_name
 from rero_ils.theme.views import localized_label, nl2br
@@ -119,6 +119,29 @@ def test_help(client):
     """Test help entrypoint."""
     result = client.get(url_for("wiki.index"))
     assert result.status_code == 302
+
+
+@pytest.mark.parametrize("role_name", ["editor", "admin"])
+def test_help_edit_permission(client, app, db, user_with_profile, role_name):
+    """Test the wiki edition permission."""
+    url = url_for("wiki.edit", url="home")
+
+    # an anonymous user is redirected to the login page
+    result = client.get(url)
+    assert result.status_code == 302
+    assert url_for_security("login") in result.location
+
+    # a logged user without any editor role is not allowed
+    login_user_via_session(client, user_with_profile)
+    assert client.get(url).status_code == 403
+
+    # the editor and admin roles both grant the wiki edition
+    datastore = app.extensions["invenio-accounts"].datastore
+    role = datastore.find_or_create_role(name=role_name)
+    datastore.add_role_to_user(user_with_profile, role)
+    datastore.commit()
+    db.session.commit()
+    assert client.get(url).status_code == 200
 
 
 # TODO: uncomment tests when rero-ils-ui is deployed on npm


### PR DESCRIPTION
The wiki edition views crashed with an AttributeError for any logged user: flask-security's `roles_required` reads `current_app.security`, an attribute flask-security-invenio never sets, as it registers its state in `app.extensions["security"]` only.

* Replace the nested `login_required`/`roles_required` decorators by an explicit authentication and role check.
* Grant the edition to the `admin` role as well, to match `wiki_edit_ui_permission`, which drives the edit buttons display.
* Add a test covering the anonymous, unauthorised and editor cases.