### PR TITLE
fix: invalidate permissions cache

### DIFF
--- a/rero_ils/modules/acquisition/acq_receipts/extensions.py
+++ b/rero_ils/modules/acquisition/acq_receipts/extensions.py
@@ -5,6 +5,8 @@
 
 from invenio_records.extensions import RecordExtension
 
+from rero_ils.modules.permissions_cache import register_record_permissions_cache_deletion
+
 
 class AcqReceiptExtension(RecordExtension):
     """Defines hooks about API functions calls for AcqReceipt."""
@@ -15,6 +17,7 @@ class AcqReceiptExtension(RecordExtension):
         :param record: the record metadata.
         :param force: force the deleting of the record.
         """
+        register_record_permissions_cache_deletion("acq_orders", record.order_pid)
         # For receipts, we are allowed to delete all of its receipt lines
         # without further checks.
         for line in record.get_receipt_lines():

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -26,6 +26,7 @@ from invenio_search import current_search
 from rero_ils.modules.loans.logs.api import NoCirculationOperationLog
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.patron_transactions.api import PatronTransactionsSearch
+from rero_ils.modules.permissions_cache import register_record_permissions_cache_deletion
 
 from ....filter import format_date_filter
 from ...circ_policies.api import CircPolicy
@@ -611,6 +612,8 @@ class ItemCirculation(ItemRecord):
             current_app.logger.error(
                 f"Loan state has not changed after REQUEST: {loan.pid} state: {old_state} kwargs: {kwargs}"
             )
+        else:
+            register_record_permissions_cache_deletion("items", self.pid)
         return self, {LoanAction.REQUEST: loan}
 
     @add_action_parameters_and_flush_indexes

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -3,14 +3,17 @@
 
 """Test record permissions API."""
 
+from unittest import mock
+
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_cache import current_cache
+from invenio_circulation.proxies import current_circulation
 from invenio_db import db
 
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.permissions_cache import record_permissions_cache_key
-from tests.utils import get_json, login_user
+from tests.utils import get_json, login_user, postdata
 
 
 def test_document_permissions(
@@ -165,6 +168,108 @@ def test_items_permissions(
 
     response = client.get(url_for("api_blueprint.permissions", route_name="items", record_pid="dummy_item_pid"))
     assert response.status_code == 404
+
+
+def test_item_permissions_cache_is_invalidated_by_request(
+    client,
+    item_lib_martigny,
+    librarian_martigny,
+    patron_martigny,
+    loc_public_martigny,
+    lib_martigny,
+    circulation_policies,
+):
+    """Test item permissions cache invalidation after a request."""
+    login_user_via_session(client, librarian_martigny.user)
+    permissions = call_api_permissions(client, "items", item_lib_martigny.pid)
+    assert permissions["delete"]["can"]
+    cache_key = record_permissions_cache_key("items", item_lib_martigny.pid)
+    current_cache.set(cache_key, permissions, timeout=10)
+
+    request_data = {
+        "item_pid": item_lib_martigny.pid,
+        "patron_pid": patron_martigny.pid,
+        "pickup_location_pid": loc_public_martigny.pid,
+        "transaction_library_pid": lib_martigny.pid,
+        "transaction_user_pid": librarian_martigny.pid,
+    }
+
+    # A failed request must not invalidate the permissions cache.
+    response, _ = postdata(
+        client,
+        "api_item.librarian_request",
+        {"item_pid": item_lib_martigny.pid, "patron_pid": patron_martigny.pid},
+    )
+    assert response.status_code == 400
+    assert current_cache.get(cache_key) == permissions
+
+    response, _ = postdata(client, "api_item.librarian_request", request_data)
+    assert response.status_code == 200
+    assert current_cache.get(cache_key) is None
+
+    permissions = call_api_permissions(client, "items", item_lib_martigny.pid)
+    assert not permissions["delete"]["can"]
+    assert permissions["delete"]["reasons"]["links"]["loans"] == 1
+
+
+def test_item_permissions_cache_is_preserved_without_request_state_change(
+    client,
+    item2_lib_martigny,
+    librarian_martigny,
+    patron_martigny,
+    loc_public_martigny,
+    lib_martigny,
+    circulation_policies,
+):
+    """Test item permissions cache preservation without a state change."""
+    login_user_via_session(client, librarian_martigny.user)
+    permissions = call_api_permissions(client, "items", item2_lib_martigny.pid)
+    assert permissions["delete"]["can"]
+    cache_key = record_permissions_cache_key("items", item2_lib_martigny.pid)
+    current_cache.set(cache_key, permissions, timeout=10)
+
+    request_data = {
+        "item_pid": item2_lib_martigny.pid,
+        "patron_pid": patron_martigny.pid,
+        "pickup_location_pid": loc_public_martigny.pid,
+        "transaction_library_pid": lib_martigny.pid,
+        "transaction_user_pid": librarian_martigny.pid,
+    }
+    with mock.patch.object(
+        current_circulation.circulation,
+        "trigger",
+        side_effect=lambda loan, **kwargs: loan,
+    ):
+        response, _ = postdata(client, "api_item.librarian_request", request_data)
+
+    assert response.status_code == 200
+    assert current_cache.get(cache_key) == permissions
+
+
+def test_order_permissions_cache_is_invalidated_by_receipt_deletion(
+    client,
+    librarian_martigny,
+    acq_order_fiction_martigny,
+    acq_receipt_fiction_martigny,
+    acq_receipt_line_1_fiction_martigny,
+):
+    """Test order permissions cache invalidation after receipt deletion."""
+    login_user_via_session(client, librarian_martigny.user)
+
+    order_key = record_permissions_cache_key("acq_orders", acq_order_fiction_martigny.pid)
+    order_permissions = call_api_permissions(client, "acq_orders", acq_order_fiction_martigny.pid)
+    assert not order_permissions["delete"]["can"]
+    assert order_permissions["delete"]["reasons"]["links"]["acq_receipts"] == 1
+    current_cache.set(order_key, order_permissions, timeout=10)
+
+    response = client.delete(url_for("invenio_records_rest.acre_item", pid_value=acq_receipt_fiction_martigny.pid))
+    assert response.status_code == 204
+    assert current_cache.get(order_key) is None
+
+    order_permissions = call_api_permissions(client, "acq_orders", acq_order_fiction_martigny.pid)
+    assert not order_permissions["delete"]["can"]
+    assert "acq_receipts" not in order_permissions["delete"]["reasons"].get("links", {})
+    assert order_permissions["delete"]["reasons"]["others"]["order_already_sent"]
 
 
 def call_api_permissions(client, route_name, pid):


### PR DESCRIPTION
Some permission responses remained cached for up to 10 seconds after related records changed, temporarily leaving delete actions in an outdated state. This change invalidates the affected cache entries so permissions are recalculated immediately.

* Invalidates cache for serial items and order receipts.
* Closes #4222