### PR TITLE
chore: update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,9 +102,6 @@ dependencies = [
     "flask-admin>=1.6.1",
     "invenio-sip2>=0.6.25",
     "markdown-captions>=2.1.2",
-    # invenio-cache 3.0.1 uses a deprecated backend name removed in Flask-Caching 2.5.
-    # Remove this constraint once invenio-cache supports the new RedisCache name.
-    "flask-caching<2.5.0",
 ]
 
 [dependency-groups]

--- a/rero_ils/modules/documents/api_views.py
+++ b/rero_ils/modules/documents/api_views.py
@@ -29,8 +29,8 @@ def document_availability(pid):
 
 
 @api_blueprint.route("/advanced-search-config")
-@cached(timeout=5 * 60, query_string=True)  # 5 minutes timeout
 @check_logged_as_librarian
+@cached(timeout=5 * 60, query_string=True)  # 5 minutes timeout
 def advanced_search_config():
     """Advanced search config."""
 

--- a/rero_ils/modules/views.py
+++ b/rero_ils/modules/views.py
@@ -36,8 +36,8 @@ api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="")
 
 @api_blueprint.route("/permissions/<route_name>", methods=["GET"])
 @api_blueprint.route("/permissions/<route_name>/<record_pid>", methods=["GET"])
-@cached(timeout=10, key_prefix=record_permissions_cache_key)  # 10 seconds timeout
 @check_authentication
+@cached(timeout=10, key_prefix=record_permissions_cache_key)  # 10 seconds timeout
 def permissions(route_name, record_pid=None):
     """HTTP GET request for record permissions.
 

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -1033,6 +1033,12 @@ def test_document_advanced_search_config(app, db, client, system_librarian_marti
     check_field_data("rdaContentType", field_data, {"label": "rdaco:1002", "value": "rdaco:1002"})
     check_field_data("rdaMediaType", field_data, {"label": "rdamt:1001", "value": "rdamt:1001"})
 
+    # Authentication must still be checked when the response is cached.
+    with client.session_transaction() as session:
+        session.clear()
+    res = client.get(config_url)
+    assert res.status_code == 401
+
 
 @mock.patch(
     "invenio_records_rest.views.verify_record_permission",

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -56,6 +56,12 @@ def test_document_permissions(
     reasons = data.get("delete", {}).get("reasons", {})
     assert "others" in reasons and "permission" in reasons["others"]
 
+    # Authentication must still be checked when permissions are cached.
+    with client.session_transaction() as session:
+        session.clear()
+    res = client.get(url_for("api_blueprint.permissions", route_name="documents", record_pid=document.pid))
+    assert res.status_code == 401
+
 
 def test_document_permissions_cache_is_invalidated_by_holding_deletion(
     client,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,7 @@ def app_config(app_config):
     """Create temporary instance dir for each test."""
     app_config["CELERY_BROKER_URL"] = "memory://"
     app_config["RATELIMIT_STORAGE_URI"] = "memory://"
-    app_config["CACHE_TYPE"] = "simple"
+    app_config["CACHE_TYPE"] = "SimpleCache"
     app_config["SEARCH_ELASTIC_HOSTS"] = None
     app_config["SEARCH_CLIENT_CONFIG"] = {"timeout": 30, "max_retries": 3, "retry_on_timeout": True}
     app_config["SQLALCHEMY_DATABASE_URI"] = "postgresql+psycopg2://rero-ils:rero-ils@localhost/rero-ils"

--- a/tests/scheduler/conftest.py
+++ b/tests/scheduler/conftest.py
@@ -30,7 +30,7 @@ def app_config(app_config):
     """Create temporary instance dir for each test."""
     app_config["CELERY_BROKER_URL"] = "memory://"
     app_config["RATELIMIT_STORAGE_URI"] = "memory://"
-    app_config["CACHE_TYPE"] = "simple"
+    app_config["CACHE_TYPE"] = "SimpleCache"
     app_config["SEARCH_ELASTIC_HOSTS"] = None
     app_config["DB_VERSIONING"] = True
     app_config["CELERY_ALWAYS_EAGER"] = True

--- a/uv.lock
+++ b/uv.lock
@@ -921,15 +921,15 @@ wheels = [
 
 [[package]]
 name = "flask-caching"
-version = "2.4.1"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib" },
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/15/d2852e86419c6c1416cba00c177b2cf609b5c2935372933684f84111c631/flask_caching-2.4.1.tar.gz", hash = "sha256:ecef4ca80b9cb1fa01d461373a0fce441527cd57eecee1aa71c1f6d750d7ff77", size = 165380, upload-time = "2026-07-08T19:23:57.264Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/ce/a54552acb28bd0ac617703780e8f2344a4e5aee7a46936328fe7cf5b3a95/flask_caching-2.5.0.tar.gz", hash = "sha256:5a8779b54695f96e1b4a7a149dd8c6d863433ea66327cde4311ce7fd7b57391f", size = 218694, upload-time = "2026-08-24T18:52:01.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/e3/ad7572c7f00b1286f2fc2a387f01b62bb46b59c5f91536093eae57889adb/flask_caching-2.4.1-py3-none-any.whl", hash = "sha256:5f5555d610ec1f230c8200ae00c1c723ee562f657c22f896b806f4689513b952", size = 28977, upload-time = "2026-07-08T19:23:55.68Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/51/ce7bc1eb0787acef0fecd6dae3f9f45cf46da5c5a51da79efa1e0eb2724c/flask_caching-2.5.0-py3-none-any.whl", hash = "sha256:8e625acd99759171a428ceb9b669ba6743c11dd9b37ace4e0ea7a3ee34097ccd", size = 34976, upload-time = "2026-08-24T18:52:00.136Z" },
 ]
 
 [[package]]
@@ -1537,15 +1537,15 @@ wheels = [
 
 [[package]]
 name = "invenio-cache"
-version = "3.0.1"
+version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-caching" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/ee/36fb71ec0f552e8dda7928607a28c5a7ac77e5c0cca3b84a2e8277d641bc/invenio_cache-3.0.1.tar.gz", hash = "sha256:c0f0d288bfac367f86abd0b5c66c4ab80883731d901cfccf3ae1116557e36fd6", size = 7393, upload-time = "2026-07-16T14:36:07.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/82/da5cd830498da53df2b5bdf9ec49b9688e9a5eaf44592eecf7b65e7718a5/invenio_cache-3.0.2.tar.gz", hash = "sha256:9e8bf45b45480926930d90104f03270c2128ae60e8d55062b51ab6ca01e10aee", size = 7417, upload-time = "2026-08-25T14:13:15.2Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/d9/a3491db20ba2509f6d38656c4dc125f80b12ef2375987551d3926f1a413a/invenio_cache-3.0.1-py3-none-any.whl", hash = "sha256:c71b50e0a7cdd250f6488037de357c974f45deb2b8f56fe973b396e051425aec", size = 10678, upload-time = "2026-07-16T14:36:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b6/d33a3e01fbfb591463cc2b9c0eeffa5495f2a508fd7314996e1b5e5c49eb/invenio_cache-3.0.2-py3-none-any.whl", hash = "sha256:eca2ed99a72bd45afbf6883c2a882f769e8f6c78e98bf6a4382e8b2d4d1210ef", size = 10717, upload-time = "2026-08-25T14:13:14.356Z" },
 ]
 
 [[package]]
@@ -3719,7 +3719,6 @@ dependencies = [
     { name = "dnspython" },
     { name = "dojson" },
     { name = "flask-admin" },
-    { name = "flask-caching" },
     { name = "flask-wiki" },
     { name = "invenio-access" },
     { name = "invenio-accounts" },
@@ -3805,7 +3804,6 @@ requires-dist = [
     { name = "dnspython", specifier = ">=2.4.2" },
     { name = "dojson", specifier = ">=1.4.0" },
     { name = "flask-admin", specifier = ">=1.6.1" },
-    { name = "flask-caching", specifier = "<2.5.0" },
     { name = "flask-wiki", specifier = ">=1.0.0" },
     { name = "invenio-access", specifier = ">=4.0.0" },
     { name = "invenio-accounts", specifier = ">=6.0.0" },


### PR DESCRIPTION
* Upgrade invenio-cache and Flask-Caching now that their compatibility issue is resolved.
* Update test configuration to use the new SimpleCache backend name required by Flask-Caching 2.5.
* Authenticate before serving cached responses so cached errors cannot
  block valid users and cached content cannot bypass access control.
* Verify authentication remains enforced when responses are cached.