### PR TITLE
feat(fees): distinguish fee library contexts

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -628,8 +628,10 @@ class Loan(IlsRecord):
 
     @cached_property
     def transaction_library_pid(self):
-        """Get loan transaction_library PID."""
-        return Location.get_record_by_pid(self.transaction_location_pid).get_library().get("pid")
+        """Get the library where the loan transaction occurred."""
+        if (location_pid := self.transaction_location_pid) and (location := Location.get_record_by_pid(location_pid)):
+            return location.library_pid
+        return None
 
     @property
     def get_overdue_fees(self):

--- a/rero_ils/modules/patron_transactions/api.py
+++ b/rero_ils/modules/patron_transactions/api.py
@@ -112,10 +112,19 @@ class PatronTransaction(IlsRecord):
 
     @property
     def library_pid(self):
-        """Get the `Library` pid related to this transaction."""
-        if loan := self.loan:
-            return loan.library_pid
+        """Get the owning or assigning library pid."""
+        if (loan := self.loan) and (item := loan.item):
+            return item.library_pid
+
+        if library := self.get("library"):
+            return extracted_data_from_ref(library)
+
         return None
+
+    @property
+    def transaction_library_pid(self):
+        """Get the library where the loan transaction occurred."""
+        return self.loan.transaction_library_pid if self.loan and self.loan.transaction_location_pid else None
 
     @property
     def patron_pid(self):

--- a/rero_ils/modules/patron_transactions/extensions.py
+++ b/rero_ils/modules/patron_transactions/extensions.py
@@ -15,6 +15,31 @@ class PatronTransactionExtension(RecordExtension):
     """Patron transactions extension."""
 
     @staticmethod
+    def _record_with_references(record):
+        """Return the persisted record when references have been resolved."""
+        reference_fields = (record.get("loan"), record.get("library"))
+        if any(field and "$ref" not in field for field in reference_fields):
+            return type(record).get_record_by_pid(record.pid)
+        return record
+
+    def post_dump(self, record, data, dumper=None):
+        """Add the owning and transaction libraries to dumped data."""
+        record = self._record_with_references(record)
+
+        if library_pid := record.library_pid:
+            data["library"] = {"pid": library_pid, "type": "lib"}
+        else:
+            data.pop("library", None)
+
+        if transaction_library_pid := record.transaction_library_pid:
+            data["transaction_library"] = {
+                "pid": transaction_library_pid,
+                "type": "lib",
+            }
+        else:
+            data.pop("transaction_library", None)
+
+    @staticmethod
     def _base_data_patron_event(record, steps=None):
         """Create a initial data for Patron Transaction Event."""
         data = {

--- a/rero_ils/modules/patron_transactions/listener.py
+++ b/rero_ils/modules/patron_transactions/listener.py
@@ -34,5 +34,4 @@ def enrich_patron_transaction_data(
 
     if loan := record.loan:
         json["document"] = {"pid": record.document_pid, "type": "doc"}
-        json["library"] = {"pid": record.library_pid, "type": "lib"}
         json["item"] = {"pid": loan.item_pid, "type": "item"}

--- a/rero_ils/modules/patron_transactions/mappings/v7/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/mappings/v7/patron_transactions/patron_transaction-v0.0.1.json
@@ -54,6 +54,16 @@
           }
         }
       },
+      "transaction_library": {
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "pid": {
+            "type": "keyword"
+          }
+        }
+      },
       "loan": {
         "properties": {
           "type": {

--- a/tests/api/patron_transactions/test_patron_transactions_rest.py
+++ b/tests/api/patron_transactions/test_patron_transactions_rest.py
@@ -62,6 +62,7 @@ def test_patron_transactions_get(client, patron_transaction_overdue_martigny, re
     result = data["hits"]["hits"][0]["metadata"]
     assert result.pop("document") == {"pid": "doc1", "type": "doc"}
     assert result.pop("library") == {"pid": "lib1", "type": "lib"}
+    assert result.pop("transaction_library") == {"pid": "lib1", "type": "lib"}
     assert result.pop("item") == {"pid": "item8", "type": "item"}
     del result["patron"]["barcode"]
     assert result == transaction.replace_refs()
@@ -103,12 +104,13 @@ def test_patron_transactions_post_put_delete(client, lib_martigny, patron_transa
     transaction_data["pid"] = pttr_pid
     res, data = postdata(client, "invenio_records_rest.pttr_list", transaction_data)
     assert res.status_code == 201
-    # Check that the returned record matches the given data
-    assert data["metadata"] == transaction_data
+    # Check that the returned record contains the derived libraries
+    expected_metadata = PatronTransaction.get_record_by_pid(pttr_pid).dumps()
+    assert data["metadata"] == expected_metadata
     res = client.get(item_url)
     assert res.status_code == 200
     data = get_json(res)
-    assert transaction_data == data["metadata"]
+    assert expected_metadata == data["metadata"]
 
     # Update record/PUT
     data = transaction_data
@@ -177,6 +179,62 @@ def test_patron_transaction_shortcuts_utils(client, patron_transaction_overdue_m
     assert patron_transaction_overdue_martigny.loan_pid == loan_overdue_martigny.pid
 
     assert patron_transaction_overdue_martigny.patron_pid == loan_overdue_martigny.patron_pid
+
+
+@mock.patch(
+    "invenio_records_rest.views.verify_record_permission",
+    mock.MagicMock(return_value=VerifyRecordPermissionPatch),
+)
+def test_patron_transaction_owning_library(
+    client,
+    patron_transaction_overdue_event_saxon,
+    patron_transaction_overdue_saxon,
+    lib_martigny,
+    lib_saxon,
+):
+    """Test the item owning library is exposed instead of the transaction library."""
+    transaction = patron_transaction_overdue_saxon
+
+    assert transaction.loan.library_pid == lib_martigny.pid
+    assert transaction.library_pid == lib_saxon.pid
+    assert transaction.transaction_library_pid == lib_martigny.pid
+
+    metadata = transaction.dumps()
+    assert metadata["library"] == {"pid": lib_saxon.pid, "type": "lib"}
+    assert metadata["transaction_library"] == {"pid": lib_martigny.pid, "type": "lib"}
+
+    list_url = url_for("invenio_records_rest.pttr_list", q=f"pid:{transaction.pid}")
+    res = client.get(list_url)
+
+    assert res.status_code == 200
+    metadata = get_json(res)["hits"]["hits"][0]["metadata"]
+    assert metadata["library"] == {"pid": lib_saxon.pid, "type": "lib"}
+    assert metadata["transaction_library"] == {"pid": lib_martigny.pid, "type": "lib"}
+
+    event = patron_transaction_overdue_event_saxon
+    list_url = url_for(
+        "invenio_records_rest.ptre_list",
+        q=f"pid:{event.pid}",
+        owning_library=lib_saxon.pid,
+    )
+    res = client.get(list_url)
+
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data["hits"]["total"]["value"] == 1
+    assert data["hits"]["hits"][0]["metadata"]["pid"] == event.pid
+
+    list_url = url_for(
+        "invenio_records_rest.ptre_list",
+        q=f"pid:{event.pid}",
+        owning_library=lib_martigny.pid,
+    )
+    res = client.get(list_url)
+
+    assert res.status_code == 200
+    assert get_json(res)["hits"]["total"]["value"] == 0
+
+    clear_patron_transaction_data(transaction.pid)
 
 
 def test_filtered_patron_transactions_get(
@@ -277,6 +335,12 @@ def test_transactions_add_manual_fee(client, librarian_sion, org_sion, patron_si
     metadata = data["metadata"]
     record = PatronTransaction.get_record_by_pid(metadata["pid"])
     assert record.get("library") == librarian_sion.get("libraries")[0]
+    dumped_record = record.dumps()
+    assert dumped_record["library"] == {
+        "pid": extracted_data_from_ref(record.get("library")),
+        "type": "lib",
+    }
+    assert "transaction_library" not in dumped_record
     event = next(record.events)
     assert extracted_data_from_ref(event.get("operator")) == librarian_sion.get("pid")
     assert event.get("library") == librarian_sion.get("libraries")[0]

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -66,6 +66,15 @@ def test_loans_properties(loan_pending_martigny, item_lib_fully):
     loan["transaction_date"] = transaction_date
 
 
+def test_transaction_library_pid_with_deleted_location(loan_pending_martigny):
+    """Test transaction library with a deleted location."""
+    loan = deepcopy(loan_pending_martigny)
+    loan.__dict__.pop("transaction_library_pid", None)
+
+    with mock.patch.object(Location, "get_record_by_pid", return_value=None):
+        assert loan.transaction_library_pid is None
+
+
 def test_loans_indexing(loan_pending_martigny, loc_public_martigny):
     """Test loan indexing."""
     loan = loan_pending_martigny


### PR DESCRIPTION
* Attribute item-related fees to the item's owning library.
* Preserve the assigning library for manual fees.
* Display the transaction library separately.
* Keep library-scoped payments based on item ownership.
* Closes #2542

----

Existing fees must be reindexed to receive the corrected library values;
otherwise, these changes will only apply to newly indexed fees.

**Deployment**
- Update the `patron_transactions` Elasticsearch mapping.
- Reindex all PatronTransactions (`pttr`) after deploying the backend.
- This corrects both open and closed existing fees.