### PR TITLE
feat(oauth): rework the authorisation page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     # Invenio auth bundle
     "invenio-access>=4.0.0",
     "invenio-accounts>=6.0.0",
-    "invenio-oauth2server>=3.0.0",
+    "invenio-oauth2server>=6.1.0",
     "invenio-oauthclient>=5.0.0",
     # Invenio metadata bundle
     "invenio-indexer>=4.0.0",

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -4158,8 +4158,9 @@ SIP2_SUMMARY_FIELDS = {
     LoanState.ITEM_ON_LOAN: "charged_items",
 }
 
-# OAuth base template
+# OAuth templates
 OAUTH2SERVER_COVER_TEMPLATE = "rero_ils/oauth/base.html"
+OAUTH2SERVER_AUTHORIZE_TEMPLATE = "rero_ils/oauth/authorize.html"
 
 # Extend the oauthlib allowed character set for Lucene query syntax.
 # Characters that commonly appear unencoded in query strings:

--- a/rero_ils/oauth/scopes.py
+++ b/rero_ils/oauth/scopes.py
@@ -3,11 +3,12 @@
 
 """OAuth server scopes."""
 
+from flask_babel import lazy_gettext as _
 from invenio_oauth2server.models import Scope
 
-fullname = Scope("fullname", help_text="Full name", group="User")
-birthdate = Scope("birthdate", help_text="Birthdate", group="User")
-expiration_date = Scope("expiration_date", help_text="Expiration date", group="User")
-institution = Scope("institution", help_text="Institution", group="User")
-patron_type = Scope("patron_type", help_text="Patron type", group="User")
-patron_types = Scope("patron_types", help_text="Patron types (deprecated)", group="User")
+fullname = Scope("fullname", help_text=_("Full name"), group="User")
+birthdate = Scope("birthdate", help_text=_("Birth date"), group="User")
+expiration_date = Scope("expiration_date", help_text=_("Expiration date"), group="User")
+institution = Scope("institution", help_text=_("Organisation"), group="User")
+patron_type = Scope("patron_type", help_text=_("Patron type"), group="User")
+patron_types = Scope("patron_types", help_text=_("Network, patron type, and expiration date (regrouped)"), group="User")

--- a/rero_ils/theme/assets/scss/rero_ils/styles.scss
+++ b/rero_ils/theme/assets/scss/rero_ils/styles.scss
@@ -56,6 +56,10 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
     width: 10em;
   }
 
+  .rero-ils-cover-panel {
+    max-width: 40rem;
+  }
+
   // CSS code to allow `ng-csp="no-inline-css"`
   [ng\:cloak],
   [ng-cloak],

--- a/rero_ils/theme/templates/rero_ils/oauth/authorize.html
+++ b/rero_ils/theme/templates/rero_ils/oauth/authorize.html
@@ -1,0 +1,57 @@
+{# SPDX-FileCopyrightText: Fondation RERO+ #}
+{# SPDX-License-Identifier: AGPL-3.0-or-later #}
+
+{%- extends 'rero_ils/page_cover.html' %}
+{%- set title = _('Authorise application') ~ ' | ' ~ _(config.THEME_SITENAME) %}
+
+{% block panel %}
+<div class="card text-left mb-4 rero-ils-cover-panel">
+  <h3 class="card-title my-4 text-center">
+    <i class="fa-solid fa-shield-halved"></i> {{ _('Authorise external application') }}
+  </h3>
+  <div class="card-body">
+    <p class="lead">
+      {{ _('%(application)s would like to use your %(sitename)s account to identify you.',
+           application=client.name, sitename=_(config.THEME_SITENAME)) }}
+    </p>
+    {%- if client.description %}
+    <p class="text-muted">{{ client.description }}</p>
+    {%- endif %}
+    {%- set website = client.website | string %}
+    {%- if website.lower().startswith(('http://', 'https://')) %}
+    <p>
+      <a href="{{ website }}" target="_blank" rel="noopener noreferrer">
+        {{ _('Visit application website') }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>
+      </a>
+    </p>
+    {%- endif %}
+
+    <h5 class="mt-4">{{ _('The following information will be shared') }}</h5>
+    {%- if scopes %}
+    <ul>
+      {%- for scope in scopes %}<li>{{ scope.help_text }}</li>{% endfor %}
+    </ul>
+    {%- else %}
+    <p><em>{{ _('No permissions granted.') }}</em></p>
+    {%- endif %}
+
+    <p class="alert alert-info" role="alert">
+      <i class="fa-solid fa-lock"></i>
+      {{ _('Your password is never shared with this application.') }}
+    </p>
+
+    <form action="" method="POST" class="text-center mt-4">
+      <button type="submit" value="yes" name="confirm" class="btn btn-primary btn-lg mb-2">
+        <i class="fa-solid fa-check"></i> {{ _('Authorise application') }}
+      </button>
+      <button type="submit" value="no" name="confirm" class="btn btn-outline-secondary btn-lg mb-2">
+        <i class="fa-solid fa-ban"></i> {{ _('Reject') }}
+      </button>
+    </form>
+  </div>
+  <div class="card-footer text-muted text-center">
+    {{ _('You are signed in as %(account)s.', account=current_user.email) }}
+    <a href="{{ url_for_security('logout') }}">{{ _('Log out') }}</a>
+  </div>
+</div>
+{% endblock panel %}

--- a/rero_ils/theme/templates/rero_ils/oauth/base.html
+++ b/rero_ils/theme/templates/rero_ils/oauth/base.html
@@ -2,12 +2,12 @@
 {# SPDX-License-Identifier: AGPL-3.0-or-later #}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ current_i18n.locale.language|safe }}" dir="{{ current_i18n.locale.text_direction }}">
 
 <head>
   <meta charset="utf-8" />
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
-    integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous" />
+  <title>{{ title or _(config.THEME_SITENAME) }}</title>
+  {{ webpack['global.css'] }}
 </head>
 
 <body style="padding: 4em;">

--- a/rero_ils/theme/webpack.py
+++ b/rero_ils/theme/webpack.py
@@ -21,7 +21,7 @@ theme = WebpackBundle(
     },
     dependencies={
         "popper.js": "1.16.1",
-        "jquery": "~3.2.1",
+        "jquery": "^3.7",
         "bootstrap": "~4.5.3",
         "@fortawesome/fontawesome-free": "^7.0.0",
     },

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -3,11 +3,16 @@
 
 """Views tests."""
 
+from urllib.parse import urlsplit
+
 import pytest
-from flask import session, url_for
+from bs4 import BeautifulSoup
+from flask import render_template, session, url_for
 from flask_login import login_user, logout_user
 from flask_security import url_for_security
 from invenio_accounts.testutils import login_user_via_session, login_user_via_view
+from invenio_oauth2server.models import Client
+from invenio_oauth2server.proxies import current_oauth2server
 
 from rero_ils.modules.users.api import user_formatted_name
 from rero_ils.theme.views import localized_label, nl2br
@@ -301,3 +306,82 @@ def test_login(client, app, user_with_profile):
         password=user_with_profile.password_plaintext,
     )
     assert res.status_code == 302
+
+
+def _asset_hosts(html):
+    """Return where the third-party hosts the scripts and stylesheets of a page come from.
+
+    The analytics tag is the one third-party script the application loads on
+    purpose, from the host the CSP allows in `script-src`.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    assets = [tag["src"] for tag in soup.select("script[src]")]
+    assets += [tag["href"] for tag in soup.select('link[rel="stylesheet"][href]')]
+    assert assets
+    # An asset served by the application has no netloc.
+    return {urlsplit(asset).netloc for asset in assets} - {"", "www.googletagmanager.com"}
+
+
+def test_assets_are_served_by_the_application(client, app):
+    """Test that the pages load their front-end libraries from no third-party host."""
+    for url in [
+        url_for("rero_ils.index"),
+        url_for("wiki.page", url="home"),
+        url_for_security("login"),
+    ]:
+        res = client.get(url)
+        assert res.status_code == 200
+        assert not _asset_hosts(res.text), url
+
+    # The OAuth cover page has no route of its own without a registered client.
+    with app.test_request_context():
+        assert not _asset_hosts(render_template(app.config["OAUTH2SERVER_COVER_TEMPLATE"]))
+
+
+def test_oauth_authorize_page(app, db, user_with_profile, user_without_name):
+    """Test that the OAuth consent page tells the patron what is at stake."""
+    oauth_client = Client(
+        name="Test application",
+        description="A test application",
+        website="https://example.org",
+        user=user_without_name,
+        is_confidential=False,
+        _redirect_uris="https://example.org/callback",
+    )
+    oauth_client.gen_salt()
+    db.session.add(oauth_client)
+    db.session.commit()
+
+    scopes = list(current_oauth2server.scopes.values())
+    with app.test_request_context():
+        login_user(user_with_profile)
+        html = render_template(app.config["OAUTH2SERVER_AUTHORIZE_TEMPLATE"], client=oauth_client, scopes=scopes)
+
+    # the application asking for the access, and the data it would receive
+    assert "Test application" in html
+    assert "A test application" in html
+    assert "Full name" in html
+    # the account about to be shared, and the reassurance about the password
+    assert user_with_profile.email in html
+    assert "Your password is never shared with this application." in html
+    # the owner of the OAuth client is no business of the patron
+    assert user_without_name.email not in html
+    # the page is styled by the theme bundle, not by a third-party stylesheet
+    assert not _asset_hosts(html)
+
+
+def test_oauth_authorize_page_website_scheme(app, user_with_profile):
+    """Test that only a web address of the application becomes a link."""
+    oauth_client = Client(name="Test application")
+
+    def render(website):
+        oauth_client.website = website
+        with app.test_request_context():
+            login_user(user_with_profile)
+            return render_template(app.config["OAUTH2SERVER_AUTHORIZE_TEMPLATE"], client=oauth_client, scopes=[])
+
+    assert 'href="https://example.org"' in render("https://example.org")
+    assert 'href="HTTP://example.org"' in render("HTTP://example.org")
+    # anything that is not a web address is not worth a link
+    for website in ["javascript:alert(1)", "javascript://example.org/%0aalert(1)", "data:text/html,x", ""]:
+        assert "Visit application website" not in render(website)

--- a/uv.lock
+++ b/uv.lock
@@ -3675,7 +3675,7 @@ requires-dist = [
     { name = "invenio-mail", specifier = ">=2.0.0" },
     { name = "invenio-oaiharvester", specifier = ">=1.0.0a4" },
     { name = "invenio-oaiserver", specifier = ">=4.0.0" },
-    { name = "invenio-oauth2server", specifier = ">=3.0.0" },
+    { name = "invenio-oauth2server", specifier = ">=6.1.0" },
     { name = "invenio-oauthclient", specifier = ">=5.0.0" },
     { name = "invenio-pidstore", specifier = ">=3.0.0" },
     { name = "invenio-records", specifier = ">=4.0.0" },


### PR DESCRIPTION
* replace the Bootstrap CDN of the OAuth cover page by the theme bundle, the last third-party asset the application loaded
* override authorize.html, which invenio-oauth2server 6.1.0 makes configurable, to address a library patron: no owner of the client, no user count, a flat list of the data shared and a word on the password
* Closes #3701.
* extend page_cover.html, as the login and password pages do
* carry the locale in the lang and dir attributes of the cover page
* mark the scope help texts for translation
* raise jquery to ^3.7, 3.2.1 predates CVE-2020-11022
* update the dependencies

:warning: Migrating to this version requires adding `OAUTH2SERVER_AUTHORIZE_TEMPLATE = "rero_ils/oauth/authorize.html"`

<img width="941" height="880" alt="image" src="https://github.com/user-attachments/assets/ebfd5b96-d76e-4777-b2da-2a11ac280018" />
