### PR TITLE
feat(circulation): add requests exports

### DIFF
--- a/rero_ils/modules/acquisition/acq_orders/serializers/csv.py
+++ b/rero_ils/modules/acquisition/acq_orders/serializers/csv.py
@@ -6,8 +6,7 @@
 
 import csv
 
-from flask import current_app, request, stream_with_context
-from invenio_i18n.ext import current_i18n
+from flask import current_app, stream_with_context
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 
 from rero_ils.modules.acquisition.acq_accounts.api import AcqAccountsSearch
@@ -18,7 +17,7 @@ from rero_ils.modules.commons.identifiers import IdentifierStatus
 from rero_ils.modules.documents.api import DocumentsSearch
 from rero_ils.modules.documents.serializers.base import DocumentFormatter
 from rero_ils.modules.vendors.api import VendorsSearch
-from rero_ils.utils import get_i18n_supported_languages
+from rero_ils.utils import get_display_language
 
 creator_role_filter = [
     "rsp",
@@ -60,9 +59,7 @@ class AcqOrderCSVSerializer(CSVSerializer):
         vendors = {}
 
         # language
-        language = request.args.get("lang", current_i18n.language)
-        if not language or language not in get_i18n_supported_languages():
-            language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
+        language = get_display_language()
 
         order_fields = {
             "order_pid": "pid",

--- a/rero_ils/modules/decorators.py
+++ b/rero_ils/modules/decorators.py
@@ -17,6 +17,8 @@ from rero_ils.permissions import (
     login_and_patron,
 )
 
+from .libraries.api import Library
+from .patrons.api import current_librarian
 from .permissions import PermissionContext
 
 
@@ -44,6 +46,22 @@ def check_logged_as_librarian(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         login_and_librarian()
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def check_library_in_organisation(fn):
+    """Decorator to check the `library_pid` is part of the user organisation.
+
+    If the library belongs to another organisation: return 403 (forbidden)
+    """
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        library = Library.get_record_by_pid(kwargs.get("library_pid"))
+        if library and (not current_librarian or library.organisation_pid != current_librarian.organisation_pid):
+            return jsonify({"status": "error: Forbidden"}), 403
         return fn(*args, **kwargs)
 
     return wrapper

--- a/rero_ils/modules/documents/serializers/ris.py
+++ b/rero_ils/modules/documents/serializers/ris.py
@@ -4,12 +4,11 @@
 
 """RIS Document serialization."""
 
-from flask import current_app, request, stream_with_context
-from invenio_i18n.ext import current_i18n
+from flask import current_app, stream_with_context
 from invenio_records_rest.serializers.base import SerializerMixinInterface
 
 from rero_ils.modules.commons.identifiers import IdentifierFactory, IdentifierType
-from rero_ils.utils import get_i18n_supported_languages
+from rero_ils.utils import get_display_language
 
 from ..dumpers import document_replace_refs_dumper
 from ..utils import process_i18n_literal_fields
@@ -67,10 +66,7 @@ class RISFormatter(BaseDocumentFormatterMixin):
         """Initialize RIS formatter with the specific record."""
         super().__init__(record)
         config = current_app.config.get("RERO_ILS_EXPORT_MAPPER").get("ris", {})
-        language = request.args.get("lang", current_i18n.language)
-        if not language or language not in get_i18n_supported_languages():
-            language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
-        self._language = language
+        self._language = get_display_language()
         self._doctype_mapping = doctype_mapping or config.get("doctype_mapping")
         self._export_fields = export_fields or config.get("export_fields")
 

--- a/rero_ils/modules/items/serializers/csv.py
+++ b/rero_ils/modules/items/serializers/csv.py
@@ -6,15 +6,14 @@
 
 from csv import QUOTE_ALL, DictWriter
 
-from flask import current_app, request, stream_with_context
-from invenio_i18n.ext import current_i18n
+from flask import stream_with_context
 from invenio_records_rest.serializers.csv import CSVSerializer, Line
 
 from rero_ils.modules.item_types.api import ItemTypesSearch
 from rero_ils.modules.libraries.api import LibrariesSearch
 from rero_ils.modules.locations.api import LocationsSearch
 from rero_ils.modules.serializers import CachedDataSerializerMixin
-from rero_ils.utils import get_i18n_supported_languages
+from rero_ils.utils import get_display_language
 
 from .collector import Collector
 
@@ -31,9 +30,7 @@ class ItemCSVSerializer(CSVSerializer, CachedDataSerializerMixin):
         :param item_links_factory: Factory function for record links.
         """
         # language
-        language = request.args.get("lang", current_i18n.language)
-        if not language or language not in get_i18n_supported_languages():
-            language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
+        language = get_display_language()
 
         def generate_csv():
             """Generate CSV records."""

--- a/rero_ils/modules/items/views/api_views.py
+++ b/rero_ils/modules/items/views/api_views.py
@@ -21,7 +21,11 @@ from jinja2 import TemplateNotFound, UndefinedError
 from werkzeug.exceptions import NotFound
 
 from rero_ils.modules.circ_policies.api import CircPolicy
-from rero_ils.modules.decorators import check_authentication, check_permission
+from rero_ils.modules.decorators import (
+    check_authentication,
+    check_library_in_organisation,
+    check_permission,
+)
 from rero_ils.modules.documents.views import record_library_pickup_locations
 from rero_ils.modules.errors import NoCirculationAction, NoCirculationActionIsPermitted
 from rero_ils.modules.item_types.api import ItemType
@@ -448,6 +452,7 @@ def extend_loan(item, data):
 
 @api_blueprint.route("/requested_loans/<library_pid>", methods=["GET"])
 @check_authentication
+@check_library_in_organisation
 @jsonify_error
 def requested_loans(library_pid):
     """HTTP GET request for sorted requested loans for a library."""

--- a/rero_ils/modules/loans/api_views.py
+++ b/rero_ils/modules/loans/api_views.py
@@ -3,21 +3,47 @@
 
 """Blueprint used for loans."""
 
-from flask import Blueprint, abort, jsonify
+from flask import Blueprint, abort, jsonify, request
 from flask_login import login_required
 
-from rero_ils.modules.decorators import check_logged_as_librarian
+from rero_ils.modules.decorators import (
+    check_library_in_organisation,
+    check_logged_as_librarian,
+)
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemCirculationAction
 from rero_ils.modules.items.views.api_views import (
     check_logged_user_authentication,
     jsonify_error,
 )
+from rero_ils.modules.libraries.api import Library
 from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.serializers import (
+    csv_requests_search,
+    json_requests_search,
+    requests_to_validate_rows,
+    xlsx_requests_search,
+)
 from rero_ils.modules.loans.utils import get_circ_policy, sum_for_fees
 from rero_ils.modules.patrons.api import current_librarian, current_patrons
 
 api_blueprint = Blueprint("api_loan", __name__, url_prefix="/loan")
+
+
+@api_blueprint.route("/requests/<library_pid>", methods=["GET"])
+@check_logged_as_librarian
+@check_library_in_organisation
+def requests_export(library_pid):
+    """HTTP GET request to export the requests to validate of a library.
+
+    The exported requests are the same as the ones listed by the professional
+    interface. The output format is given by the `format` argument.
+    """
+    serializers = {"csv": csv_requests_search, "json": json_requests_search, "xlsx": xlsx_requests_search}
+    if not (serializer := serializers.get(request.args.get("format", "csv"))):
+        abort(400, "Unsupported export format")
+    library = Library.get_record_by_pid(library_pid)
+    return serializer(None, requests_to_validate_rows(library) if library else [])
 
 
 @api_blueprint.route("/<loan_pid>/circulation_policy", methods=["GET"])

--- a/rero_ils/modules/loans/serializers/__init__.py
+++ b/rero_ils/modules/loans/serializers/__init__.py
@@ -12,10 +12,19 @@ from rero_ils.modules.serializers import (
     search_responsify_file,
 )
 
-from .csv import LoanStreamedCSVSerializer
-from .json import LoanJSONSerializer
+from .base import requests_to_validate_rows
+from .csv import LoanStreamedCSVSerializer, RequestsToValidateCSVSerializer
+from .json import LoanJSONSerializer, RequestsToValidateJSONSerializer
 
-__all__ = ["csv_stream_search", "json_loan_search", "xlsx_loan_search"]
+__all__ = [
+    "csv_requests_search",
+    "csv_stream_search",
+    "json_loan_search",
+    "json_requests_search",
+    "requests_to_validate_rows",
+    "xlsx_loan_search",
+    "xlsx_requests_search",
+]
 
 
 _json = LoanJSONSerializer(RecordSchemaJSONV1)
@@ -49,5 +58,38 @@ xlsx_loan_search = search_responsify_file(
     content_converter=xlsx_converter(
         "rero_ils/exports/loans.xml",
         worksheet_name="Loans",
+    ),
+)
+
+_requests_csv = RequestsToValidateCSVSerializer(
+    csv_included_fields=[
+        "item_barcode",
+        "document_title",
+        "document_contributions",
+        "item_first_call_number",
+        "item_second_call_number",
+        "item_enumerationAndChronology",
+        "requested_by",
+        "item_location",
+        "pickup_location",
+        "request_date",
+    ]
+)
+_requests_json = RequestsToValidateJSONSerializer()
+
+json_requests_search = search_responsify_file(
+    _requests_json, "application/json", file_extension="json", file_prefix="export-requests"
+)
+csv_requests_search = search_responsify_file(
+    _requests_csv, "text/csv", file_extension="csv", file_prefix="export-requests"
+)
+xlsx_requests_search = search_responsify_file(
+    _requests_csv,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    file_extension="xlsx",
+    file_prefix="export-requests",
+    content_converter=xlsx_converter(
+        "rero_ils/exports/requests.xml",
+        worksheet_name="Requests",
     ),
 )

--- a/rero_ils/modules/loans/serializers/base.py
+++ b/rero_ils/modules/loans/serializers/base.py
@@ -5,23 +5,13 @@
 """RERO-ILS Loan resource serializers shared helpers."""
 
 import ciso8601
-from flask import current_app, request
-from invenio_i18n.ext import current_i18n
 
 from rero_ils.modules.documents.api import DocumentsSearch
 from rero_ils.modules.documents.extensions import TitleExtension
 from rero_ils.modules.holdings.api import HoldingsSearch
-from rero_ils.utils import get_i18n_supported_languages
+from rero_ils.utils import get_display_language
 
 from ..api import Loan
-
-
-def _display_language():
-    """Get the language used to display the localized entity names."""
-    language = request.args.get("lang", current_i18n.language)
-    if not language or language not in get_i18n_supported_languages():
-        language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
-    return language
 
 
 def _document_contributions(document, language):
@@ -73,7 +63,7 @@ def requests_to_validate_rows(library):
     :returns: a list of dict, one per request.
     """
     metadata = Loan.requested_loans_to_validate(library.pid)
-    language = _display_language()
+    language = get_display_language()
     timezone = library.get_timezone()
     documents = DocumentsSearch().get_records_by_terms(
         [data["loan"]["document_pid"] for data in metadata],

--- a/rero_ils/modules/loans/serializers/base.py
+++ b/rero_ils/modules/loans/serializers/base.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-FileCopyrightText: UCLouvain
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RERO-ILS Loan resource serializers shared helpers."""
+
+import ciso8601
+from flask import current_app, request
+from invenio_i18n.ext import current_i18n
+
+from rero_ils.modules.documents.api import DocumentsSearch
+from rero_ils.modules.documents.extensions import TitleExtension
+from rero_ils.modules.holdings.api import HoldingsSearch
+from rero_ils.utils import get_i18n_supported_languages
+
+from ..api import Loan
+
+
+def _display_language():
+    """Get the language used to display the localized entity names."""
+    language = request.args.get("lang", current_i18n.language)
+    if not language or language not in get_i18n_supported_languages():
+        language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
+    return language
+
+
+def _document_contributions(document, language):
+    """Get the first contributions of a document as a single string.
+
+    :param document: the document data from the search index.
+    :param language: the language used for the authorized access points.
+    """
+    names = []
+    for contribution in document.get("contribution", [])[:3]:
+        entity = contribution.get("entity", {})
+        if name := entity.get(f"authorized_access_point_{language}") or entity.get("authorized_access_point"):
+            names.append(name)
+    return " ; ".join(names)
+
+
+def _item_location(item):
+    """Format the owning library and location of an item.
+
+    The temporary location takes precedence, as in the professional interface.
+
+    :param item: the item data from the search index.
+    """
+    name = item.get("temporary_location", {}).get("name") or item.get("location", {}).get("name", "")
+    return f"{item.get('library', {}).get('name', '')} - {name}"
+
+
+def _pickup_location(loan):
+    """Format the pickup location of a loan.
+
+    The location pickup name takes precedence, as in the professional interface.
+
+    :param loan: the loan data from the search index.
+    """
+    location = loan.get("pickup_location", {})
+    if pickup_name := location.get("pickup_name"):
+        return pickup_name
+    return f"{location.get('library_name', '')}: {location.get('name', '')}"
+
+
+def requests_to_validate_rows(library):
+    """Get the requests to validate of a library as flat export rows.
+
+    The requests are the same as the ones listed by the professional interface.
+    Only the documents and the call numbers inherited from the holdings need to
+    be loaded, both with a single search each.
+
+    :param library: the `Library` record to export the requests from.
+    :returns: a list of dict, one per request.
+    """
+    metadata = Loan.requested_loans_to_validate(library.pid)
+    language = _display_language()
+    timezone = library.get_timezone()
+    documents = DocumentsSearch().get_records_by_terms(
+        [data["loan"]["document_pid"] for data in metadata],
+        fields=["pid", "title", "contribution"],
+        as_dict=True,
+    )
+    holdings = HoldingsSearch().get_records_by_terms(
+        [data["item"]["holding"]["pid"] for data in metadata],
+        fields=["pid", "call_number", "second_call_number"],
+        as_dict=True,
+    )
+
+    rows = []
+    for data in metadata:
+        item, loan = data["item"], data["loan"]
+        document = documents.get(loan["document_pid"], {})
+        holding = holdings.get(item["holding"]["pid"], {})
+        request_date = ciso8601.parse_datetime(loan["creation_date"]).astimezone(timezone)
+        rows.append(
+            {
+                "item_barcode": item.get("barcode", ""),
+                "document_title": TitleExtension.format_text(document.get("title", [])),
+                "document_contributions": _document_contributions(document, language),
+                "item_first_call_number": item.get("call_number") or holding.get("call_number", ""),
+                "item_second_call_number": item.get("second_call_number") or holding.get("second_call_number", ""),
+                "item_enumerationAndChronology": item.get("enumerationAndChronology", ""),
+                "requested_by": f"{loan['patron']['name']} ({loan['patron']['barcode']})",
+                "item_location": _item_location(item),
+                "pickup_location": _pickup_location(loan),
+                "request_date": request_date.strftime("%Y-%m-%d %H:%M"),
+            }
+        )
+    return rows

--- a/rero_ils/modules/loans/serializers/csv.py
+++ b/rero_ils/modules/loans/serializers/csv.py
@@ -109,3 +109,28 @@ class LoanStreamedCSVSerializer(CSVSerializer, StreamSerializerMixin, CachedData
 
         self.load_all(LibrariesSearch(), PatronTypesSearch())
         return stream_with_context(generate_csv())
+
+
+class RequestsToValidateCSVSerializer(CSVSerializer):
+    """CSV serializer for the requests to validate of a library."""
+
+    def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
+        """Serialize the export rows as a CSV stream.
+
+        :param pid_fetcher: unused, kept for the serializer interface.
+        :param search_result: the rows built by `requests_to_validate_rows`.
+        :param links: Dictionary of links to add to response.
+        :param item_links_factory: Factory function for record links.
+        """
+
+        def generate_csv():
+            """Generate the CSV content as a generator."""
+            line = Line()
+            writer = DictWriter(line, dialect="excel", quoting=QUOTE_ALL, fieldnames=self.csv_included_fields)
+            writer.writeheader()
+            yield line.read()
+            for row in search_result:
+                writer.writerow(row)
+                yield line.read()
+
+        return stream_with_context(generate_csv())

--- a/rero_ils/modules/loans/serializers/json.py
+++ b/rero_ils/modules/loans/serializers/json.py
@@ -4,6 +4,8 @@
 
 """RERO-ILS Loan resource serializers for JSON format."""
 
+import json
+
 from rero_ils.modules.documents.api import DocumentsSearch
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.dumpers import ItemCirculationDumper
@@ -135,3 +137,17 @@ class LoanJSONSerializer(JSONSerializer, CachedDataSerializerMixin):
             aggregations["misc_status"]["buckets"] = [
                 {"key": term, "doc_count": hit["doc_count"]} for term, hit in misc_aggr.items() if hit.get("doc_count")
             ]
+
+
+class RequestsToValidateJSONSerializer:
+    """JSON serializer for the requests to validate of a library."""
+
+    def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
+        """Serialize the export rows as a JSON array.
+
+        :param pid_fetcher: unused, kept for the serializer interface.
+        :param search_result: the rows built by `requests_to_validate_rows`.
+        :param links: Dictionary of links to add to response.
+        :param item_links_factory: Factory function for record links.
+        """
+        return json.dumps(search_result)

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -10,7 +10,6 @@ from dateutil.relativedelta import relativedelta
 from elasticsearch_dsl.query import Q
 from flask import abort, current_app, request
 from flask import request as flask_request
-from invenio_i18n.ext import current_i18n
 from invenio_records_rest.errors import InvalidQueryRESTError
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 
@@ -22,7 +21,7 @@ from .modules.items.models import TypeOfItem
 from .modules.organisations.api import Organisation
 from .modules.patrons.api import current_librarian, current_patrons
 from .modules.templates.models import TemplateVisibility
-from .utils import get_i18n_supported_languages
+from .utils import get_display_language
 
 _PUNCTUATION_REGEX = re.compile(r"[:,\?,\,,\.,;,!,=,-]+(\s+|$)")
 
@@ -57,9 +56,7 @@ def and_i18n_term_filter(field, **kwargs):
     """
 
     def inner(values):
-        language = request.args.get("lang", current_i18n.language)
-        if not language or language not in get_i18n_supported_languages():
-            language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
+        language = get_display_language()
         i18n_field = f"{field}_{language}"
         must = [Q("term", **{i18n_field: value}) for value in values]
         _filter = Q("bool", must=must)
@@ -81,9 +78,7 @@ def i18n_terms_filter(field):
     """
 
     def inner(values):
-        language = request.args.get("lang", current_i18n.language)
-        if not language or language not in get_i18n_supported_languages():
-            language = current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
+        language = get_display_language()
         i18n_field = f"{field}_{language}"
         return Q("terms", **{i18n_field: values})
 

--- a/rero_ils/theme/templates/rero_ils/exports/requests.xml
+++ b/rero_ils/theme/templates/rero_ils/exports/requests.xml
@@ -1,0 +1,1 @@
+{% include "rero_ils/exports/_xlsx_sheet.xml" %}

--- a/rero_ils/utils.py
+++ b/rero_ils/utils.py
@@ -4,7 +4,7 @@
 """Utilities functions for rero-ils."""
 
 import iso639
-from flask import current_app
+from flask import current_app, request
 from flask_babel import gettext
 from invenio_i18n.ext import current_i18n
 
@@ -27,6 +27,20 @@ def get_i18n_supported_languages():
     languages = [current_app.config.get("BABEL_DEFAULT_LANGUAGE")]
     i18n_languages = current_app.config.get("I18N_LANGUAGES")
     return languages + [ln[0] for ln in i18n_languages]
+
+
+def get_display_language():
+    """Get the language to use to display the i18n fields.
+
+    The `lang` argument of the request takes precedence over the language of
+    the interface, and an unsupported language falls back to the default one.
+
+    :returns: the language code to use.
+    """
+    language = request.args.get("lang", current_i18n.language)
+    if not language or language not in get_i18n_supported_languages():
+        return current_app.config.get("BABEL_DEFAULT_LANGUAGE", "en")
+    return language
 
 
 def remove_empties_from_dict(a_dict):

--- a/tests/api/items/test_items_rest.py
+++ b/tests/api/items/test_items_rest.py
@@ -886,6 +886,7 @@ def test_items_notes(client, librarian_martigny, item_lib_martigny, json_header)
 def test_requested_loans_to_validate(
     client,
     librarian_martigny,
+    librarian_sion,
     loc_public_martigny,
     loc_restricted_martigny,
     item_type_standard_martigny,
@@ -940,6 +941,11 @@ def test_requested_loans_to_validate(
     assert patron_martigny.pid == requested_loan["loan"]["patron_pid"]
 
     assert requested_loan["item"]["temporary_location"]["name"]
+
+    # a librarian of another organisation cannot read these requests
+    login_user_via_session(client, librarian_sion.user)
+    res = client.get(url_for("api_item.requested_loans", library_pid=library_pid))
+    assert res.status_code == 403
 
     # RESET - the item
     del item2_lib_martigny["temporary_item_type"]

--- a/tests/api/loans/test_loans_serializers.py
+++ b/tests/api/loans/test_loans_serializers.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-FileCopyrightText: UCLouvain
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests Serializers."""
+
+import re
+from copy import deepcopy
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+from rero_ils.modules.holdings.api import Holding
+from tests.utils import get_csv, get_json, parse_csv, parse_xlsx
+
+
+def test_requests_export(
+    client,
+    csv_header,
+    patron_martigny,
+    librarian_martigny,
+    librarian_sion,
+    lib_martigny,
+    loc_public_martigny,
+    item_on_shelf_martigny_patron_and_loan_pending,
+):
+    """Test requests to validate exportation."""
+    item, patron, _ = item_on_shelf_martigny_patron_and_loan_pending
+    url = url_for("api_loan.requests_export", library_pid=lib_martigny.pid)
+
+    # STEP#1 :: CHECK EXPORT PERMISSION
+    #   Only librarians of the library organisation can export the requests.
+    res = client.get(url)
+    assert res.status_code == 401
+
+    login_user_via_session(client, patron_martigny.user)
+    res = client.get(url)
+    assert res.status_code == 403
+
+    login_user_via_session(client, librarian_sion.user)
+    res = client.get(url)
+    assert res.status_code == 403
+
+    login_user_via_session(client, librarian_martigny.user)
+    res = client.get(url_for("api_loan.requests_export", library_pid=lib_martigny.pid, format="pdf"))
+    assert res.status_code == 400
+
+    # an unknown library exports an empty file
+    res = client.get(url_for("api_loan.requests_export", library_pid="dummy_pid"), headers=csv_header)
+    assert res.status_code == 200
+    assert len(list(parse_csv(get_csv(res)))) == 1
+
+    # STEP#2 :: CHECK CSV CONTENT
+    res = client.get(url, headers=csv_header)
+    assert res.status_code == 200
+    assert res.headers["Content-Disposition"].startswith('attachment; filename="export-requests-')
+    assert res.headers["Content-Disposition"].endswith('.csv"')
+
+    csv_rows = list(parse_csv(get_csv(res)))
+    data = list(csv_rows)
+
+    header = data.pop(0)
+    assert header == [
+        "item_barcode",
+        "document_title",
+        "document_contributions",
+        "item_first_call_number",
+        "item_second_call_number",
+        "item_enumerationAndChronology",
+        "requested_by",
+        "item_location",
+        "pickup_location",
+        "request_date",
+    ]
+    assert len(data) == 1
+
+    row = dict(zip(header, data[0], strict=True))
+    assert row["item_barcode"] == item["barcode"]
+    # the document has an alternate graphic title, displayed first as in the interface
+    assert row["document_title"] == "titre en chinois. Part Number, Part Number = Titolo cinese : sottotitolo in cinese"
+    assert row["document_contributions"] == "Nebehay, Christian Michael"
+    assert row["item_first_call_number"] == item["call_number"]
+    assert row["requested_by"] == f"{patron.formatted_name} ({patron['patron']['barcode'][0]})"
+    assert row["item_location"] == f"{lib_martigny['name']} - {loc_public_martigny['name']}"
+    # the pickup location defines a `pickup_name`, it takes precedence
+    assert row["pickup_location"] == loc_public_martigny["pickup_name"]
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", row["request_date"])
+
+    # STEP#3 :: CHECK JSON CONTENT
+    #   The JSON export is a simple array of objects.
+    res = client.get(url_for("api_loan.requests_export", library_pid=lib_martigny.pid, format="json"))
+    assert res.status_code == 200
+    assert res.headers["Content-Disposition"].endswith('.json"')
+    assert get_json(res) == [row]
+
+    # STEP#4 :: CHECK XLSX CONTENT
+    res = client.get(url_for("api_loan.requests_export", library_pid=lib_martigny.pid, format="xlsx"))
+    assert res.status_code == 200
+    assert res.mimetype == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert res.headers["Content-Disposition"].endswith('.xlsx"')
+    assert res.headers["X-Accel-Buffering"] == "no"
+    assert parse_xlsx(res.get_data()) == csv_rows
+
+
+def test_requests_export_inherited_call_numbers(
+    client,
+    csv_header,
+    librarian_martigny,
+    lib_martigny,
+    item_on_shelf_martigny_patron_and_loan_pending,
+):
+    """Test the exported call numbers are inherited from the holdings."""
+    item, _, _ = item_on_shelf_martigny_patron_and_loan_pending
+    holding = Holding.get_record_by_pid(item.holding_pid)
+    original_item, original_holding = deepcopy(item), deepcopy(holding)
+
+    # move the call number to the holdings and add a second one
+    holding["call_number"] = item.pop("call_number")
+    holding["second_call_number"] = "second call number"
+    holding.update(holding, dbcommit=True, reindex=True)
+    item.update(item, dbcommit=True, reindex=True)
+
+    login_user_via_session(client, librarian_martigny.user)
+    url = url_for("api_loan.requests_export", library_pid=lib_martigny.pid)
+    res = client.get(url, headers=csv_header)
+    assert res.status_code == 200
+
+    data = list(parse_csv(get_csv(res)))
+    row = dict(zip(data[0], data[1], strict=True))
+    assert row["item_first_call_number"] == holding["call_number"]
+    assert row["item_second_call_number"] == holding["second_call_number"]
+
+    holding.update(original_holding, dbcommit=True, reindex=True)
+    item.update(original_item, dbcommit=True, reindex=True)
+
+
+def test_requests_export_contributions(
+    client,
+    csv_header,
+    librarian_martigny,
+    lib_martigny,
+    document,
+    item_on_shelf_martigny_patron_and_loan_pending,
+):
+    """Test only the first three contributions of a document are exported."""
+    original_document = deepcopy(document)
+    document["contribution"] = [
+        {
+            "entity": {"type": "bf:Person", "authorized_access_point": f"Author {index}"},
+            "role": ["aut"],
+        }
+        for index in range(1, 5)
+    ]
+    document.update(document, dbcommit=True, reindex=True)
+
+    login_user_via_session(client, librarian_martigny.user)
+    url = url_for("api_loan.requests_export", library_pid=lib_martigny.pid)
+    res = client.get(url, headers=csv_header)
+    assert res.status_code == 200
+
+    data = list(parse_csv(get_csv(res)))
+    row = dict(zip(data[0], data[1], strict=True))
+    assert row["document_contributions"] == "Author 1 ; Author 2 ; Author 3"
+
+    document.update(original_document, dbcommit=True, reindex=True)

--- a/tests/ui/test_utils_app.py
+++ b/tests/ui/test_utils_app.py
@@ -11,7 +11,7 @@ from rero_ils.modules.utils import (
     pids_exists_in_data,
     truncate_string,
 )
-from rero_ils.utils import get_current_language, remove_empties_from_dict
+from rero_ils.utils import get_current_language, get_display_language, remove_empties_from_dict
 
 
 def test_truncate_string():
@@ -134,6 +134,18 @@ def test_pids_exists_in_data(app, org_martigny, lib_martigny):
 def test_get_language(app):
     """Test get the current language of the application."""
     assert get_current_language() == "en"
+
+
+def test_get_display_language(app):
+    """Test the language used to display the i18n fields."""
+    with app.test_request_context("/"):
+        assert get_display_language() == "en"
+    # the `lang` argument takes precedence over the interface language
+    with app.test_request_context("/?lang=fr"):
+        assert get_display_language() == "fr"
+    # an unsupported language falls back to the default one
+    with app.test_request_context("/?lang=dummy"):
+        assert get_display_language() == "en"
 
 
 def test_get_record_class_from_schema_or_pid_type(app):


### PR DESCRIPTION
## 1. fix(circulation): restrict requests view by org

* Restrict the requests list to the librarians of its
  organisation, so that not any librarian could read the
  requests of any library, including one of another organisation.

## 2. feat(circulation): add requests exports

* Export the requests for a library as CSV, JSON or
  XLSX, so that librarians can work on the list outside of the
  professional interface.
* Build the export from the list the UI already uses,
  rather than from a dedicated search, so that both always show
  the same requests. This means that this specific export cannot
  use a standard `api_exports` without a much bigger refactor.
* Closes https://tree.taiga.io/project/rero21-reroils/us/3038.

## 3. refactor: share the display language resolution

* Move the resolution of the language used to display the i18n
  fields into `get_display_language` because the same three lines
  were repeated in the search query builder, in three exports and
  in the requests export just added.
* Keep the `lang` argument of the request, unused by any client yet,
  but useful when fetching exports directly from the API.

---

Linked to https://github.com/rero/rero-ils-ui/pull/1564