### PR TITLE
chore(languages): remove dutch as preferred language

### DIFF
--- a/rero_ils/jsonschemas/common/languages-v0.0.1.json
+++ b/rero_ils/jsonschemas/common/languages-v0.0.1.json
@@ -962,8 +962,7 @@
             },
             {
               "label": "lang_dut",
-              "value": "dut",
-              "preferred": true
+              "value": "dut"
             },
             {
               "label": "lang_dyu",


### PR DESCRIPTION
* Dutch does not need to be in the top of the language dropdowns for Swiss libraries/users.