### PR TITLE
fix(files): allow the file metadata extraction

### DIFF
--- a/rero_ils/modules/files/permissions.py
+++ b/rero_ils/modules/files/permissions.py
@@ -66,6 +66,10 @@ class FilePermissionPolicy(RecordPermissionPolicy):
         AllowedByActionRestrictByManageableLibrary(update_action, get_library_pid),
         SystemProcess(),
     ]
+    # Runs from the `extract_file_metadata` task once a file is committed, under the system identity. It carries
+    # its own action since invenio-records-resources 11.0.3, up to 11.0.2 it was checked against `create_files`.
+    # Without it the task is denied and the metadata entry of the file is never written.
+    can_extract_file_metadata = [AllowedByAction(create_action), SystemProcess()]
     can_delete_files = [
         AllowedByActionRestrictByManageableLibrary(delete_action, get_library_pid),
         SystemProcess(),

--- a/rero_ils/modules/files/results.py
+++ b/rero_ils/modules/files/results.py
@@ -3,6 +3,7 @@
 
 """Files results classes."""
 
+from flask import current_app
 from invenio_records_resources.services.files.results import FileList
 
 
@@ -12,9 +13,16 @@ class MainFileList(FileList):
     @property
     def entries(self):
         """Iterator over the hits."""
+        record_id = self._record.get("id")
         for entry in self._results:
+            if (metadata := entry.metadata) is None:
+                # Every file is expected to carry a metadata entry, an empty one for an uploaded file and a typed
+                # one for the thumbnails and the full texts. Missing it altogether is not a shape this code
+                # produces, so the file is reported and left out rather than guessed about.
+                current_app.logger.error("File without metadata, record: %s file: %s", record_id, entry.key)
+                continue
             # keep only the main files
-            if entry.metadata.get("type") in ["fulltext", "thumbnail"]:
+            if metadata.get("type") in ["fulltext", "thumbnail"]:
                 continue
             projection = self._service.file_schema.dump(
                 entry,

--- a/tests/api/files/test_files_permissions.py
+++ b/tests/api/files/test_files_permissions.py
@@ -8,6 +8,7 @@ from unittest import mock
 from flask import current_app, url_for
 from flask_principal import AnonymousIdentity, identity_changed
 from flask_security import login_user
+from invenio_access.permissions import system_identity
 from invenio_accounts.testutils import login_user_via_session
 
 from rero_ils.modules.files.permissions import FilePermissionPolicy
@@ -213,3 +214,16 @@ def test_files_permissions(
         {"search": True, "read": True, "create": True, "update": True, "delete": True},
         record_file,
     )
+
+
+def test_files_extract_metadata_permission(app, document_with_files):
+    """Test that the file metadata extraction is allowed to the system.
+
+    The extraction runs from a task under the system identity once a file is committed, and it is the only
+    thing that gives an uploaded file its metadata entry. An action the policy does not know about falls
+    back to `Disable()`, which leaves every uploaded file without metadata.
+    """
+    record_file = next(document_with_files.get_records_files())
+    permission = FilePermissionPolicy("extract_file_metadata", record=record_file)
+    assert permission.allows(system_identity)
+    assert not permission.allows(AnonymousIdentity())

--- a/tests/api/files/test_files_rest.py
+++ b/tests/api/files/test_files_rest.py
@@ -24,3 +24,37 @@ def test_documents_get(client, document_with_files, librarian_martigny):
         "n_files",
         "file_size",
     }
+
+
+def test_files_get(client, document_with_files, librarian_martigny):
+    """Test the file list of a record.
+
+    Only the extracted full texts and the thumbnails carry a type, so the
+    uploaded files are the ones left in the list.
+    """
+    login_user_via_session(client, librarian_martigny.user)
+    res = client.get(url_for("records.search"))
+    assert res.status_code == 200
+    record_id = get_json(res)["hits"]["hits"][0]["id"]
+
+    res = client.get(url_for("records_files.search", pid_value=record_id))
+    assert res.status_code == 200
+
+    entries = get_json(res)["entries"]
+    assert entries
+    # the uploaded files are listed, the derivatives are filtered out
+    assert all(entry.get("metadata", {}).get("type") is None for entry in entries)
+    assert any(entry["key"].endswith(".pdf") for entry in entries)
+
+
+def test_files_have_metadata(document_with_files):
+    """Test that a committed file ends up with a metadata entry.
+
+    The entry is written by the `extract_file_metadata` task, which runs under the system identity once the
+    file is committed. The task logs its own errors instead of raising, so a missing permission leaves every
+    file without metadata without anything failing.
+    """
+    record_file = next(document_with_files.get_records_files())
+    assert record_file.files
+    for key, file_record in record_file.files.items():
+        assert file_record.metadata is not None, f"{key} has no metadata entry"


### PR DESCRIPTION
The metadata entry of a file is written by the `extract_file_metadata` task, which runs under the system identity once the file is committed. invenio-records-resources 11.0.3 gave that operation its own permission action, up to 11.0.2 it was checked against `create_files`. An action the policy does not know about falls back to `Disable()`, so the task was denied and no file got its entry any more.

Nothing surfaced it: the task logs its own errors instead of raising, so celery reported every one of them as succeeded. Listing the files of a record then answered a 500, as the type was read from an entry that was never written.

* Grant the action to whoever may create files. It reuses the existing `file-create` action, so the audience is the same as for adding a file and no role has to be changed.
* Report a file without a metadata entry and leave it out of the list, rather than reading the type from it.
* Cover both with tests. The file list endpoint had no test at all, and none asserted that a committed file ends up with an entry, which is why a silently denied task went unnoticed.