### PR TITLE
feat(patrons): send welcome email

### DIFF
--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -44,7 +44,7 @@ from rero_ils.modules.utils import (
     sorted_pids,
 )
 
-from .extensions import UserDataExtension
+from .extensions import PatronWelcomeEmailExtension, UserDataExtension
 from .models import CommunicationChannel, PatronIdentifier, PatronMetadata
 from .utils import get_patron_pid_by_email
 
@@ -90,7 +90,11 @@ class Patron(IlsRecord):
     model_cls = PatronMetadata
     schema = "patrons/patron-v0.0.1.json"
 
-    _extensions = [UserDataExtension(), OperationLogObserverExtension()]
+    _extensions = [
+        UserDataExtension(),
+        OperationLogObserverExtension(),
+        PatronWelcomeEmailExtension(),
+    ]
 
     def extended_validation(self, **kwargs):
         """Return reasons for validation failures, otherwise True.

--- a/rero_ils/modules/patrons/extensions.py
+++ b/rero_ils/modules/patrons/extensions.py
@@ -4,6 +4,9 @@
 
 """Patron record extensions."""
 
+from flask import current_app, render_template
+from flask_mail import Message
+from invenio_mail.tasks import send_email
 from invenio_records.extensions import RecordExtension
 
 from rero_ils.modules.users.api import User
@@ -23,3 +26,48 @@ class UserDataExtension(RecordExtension):
         user = User.get_record(record.get("user_id"))
         user_info = user.dumps_metadata()
         return data.update(user_info)
+
+
+class PatronWelcomeEmailExtension(RecordExtension):
+    """Send a welcome email when a patron is created."""
+
+    def post_create(self, record):
+        """Build and enqueue the patron welcome email."""
+        if not record.is_patron:
+            return
+
+        user = record.user
+        additional_email = record.patron.get("additional_communication_email")
+        recipients = list(dict.fromkeys(address for address in (user.email, additional_email) if address))
+        if not recipients:
+            return
+
+        organisation = record.organisation
+        profile = user.user_profile or {}
+        patron_name = " ".join(filter(None, (profile.get("first_name"), profile.get("last_name"))))
+        language = record.patron.get(
+            "communication_language",
+            current_app.config.get("RERO_ILS_DEFAULT_LANGUAGE", "eng"),
+        )
+        body = render_template(
+            f"rero_ils/patrons/email/welcome/{language}.txt",
+            patron={
+                "name": patron_name or record.formatted_name,
+                "additional_email": additional_email,
+            },
+            organisation={
+                "name": organisation.get("name"),
+                "address": organisation.get("address"),
+                "url": f"{current_app.config.get('RERO_ILS_URL', '').rstrip('/')}/{organisation.get('code')}/",
+            },
+        )
+        subject, _, body = body.partition("\n")
+        sender = current_app.config.get("DEFAULT_SENDER_EMAIL", "noreply@rero.ch")
+        message = Message(
+            subject=subject,
+            body=body,
+            sender=sender,
+            reply_to=sender,
+            recipients=recipients,
+        )
+        send_email.apply_async((message.__dict__,))

--- a/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/eng.txt
+++ b/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/eng.txt
@@ -1,0 +1,15 @@
+Registration: {{ organisation.name }}
+Dear {{ patron.name }},
+
+We are pleased to have you as one of our patrons!
+
+Here you can access our catalogue and your account: {{ organisation.url }}
+{%- if patron.additional_email %}
+
+A copy of all your notifications is sent to the following email: {{ patron.additional_email }}
+{%- endif %}
+
+Best regards,
+
+{{ organisation.name }}
+{{ organisation.address }}

--- a/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/fre.txt
+++ b/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/fre.txt
@@ -1,0 +1,15 @@
+Inscription: {{ organisation.name }}
+Chère/cher {{ patron.name }},
+
+Nous sommes ravi·e·s de pouvoir vous compter parmi nos lectrices et lecteurs !
+
+C'est ici que vous accédez à notre catalogue et à votre compte en ligne : {{ organisation.url }}
+{%- if patron.additional_email %}
+
+Une copie de toutes vos notifications est envoyée à l'adresse suivante : {{ patron.additional_email }}
+{%- endif %}
+
+Avec nos compliments,
+
+{{ organisation.name }}
+{{ organisation.address }}

--- a/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/ger.txt
+++ b/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/ger.txt
@@ -1,0 +1,15 @@
+Registrierung: {{ organisation.name }}
+Sehr geehrte(r) {{ patron.name }},
+
+Es freut uns, Sie zu unseren Leserinnen und Lesern zählen zu dürfen!
+
+Sie können auf unseren Katalog und Ihr Konto hier zugreifen: {{ organisation.url }}
+{%- if patron.additional_email %}
+
+Eine Kopie aller Ihrer Benachrichtigungen wird an die folgende E-Mail-Adresse gesendet: {{ patron.additional_email }}
+{%- endif %}
+
+Freundliche Grüsse,
+
+{{ organisation.name }}
+{{ organisation.address }}

--- a/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/ita.txt
+++ b/rero_ils/modules/patrons/templates/rero_ils/patrons/email/welcome/ita.txt
@@ -1,0 +1,15 @@
+Registrazione: {{ organisation.name }}
+Cara/caro {{ patron.name }},
+
+Siamo liete·i di avervi come nostra lettrice o nostro lettore!
+
+Qui si può accedere al catalogo e all'account online: {{ organisation.url }}
+{%- if patron.additional_email %}
+
+Una copia di tutte le vostre notifiche viene inviata alla seguente email: {{ patron.additional_email }}
+{%- endif %}
+
+Cordiali saluti,
+
+{{ organisation.name }}
+{{ organisation.address }}

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from unittest import mock
 
+import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_db import db
@@ -15,6 +16,7 @@ from invenio_oauth2server.models import Client, Token
 
 from rero_ils.modules.patron_transactions.api import PatronTransaction
 from rero_ils.modules.patrons.api import Patron
+from rero_ils.modules.patrons.extensions import PatronWelcomeEmailExtension
 from rero_ils.modules.patrons.models import CommunicationChannel
 from rero_ils.modules.patrons.utils import create_user_from_data
 from rero_ils.modules.utils import extracted_data_from_ref, get_ref_for_pid
@@ -257,8 +259,12 @@ def test_patrons_post_put_delete(
 
     assert res.status_code == 201
     assert Patron.count() == pids + 1
-    # assert len(mailbox) == 1
-    # assert re.search(r'localhost/lost-password', mailbox[0].body)
+    assert len(mailbox) == 1
+    assert mailbox[0].recipients == ["post_put_delete@test.ch"]
+    assert mailbox[0].subject == "Inscription: The district of Martigny Libraries"
+    assert "Chère/cher Louis Roduit" in mailbox[0].body
+    expected_url = f"{app.config['RERO_ILS_URL'].rstrip('/')}/org1/"
+    assert expected_url in mailbox[0].body
 
     # # Check that the returned record matches the given data
     # data = get_json(res)
@@ -277,6 +283,7 @@ def test_patrons_post_put_delete(
     data["patron"]["barcode"] = ["barcode_test"]
     res = client.put(item_url, data=json.dumps(data), headers=json_header)
     assert res.status_code == 200
+    assert len(mailbox) == 1
     # assert res.headers['ETag'] != f'"{ptrnrarie.revision_id}"'
 
     # Check that the returned record matches the given data
@@ -341,6 +348,94 @@ def test_patrons_post_without_email(
     data = get_json(res)
     data["metadata"]["patron"]["communication_channel"] = CommunicationChannel.MAIL
 
+    ds = app.extensions["invenio-accounts"].datastore
+    ds.delete_user(ds.find_user(id=patron_data["user_id"]))
+
+
+def test_welcome_email_skips_non_patron(librarian_martigny):
+    """Do not enqueue a welcome email for a professional-only account."""
+    with mock.patch("rero_ils.modules.patrons.extensions.send_email.apply_async") as enqueue:
+        PatronWelcomeEmailExtension().post_create(librarian_martigny)
+
+    enqueue.assert_not_called()
+
+
+def test_patrons_post_with_additional_email_only(
+    app,
+    client,
+    patron_type_children_martigny,
+    patron_martigny_data_tmp,
+    roles,
+    mailbox,
+    system_librarian_martigny,
+):
+    """Send the welcome email to the additional address when it is the only one."""
+    login_user_via_session(client, system_librarian_martigny.user)
+    patron_data = deepcopy(patron_martigny_data_tmp)
+    patron_data.pop("pid")
+    patron_data.pop("email")
+    patron_data["username"] = "welcome_additional_email"
+    patron_data["patron"]["barcode"] = ["welcome1534"]
+    patron_data["patron"]["communication_channel"] = CommunicationChannel.EMAIL
+    patron_data["patron"]["additional_communication_email"] = "welcome-additional@test.ch"
+    patron_data = create_user_from_data(patron_data)
+
+    res, data = postdata(client, "invenio_records_rest.ptrn_list", patron_data)
+
+    assert res.status_code == 201
+    assert len(mailbox) == 1
+    assert mailbox[0].recipients == ["welcome-additional@test.ch"]
+    assert "welcome-additional@test.ch" in mailbox[0].body
+
+    patron_pid = data["metadata"]["pid"]
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_pid)
+    assert client.delete(item_url).status_code == 204
+    ds = app.extensions["invenio-accounts"].datastore
+    ds.delete_user(ds.find_user(id=patron_data["user_id"]))
+
+
+@pytest.mark.parametrize(
+    ("additional_email", "expected_recipients"),
+    [
+        (
+            "welcome-secondary@test.ch",
+            ["welcome-primary@test.ch", "welcome-secondary@test.ch"],
+        ),
+        ("welcome-primary@test.ch", ["welcome-primary@test.ch"]),
+    ],
+    ids=["both-addresses", "duplicate-address"],
+)
+def test_patrons_post_with_primary_and_additional_email(
+    additional_email,
+    expected_recipients,
+    app,
+    client,
+    patron_type_children_martigny,
+    patron_martigny_data_tmp,
+    roles,
+    mailbox,
+    system_librarian_martigny,
+):
+    """Send to both patron addresses without duplicate recipients."""
+    login_user_via_session(client, system_librarian_martigny.user)
+    suffix = "duplicate" if len(expected_recipients) == 1 else "both"
+    patron_data = deepcopy(patron_martigny_data_tmp)
+    patron_data.pop("pid")
+    patron_data["email"] = "welcome-primary@test.ch"
+    patron_data["username"] = f"welcome_{suffix}_email"
+    patron_data["patron"]["barcode"] = [f"welcome1534-{suffix}"]
+    patron_data["patron"]["additional_communication_email"] = additional_email
+    patron_data = create_user_from_data(patron_data)
+
+    res, data = postdata(client, "invenio_records_rest.ptrn_list", patron_data)
+
+    assert res.status_code == 201
+    assert len(mailbox) == 1
+    assert mailbox[0].recipients == expected_recipients
+
+    patron_pid = data["metadata"]["pid"]
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=patron_pid)
+    assert client.delete(item_url).status_code == 204
     ds = app.extensions["invenio-accounts"].datastore
     ds.delete_user(ds.find_user(id=patron_data["user_id"]))
 


### PR DESCRIPTION
* Send a welcome email when a patron with an email is created.
* Support primary and additional email addresses.
* Provides localized templates (en, fr, de, it).
* Queue a Flask-Mail message asynchronously with Invenio mail.
* Closes https://github.com/rero/rero-ils/issues/1534