### PR TITLE
fix(holdings): harden serial issue inheritance

### DIFF
--- a/rero_ils/modules/holdings/listener.py
+++ b/rero_ils/modules/holdings/listener.py
@@ -3,9 +3,8 @@
 
 """Signals connector for Holding."""
 
-import contextlib
-
 from elasticsearch_dsl.query import Q
+from flask import current_app
 from invenio_db import db
 
 from rero_ils.modules.holdings.models import HoldingTypes
@@ -88,31 +87,39 @@ def update_items_locations_and_types(sender, record=None, **kwargs):
     # update these items so that they inherit the fields location,
     # item_type and call numbers from the parent holdings record.
     for id in items:
-        with contextlib.suppress(Exception):
-            item = Item.get_record(id)
-            if not item:
-                continue
-            items_to_index.append(id)
-            item_temp_loc_pid, item_temp_type_pid = None, None
-            # remove the item temporary_location if it is equal to the
-            # new item location.
-            if temporary_location := item.get("temporary_location"):
-                item_temp_loc_pid = extracted_data_from_ref(temporary_location.get("$ref"))
-            if hold_loc_pid != item.location_pid:
-                if item_temp_loc_pid == hold_loc_pid:
-                    item.pop("temporary_location", None)
-                item["location"] = {"$ref": get_ref_for_pid("locations", hold_loc_pid)}
+        try:
+            # a savepoint keeps a failing item from invalidating the whole
+            # transaction, so the other items can still be committed below.
+            with db.session.begin_nested():
+                item = Item.get_record(id)
+                if not item:
+                    continue
+                item_temp_loc_pid, item_temp_type_pid = None, None
+                # remove the item temporary_location if it is equal to the
+                # new item location.
+                if temporary_location := item.get("temporary_location"):
+                    item_temp_loc_pid = extracted_data_from_ref(temporary_location.get("$ref"))
+                if hold_loc_pid != item.location_pid:
+                    if item_temp_loc_pid == hold_loc_pid:
+                        item.pop("temporary_location", None)
+                    item["location"] = {"$ref": get_ref_for_pid("locations", hold_loc_pid)}
 
-            # remove the item temporary_item_type if it is equal to the
-            # new item item_type.
-            if temporary_type := item.get("temporary_item_type"):
-                item_temp_type_pid = extracted_data_from_ref(temporary_type.get("$ref"))
-            if hold_circ_pid != item.item_type_pid:
-                if item_temp_type_pid == hold_circ_pid:
-                    item.pop("temporary_item_type", None)
-                item["item_type"] = {"$ref": get_ref_for_pid("item_types", hold_circ_pid)}
-            # update directly in database.
-            db.session.query(item.model_cls).filter_by(id=item.id).update({item.model_cls.json: item})
+                # remove the item temporary_item_type if it is equal to the
+                # new item item_type.
+                if temporary_type := item.get("temporary_item_type"):
+                    item_temp_type_pid = extracted_data_from_ref(temporary_type.get("$ref"))
+                if hold_circ_pid != item.item_type_pid:
+                    if item_temp_type_pid == hold_circ_pid:
+                        item.pop("temporary_item_type", None)
+                    item["item_type"] = {"$ref": get_ref_for_pid("item_types", hold_circ_pid)}
+                # update directly in database.
+                db.session.query(item.model_cls).filter_by(id=item.id).update({item.model_cls.json: item})
+            # only index items whose savepoint was released, otherwise the item
+            # would be reindexed from its unchanged record and the drift would
+            # go unnoticed.
+            items_to_index.append(id)
+        except Exception:
+            current_app.logger.exception(f"Unable to inherit holding {record.pid} fields on item {id}")
 
     if items_to_index:
         # commit session

--- a/rero_ils/modules/items/api/record.py
+++ b/rero_ils/modules/items/api/record.py
@@ -57,6 +57,9 @@ class ItemRecord(IlsRecord):
 
         Ensures that only one note of each type is present.
 
+        Ensures that an issue inherits the location and the circulation
+        category of its parent serial holdings.
+
         :return: Error message if
             - barcode already exists
             - holdings type is not journal and item type is issue.
@@ -65,6 +68,7 @@ class ItemRecord(IlsRecord):
             - if notes array has multiple notes with same type
             - `temporary_item_type` has same value than `item_type`
             - temporary_item_type isn't in the future (if specified)
+            - an issue location or item_type differs from its serial holdings
 
         """
         from . import ItemsSearch
@@ -87,6 +91,14 @@ class ItemRecord(IlsRecord):
                 return _("Issue item must have an issue field.")
             if not self.get("enumerationAndChronology"):
                 return _("enumerationAndChronology field is required for an issue item")
+            # an issue always inherits these fields from its parent holdings ;
+            # they are hidden in the editor, but nothing prevents an API call
+            # from desynchronizing them.
+            if holding.holdings_type == HoldingTypes.SERIAL:
+                if extracted_data_from_ref(self["location"]) != holding.location_pid:
+                    return _("Issue location must be the same as the parent holdings location.")
+                if extracted_data_from_ref(self["item_type"]) != holding.circulation_category_pid:
+                    return _("Issue circulation category must be the same as the parent holdings one.")
         note_types = [note.get("type") for note in self.get("notes", [])]
         if len(note_types) != len(set(note_types)):
             return _("Cannot have multiple notes of the same type.")

--- a/tests/ui/holdings/test_issues_reindex.py
+++ b/tests/ui/holdings/test_issues_reindex.py
@@ -3,8 +3,10 @@
 
 """Issues reindexing tests."""
 
+from unittest import mock
+
 from rero_ils.modules.holdings.models import HoldingTypes
-from rero_ils.modules.items.api import Item, ItemsSearch
+from rero_ils.modules.items.api import Item, ItemsIndexer, ItemsSearch
 from rero_ils.modules.items.models import ItemIssueStatus
 from rero_ils.modules.tasks import process_bulk_queue
 from rero_ils.modules.utils import get_ref_for_pid
@@ -40,10 +42,87 @@ def test_issue_location_after_holdings_update(
     assert item.location_pid == holding.location_pid
     assert ItemsSearch().filter("term", location__pid=holding.location_pid).count() == 1
 
+    # clean up data ; restore the module scoped fixture record itself, as
+    # `update(dbcommit=True)` returned another instance.
+    holding_lib_martigny_w_patterns.update(initial_holding_data, dbcommit=True, reindex=True)
+    item.delete(force=True, dbcommit=True, delindex=True)
+    assert ItemsSearch().filter("term", holding__pid=holding.pid).count() == 0
+
+
+def test_issue_not_indexed_when_inheritance_fails(
+    holding_lib_martigny_w_patterns,
+    loc_restricted_martigny,
+    holding_lib_martigny_w_patterns_data,
+    caplog,
+):
+    """Test a failed field inheritance is logged and the item is not indexed."""
+    initial_holding_data = holding_lib_martigny_w_patterns_data
+    holding = holding_lib_martigny_w_patterns
+
+    item = holding.create_regular_issue(status=ItemIssueStatus.RECEIVED, dbcommit=True, reindex=True)
+    initial_location_pid = item.location_pid
+
+    # change the holdings location, but make the item update fail
+    holding["location"] = {"$ref": get_ref_for_pid("locations", loc_restricted_martigny.pid)}
+    with (
+        mock.patch(
+            "rero_ils.modules.holdings.listener.get_ref_for_pid",
+            side_effect=Exception("inheritance failure"),
+        ),
+        mock.patch.object(ItemsIndexer, "bulk_index") as mock_bulk_index,
+    ):
+        holding.update(holding, dbcommit=True, reindex=True)
+
+    # the failure is reported and the untouched item is not reindexed
+    assert "Unable to inherit holding" in caplog.text
+    mock_bulk_index.assert_not_called()
+    assert Item.get_record(item.id).location_pid == initial_location_pid
+
     # clean up data
     holding.update(initial_holding_data, dbcommit=True, reindex=True)
     item.delete(force=True, dbcommit=True, delindex=True)
-    assert ItemsSearch().filter("term", holding__pid=holding.pid).count() == 0
+
+
+def test_issues_partially_inherit_when_one_fails(
+    holding_lib_martigny_w_patterns,
+    loc_restricted_martigny,
+    holding_lib_martigny_w_patterns_data,
+    caplog,
+):
+    """Test a failing item does not prevent the other ones from inheriting."""
+    initial_holding_data = holding_lib_martigny_w_patterns_data
+    holding = holding_lib_martigny_w_patterns
+
+    items = [
+        holding.create_regular_issue(status=ItemIssueStatus.RECEIVED, dbcommit=True, reindex=True) for _ in range(2)
+    ]
+    initial_location_pid = items[0].location_pid
+
+    # change the holdings location, but make the first item update fail
+    new_location_ref = get_ref_for_pid("locations", loc_restricted_martigny.pid)
+    holding["location"] = {"$ref": new_location_ref}
+    with (
+        mock.patch(
+            "rero_ils.modules.holdings.listener.get_ref_for_pid",
+            side_effect=[Exception("inheritance failure"), new_location_ref],
+        ),
+        mock.patch.object(ItemsIndexer, "bulk_index") as mock_bulk_index,
+    ):
+        holding.update(holding, dbcommit=True, reindex=True)
+
+    # the failed item keeps its location, the other one inherits the new one
+    assert "Unable to inherit holding" in caplog.text
+    assert sorted(Item.get_record(item.id).location_pid for item in items) == sorted(
+        [initial_location_pid, loc_restricted_martigny.pid]
+    )
+    # and only the updated item is sent to the indexer
+    mock_bulk_index.assert_called_once()
+    assert len(mock_bulk_index.call_args[0][0]) == 1
+
+    # clean up data
+    holding.update(initial_holding_data, dbcommit=True, reindex=True)
+    for item in items:
+        item.delete(force=True, dbcommit=True, delindex=True)
 
 
 def test_issue_item_types_after_holdings_update(
@@ -75,8 +154,9 @@ def test_issue_item_types_after_holdings_update(
     assert item.item_type_pid == holding.circulation_category_pid
     assert ItemsSearch().filter("term", item_type__pid=holding.circulation_category_pid).count() == 1
 
-    # clean up data
-    holding.update(initial_holding_data, dbcommit=True, reindex=True)
+    # clean up data ; restore the module scoped fixture record itself, as
+    # `update(dbcommit=True)` returned another instance.
+    holding_lib_martigny_w_patterns.update(initial_holding_data, dbcommit=True, reindex=True)
     item.delete(force=True, dbcommit=True, delindex=True)
     ItemsSearch.flush_and_refresh()
     assert ItemsSearch().filter("term", holding__pid=holding.pid).count() == 0
@@ -141,7 +221,8 @@ def test_inherited_call_numbers_after_holdings_update(
     assert ItemsSearch().filter("term", sort_second_call_number="cote2").count() == 1
     assert ItemsSearch().filter("term", sort_call_number="cote1").count() == 0
 
-    # clean up data
-    holding.update(initial_holding_data, dbcommit=True, reindex=True)
+    # clean up data ; restore the module scoped fixture record itself, as
+    # `update(dbcommit=True)` returned another instance.
+    holding_lib_martigny_w_patterns.update(initial_holding_data, dbcommit=True, reindex=True)
     item.delete(force=True, dbcommit=True, delindex=True)
     assert ItemsSearch().filter("term", holding__pid=holding.pid).count() == 0

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -96,18 +96,62 @@ def test_item_extended_validation(client, holding_lib_martigny_w_patterns):
             "regular": False,
         },
     }
-    Item.create(data, dbcommit=True, reindex=True, delete_pid=True)
+    Item.create(deepcopy(data), dbcommit=True, reindex=True, delete_pid=True)
 
-    # TODO: check why system is not raising validation error here
-    # # cannot have a standard item with issues on a serial holdings
-    # data['type'] = 'standard'
-    # with pytest.raises(ValidationError):
-    #     Item.create(data, dbcommit=True, reindex=True, delete_pid=True)
-    # data['type'] == 'issue'
-    # data.pop('issue')
-    # # cannot create an issue item without issues on a serial holdings
-    # with pytest.raises(ValidationError):
-    #     Item.create(data, dbcommit=True, reindex=True, delete_pid=True)
+    # `Item.create` completes its data in place, barcode included, so each case
+    # below starts from a pristine copy. Reusing the same dict would make every
+    # creation fail on the barcode uniqueness check instead of the tested one.
+
+    # cannot have a standard item with issues on a serial holdings
+    standard_data = deepcopy(data)
+    standard_data["type"] = TypeOfItem.STANDARD
+    with pytest.raises(ValidationError) as err:
+        Item.create(standard_data, dbcommit=True, reindex=True, delete_pid=True)
+    assert "Standard item cannot have a issue field" in str(err.value)
+
+    # cannot create an issue item without issues on a serial holdings
+    issue_data = deepcopy(data)
+    issue_data.pop("issue")
+    with pytest.raises(ValidationError) as err:
+        Item.create(issue_data, dbcommit=True, reindex=True, delete_pid=True)
+    assert "Issue item must have" in str(err.value)
+
+
+def test_issue_inherits_holding_location_and_item_type(
+    holding_lib_martigny_w_patterns, loc_restricted_martigny, item_type_on_site_martigny
+):
+    """Test an issue cannot diverge from its serial holdings."""
+    holding = holding_lib_martigny_w_patterns
+    issue = holding.create_regular_issue(status=ItemIssueStatus.RECEIVED, dbcommit=True, reindex=True)
+    assert issue.location_pid == holding.location_pid
+    assert issue.item_type_pid == holding.circulation_category_pid
+    issue_pid = issue.pid
+
+    # a rejected update leaves the record instance dirty, so always start over
+    # from the stored issue.
+    # the location cannot be changed to another one than the holdings location
+    issue = Item.get_record_by_pid(issue_pid)
+    data = deepcopy(dict(issue))
+    data["location"] = {"$ref": get_ref_for_pid("loc", loc_restricted_martigny.pid)}
+    with pytest.raises(ValidationError) as err:
+        issue.update(data, dbcommit=True, reindex=True)
+    assert "Issue location must be the same" in str(err.value)
+
+    # the circulation category cannot be changed either
+    issue = Item.get_record_by_pid(issue_pid)
+    data = deepcopy(dict(issue))
+    data["item_type"] = {"$ref": get_ref_for_pid("itty", item_type_on_site_martigny.pid)}
+    with pytest.raises(ValidationError) as err:
+        issue.update(data, dbcommit=True, reindex=True)
+    assert "Issue circulation category must be the same" in str(err.value)
+
+    # any other update is still allowed
+    issue = Item.get_record_by_pid(issue_pid)
+    data = deepcopy(dict(issue))
+    data["call_number"] = "issue-call-number"
+    assert issue.update(data, dbcommit=True, reindex=True)
+
+    Item.get_record_by_pid(issue_pid).delete(force=True, dbcommit=True, delindex=True)
 
 
 def test_extended_validation_unique_barcode(


### PR DESCRIPTION
Items of type issue inherit their location and circulation category from the parent serial holdings. Three weaknesses let them drift apart without leaving any trace.

* Log inheritance failures instead of swallowing them, so a skipped item is reported.
* Queue an item for indexing only once its update succeeded. Previously it was queued before being modified, so a failure reindexed the unchanged record and hid the drift.
* Reject an issue whose location or circulation category differs from its serial holdings. The editor hides both fields, but nothing stopped an API call from desynchronizing them.
* Restore the module scoped holdings fixture in the reindex tests. update(dbcommit=True) returns another instance, so cleaning up the returned one left a stale record for the next test.
* Repair the disabled item validation assertions. Item.create completes its data in place, barcode included, so reusing one dict made every creation fail on the barcode check instead of the tested one.