### PR TITLE
fix(patrons): drop empty entries in record links

### DIFF
--- a/rero_ils/modules/acquisition/acq_orders/api.py
+++ b/rero_ils/modules/acquisition/acq_orders/api.py
@@ -394,8 +394,7 @@ class AcqOrder(AcquisitionIlsRecord):
     def get_links_to_me(self, get_pids=False):
         """Get related record links.
 
-        :param get_pids: if True list of related record pids, if False count
-                         of related records.
+        :param get_pids: if True list of related record pids, if False count of related records.
         """
         output = "query" if get_pids else "count"
         links = {
@@ -403,10 +402,11 @@ class AcqOrder(AcquisitionIlsRecord):
             "acq_order_lines": self.get_order_lines(output=output),
             "acq_receipts": self.get_receipts(output=output),
         }
-        links = {k: v for k, v in links.items() if v}
         if get_pids:
+            # the queries are resolved before the empty ones are dropped: a
+            # query is an object and is still truthy when it matches nothing
             links = {k: sorted_pids(v) for k, v in links.items()}
-        return links
+        return {k: v for k, v in links.items() if v}
 
     def reasons_not_to_delete(self):
         """Get reasons not to delete record."""

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -27,11 +27,7 @@ from rero_ils.modules.minters import id_minter
 from rero_ils.modules.operation_logs.extensions import OperationLogObserverExtension
 from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patron_transactions.api import PatronTransaction
-from rero_ils.modules.patron_transactions.utils import (
-    create_subscription_for_patron,
-    get_transactions_count_for_patron,
-    get_transactions_pids_for_patron,
-)
+from rero_ils.modules.patron_transactions.utils import _build_transaction_query, create_subscription_for_patron
 from rero_ils.modules.providers import Provider
 from rero_ils.modules.tasks import process_bulk_queue
 from rero_ils.modules.templates.api import TemplatesSearch
@@ -334,14 +330,15 @@ class Patron(IlsRecord):
         )
         template_query = TemplatesSearch().filter("term", creator__pid=self.pid)
         ill_query = ILLRequestsSearch().filter("term", patron__pid=self.pid)
+        transaction_query = _build_transaction_query(patron_pid=self.pid, status="open")
         if get_pids:
             loans = sorted_pids(loan_query)
-            transactions = get_transactions_pids_for_patron(self.pid, status="open")
+            transactions = sorted_pids(transaction_query)
             templates = sorted_pids(template_query)
             ill_requests = sorted_pids(ill_query)
         else:
             loans = loan_query.count()
-            transactions = get_transactions_count_for_patron(self.pid, status="open")
+            transactions = transaction_query.count()
             templates = template_query.count()
             ill_requests = ill_query.count()
         if loans:

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -626,3 +626,19 @@ def test_patron_get_links_to_me_ill_requests(
     links_pids = patron_martigny.get_links_to_me(get_pids=True)
     assert "ill_requests" in links_pids
     assert len(links_pids["ill_requests"]) > 0
+
+
+def test_patron_get_links_to_me_pids(app, patron_martigny, patron_transaction_overdue_martigny):
+    """Test that get_links_to_me reports pid lists and drops the empty ones."""
+    links = patron_martigny.get_links_to_me()
+    links_pids = patron_martigny.get_links_to_me(get_pids=True)
+
+    # the open transaction is reported by both variants
+    assert "transactions" in links_pids
+    # both variants report the same resources: a resource without any linked
+    # pid must not be added to the links
+    assert set(links_pids) == set(links)
+    # every value is a list of pids, matching the counted variant
+    for resource, pids in links_pids.items():
+        assert isinstance(pids, list)
+        assert len(pids) == links[resource]

--- a/tests/ui/acq_orders/test_acq_orders_api.py
+++ b/tests/ui/acq_orders/test_acq_orders_api.py
@@ -79,3 +79,19 @@ def test_get_related_orders(acq_order_fiction_martigny, acq_order_fiction_saxon)
     assert related_acors == [acor_saxon]
     assert acor_martigny.get_related_orders(output="count") == 1
     assert acor_martigny.get_links_to_me(True)["acq_orders"] == [acor_saxon.pid]
+
+
+def test_order_get_links_to_me_empty_pids(acq_order_fiction_martigny):
+    """Test that a resource without any linked pid is not in the links."""
+    acor = acq_order_fiction_martigny
+    links = acor.get_links_to_me()
+    links_pids = acor.get_links_to_me(get_pids=True)
+
+    # no receipt is attached to the order: the resource is reported by neither
+    # variant, a query is truthy even when it matches nothing
+    assert "acq_receipts" not in links
+    assert "acq_receipts" not in links_pids
+    # both variants report the same resources, with matching lengths
+    assert set(links_pids) == set(links)
+    for resource, pids in links_pids.items():
+        assert len(pids) == links[resource]


### PR DESCRIPTION
A resource without any linked pid was still reported by `get_links_to_me(get_pids=True)`: the value tested for truthiness was a lazy object, and such an object is always true.

* patrons: the transaction pids are yielded and an exhausted generator is still truthy, so `transactions` was always present, holding the generator itself. Build the query locally and resolve it with `sorted_pids`, as the three other link types already do. The count branch reuses that query, which is what `get_transactions_count_for_patron` did.
* acq_orders: the empty entries were dropped before the queries were resolved, and an `elasticsearch_dsl` query defines neither `__bool__` nor `__len__`. Resolve the pids first, then drop the entries left empty.

The counted variant was already correct in both cases, so `reasons_not_to_delete` and the deletion rules do not change.