### PR TITLE
perf(search): right-size the index shards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -437,6 +437,7 @@ templates = "rero_ils.modules.templates.mappings"
 vendors = "rero_ils.modules.vendors.mappings"
 
 [project.entry-points."invenio_search.templates"]
+migrations = "rero_ils.modules.migrations.es_templates:list_search_templates"
 operation_logs = "rero_ils.modules.operation_logs.es_templates:list_search_templates"
 rero_ils = "rero_ils.es_templates:list_search_templates"
 

--- a/rero_ils/modules/migrations/api.py
+++ b/rero_ils/modules/migrations/api.py
@@ -61,7 +61,6 @@ class Migration(Document):
         """Migration Index configuration."""
 
         name = "migrations-20240909"
-        settings = {"number_of_shards": 2, "number_of_replicas": 2}
         aliases = {"migrations": {}}
 
     @property
@@ -78,7 +77,6 @@ class Migration(Document):
     def data_class(self):
         """Returns the class to create a migration data."""
         index = Index(name=self.data_index_name)
-        index.settings(**IndexCfg.settings)
         index.aliases(**IndexCfg.aliases)
         cls = MigrationData.clone()
         return index.document(cls)

--- a/rero_ils/modules/migrations/data/api.py
+++ b/rero_ils/modules/migrations/data/api.py
@@ -27,7 +27,6 @@ def _(x):
 class IndexCfg:
     """Migration Data Index configuration."""
 
-    settings = {"number_of_shards": 2, "number_of_replicas": 2}
     aliases = {"migration-data": {}}
 
 

--- a/rero_ils/modules/migrations/es_templates/__init__.py
+++ b/rero_ils/modules/migrations/es_templates/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""search index templates for Migration records."""
+
+
+def list_search_templates():
+    """Search index templates path."""
+    return ["rero_ils.modules.migrations.es_templates"]

--- a/rero_ils/modules/migrations/es_templates/v7/__init__.py
+++ b/rero_ils/modules/migrations/es_templates/v7/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""search Templates module for the migrations."""

--- a/rero_ils/modules/migrations/es_templates/v7/migrations.json
+++ b/rero_ils/modules/migrations/es_templates/v7/migrations.json
@@ -1,0 +1,11 @@
+{
+  "index_patterns": [
+    "migrations-*",
+    "migration-data-*"
+  ],
+  "order": 10,
+  "settings": {
+    "number_of_shards": "1",
+    "number_of_replicas": "1"
+  }
+}

--- a/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
+++ b/rero_ils/modules/operation_logs/es_templates/v7/operation_logs.json
@@ -3,7 +3,7 @@
     "operation_logs*"
   ],
   "settings": {
-    "number_of_shards": "8",
+    "number_of_shards": "2",
     "number_of_replicas": "1",
     "max_result_window": "100000"
   },


### PR DESCRIPTION
Three values, measured on a copy of the production cluster rather than chosen by
rule of thumb. The full audit that produced them is separate; this PR carries
only what the measurements justify.

### What the cluster looks like today

| | |
| --- | --- |
| primary shards | 528 |
| primary data | 44.68 GB |
| average per primary shard | **86.6 MB** |
| indices under 10 MB per shard | **46 of 70** |
| shards per data node | 266, on 4 nodes with 16 GB of heap |

### `operation_logs`: 8 → 2 shards

This is where the shards concentrate. 35 yearly indices with 8 shards each make
**560 shards, more than half the cluster**, for 27 GB — and every year before
2021 sits under 50 MB per shard. Three of them are absurd: `operation_logs-1900`
and `-1988` hold **one document each**, `-1899` holds 285, for 16 shards apiece.
They come from out-of-range dates in migrated data.

Going to 2 shards removes 426 shards. The template for this family already
exists, so this is one value in one file.

**Why 2 and not 1.** The `stats` module aggregates over these indices. Measured
on `operation_logs-2023`, 21.4 million entries:

| | |
| --- | --- |
| across the 8 shards | 157 ms |
| a single shard, 2.7 M of the 21.4 M entries | 133 ms |
| extrapolated, one shard for the whole index | ~1 s |
| extrapolated, two shards | ~0.5 s |

Those aggregations are nightly and tolerant, but two shards cost only 35 shards
more than one across the whole family. Not worth the second.

### Migration indices: the template they never had

`migrations-*` and `migration-data-*` asked for 2 replicas, which needs at least
**three data nodes** to turn green. Production has four, so they are green there;
on a smaller cluster they stay yellow forever. And the value had already drifted:
on a copy of production, `migrations-20240909` sits at 2 replicas while both
`migration-data-*` indices sit at 1. `number_of_replicas` is dynamic, so anything
can change it after creation and nothing asserts the intent again.

But the value was not the real problem: **these were the only indices whose shard
count lived in Python**, as explicit index settings in `migrations/api.py` and
`migrations/data/api.py`. Explicit settings beat any template whatever its
`order`, so this one index family silently escaped the mechanism that governs
every other. Correcting the number in place would have left that exception
standing.

So they now get a template like everyone else, and the Python settings are gone.
It declares nothing but the two counts, at `order: 10`, so `migrations-*` keeps
everything `record.json` gives it at order 0. Verified on an index built from both
templates:

| | |
| --- | --- |
| `number_of_shards` | **1**, from the new template |
| `number_of_replicas` | **1**, from the new template |
| `max_result_window` | **100000**, still inherited from `record.json` |

That inheritance matters: `Migration.name` and `.description` are `Text` fields,
analysed by the `default` analyzer that `record.json` defines — a custom analyzer
with ICU folding and German normalisation. Dropping `migrations-*` from
`record.json` instead would have changed how migration names are searched.

`migration-data-*` is matched by no other template, so it simply gains the two
counts it was setting in Python.

### What this PR deliberately does not touch

`es_templates/v7/record.json` keeps its 8 shards. Reducing them would slow down
the most critical query of the catalogue.

The per-shard aggregation cost is linear — **0.38 ms per thousand documents
examined** — and the shards genuinely work in parallel: a facet query takes
**102 ms across the 8 shards** of `documents` and **100 ms on a single shard**
holding an eighth of the data. So halving the shards doubles the latency:

| shards of `documents` | documents per shard | facet query |
| --- | --- | --- |
| 8 | 251 176 | **102 ms, measured** |
| 4 | 502 352 | ~196 ms |
| 1 | 2 009 409 | ~769 ms |

The same holds for `items` (3.4 M entries, 10 facets, a facet query measured at
118 ms) and `loans` (7.6 M entries, 8 facets). The 59 remaining small indices are
left alone too: the fan-out costs them between 0.07 and 0.71 ms per request,
against 4.5 ms of network round trip, so reducing their shards would be hygiene
rather than optimisation — and each one would need a reindex.

### Deploying

`number_of_replicas` is dynamic; `number_of_shards` is fixed at creation. So both
templates apply in full to indices created after them, and to nothing that
already exists. Measured on a copy of production:

| index | primaries | replicas | documents | to do |
| --- | --- | --- | --- | --- |
| `migrations-20240909` | 2 | **2** | 2 | drop a replica |
| `migration-data-bramois` | 2 | 1 | 7 492 | nothing |
| `migration-data-rerodocvs` | 2 | 1 | 648 | nothing |

One call covers it, and needs no reindex:

```
PUT migrations-20240909/_settings
{"index": {"number_of_replicas": 1}}
```

The primaries are left alone: 2 → 1 on these three indices saves 3 shards, which
does not pay for a reindex. The reindex that pays is `operation_logs`, where the
35 yearly indices keep their 8 shards until
`invenio rero es index rebuild` runs — 426 shards, and the only reason the 8 → 2
change is worth making.

The three one-document `operation_logs` indices are worth deleting, and the
out-of-range dates worth fixing upstream in the migrated data, otherwise they
come back on the next load. That is a data fix, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

