### PR TITLE
fix(indexer): ignore bulk index version conflicts

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -556,6 +556,14 @@ class IlsRecordsIndexer(RecordIndexer):
     def process_bulk_queue(self, search_bulk_kwargs=None, stats_only=True):
         """Process bulk indexing queue.
 
+        A queued message carries a record revision that can be older than the
+        document already indexed, typically when the record was indexed again
+        before the queue was drained. The `external_gte` version type answers
+        such a message with a 409 and keeps the newer document, which is the
+        wanted behaviour, so the status is ignored instead of aborting the
+        chunk and leaving the rest of the queue to the next run. The count
+        still reports these messages as failed.
+
         :param dict search_bulk_kwargs: Passed to
             :func:`elasticsearch:elasticsearch.helpers.bulk`.
         :param boolean stats_only: if `True` only report number of
@@ -573,7 +581,7 @@ class IlsRecordsIndexer(RecordIndexer):
 
             req_timeout = current_app.config["INDEXER_BULK_REQUEST_TIMEOUT"]
 
-            search_bulk_kwargs = search_bulk_kwargs or {}
+            search_bulk_kwargs = {"ignore_status": (409,)} | (search_bulk_kwargs or {})
 
             count = bulk(
                 self.client,

--- a/tests/ui/test_indexer_utils.py
+++ b/tests/ui/test_indexer_utils.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 from elasticsearch import NotFoundError
+from invenio_search import current_search_client
 
 from rero_ils.modules.documents.api import DocumentsSearch
 from rero_ils.modules.indexer_utils import record_to_index
@@ -35,6 +36,39 @@ def test_record_indexing(app, lib_martigny):
     # RESET INDEX
     app.config["INDEXER_REPLACE_REFS"] = True
     lib_martigny.reindex()
+    LibrariesSearch.flush_and_refresh()
+
+
+def test_process_bulk_queue_version_conflict(app, lib_martigny, lib_saxon):
+    """Test a queued message older than the indexed document."""
+    indexer = LibrariesIndexer()
+    # drain anything a previous test left in the shared queue
+    indexer.process_bulk_queue()
+    # index the record one revision ahead, as if it had been indexed again
+    # while its message was still waiting in the queue
+    action = indexer._index_action({"id": str(lib_martigny.id)})
+    newer_version = action["_version"] + 1
+    current_search_client.index(
+        index=action["_index"],
+        id=action["_id"],
+        body=action["_source"],
+        version=newer_version,
+        version_type="external_gte",
+        refresh=True,
+    )
+
+    # the stale message conflicts, the second one must still be indexed
+    indexer.bulk_index([lib_martigny.id, lib_saxon.id])
+    # the conflict is counted as a failed message and does not raise, so the
+    # rest of the queue is still processed
+    assert indexer.process_bulk_queue()[1] == (1, 1)
+
+    # the refused message left the newer document in place
+    indexed = current_search_client.get(index=action["_index"], id=action["_id"])
+    assert indexed["_version"] == newer_version
+
+    # RESET INDEX: realign the record revision with the indexed document
+    lib_martigny.update(data=lib_martigny, dbcommit=True, reindex=True)
     LibrariesSearch.flush_and_refresh()
 
 


### PR DESCRIPTION
A queued message carries the record revision read when the queue is drained. When the record was indexed again in the meantime, the `external_gte` version type answers with a 409 and keeps the newer document, which is the wanted behaviour. Elasticsearch raised a BulkIndexError for it, aborting the whole chunk and leaving the rest of the queue to the next run.

* Ignore the 409 status in `IlsRecordsIndexer.process_bulk_queue`, so the conflict is only counted as a failed message. Every other error still raises.
* Set it as a default the caller can override, in the indexer rather than in the beat schedule, so the CLI, the alembic recipes and the listeners are covered as well.
* Add a test queueing a message older than the indexed document. It reproduces the BulkIndexError without the fix.