### PR TITLE
fix(circulation): wrong statuts when cancelling an at_desk loan

### DIFF
--- a/doc/circulation/actions.md
+++ b/doc/circulation/actions.md
@@ -20,10 +20,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     1. __ADD_REQUEST_1_2__: PENDING loan exists
         1. __ADD_REQUEST_1_2_1__: request patron = current loan patron → request denied
         1. :white_check_mark: __ADD_REQUEST_1_2_2__: request patron != current loan patron →  (add loan PENDING)
-1. :100: __ADD_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK) 
+1. :100: __ADD_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK)
     1. __ADD_REQUEST_2_1__: request patron = current loan patron → request denied
     1. :white_check_mark: __ADD_REQUEST_2_2__: request patron != current loan patron →  (add loan PENDING)
-1. :100: __ADD_REQUEST_3__: item on_loan (ITEM_ON_LOAN) 
+1. :100: __ADD_REQUEST_3__: item on_loan (ITEM_ON_LOAN)
     1. __ADD_REQUEST_3_1__: request patron = current loan patron → request denied
     1. __ADD_REQUEST_3_2__: request patron != current loan patron:
         1. :white_check_mark: __ADD_REQUEST_3_2_1__: PENDING loan does not exist →  (add loan PENDING)
@@ -55,11 +55,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 1. :100: __CANCEL_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK)
 	1. __CANCEL_REQUEST_2_1__: loan to cancel = current loan
 		1. __CANCEL_REQUEST_2_1_1__: PENDING loan does not exist Make it impossible to cancel loan from public interface. Future: make it possible and give an alert to the library that the item should not stayed at desk
-			1. __CANCEL_REQUEST_2_1_1_1__: item library != pickup location of current loan → (update loan to IN_TRANSIT_TO_HOUSE, item is: in_transit)
-			1. __CANCEL_REQUEST_2_1_1_2__: item library = pickup location of current loan → (cancel loan, item is: on_shelf)
+			1. __CANCEL_REQUEST_2_1_1_1__: item library != library where the item is → (update loan to IN_TRANSIT_TO_HOUSE, item is: in_transit)
+			1. __CANCEL_REQUEST_2_1_1_2__: item library = library where the item is → (cancel loan, item is: on_shelf)
 		1. __CANCEL_REQUEST_2_1_2__: PENDING loan exists
-			1. __CANCEL_REQUEST_2_1_2_1__: pickup location of 1st pending loan != pickup location of current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
-			1. __CANCEL_REQUEST_2_1_2_2__: pickup location of 1st pending loan = pickup location of current loan → (cancel loan, item is: at_desk (ITEM_AT_DESK))[automatic validate next PENDING loan]
+			1. __CANCEL_REQUEST_2_1_2_1__: pickup location of 1st pending loan != location where the item is → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
+			1. __CANCEL_REQUEST_2_1_2_2__: pickup location of 1st pending loan = location where the item is → (cancel loan, item is: at_desk (ITEM_AT_DESK))[automatic validate next PENDING loan]
 	1. __CANCEL_REQUEST_2_2__: loan to cancel != current loan → (cancel loan, item is: at desk)
 
 1. :100: __CANCEL_REQUEST_3__: item on_loan (ITEM_ON_LOAN)
@@ -69,8 +69,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 1. :100: __CANCEL_REQUEST_4__: item in_transit (IN_TRANSIT_FOR_PICKUP)
 	1. __CANCEL_REQUEST_4_1__: loan to cancel = current loan
 		1. __CANCEL_REQUEST_4_1_1__: PENDING loan does not exist → (update loan, item is: in_transit (IN_TRANSIT_TO_HOUSE))
-		1. __CANCEL_REQUEST_4_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate logic is applied next PENDING loan] 
-		
+		1. __CANCEL_REQUEST_4_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate logic is applied next PENDING loan]
+
 	1. __CANCEL_REQUEST_4_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))
 
 1. :100: __CANCEL_REQUEST_5__: item in_transit (IN_TRANSIT_TO_HOUSE)

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -483,7 +483,7 @@ class ItemCirculation(ItemRecord):
         actions = {}
         loan = Loan.get_record_by_pid(pid)
         # decide  which actions need to be executed according to loan state.
-        actions_to_execute = self.checks_before_a_cancel_item_request(loan, **kwargs)
+        actions_to_execute = self.checks_before_a_cancel_item_request(loan)
         # execute the actions
         if actions_to_execute.get("cancel_loan"):
             item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
@@ -494,14 +494,16 @@ class ItemCirculation(ItemRecord):
             actions.update({LoanAction.UPDATE: loan})
         elif actions_to_execute.get("validate_first_pending"):
             pending = self.get_first_loan_by_state(state=LoanState.PENDING)
-            loan_pickup = loan.get("pickup_location_pid", None)
+            # for an at desk loan, the last `validate`/`receive` action took
+            # place where the item is.
+            item_location_pid = loan.transaction_location_pid
             pending_pickup = pending.get("pickup_location_pid", None)
             # If the item is at_desk at the same location as the next loan
             # pickup we can validate the next loan so that it becomes at desk
             # for the next patron.
-            if loan.get("state") == LoanState.ITEM_AT_DESK and loan_pickup == pending_pickup:
+            if loan.get("state") == LoanState.ITEM_AT_DESK and item_location_pid == pending_pickup:
                 item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
-                kwargs["transaction_location_pid"] = loan_pickup
+                kwargs["transaction_location_pid"] = item_location_pid
                 kwargs.pop("transaction_library_pid", None)
                 item, validate_actions = self.validate_request(pid=pending.pid, **kwargs)
                 actions.update(validate_actions)
@@ -516,11 +518,14 @@ class ItemCirculation(ItemRecord):
         item = self
         return item, actions
 
-    def checks_before_a_cancel_item_request(self, loan, **kwargs):
-        """Actions tobe executed before a cancel item request.
+    def checks_before_a_cancel_item_request(self, loan):
+        """Actions to be executed before a cancel item request.
+
+        When the loan is at desk, the item is located at the transaction
+        location of the loan, ie. where its last `validate` or `receive`
+        action took place.
 
         :param loan : the current loan to cancel
-        :param kwargs : all others named arguments
         :return: the item record and list of actions performed
         """
         actions_to_execute = {
@@ -528,7 +533,6 @@ class ItemCirculation(ItemRecord):
             "loan_update": {},
             "validate_first_pending": False,
         }
-        libraries = self.compare_item_pickup_transaction_libraries(**kwargs)
         # List all loan states attached to this item except the loan to cancel.
         # If the list is empty, no pending request/loan are linked to this item
         states = self.get_loans_states_by_item_pid_exclude_loan_pid(self.pid, loan.pid)
@@ -550,9 +554,10 @@ class ItemCirculation(ItemRecord):
                 # OperationLog about this cancellation.
                 actions_to_execute["cancel_loan"] = True
             elif loan["state"] == LoanState.ITEM_AT_DESK:
-                if not libraries["item_pickup_libraries"]:
-                    # CANCEL_REQUEST_2_1_1_1: when item library and pickup
-                    # pickup library arent equal, update loan to go in_transit.
+                if loan.transaction_library_pid != self.library_pid:
+                    # CANCEL_REQUEST_2_1_1_1: the item is at desk in a library
+                    # that isn't its owning library, update the loan to send
+                    # the item back home.
                     actions_to_execute["loan_update"]["state"] = LoanState.ITEM_IN_TRANSIT_TO_HOUSE
                 # Always mark the loan to be cancelled to create an
                 # OperationLog about this cancellation.

--- a/tests/api/circulation/test_actions_views_cancel_request.py
+++ b/tests/api/circulation/test_actions_views_cancel_request.py
@@ -5,6 +5,10 @@
 
 from invenio_accounts.testutils import login_user_via_session
 
+from rero_ils.modules.items.api import Item
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.models import LoanState
 from tests.utils import postdata
 
 
@@ -71,3 +75,30 @@ def test_cancel_an_item_request(
         },
     )
     assert res.status_code == 200
+
+
+def test_cancel_an_item_request_at_desk_in_another_library(
+    client,
+    librarian_martigny,
+    lib_martigny,
+    item_martigny_at_desk_fully_patron_and_loan_at_desk,
+    circulation_policies,
+):
+    """Test the frontend cancel of a request at desk in an external library."""
+    # A martigny item is at desk in the fully library, its request is
+    # cancelled by a librarian of the owning library: the item must go back
+    # home instead of going on shelf.
+    item, patron, loan = item_martigny_at_desk_fully_patron_and_loan_at_desk
+    login_user_via_session(client, librarian_martigny.user)
+    res, _ = postdata(
+        client,
+        "api_item.cancel_item_request",
+        {
+            "pid": loan.pid,
+            "transaction_library_pid": lib_martigny.pid,
+            "transaction_user_pid": librarian_martigny.pid,
+        },
+    )
+    assert res.status_code == 200
+    assert Item.get_record_by_pid(item.pid).status == ItemStatus.IN_TRANSIT
+    assert Loan.get_record_by_pid(loan.pid)["state"] == LoanState.ITEM_IN_TRANSIT_TO_HOUSE

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -757,7 +757,8 @@ def test_multiple_loans_on_item_error(
     new_loan = Loan.get_record_by_pid(req_loan_pid)
     assert new_loan.get("state") == "ITEM_AT_DESK"
     assert Item.get_record_by_pid(item.pid).get("status") == ItemStatus.AT_DESK
-    # cancel request
+    # cancel request: the item is at desk in an external library, it has to go
+    # back to its owning library
     res, _ = postdata(
         client,
         "api_item.cancel_item_request",
@@ -769,6 +770,20 @@ def test_multiple_loans_on_item_error(
         },
     )
     assert res.status_code == 200
+    assert Item.get_record_by_pid(item.pid).get("status") == ItemStatus.IN_TRANSIT
+
+    # receive the item at its owning library
+    res, _ = postdata(
+        client,
+        "api_item.checkin",
+        {
+            "item_pid": item.pid,
+            "transaction_user_pid": librarian_martigny.pid,
+            "transaction_location_pid": loc_public_martigny.pid,
+        },
+    )
+    assert res.status_code == 200
+    assert Item.get_record_by_pid(item.pid).get("status") == ItemStatus.ON_SHELF
 
 
 def test_filtered_items_get(

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -1074,6 +1074,43 @@ def item5_at_desk_martigny_patron_and_loan_at_desk(
 
 
 @pytest.fixture(scope="module")
+def item_martigny_at_desk_fully_patron_and_loan_at_desk(
+    app,
+    librarian_martigny,
+    librarian_fully,
+    item_lib_martigny,
+    loc_public_martigny,
+    loc_public_fully,
+    patron_martigny,
+    circulation_policies,
+):
+    """Creates a martigny item validated and received at the fully library.
+
+    :return item: the created or copied item.
+    :return patron: the patron placed the request.
+    :return loan: the received loan, at desk in an external library.
+    """
+    params = {
+        "patron_pid": patron_martigny.pid,
+        "transaction_location_pid": loc_public_martigny.pid,
+        "transaction_user_pid": librarian_martigny.pid,
+        "pickup_location_pid": loc_public_fully.pid,
+    }
+    item, loan = item_record_to_a_specific_loan_state(
+        item=item_lib_martigny,
+        loan_state=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
+        params=params,
+        copy_item=True,
+    )
+    item, _ = item.receive(
+        pid=loan.pid,
+        transaction_location_pid=loc_public_fully.pid,
+        transaction_user_pid=librarian_fully.pid,
+    )
+    return item, patron_martigny, Loan.get_record_by_pid(loan.pid)
+
+
+@pytest.fixture(scope="module")
 def item_on_shelf_fully_patron_and_loan_pending(
     app,
     librarian_martigny,

--- a/tests/ui/circulation/test_actions_cancel_request.py
+++ b/tests/ui/circulation/test_actions_cancel_request.py
@@ -103,22 +103,21 @@ def test_cancel_request_on_item_on_shelf(
     assert loan["state"] == LoanState.CANCELLED
 
 
-def test_cancel_request_on_item_at_desk_no_requests_externally(
+def test_cancel_request_on_item_at_desk_in_another_library(
     client,
-    item_at_desk_martigny_patron_and_loan_at_desk,
+    item_martigny_at_desk_fully_patron_and_loan_at_desk,
     loc_public_martigny,
     librarian_martigny,
-    loc_public_fully,
 ):
-    """Test cancel requests on an at_desk item externally."""
-    item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
+    """Test cancel requests on an item at desk in an external library."""
+    item, patron, loan = item_martigny_at_desk_fully_patron_and_loan_at_desk
     # the following tests the circulation action CANCEL_REQUEST_2_1_1_1
-    # an item at_desk with no other pending loans.
-    # if the item library != pickup location, update the at_desk loan.
-    # loan ITEM_IN_TRANSIT_TO_HOUSE and item is: in_transit
+    # an item at_desk in an external library with no other pending loans.
+    # the item has to go back home: update the at_desk loan to
+    # ITEM_IN_TRANSIT_TO_HOUSE and item is: in_transit
     params = {
         "pid": loan.pid,
-        "transaction_location_pid": loc_public_fully.pid,
+        "transaction_location_pid": loc_public_martigny.pid,
         "transaction_user_pid": librarian_martigny.pid,
     }
     item.cancel_item_request(**params)
@@ -126,6 +125,30 @@ def test_cancel_request_on_item_at_desk_no_requests_externally(
     loan = Loan.get_record_by_pid(loan.pid)
     assert item.status == ItemStatus.IN_TRANSIT
     assert loan["state"] == LoanState.ITEM_IN_TRANSIT_TO_HOUSE
+
+
+def test_cancel_request_on_item_at_desk_no_requests_externally(
+    client,
+    item_at_desk_martigny_patron_and_loan_at_desk,
+    librarian_fully,
+    loc_public_fully,
+):
+    """Test cancel requests on an at_desk item externally."""
+    item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
+    # the following tests the circulation action CANCEL_REQUEST_2_1_1_2
+    # an item at_desk in its owning library with no other pending loans.
+    # the library where the request is cancelled has no influence: cancel the
+    # loan and item is: on_shelf
+    params = {
+        "pid": loan.pid,
+        "transaction_location_pid": loc_public_fully.pid,
+        "transaction_user_pid": librarian_fully.pid,
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.ON_SHELF
+    assert loan["state"] == LoanState.CANCELLED
 
 
 def test_cancel_request_on_item_at_desk_no_requests_at_home(


### PR DESCRIPTION
* Cancelling the request of an item at desk in an external library
  sent the item on shelf instead of in transit to house.
* The position of the item was deduced from the pickup location of
  the loan, which can be updated afterwards, or from the transaction
  library of the cancel operation, ie. where the librarian is.
* Use the transaction location of the loan instead, ie. the location
  of its last validate or receive action, both to determine the state
  of the cancelled loan and to validate the next pending request.
* Closes #3663.