### PR TITLE
fix(circulation): log the real scan transaction location

### DIFF
--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -81,13 +81,9 @@ class ItemCirculation(ItemRecord):
         else:
             # no validation is possible when loan is not found/given
             message = _("No circulation action performed: validate impossible")
-            transaction_location_pid = kwargs.get("transaction_location_pid")
-            if not transaction_location_pid and (transaction_library_pid := kwargs.pop("transaction_library_pid")):
-                lib = Library.get_record_by_pid(transaction_library_pid)
-                transaction_location_pid = lib.get_transaction_location_pid()
             scan = {
                 "item": self,
-                "transaction_location_pid": transaction_location_pid,
+                "transaction_location_pid": self.get_transaction_location_pid_from_params(**kwargs),
                 "note": message,
             }
             NoCirculationOperationLog.create(scan=scan, index_refresh=True)
@@ -105,15 +101,8 @@ class ItemCirculation(ItemRecord):
         else:
             loan = Loan.get_record_by_pid(loan_pid)
 
-        pickup_location_pid = None
-        if loan:
-            pickup_location_pid = loan.get("pickup_location_pid")
-            transaction_location_pid = loan.get("transaction_location_pid")
-        else:
-            transaction_location_pid = kwargs.get("transaction_location_pid")
-            if not transaction_location_pid and (transaction_library_pid := kwargs.pop("transaction_library_pid")):
-                lib = Library.get_record_by_pid(transaction_library_pid)
-                transaction_location_pid = lib.get_transaction_location_pid()
+        pickup_location_pid = loan.get("pickup_location_pid") if loan else None
+        transaction_location_pid = self.get_transaction_location_pid_from_params(loan=loan, **kwargs)
 
         # Check extend is allowed
         #   It's not allowed to extend an item if it is not checked out
@@ -213,13 +202,9 @@ class ItemCirculation(ItemRecord):
         libraries = self.compare_item_pickup_transaction_libraries(**kwargs)
         transaction_item_libraries = libraries["transaction_item_libraries"]
 
-        transaction_location_pid = kwargs.get("transaction_location_pid")
-        if not transaction_location_pid and (transaction_library_pid := kwargs.pop("transaction_library_pid")):
-            lib = Library.get_record_by_pid(transaction_library_pid)
-            transaction_location_pid = lib.get_transaction_location_pid()
         scan = {
             "item": self,
-            "transaction_location_pid": transaction_location_pid,
+            "transaction_location_pid": self.get_transaction_location_pid_from_params(**kwargs),
         }
         if transaction_item_libraries:
             # CHECKIN_1_1_1, item library = transaction library
@@ -261,7 +246,7 @@ class ItemCirculation(ItemRecord):
             scan = {
                 "item": self,
                 "pickup_location_pid": at_desk_loan.get("pickup_location_pid"),
-                "transaction_location_pid": at_desk_loan.get("transaction_location_pid"),
+                "transaction_location_pid": self.get_transaction_location_pid_from_params(loan=at_desk_loan, **kwargs),
                 "note": message,
             }
             NoCirculationOperationLog.create(scan=scan, index_refresh=True)
@@ -276,7 +261,7 @@ class ItemCirculation(ItemRecord):
         scan = {
             "item": self,
             "pickup_location_pid": at_desk_loan.get("pickup_location_pid"),
-            "transaction_location_pid": at_desk_loan.get("transaction_location_pid"),
+            "transaction_location_pid": self.get_transaction_location_pid_from_params(loan=at_desk_loan, **kwargs),
             "note": message,
         }
         NoCirculationOperationLog.create(scan=scan, index_refresh=True)
@@ -303,7 +288,7 @@ class ItemCirculation(ItemRecord):
         scan = {
             "item": self,
             "pickup_location_pid": in_transit_loan.get("pickup_location_pid"),
-            "transaction_location_pid": in_transit_loan.get("transaction_location_pid"),
+            "transaction_location_pid": self.get_transaction_location_pid_from_params(loan=in_transit_loan, **kwargs),
             "note": message,
         }
         NoCirculationOperationLog.create(scan=scan, index_refresh=True)
@@ -326,13 +311,11 @@ class ItemCirculation(ItemRecord):
                 # CHECKIN_5_1_2: item location != transaction library
                 # (no action, item is: in_transit (IN_TRANSIT_TO_HOUSE))
                 message = _("No circulation action performed: in transit to house")
-                transaction_location_pid = kwargs.get("transaction_location_pid")
-                if not transaction_location_pid and (transaction_library_pid := kwargs.pop("transaction_library_pid")):
-                    lib = Library.get_record_by_pid(transaction_library_pid)
-                    transaction_location_pid = lib.get_transaction_location_pid()
                 scan = {
                     "item": self,
-                    "transaction_location_pid": transaction_location_pid,
+                    "transaction_location_pid": self.get_transaction_location_pid_from_params(
+                        loan=in_transit_loan, **kwargs
+                    ),
                     "note": message,
                 }
                 NoCirculationOperationLog.create(scan=scan, index_refresh=True)
@@ -378,7 +361,9 @@ class ItemCirculation(ItemRecord):
                     scan = {
                         "item": self,
                         "pickup_location_pid": in_transit_loan.get("pickup_location_pid"),
-                        "transaction_location_pid": in_transit_loan.get("transaction_location_pid"),
+                        "transaction_location_pid": self.get_transaction_location_pid_from_params(
+                            loan=in_transit_loan, **kwargs
+                        ),
                         "note": message,
                     }
                     NoCirculationOperationLog.create(scan=scan, index_refresh=True)
@@ -401,6 +386,23 @@ class ItemCirculation(ItemRecord):
             kwargs["validate_current_loan"] = True
             loan = pending
         return loan, kwargs
+
+    def get_transaction_location_pid_from_params(self, loan=None, **kwargs):
+        """Get the transaction location pid of the current circulation operation.
+
+        :param loan: the loan of the operation, used as a fallback when the
+            circulation parameters give no transaction location.
+        :param kwargs: all others named arguments.
+        :return the transaction location pid.
+        """
+        if transaction_location_pid := kwargs.get("transaction_location_pid"):
+            return transaction_location_pid
+        if transaction_library_pid := kwargs.get("transaction_library_pid"):
+            return Library.get_record_by_pid(transaction_library_pid).get_transaction_location_pid()
+        # no transaction parameter given, fall back on the loan or the item
+        if loan and (transaction_location_pid := loan.get("transaction_location_pid")):
+            return transaction_location_pid
+        return self.location_pid
 
     def compare_item_pickup_transaction_libraries(self, **kwargs):
         """Compare item library, pickup and transaction libraries.

--- a/tests/api/circulation/test_actions_views_checkin.py
+++ b/tests/api/circulation/test_actions_views_checkin.py
@@ -11,6 +11,8 @@ from invenio_accounts.testutils import login_user_via_session
 
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanState
 from rero_ils.modules.loans.utils import get_circ_policy, sum_for_fees
 from rero_ils.modules.operation_logs.api import OperationLogsSearch
 from rero_ils.modules.patron_transactions.utils import get_last_transaction_by_loan_pid
@@ -208,3 +210,81 @@ def test_checkin_overdue_item(
     # reset the cipo
     del cipo["overdue_fees"]
     cipo.update(data=cipo, dbcommit=True, reindex=True)
+
+
+def test_checkin_scan_log_transaction_location(
+    client,
+    librarian_fully,
+    lib_fully,
+    loc_public_fully,
+    loc_public_martigny,
+    item_at_desk_martigny_patron_and_loan_at_desk,
+):
+    """Test the scan log keeps the location where the item was really scanned."""
+    # An item at desk for a Martigny pickup is wrongly sent to Fully. The scan
+    # log must reference the Fully location and not the last transaction
+    # location recorded on the loan (Martigny).
+    item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
+    assert loan["transaction_location_pid"] == loc_public_martigny.pid
+
+    login_user_via_session(client, librarian_fully.user)
+    res, _ = postdata(
+        client,
+        "api_item.checkin",
+        {
+            "item_pid": item.pid,
+            "transaction_location_pid": loc_public_fully.pid,
+            "transaction_user_pid": librarian_fully.pid,
+        },
+    )
+    assert res.status_code == 400
+
+    query = OperationLogsSearch().filter("term", scan__item__pid=item.pid)
+    assert query.count() == 1
+    log_data = query.execute()[0].to_dict()
+    assert log_data["library"]["value"] == lib_fully.pid
+    assert log_data["scan"]["transaction_location"]["pid"] == loc_public_fully.pid
+    assert log_data["scan"]["pickup_location"]["pid"] == loc_public_martigny.pid
+
+    # restore the fixture state: the checkin sent the item in transit
+    loan = Loan.get_record_by_pid(loan.pid)
+    loan["state"] = LoanState.ITEM_AT_DESK
+    loan.update(loan, dbcommit=True, reindex=True)
+    item = Item.get_record_by_pid(item.pid)
+    item["status"] = ItemStatus.AT_DESK
+    item.update(item, dbcommit=True, reindex=True)
+
+
+def test_checkin_scan_log_transaction_location_in_transit(
+    client,
+    librarian_saxon,
+    lib_saxon,
+    loc_public_saxon,
+    loc_public_fully,
+    loc_public_martigny,
+    item_in_transit_martigny_patron_and_loan_for_pickup,
+):
+    """Test the scan log of an in transit item scanned in a third library."""
+    # An item in transit to Fully is scanned in Saxon. The scan log must
+    # reference a Saxon location, resolved from the transaction library, and
+    # not the transaction location recorded on the loan (Martigny).
+    item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
+    assert loan["transaction_location_pid"] == loc_public_martigny.pid
+
+    login_user_via_session(client, librarian_saxon.user)
+    res, _ = postdata(
+        client,
+        "api_item.checkin",
+        {
+            "item_pid": item.pid,
+            "transaction_library_pid": lib_saxon.pid,
+            "transaction_user_pid": librarian_saxon.pid,
+        },
+    )
+    assert res.status_code == 400
+
+    query = OperationLogsSearch().filter("term", scan__item__pid=item.pid)
+    assert query.count() == 1
+    log_data = query.execute()[0].to_dict()
+    assert log_data["scan"]["transaction_location"]["pid"] == loc_public_saxon.pid
+    assert log_data["scan"]["pickup_location"]["pid"] == loc_public_fully.pid

--- a/tests/ui/circulation/test_actions_extend.py
+++ b/tests/ui/circulation/test_actions_extend.py
@@ -18,6 +18,7 @@ from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.loans.models import LoanAction, LoanState
 from rero_ils.modules.loans.utils import get_circ_policy
+from rero_ils.modules.operation_logs.api import OperationLogsSearch
 from rero_ils.modules.patron_transactions.api import PatronTransactionsSearch
 from rero_ils.modules.patron_transactions.utils import get_last_transaction_by_loan_pid
 from rero_ils.modules.utils import get_ref_for_pid
@@ -246,6 +247,7 @@ def test_extend_on_item_on_loan_with_no_requests(
 def test_extend_on_item_on_loan_with_requests(
     item_on_loan_martigny_patron_and_loan_on_loan,
     loc_public_martigny,
+    loc_public_saxon,
     librarian_martigny,
     circulation_policies,
     patron2_martigny,
@@ -272,15 +274,27 @@ def test_extend_on_item_on_loan_with_requests(
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
     assert item.status == ItemStatus.ON_LOAN
-    # test fails if loan pid is given
+    # test fails if loan pid is given. The scan log must reference the location
+    # where the extension was attempted (Saxon) and not the transaction
+    # location recorded on the loan.
     params = {
         "pid": loan.pid,
-        "transaction_location_pid": loc_public_martigny.pid,
+        "transaction_location_pid": loc_public_saxon.pid,
         "transaction_user_pid": librarian_martigny.pid,
     }
     with pytest.raises(NoCirculationAction):
         item, actions = item.extend_loan(**params)
     assert item.status == ItemStatus.ON_LOAN
+    query = OperationLogsSearch().filter("term", scan__item__pid=item.pid).sort("-date")
+    assert query.execute()[0].to_dict()["scan"]["transaction_location"]["pid"] == loc_public_saxon.pid
+
+    # without any transaction parameter, the loan transaction location is kept
+    params = {"pid": loan.pid, "transaction_user_pid": librarian_martigny.pid}
+    with pytest.raises(NoCirculationAction):
+        item, actions = item.extend_loan(**params)
+    loan_location_pid = Loan.get_record_by_pid(loan.pid)["transaction_location_pid"]
+    query = OperationLogsSearch().filter("term", scan__item__pid=item.pid).sort("-date")
+    assert query.execute()[0].to_dict()["scan"]["transaction_location"]["pid"] == loan_location_pid
 
 
 def test_extend_on_item_in_transit_for_pickup(


### PR DESCRIPTION
* The transaction location of `scan_item` operation logs was taken from the loan when it existed, this could cause a wrong transaction location to be logged, for example if an item is `in_transit` and is scanned in the wrong library. Take this data directly from the current circ parameters instead.
* Adds `ItemCirculation.get_transaction_location_pid_from_params()` and reuses it for the at desk, in transit and extend cases.