### PR TITLE
fix(entities): log replace_identified_by failures

### DIFF
--- a/rero_ils/modules/entities/remote_entities/replace.py
+++ b/rero_ils/modules/entities/remote_entities/replace.py
@@ -341,6 +341,11 @@ class ReplaceIdentifiedBy:
         self.type_mismatch = {}
         self.type_not_allowed = {}
         self.logger.info("Found %s identifiedBy: %s", self.field, self.count())
+        # Deterministic order keeps the reports reproducible: `not_found` holds
+        # the access point of the first document seen for a given identifier.
+        # `preserve_order` is required, `scan` overwrites `sort` with `_doc`
+        # otherwise. Results are materialized because the loop below writes to
+        # the scanned index.
         query = self.query.params(preserve_order=True).sort({"_created": {"order": "asc"}}).source(["pid", self.field])
         for hit in list(query.scan()):
             if doc := self._replace_entities_in_document(hit.meta.id):

--- a/rero_ils/modules/entities/remote_entities/tasks.py
+++ b/rero_ils/modules/entities/remote_entities/tasks.py
@@ -74,5 +74,8 @@ def replace_identified_by(fields=None, verbose=False, dry_run=False):
                 "type_mismatch": sum(len(v) for v in replace.type_mismatch.values()),
             }
         except Exception as err:
+            # the task result is discarded (`ignore_result`): without this the
+            # reason of a failed scheduled run would be lost.
+            current_app.logger.exception(f"replace_identified_by {field}")
             result[field] = {"error": err}
     return result

--- a/rero_ils/modules/operation_logs/api.py
+++ b/rero_ils/modules/operation_logs/api.py
@@ -43,6 +43,9 @@ class OperationLogsSearch(IlsRecordsSearch):
     def get_logs_by_record_pid(self, pid):
         """Get all logs for a given record PID.
 
+        The results are materialized on purpose: callers update each log while
+        iterating, which would let the scroll expire.
+
         :param str pid: record PID.
         :returns: List of logs.
         """

--- a/tests/ui/entities/remote_entities/test_remote_entities_api.py
+++ b/tests/ui/entities/remote_entities/test_remote_entities_api.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from unittest import mock
 
 from rero_ils.modules.documents.api import Document, DocumentsSearch
+from rero_ils.modules.entities.remote_entities import tasks
 from rero_ils.modules.entities.remote_entities.api import (
     RemoteEntitiesSearch,
     RemoteEntity,
@@ -407,6 +408,14 @@ def test_replace_identified_by(
         assert replace_identified_by.not_found == {
             "bf:Work": {"rero:A001234567": "Bases de donnéesi (Voltenauer, Marc)"}
         }
+
+
+def test_replace_identified_by_task_error(app, caplog):
+    """Test a failure of the scheduled task is logged, not only returned."""
+    error = Exception("MEF server is down")
+    with mock.patch.object(tasks, "ReplaceIdentifiedBy", side_effect=error):
+        assert tasks.replace_identified_by(fields=["contribution"]) == {"contribution": {"error": error}}
+    assert caplog.record_tuples[-1] == ("invenio", 40, "replace_identified_by contribution")
 
 
 def test_replace_identified_by_type_mismatch(app, entity_organisation, entity_organisation_data):


### PR DESCRIPTION
Three small changes around `ReplaceIdentifiedBy`, found while reviewing
the `list(scan())` pattern used across the code base.

### `fix(entities)`: log the task failures

`replace_identified_by` catches every exception per field and stores it in
the returned dict, but the task is declared `@shared_task(ignore_result=True)`
— so Celery discards it. A failure left no trace beyond a stale entry in
`/monitoring/timestamps`: visible as *something did not run*, never why.

The exception is now logged with its traceback, following the pattern
already used for per-item failures in `documents/tasks.py` and
`stats/tasks.py`. A test covers the error path.

This is a prerequisite to ever setting `enabled: True` on the weekly
`celery.replace-identified-by` schedule.

### `docs(operation_logs)` and `docs(entities)`: two deliberate patterns

Both changes are comments only, no behaviour change. They record why
`list(scan())` is intentional in these two places, which is not obvious
and was worth a fair amount of digging:

* `OperationLogsSearch.get_logs_by_record_pid` — the caller rewrites each
  log while iterating, so the scroll is drained first.
* `ReplaceIdentifiedBy.run` — the sort keeps the `not_found` report
  reproducible, and `preserve_order` is inseparable from it (the scan
  helper overwrites `sort` with `_doc` without it).

On the second one, dropping the sort was measured on a local ES 7.10.2
with an 8-shard index: about 1.5s saved on 300k documents, against a loop
that spends hours on MEF requests and reindexing. Not worth the change,
worth the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)