### PR TITLE
fix(users): no reset password email on creation

### DIFF
--- a/rero_ils/modules/patrons/utils.py
+++ b/rero_ils/modules/patrons/utils.py
@@ -60,32 +60,25 @@ def validate_role_changes(user, changes, raise_exc=True):
     return True
 
 
-def create_user_from_data(data, send_email=False):
+def create_user_from_data(data):
     """Create a user and set the profile fields from a data.
 
     :param data: A dict containing a mix of patron and user data.
-    :param send_email: send the reset password email to the user
     :returns: The modified dict.
     """
-    user = User.get_by_username(data.get("username"))
-    if not user:
-        user = User.create(data, send_email)
-        user_id = user.id
-    else:
-        user_id = user.user.id
-    data["user_id"] = user_id
+    user = User.get_by_username(data.get("username")) or User.create(data)
+    data["user_id"] = user.id
 
     return User.remove_fields(data)
 
 
-def create_patron_from_data(data, dbcommit=True, reindex=True, send_email=False):
+def create_patron_from_data(data, dbcommit=True, reindex=True):
     """Create a patron and a user from a data dict.
 
     :param data: dictionary representing a library user
-    :param send_email: send the reset password email to the user
     :returns: - A `Patron` instance
     """
     from .api import Patron
 
-    data = create_user_from_data(data, send_email)
+    data = create_user_from_data(data)
     return Patron.create(data=data, delete_pid=False, dbcommit=dbcommit, reindex=reindex)

--- a/rero_ils/modules/users/api.py
+++ b/rero_ils/modules/users/api.py
@@ -8,7 +8,6 @@ from flask import current_app, url_for
 from flask_babel import lazy_gettext as _
 from flask_login import current_user
 from flask_security.confirmable import confirm_user
-from flask_security.recoverable import send_reset_password_instructions
 from flask_security.utils import hash_password
 from invenio_accounts.models import User as BaseUser
 from invenio_db import db
@@ -103,12 +102,11 @@ class User:
         return self.user.id
 
     @classmethod
-    def create(cls, data, send_email=True, **kwargs):
+    def create(cls, data):
         """User record creation.
 
         :param cls - class object
         :param data - dictionary representing a user record
-        :param send_email - send the reset password email to the user
         """
         with db.session.begin_nested():
             # Generate password if not present
@@ -125,15 +123,12 @@ class User:
                 active=True,
             )
             db.session.add(user)
-            # send the reset password notification for new users
             if email := data.get("email"):
                 user.email = email
             else:
                 user.domain = "unknown"
             db.session.merge(user)
         db.session.commit()
-        if data.get("email") and send_email:
-            send_reset_password_instructions(user)
         confirm_user(user)
         return cls(user)
 

--- a/rero_ils/modules/users/api.py
+++ b/rero_ils/modules/users/api.py
@@ -116,7 +116,7 @@ class User:
             if profile:
                 cls._validate_profile(profile)
             cls._validate_data(data=data)
-            password = data.get("password", password_generator())
+            password = data.get("password") or password_generator()
             cls._validate_password(password=password)
             user = BaseUser(
                 username=data.get("username"),

--- a/rero_ils/modules/users/views.py
+++ b/rero_ils/modules/users/views.py
@@ -169,11 +169,6 @@ class UsersCreateResource(ContentNegotiatedMethodView):
     def post(self):
         """Implement the POST."""
         user = User.create(request.get_json())
-        editing_own_public_profile = str(current_user.id) == user.id and not (
-            current_user.has_role(UserRole.FULL_PERMISSIONS) and current_user.has_role(UserRole.USER_MANAGER)
-        )
-        if editing_own_public_profile:
-            Patron.set_communication_channel(user)
         return user.dumps()
 
 

--- a/tests/api/patrons/test_patrons_rest.py
+++ b/tests/api/patrons/test_patrons_rest.py
@@ -19,6 +19,7 @@ from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.patrons.extensions import PatronWelcomeEmailExtension
 from rero_ils.modules.patrons.models import CommunicationChannel
 from rero_ils.modules.patrons.utils import create_user_from_data
+from rero_ils.modules.users.api import User
 from rero_ils.modules.utils import extracted_data_from_ref, get_ref_for_pid
 from tests.utils import VerifyRecordPermissionPatch, get_json, postdata, to_relative_url
 
@@ -358,6 +359,45 @@ def test_welcome_email_skips_non_patron(librarian_martigny):
         PatronWelcomeEmailExtension().post_create(librarian_martigny)
 
     enqueue.assert_not_called()
+
+
+def test_patrons_post_from_professional_interface(
+    app,
+    client,
+    patron_type_children_martigny,
+    patron_martigny_data_tmp,
+    roles,
+    mailbox,
+    system_librarian_martigny,
+):
+    """Send only the welcome email when a patron is created from the pro interface."""
+    login_user_via_session(client, system_librarian_martigny.user)
+    patron_data = deepcopy(patron_martigny_data_tmp)
+    patron_data.pop("pid")
+    patron_data["username"] = "professional_interface"
+    patron_data["email"] = "professional-interface@test.ch"
+    patron_data["patron"]["barcode"] = ["professional_interface"]
+
+    # the professional interface first creates the user account
+    res, user = postdata(client, "api_users.users_list", patron_data)
+    assert res.status_code == 200
+    assert not mailbox
+
+    # then the patron record, which is the only step sending an email
+    res, data = postdata(
+        client,
+        "invenio_records_rest.ptrn_list",
+        User.remove_fields(patron_data) | {"user_id": user["id"]},
+    )
+    assert res.status_code == 201
+    assert len(mailbox) == 1
+    assert mailbox[0].recipients == ["professional-interface@test.ch"]
+    assert mailbox[0].subject == "Inscription: The district of Martigny Libraries"
+
+    item_url = url_for("invenio_records_rest.ptrn_item", pid_value=data["metadata"]["pid"])
+    assert client.delete(item_url).status_code == 204
+    ds = app.extensions["invenio-accounts"].datastore
+    ds.delete_user(ds.find_user(id=user["id"]))
 
 
 def test_patrons_post_with_additional_email_only(

--- a/tests/api/users/test_users_rest.py
+++ b/tests/api/users/test_users_rest.py
@@ -4,6 +4,7 @@
 """Users Record tests."""
 
 import json
+from copy import deepcopy
 
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
@@ -87,6 +88,23 @@ def test_users_post_put(client, user_data_tmp, librarian_martigny, json_header, 
         headers=json_header,
     )
     assert res.status_code == 200
+
+
+def test_users_post_without_reset_password_email(app, client, data, librarian_martigny, default_user_password, mailbox):
+    """Test that the user creation does not send a reset password email."""
+    login_user_via_session(client, librarian_martigny.user)
+    user_data = deepcopy(data["user1"]) | {
+        "username": "no_reset_password_email",
+        "email": "no_reset_password_email@test.ch",
+        "password": default_user_password,
+    }
+    res, user = postdata(client, "api_users.users_list", user_data)
+    assert res.status_code == 200
+    reset_subject = str(app.config["SECURITY_EMAIL_SUBJECT_PASSWORD_RESET"])
+    assert not [message for message in mailbox if message.subject == reset_subject]
+
+    ds = app.extensions["invenio-accounts"].datastore
+    ds.delete_user(ds.find_user(id=user["id"]))
 
 
 def test_users_search_api(client, librarian_martigny, patron_martigny, user_without_profile):


### PR DESCRIPTION
## 1. refactor(users): remove dead code on user creation

* Remove unreachable `editing_own_public_profile` branch of
  the user POST handler: it compares a string to an integer user
  id, and a freshly created user can never be the current one.
* Only generate a password when none is given, instead of
  evaluating the generator on every call.

## 2. fix(users): no reset password email on creation

* Remove the reset password email sent when a user is created
  from the professional interface.
* Drop the now unused `send_email` argument of `User.create`,
  `create_user_from_data` and `create_patron_from_data`.
* Closes [#4245](https://github.com/rero/rero-ils/issues/4245)
